### PR TITLE
#42: Add daily auto-update check for CCGM

### DIFF
--- a/modules/hooks/hooks/ccgm-update-check.py
+++ b/modules/hooks/hooks/ccgm-update-check.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook that checks for CCGM updates once per day.
+
+On the first tool call of each day, fetches the CCGM remote and checks
+if new commits are available. If updates are found, prints a notification
+to stderr. Uses a daily flag file to avoid repeated checks.
+
+Can be disabled by setting CCGM_AUTO_UPDATE_CHECK=false in ~/.claude/.ccgm.env
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+
+MANIFEST_FILE = Path.home() / ".claude" / ".ccgm-manifest.json"
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG_DIR = Path(tempfile.gettempdir())
+
+
+def is_enabled():
+    """Check if auto-update check is enabled in .ccgm.env."""
+    if not ENV_FILE.exists():
+        return False
+    try:
+        with open(ENV_FILE) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("CCGM_AUTO_UPDATE_CHECK="):
+                    value = line.split("=", 1)[1].strip().lower()
+                    return value in ("true", "1", "yes")
+    except (OSError, IOError):
+        pass
+    return False
+
+
+def already_checked_today():
+    """Check if we already ran the update check today."""
+    flag_file = FLAG_DIR / f".ccgm-update-check-{date.today().isoformat()}"
+    if flag_file.exists():
+        return True
+    # Create flag file for today, clean up old ones
+    for old_flag in FLAG_DIR.glob(".ccgm-update-check-*"):
+        try:
+            old_flag.unlink()
+        except OSError:
+            pass
+    try:
+        flag_file.touch()
+    except OSError:
+        pass
+    return False
+
+
+def get_ccgm_root():
+    """Read the CCGM clone path from the manifest."""
+    if not MANIFEST_FILE.exists():
+        return None
+    try:
+        with open(MANIFEST_FILE) as f:
+            manifest = json.load(f)
+            return manifest.get("ccgmRoot")
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def check_for_updates(ccgm_root):
+    """Fetch remote and count new commits on main."""
+    try:
+        # Fetch latest (quiet, fast)
+        subprocess.run(
+            ["git", "fetch", "origin", "--quiet"],
+            cwd=ccgm_root,
+            capture_output=True,
+            timeout=10,
+        )
+        # Count commits ahead on remote
+        result = subprocess.run(
+            ["git", "rev-list", "HEAD..origin/main", "--count"],
+            cwd=ccgm_root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            count = int(result.stdout.strip())
+            return count
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, ValueError):
+        pass
+    return 0
+
+
+def main():
+    # Read stdin (required by hook contract) but we don't use it
+    try:
+        json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        pass
+
+    # Quick exit paths
+    if not is_enabled():
+        return
+
+    if already_checked_today():
+        return
+
+    ccgm_root = get_ccgm_root()
+    if not ccgm_root or not Path(ccgm_root).is_dir():
+        return
+
+    count = check_for_updates(ccgm_root)
+    if count > 0:
+        s = "s" if count != 1 else ""
+        print(
+            f"\n  CCGM: {count} update{s} available. "
+            f"Run: cd {ccgm_root} && ./update.sh\n",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/hooks/module.json
+++ b/modules/hooks/module.json
@@ -26,6 +26,11 @@
       "type": "hook",
       "template": false
     },
+    "hooks/ccgm-update-check.py": {
+      "target": "hooks/ccgm-update-check.py",
+      "type": "hook",
+      "template": false
+    },
     "settings.partial.json": {
       "target": "settings.json",
       "type": "config",
@@ -39,6 +44,12 @@
       "key": "protectedBranches",
       "prompt": "Any additional protected branches? (comma-separated, leave empty if none)",
       "default": ""
+    },
+    {
+      "key": "autoUpdateCheck",
+      "prompt": "Check for CCGM updates daily? (notifies you when new updates are available)",
+      "default": "yes",
+      "options": ["yes", "no"]
     }
   ]
 }

--- a/modules/hooks/settings.partial.json
+++ b/modules/hooks/settings.partial.json
@@ -7,6 +7,11 @@
             "type": "command",
             "command": "python3 $HOME/.claude/hooks/enforce-issue-workflow.py",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/ccgm-update-check.py",
+            "timeout": 15000
           }
         ]
       }

--- a/start.sh
+++ b/start.sh
@@ -692,6 +692,12 @@ main() {
   log_repo=$(_get_module_config "session-logging____LOG_REPO__" "${github_username}-agent-logs")
   local default_mode
   default_mode=$(_get_module_config "settings__defaultMode" "ask")
+  local auto_update_raw
+  auto_update_raw=$(_get_module_config "hooks__autoUpdateCheck" "yes")
+  local auto_update_check="false"
+  case "$auto_update_raw" in
+    yes|true|1) auto_update_check="true" ;;
+  esac
   local env_entries=(
     "CCGM_HOME=${HOME}"
     "CCGM_USERNAME=${github_username}"
@@ -699,6 +705,7 @@ main() {
     "CCGM_LOG_REPO=${log_repo}"
     "CCGM_TIMEZONE=${timezone}"
     "CCGM_DEFAULT_MODE=${default_mode}"
+    "CCGM_AUTO_UPDATE_CHECK=${auto_update_check}"
   )
 
   # Add module-specific configs
@@ -706,7 +713,7 @@ main() {
   while [ $cfg_idx -lt ${#MODULE_CONFIG_KEYS[@]} ]; do
     local cfg_key="${MODULE_CONFIG_KEYS[$cfg_idx]}"
     case "$cfg_key" in
-      *__LOG_REPO__*|*__defaultMode__*) cfg_idx=$((cfg_idx + 1)); continue ;;
+      *__LOG_REPO__*|*__defaultMode__*|*__autoUpdateCheck__*) cfg_idx=$((cfg_idx + 1)); continue ;;
     esac
     env_entries+=("CCGM_MODULE_${cfg_key}=${MODULE_CONFIG_VALS[$cfg_idx]}")
     cfg_idx=$((cfg_idx + 1))


### PR DESCRIPTION
Adds a UserPromptSubmit hook that checks for CCGM updates once per day.

## How it works
- On the first user message of each day, fetches the CCGM remote and counts new commits
- Uses a daily flag file (`/tmp/.ccgm-update-check-YYYY-MM-DD`) so it only runs once per day
- Reads `~/.claude/.ccgm-manifest.json` to find the CCGM clone path
- If updates are available, prints: "CCGM: N updates available. Run: cd /path && ./update.sh"
- Enabled/disabled via `CCGM_AUTO_UPDATE_CHECK=true/false` in `~/.claude/.ccgm.env`

## Setup integration
- New config prompt during setup: "Check for CCGM updates daily?" (yes/no, defaults to yes)
- Value stored in `.ccgm.env` as `CCGM_AUTO_UPDATE_CHECK`

## Files
- `modules/hooks/hooks/ccgm-update-check.py` - the hook (115 lines)
- `modules/hooks/module.json` - added file entry + configPrompt
- `modules/hooks/settings.partial.json` - registered as UserPromptSubmit hook
- `start.sh` - reads autoUpdateCheck config and writes to env file

Closes #42