### PR TITLE
#4: Add comprehensive README and CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,245 @@
+# Contributing to CCGM
+
+Thanks for your interest in contributing to CCGM. This guide covers how modules work, how to create new ones, and how to submit changes.
+
+## How Modules Work
+
+Each module is a self-contained directory under `modules/` with a `module.json` manifest and one or more content files. The installer reads the manifest to know what to install, where to put it, and what configuration to prompt for.
+
+Modules install files into `~/.claude/` (global scope) or `.claude/` (project scope). The target location is determined by the `target` field in each file entry.
+
+### Module Directory Structure
+
+```
+modules/{name}/
+├── module.json          # Required: manifest with metadata, files, dependencies
+├── README.md            # Required: documentation with manual install instructions
+├── rules/               # Rule files (.md) - loaded automatically by Claude Code
+│   └── {name}.md
+├── commands/            # Command files (.md) - available as /command-name
+│   └── {command}.md
+├── hooks/               # Hook scripts (.py) - triggered by Claude Code events
+│   └── {hook}.py
+├── settings.base.json   # Settings template (merged into settings.json)
+├── settings.partial.json # Partial settings (merged into settings.json)
+└── *.md                 # Additional documentation files
+```
+
+Not every module has all subdirectories. A simple module might only have `module.json`, `README.md`, and a single rule file.
+
+## Creating a New Module
+
+### 1. Create the module directory
+
+```bash
+mkdir -p modules/{your-module-name}
+```
+
+Use lowercase with hyphens for the directory name.
+
+### 2. Create module.json
+
+Every module needs a `module.json` manifest. Here is the full schema:
+
+```json
+{
+  "name": "your-module-name",
+  "displayName": "Your Module Name",
+  "description": "One-line description of what the module does.",
+  "category": "core",
+  "scope": ["global", "project"],
+  "dependencies": [],
+  "files": {
+    "rules/your-module.md": {
+      "target": "rules/your-module.md",
+      "type": "rule",
+      "template": false
+    }
+  },
+  "tags": ["relevant", "tags"],
+  "configPrompts": []
+}
+```
+
+### 3. Add content files
+
+Create the files referenced in `module.json`. Place them in subdirectories that match the target location:
+
+- `rules/*.md` for rule files
+- `commands/*.md` for slash commands
+- `hooks/*.py` for event hooks
+
+### 4. Write a README.md
+
+Every module must have a README.md that explains:
+
+- What the module does
+- What files it installs
+- Manual installation instructions (copy commands)
+- Dependencies, if any
+- Template variables, if any
+
+Look at `modules/autonomy/README.md` for a minimal example and `modules/hooks/README.md` for a full-featured example.
+
+### 5. Add to relevant presets
+
+If your module is broadly useful, add its name to the appropriate preset arrays in `presets/`:
+
+- `minimal.json` - Only essential modules
+- `standard.json` - Modules most users will want
+- `full.json` - All modules (your module should always be here)
+- `team.json` - Modules useful for team workflows
+
+### 6. Run tests
+
+```bash
+# Validate all module manifests
+bash tests/test-modules.sh
+
+# Check for personal data leaks
+bash tests/test-no-personal-data.sh
+```
+
+## module.json Schema Reference
+
+### Top-Level Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Module identifier, matches directory name. Lowercase with hyphens. |
+| `displayName` | string | yes | Human-readable name shown during installation. |
+| `description` | string | yes | One-line description of what the module provides. |
+| `category` | string | yes | Module category (see categories below). |
+| `scope` | string[] | yes | Where the module can be installed: `"global"`, `"project"`, or both. |
+| `dependencies` | string[] | yes | Module names that must be installed first. Use `[]` for no dependencies. |
+| `files` | object | yes | Map of source paths to file descriptors (see below). |
+| `tags` | string[] | yes | Searchable tags for discovery. |
+| `configPrompts` | object[] | yes | Configuration questions asked during installation. Use `[]` for none. |
+
+### Categories
+
+| Category | Description |
+|----------|-------------|
+| `core` | Foundational modules that most users will want |
+| `commands` | Slash command collections |
+| `workflow` | Development workflow automation |
+| `patterns` | Coding patterns, standards, and anti-patterns |
+| `tech-specific` | Rules for specific technologies (Cloudflare, Supabase, etc.) |
+
+### File Descriptor Fields
+
+Each entry in the `files` object maps a source path (relative to the module directory) to a descriptor:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `target` | string | yes | Destination path relative to the install root (`~/.claude/` or `.claude/`). |
+| `type` | string | yes | File type: `rule`, `command`, `hook`, `config`, or `doc`. |
+| `template` | boolean | yes | Whether the file contains `__PLACEHOLDER__` template variables to expand. |
+| `merge` | boolean | no | For `config` type only. If `true`, the file is merged into the target rather than replacing it. Used for settings partials. |
+
+### File Types
+
+| Type | Extension | Description |
+|------|-----------|-------------|
+| `rule` | `.md` | Markdown rules loaded by Claude Code at session start. Shapes behavior and decision-making. |
+| `command` | `.md` | Markdown files that become slash commands in Claude Code. File name becomes the command name. |
+| `hook` | `.py` | Python scripts triggered by Claude Code events (PreToolUse, UserPromptSubmit, etc.). |
+| `config` | `.json` | JSON configuration files (settings, partials). May be merged into existing files. |
+| `doc` | `.md` | Documentation files installed alongside rules. Referenced by rules but not auto-loaded. |
+
+### Config Prompts
+
+Each entry in `configPrompts` defines a question asked during installation:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `key` | string | yes | The template variable name (e.g., `__LOG_REPO__`) or a config key. |
+| `prompt` | string | yes | The question shown to the user. |
+| `default` | string | yes | Default value if the user presses Enter. |
+| `options` | string[] | no | If provided, restricts answers to these values (shown as a select menu). |
+
+## Template Variables
+
+Template variables use `__DOUBLE_UNDERSCORE__` syntax and are expanded during installation. They are only used in files where `"template": true` in the file descriptor.
+
+### When to Use Template Variables
+
+- **Config files** (settings.json, hook scripts) that need user-specific paths or usernames
+- **Never in rule files** - rules use generic language that works for anyone without substitution
+
+### Available Variables
+
+| Variable | Description | Prompted By |
+|----------|-------------|-------------|
+| `__HOME__` | User's home directory | Auto-detected |
+| `__USERNAME__` | GitHub username | Prompted during install |
+| `__CODE_DIR__` | Code workspace directory | Prompted during install |
+| `__LOG_REPO__` | Agent log repo name | session-logging module |
+| `__TIMEZONE__` | User's timezone | Auto-detected |
+| `__DEFAULT_MODE__` | Permission default mode (ask/dontAsk) | settings module |
+
+## Rule File Conventions
+
+Rule files (`rules/*.md`) are the most common file type. Follow these conventions:
+
+1. **Use generic language.** Rules must work for any user without template variable substitution. Write "your home directory" instead of a specific path.
+
+2. **Be prescriptive.** Rules should clearly state what Claude should and should not do. Use imperative language.
+
+3. **Include examples.** Show concrete examples of correct and incorrect behavior when helpful.
+
+4. **Keep scope narrow.** Each rule file should cover one coherent topic. If a rule file grows beyond a few hundred lines, consider splitting it into a separate module.
+
+5. **No personal data.** Never include specific usernames, paths, repo names, or API endpoints. Run `tests/test-no-personal-data.sh` to verify.
+
+## Testing Your Module
+
+### Validate module manifests
+
+```bash
+bash tests/test-modules.sh
+```
+
+This checks that every `module.json` is valid JSON, has required fields, references files that exist, and that dependencies point to real modules.
+
+### Check for personal data
+
+```bash
+bash tests/test-no-personal-data.sh
+```
+
+This scans all files for personal data patterns (specific usernames, paths like `/Users/specific-name`, project IDs, etc.). The test must pass before your changes can be merged.
+
+### Test the installer
+
+```bash
+bash tests/test-installer.sh
+```
+
+This runs the installer in a temporary directory to verify end-to-end behavior.
+
+## Commit Message Format
+
+All commits must follow this format:
+
+```
+#{issue_number}: {description}
+```
+
+Examples:
+
+```
+#12: Add Redis module with connection rules
+#5: Fix template variable expansion in hooks
+```
+
+## Pull Request Process
+
+1. Create a feature branch from `main` (e.g., `12-add-redis-module`).
+2. Make your changes and ensure all tests pass.
+3. Push and create a PR. PRs are squash-merged into `main`.
+4. Reference the issue number in the PR description with `Closes #N`.
+
+## Questions?
+
+Open an issue on the repository if anything is unclear.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,169 @@
 # CCGM (Claude Code God Mode)
+
+Modular Claude Code configuration system - pick the modules you want, install in seconds.
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+## What is CCGM?
+
+CCGM is a curated collection of configuration modules for [Claude Code](https://claude.ai/code), Anthropic's CLI coding agent. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, CCGM lets you pick from 15 ready-made modules and install them with a single command.
+
+Each module is self-contained with its own documentation, so you can also copy individual files manually if you prefer.
+
+## Quick Start
+
+```bash
+git clone https://github.com/your-username/ccgm.git
+cd ccgm
+./install.sh
+```
+
+The interactive installer walks you through module selection. For a quick setup, use a preset:
+
+```bash
+./install.sh --preset standard
+```
+
+## Module Catalog
+
+| Module | Category | Description | Dependencies | Scope |
+|--------|----------|-------------|--------------|-------|
+| **autonomy** | core | Configure Claude as a fully autonomous Staff-level engineer who executes tasks end-to-end without asking unnecessary questions. | - | global, project |
+| **git-workflow** | core | Git workflow rules: sync before history changes, rebase by default, post-merge cleanup, PR template detection, no AI attribution in commits. | - | global, project |
+| **settings** | core | Base settings.json with comprehensive tool permissions (800+ allow entries), deny list for dangerous operations, and plugin configuration. Defaults to 'ask' mode for safety. | - | global |
+| **hooks** | core | Python hooks that enforce git workflow rules: issue-first workflow, commit message format, branch protection, and auto-approval for file operations. | settings | global |
+| **commands-core** | commands | Essential slash commands: /commit, /pr, /cpm (commit-PR-merge), /gs (git status), /new-issue. | - | global |
+| **commands-extra** | commands | Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global). | - | global |
+| **github-protocols** | workflow | GitHub repository management protocols: issue-first workflow, PR conventions, label taxonomy, code review standards. | - | global, project |
+| **session-logging** | workflow | Structured agent session logging system with mandatory log triggers, log repo management, and session startup command. | - | global |
+| **multi-agent** | workflow | Multi-clone architecture for parallel agent work with issue claiming, port allocation, and the /mawf workflow command. | session-logging | global |
+| **xplan** | workflow | Deep research + planning + execution framework. Spawns parallel research/review agents, creates comprehensive plans, and executes via parallel agent waves. | multi-agent | global |
+| **code-quality** | patterns | Code standards, testing requirements, error handling patterns, security practices, build verification, and living documents maintenance. | - | global, project |
+| **browser-automation** | patterns | Rules for browser automation tool selection: Chrome extension, Playwright, and WebMCP. Includes verification priority order and UI verification workflow. | - | global |
+| **common-mistakes** | patterns | 8 battle-tested anti-patterns to avoid: shallow directory exploration, dependency blindness, ESLint Fast Refresh, and more. | - | global, project |
+| **cloudflare** | tech-specific | Cloudflare-specific rules: Pages vs Workers selection, deployment methods, Git integration requirements. | - | global, project |
+| **supabase** | tech-specific | Supabase-specific rules: API key terminology (publishable/secret), environment variable naming, migration validation, and database change workflow. | - | global, project |
+
+## Presets
+
+Presets are named collections of modules for common use cases:
+
+| Preset | Modules | Best For |
+|--------|---------|----------|
+| **minimal** | autonomy, git-workflow | Getting started with the basics |
+| **standard** | autonomy, git-workflow, hooks, settings, commands-core | Most users |
+| **full** | All 15 modules | Power users who want everything |
+| **team** | autonomy, git-workflow, hooks, settings, commands-core, github-protocols, code-quality | Teams with shared conventions |
+
+## Installation Options
+
+```bash
+# Interactive mode - choose modules one by one
+./install.sh
+
+# Preset mode - install a named collection
+./install.sh --preset standard
+
+# Project-level install - writes to .claude/ in current project instead of ~/.claude/
+./install.sh --scope project
+
+# Symlink mode - symlinks files instead of copying (for CCGM developers)
+./install.sh --link
+```
+
+## What Gets Installed
+
+CCGM installs files into `~/.claude/` (global) or `.claude/` (project-level):
+
+```
+~/.claude/
+├── rules/*.md             # Claude Code rules (loaded automatically)
+├── commands/*.md           # Custom slash commands (available as /command-name)
+├── hooks/*.py              # Git workflow automation hooks
+├── settings.json           # Permissions and tool configurations
+├── .ccgm-manifest.json     # Tracks which modules are installed
+└── .ccgm.env               # Your configuration values (template variables)
+```
+
+- **Rules** are markdown files that Claude reads automatically at session start. They shape Claude's behavior, coding style, and decision-making.
+- **Commands** are slash commands you can invoke in Claude Code (e.g., `/commit`, `/pr`).
+- **Hooks** are Python scripts triggered by Claude Code events (PreToolUse, UserPromptSubmit) that enforce workflow rules and auto-approve safe operations.
+- **Settings** control which tools Claude can use without asking, which commands are denied, and plugin configuration.
+- **Manifest** tracks installed modules so updates and uninstalls work correctly.
+- **Env file** stores your personal configuration values (GitHub username, code directory path, etc.) used to expand template variables.
+
+## Customization
+
+### Personal rules
+
+Create `~/.claude/rules/personal.md` with any rules specific to your workflow. CCGM will not overwrite this file.
+
+### Settings overrides
+
+Claude Code natively supports `~/.claude/settings.local.json` as a local override file. Any settings you put there will take precedence over the CCGM-managed `settings.json`.
+
+### MCP servers
+
+MCP server configuration lives in `~/.claude/mcp.json`, which is not managed by CCGM. Configure your MCP servers there independently.
+
+### Template variables
+
+Some modules use `__PLACEHOLDER__` template variables in their config files. During installation, you are prompted for values. These are stored in `~/.ccgm.env` and expanded at install time:
+
+| Variable | Description | Used By |
+|----------|-------------|---------|
+| `__HOME__` | Home directory path | settings |
+| `__USERNAME__` | GitHub username | hooks |
+| `__CODE_DIR__` | Code workspace directory | settings |
+| `__LOG_REPO__` | Agent log repo name | session-logging |
+| `__TIMEZONE__` | Your timezone | session-logging |
+| `__DEFAULT_MODE__` | Permission mode (ask/dontAsk) | settings |
+
+## Updating
+
+Pull the latest changes and re-run the installer to pick up new modules or updates to existing ones:
+
+```bash
+cd ccgm
+./update.sh
+```
+
+## Uninstalling
+
+Remove all CCGM-installed files (uses the manifest to remove only what CCGM installed):
+
+```bash
+cd ccgm
+./uninstall.sh
+```
+
+## Manual Installation
+
+Every module has its own `README.md` with copy-paste instructions for manual installation without the installer. Browse the `modules/` directory and copy the files you want:
+
+```bash
+# Example: manually install the autonomy module
+cp modules/autonomy/rules/autonomy.md ~/.claude/rules/autonomy.md
+
+# Example: manually install core commands
+mkdir -p ~/.claude/commands
+cp modules/commands-core/commands/*.md ~/.claude/commands/
+```
+
+## Requirements
+
+- macOS or Linux
+- bash 4+ or zsh
+- git
+- **gh CLI** (for modules that interact with GitHub: commands-core, commands-extra, github-protocols)
+- **Python 3** (for the hooks module)
+- **jq** (for the settings and hooks modules - merges JSON configurations)
+- **gum** (optional - provides enhanced terminal UI during installation; falls back to plain bash prompts)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on creating modules, the module.json schema, and how to submit changes.
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
Closes #4

## Summary

- README.md with full documentation: module catalog (all 15 modules with accurate descriptions from module.json), preset comparison table, installation options, file structure explanation, customization guide, requirements
- CONTRIBUTING.md with module development guide: module.json schema reference, file type documentation, template variable guide, rule file conventions, testing instructions, commit and PR conventions

## Changes

- **README.md**: Replaced placeholder with comprehensive project documentation covering quick start, module catalog, presets, installation options, what gets installed, customization, updating, uninstalling, manual installation, and requirements
- **CONTRIBUTING.md**: New file with full contributor guide covering module structure, step-by-step creation guide, module.json schema reference, file types, template variables, rule conventions, testing, and PR process