### PR TITLE
#36: Improve protected branches prompt with context

### DIFF
--- a/modules/hooks/module.json
+++ b/modules/hooks/module.json
@@ -37,7 +37,7 @@
   "configPrompts": [
     {
       "key": "protectedBranches",
-      "prompt": "Additional protected branches (comma-separated, e.g. staging,develop)?",
+      "prompt": "Additional protected branches beyond main/master? (branches that require feature branches and PRs, comma-separated, e.g. staging,develop - leave empty if none)",
       "default": ""
     }
   ]


### PR DESCRIPTION
Clarifies that main/master are already protected by default, explains what protected branches means (require feature branches and PRs), and tells users to leave empty if they don't need additional ones.

Closes #36