### PR TITLE
#12: Rename install.sh to start.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ CCGM is a modular Claude Code configuration system. It contains 15 modules that 
 
 ```
 ccgm/
-├── install.sh          # Main installer (bash)
+├── start.sh            # Main entry point (bash)
 ├── update.sh           # Check for upstream changes
 ├── uninstall.sh        # Clean removal
 ├── lib/                # Installer utilities

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ Each module is self-contained with its own documentation, so you can also copy i
 ```bash
 git clone https://github.com/your-username/ccgm.git
 cd ccgm
-./install.sh
+./start.sh
 ```
 
-The interactive installer walks you through module selection. For a quick setup, use a preset:
+That's it. The interactive setup walks you through everything - module selection, scope, configuration. No flags needed.
+
+For a quick setup, you can optionally pass a preset:
 
 ```bash
-./install.sh --preset standard
+./start.sh --preset standard
 ```
 
 ## Module Catalog
@@ -58,17 +60,13 @@ Presets are named collections of modules for common use cases:
 ## Installation Options
 
 ```bash
-# Interactive mode - choose modules one by one
-./install.sh
+# Interactive mode (recommended) - walks you through everything
+./start.sh
 
-# Preset mode - install a named collection
-./install.sh --preset standard
-
-# Project-level install - writes to .claude/ in current project instead of ~/.claude/
-./install.sh --scope project
-
-# Symlink mode - symlinks files instead of copying (for CCGM developers)
-./install.sh --link
+# Optional shortcuts:
+./start.sh --preset standard       # Skip module selection, use a preset
+./start.sh --scope project         # Install to .claude/ in current project instead of ~/.claude/
+./start.sh --link                  # Symlink files instead of copying (for CCGM developers)
 ```
 
 ## What Gets Installed

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# CCGM - Claude Code God Mode Installer
-# Usage: ./install.sh [--link] [--preset <name>] [--scope <global|project|both>]
+# CCGM - Claude Code God Mode
+# Usage: ./start.sh [--link] [--preset <name>] [--scope <global|project|both>]
 
 # --- Determine script location ---
 CCGM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -110,9 +110,9 @@ main() {
         shift 2
         ;;
       --help|-h)
-        echo "CCGM Installer"
+        echo "CCGM - Claude Code God Mode"
         echo ""
-        echo "Usage: ./install.sh [OPTIONS]"
+        echo "Usage: ./start.sh [OPTIONS]"
         echo ""
         echo "Options:"
         echo "  --link              Create symlinks instead of copies"
@@ -121,14 +121,14 @@ main() {
         echo "  -h, --help          Show this help"
         echo ""
         echo "Examples:"
-        echo "  ./install.sh                        Interactive installation"
-        echo "  ./install.sh --preset standard       Quick install with standard preset"
-        echo "  ./install.sh --link --preset full    Symlink full preset"
+        echo "  ./start.sh                        Interactive installation"
+        echo "  ./start.sh --preset standard       Quick install with standard preset"
+        echo "  ./start.sh --link --preset full    Symlink full preset"
         exit 0
         ;;
       *)
         echo "Unknown option: $1"
-        echo "Run ./install.sh --help for usage"
+        echo "Run ./start.sh --help for usage"
         exit 1
         ;;
     esac
@@ -684,7 +684,7 @@ main() {
   if [ "$LINK_MODE" = true ]; then
     echo "  3. Run './update.sh' to check for CCGM updates"
   else
-    echo "  3. Re-run './install.sh' to apply future CCGM updates"
+    echo "  3. Re-run './start.sh' to apply future CCGM updates"
   fi
   echo ""
   ui_info "Useful commands:"

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -63,7 +63,7 @@ export HOME="$TEST1_HOME"
 
 # Run installer with minimal preset
 set +e
-"$REPO_ROOT/install.sh" --preset minimal --scope global </dev/null 2>&1
+"$REPO_ROOT/start.sh" --preset minimal --scope global </dev/null 2>&1
 installer_exit=$?
 set -e
 
@@ -136,7 +136,7 @@ export HOME="$TEST2_HOME"
 export CCGM_CODE_DIR="$TEST2_HOME/code"
 
 set +e
-"$REPO_ROOT/install.sh" --preset standard --scope global </dev/null 2>&1
+"$REPO_ROOT/start.sh" --preset standard --scope global </dev/null 2>&1
 installer_exit=$?
 set -e
 
@@ -199,7 +199,7 @@ export HOME="$TEST3_HOME"
 export CCGM_CODE_DIR="$TEST3_HOME/code"
 
 set +e
-"$REPO_ROOT/install.sh" --preset full --scope global </dev/null 2>&1
+"$REPO_ROOT/start.sh" --preset full --scope global </dev/null 2>&1
 installer_exit=$?
 set -e
 

--- a/tests/test-link-mode.sh
+++ b/tests/test-link-mode.sh
@@ -55,7 +55,7 @@ export HOME="$LINK_HOME"
 
 echo "--- Installing with --link --preset minimal ---"
 set +e
-"$REPO_ROOT/install.sh" --link --preset minimal --scope global </dev/null 2>&1
+"$REPO_ROOT/start.sh" --link --preset minimal --scope global </dev/null 2>&1
 installer_exit=$?
 set -e
 
@@ -116,7 +116,7 @@ export HOME="$LINK2_HOME"
 export CCGM_CODE_DIR="$LINK2_HOME/code"
 
 set +e
-"$REPO_ROOT/install.sh" --link --preset standard --scope global </dev/null 2>&1
+"$REPO_ROOT/start.sh" --link --preset standard --scope global </dev/null 2>&1
 installer_exit=$?
 set -e
 

--- a/tests/test-no-personal-data.sh
+++ b/tests/test-no-personal-data.sh
@@ -20,7 +20,7 @@ SCAN_TARGETS=(
   "$REPO_ROOT/modules/"
   "$REPO_ROOT/lib/"
   "$REPO_ROOT/presets/"
-  "$REPO_ROOT/install.sh"
+  "$REPO_ROOT/start.sh"
   "$REPO_ROOT/update.sh"
   "$REPO_ROOT/uninstall.sh"
   "$REPO_ROOT/README.md"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -183,7 +183,7 @@ main() {
   # Done
   echo ""
   ui_success "CCGM uninstalled."
-  ui_info "To reinstall: ./install.sh"
+  ui_info "To reinstall: ./start.sh"
   echo ""
 }
 

--- a/update.sh
+++ b/update.sh
@@ -55,7 +55,7 @@ _check_installed_drift() {
     ui_success "No drift detected - installed files match source"
   else
     ui_warn "$drift_count file(s) differ from source"
-    ui_info "Run ./install.sh to re-apply from source"
+    ui_info "Run ./start.sh to re-apply from source"
   fi
 }
 
@@ -85,15 +85,15 @@ _offer_reinstall() {
       if [ "$prev_link" = "true" ]; then
         args+=("--link")
       fi
-      exec "${CCGM_ROOT}/install.sh" "${args[@]}"
+      exec "${CCGM_ROOT}/start.sh" "${args[@]}"
     else
-      ui_info "Run ./install.sh to configure a new installation."
+      ui_info "Run ./start.sh to configure a new installation."
     fi
   else
     if ui_confirm "Run the installer to apply updates?"; then
-      exec "${CCGM_ROOT}/install.sh"
+      exec "${CCGM_ROOT}/start.sh"
     else
-      ui_info "Run ./install.sh when ready to apply updates."
+      ui_info "Run ./start.sh when ready to apply updates."
     fi
   fi
 }
@@ -166,7 +166,7 @@ main() {
       case "$file" in
         modules/*) module_changes+=("$file") ;;
         presets/*) preset_changes+=("$file") ;;
-        install.sh|update.sh|uninstall.sh|lib/*) installer_changes+=("$file") ;;
+        start.sh|update.sh|uninstall.sh|lib/*) installer_changes+=("$file") ;;
         *) other_changes+=("$file") ;;
       esac
     done <<< "$changed_files"


### PR DESCRIPTION
Closes #12

## Summary
Rename the installer entry point from install.sh to start.sh. Users just clone and run ./start.sh - no flags needed.

## Changes
- Renamed install.sh to start.sh
- Updated all references across README, CLAUDE.md, update.sh, uninstall.sh, tests, CONTRIBUTING.md