### PR TITLE
#40: Expand default protected branches and show during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For a quick install with a preset:
 | **autonomy** | core | Claude as a fully autonomous engineer - executes tasks end-to-end without unnecessary questions | - |
 | **git-workflow** | core | Git rules: sync before history changes, rebase by default, post-merge cleanup, no AI attribution | - |
 | **settings** | core | Base settings.json with 800+ tool permissions, deny list, plugin config. Defaults to safe 'ask' mode | - |
-| **hooks** | core | Python hooks: issue-first workflow, commit format, branch protection, auto-approval for safe ops | settings |
+| **hooks** | core | Python hooks: issue-first workflow, commit format, branch protection (dev, develop, main, master, prod, production, release, stag, staging, trunk), auto-approval for safe ops | settings |
 | **commands-core** | commands | /commit, /pr, /cpm (commit-PR-merge), /gs (git status), /ghi (create issue) | - |
 | **commands-extra** | commands | /audit (codebase audit), /pwv (Playwright verify), /walkthrough, /promote-rule | - |
 | **github-protocols** | workflow | Issue-first workflow, PR conventions, label taxonomy, code review standards | - |

--- a/modules/hooks/hooks/enforce-git-workflow.py
+++ b/modules/hooks/hooks/enforce-git-workflow.py
@@ -27,15 +27,15 @@ import sys
 # To add custom branches, append to this list or use the setup script
 # which writes them to a config file.
 PROTECTED_BRANCHES = [
+    "dev",
+    "develop",
     "main",
     "master",
-    "production",
     "prod",
-    "staging",
-    "stag",
-    "develop",
-    "dev",
+    "production",
     "release",
+    "stag",
+    "staging",
     "trunk",
 ]
 

--- a/modules/hooks/module.json
+++ b/modules/hooks/module.json
@@ -37,7 +37,7 @@
   "configPrompts": [
     {
       "key": "protectedBranches",
-      "prompt": "Additional protected branches beyond main/master? (branches that require feature branches and PRs, comma-separated, e.g. staging,develop - leave empty if none)",
+      "prompt": "Any additional protected branches? (comma-separated, leave empty if none)",
       "default": ""
     }
   ]

--- a/start.sh
+++ b/start.sh
@@ -561,11 +561,23 @@ main() {
               __LOG_REPO__)
                 default="${default:-${github_username}-agent-logs}"
                 ;;
+              protectedBranches)
+                ui_info "Default protected branches (direct commits blocked, PRs required):"
+                echo "  develop, dev, main, master, prod, production, release, staging, stag, trunk"
+                echo ""
+                ;;
             esac
             value=$(ui_input "$prompt" "$default")
           fi
 
-          ui_success "Set: $value"
+          if [ -n "$value" ]; then
+            ui_success "Set: $value"
+          else
+            case "$key" in
+              protectedBranches) ui_success "Using defaults only" ;;
+              *) ui_success "Set: (empty)" ;;
+            esac
+          fi
           _set_module_config "${mod}__${key}" "$value"
         done < <(get_module_config_prompts "$mod")
         echo ""


### PR DESCRIPTION
- Default protected branches now include: dev, develop, main, master, prod, production, release, stag, staging, trunk (sorted alphabetically)
- During setup, shows the full default list before asking if user wants to add more
- Simplified the prompt since the context is now shown inline
- Shows 'Using defaults only' when user leaves the field empty
- Updated README module catalog to list the defaults

Closes #40