### PR TITLE
#30: Add labels above gum input prompts

### DIFF
--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -147,6 +147,7 @@ ui_input() {
   fi
 
   if _has_gum; then
+    echo -e "${UI_CYAN}? ${UI_RESET}${UI_BOLD}$prompt${UI_RESET}" >&2
     local args=(--placeholder "$prompt")
     if [ -n "$default" ]; then
       args+=(--value "$default")


### PR DESCRIPTION
gum input's --placeholder is hidden when --value is pre-filled, so users see an editable field with no context for what it is. Prints the prompt label above the input, matching the pattern ui_choose already uses.

Closes #30