### PR TITLE
#10: Rename /new-issue command to /ghi

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The interactive installer walks you through module selection. For a quick setup,
 | **git-workflow** | core | Git workflow rules: sync before history changes, rebase by default, post-merge cleanup, PR template detection, no AI attribution in commits. | - | global, project |
 | **settings** | core | Base settings.json with comprehensive tool permissions (800+ allow entries), deny list for dangerous operations, and plugin configuration. Defaults to 'ask' mode for safety. | - | global |
 | **hooks** | core | Python hooks that enforce git workflow rules: issue-first workflow, commit message format, branch protection, and auto-approval for file operations. | settings | global |
-| **commands-core** | commands | Essential slash commands: /commit, /pr, /cpm (commit-PR-merge), /gs (git status), /new-issue. | - | global |
+| **commands-core** | commands | Essential slash commands: /commit, /pr, /cpm (commit-PR-merge), /gs (git status), /ghi (create issue). | - | global |
 | **commands-extra** | commands | Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global). | - | global |
 | **github-protocols** | workflow | GitHub repository management protocols: issue-first workflow, PR conventions, label taxonomy, code review standards. | - | global, project |
 | **session-logging** | workflow | Structured agent session logging system with mandatory log triggers, log repo management, and session startup command. | - | global |

--- a/modules/commands-core/README.md
+++ b/modules/commands-core/README.md
@@ -10,7 +10,7 @@ Provides five foundational commands that cover the most common development opera
 - **/pr** - Push branch and create a pull request that closes an issue
 - **/cpm** - One-shot commit + PR + merge workflow for solo developers
 - **/gs** - Show git status and project overview
-- **/new-issue** - Create a GitHub issue with proper labels
+- **/ghi** - Create a GitHub issue with proper labels
 
 ## Files
 
@@ -20,7 +20,7 @@ Provides five foundational commands that cover the most common development opera
 | `commands/pr.md` | command | Push branch and create PR closing an issue |
 | `commands/cpm.md` | command | Commit, create PR, and merge in one shot |
 | `commands/gs.md` | command | Git status dashboard with project info |
-| `commands/new-issue.md` | command | Create GitHub issue with labels |
+| `commands/ghi.md` | command | Create GitHub issue with labels |
 
 ## Dependencies
 
@@ -39,7 +39,7 @@ cp commands/commit.md ~/.claude/commands/commit.md
 cp commands/pr.md ~/.claude/commands/pr.md
 cp commands/cpm.md ~/.claude/commands/cpm.md
 cp commands/gs.md ~/.claude/commands/gs.md
-cp commands/new-issue.md ~/.claude/commands/new-issue.md
+cp commands/ghi.md ~/.claude/commands/ghi.md
 ```
 
-After copying, the commands are available as `/commit`, `/pr`, `/cpm`, `/gs`, and `/new-issue` in Claude Code.
+After copying, the commands are available as `/commit`, `/pr`, `/cpm`, `/gs`, and `/ghi` in Claude Code.

--- a/modules/commands-core/commands/ghi.md
+++ b/modules/commands-core/commands/ghi.md
@@ -3,7 +3,7 @@ description: Create a new GitHub issue with proper labels
 allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
 ---
 
-# /new-issue - Create GitHub Issue
+# /ghi - Create GitHub Issue
 
 Create a new GitHub issue with appropriate labels based on the type of work.
 

--- a/modules/commands-core/commands/gs.md
+++ b/modules/commands-core/commands/gs.md
@@ -87,7 +87,7 @@ Based on the gathered state, suggest the most logical next action:
 |-------|---------------|
 | Uncommitted changes on feature branch | Run `/commit` to commit your changes |
 | Committed changes, no PR | Run `/pr` to push and create a pull request |
-| On main with no changes | Create a feature branch or run `/new-issue` |
+| On main with no changes | Create a feature branch or run `/ghi` |
 | Behind main on feature branch | Run `git fetch origin && git rebase origin/main` |
 | PR open and CI passing | Run `gh pr merge --squash --delete-branch` |
 | Merge conflicts | Resolve conflicts, then `git rebase --continue` |

--- a/modules/commands-core/module.json
+++ b/modules/commands-core/module.json
@@ -1,7 +1,7 @@
 {
   "name": "commands-core",
   "displayName": "Core Commands",
-  "description": "Essential slash commands: /commit, /pr, /cpm (commit-PR-merge), /gs (git status), /new-issue.",
+  "description": "Essential slash commands: /commit, /pr, /cpm (commit-PR-merge), /gs (git status), /ghi (create issue).",
   "category": "commands",
   "scope": ["global"],
   "dependencies": [],
@@ -10,7 +10,7 @@
     "commands/pr.md": { "target": "commands/pr.md", "type": "command", "template": false },
     "commands/cpm.md": { "target": "commands/cpm.md", "type": "command", "template": false },
     "commands/gs.md": { "target": "commands/gs.md", "type": "command", "template": false },
-    "commands/new-issue.md": { "target": "commands/new-issue.md", "type": "command", "template": false }
+    "commands/ghi.md": { "target": "commands/ghi.md", "type": "command", "template": false }
   },
   "tags": ["commands", "git", "github", "workflow"],
   "configPrompts": []


### PR DESCRIPTION
Closes #10

## Summary
Rename the /new-issue command to /ghi across the commands-core module and all references.

## Changes
- Renamed commands/new-issue.md to commands/ghi.md
- Updated module.json, README.md, gs.md, and top-level README.md