### PR TITLE
#44: Fix gum input reading from process substitution stdin

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -548,8 +548,17 @@ main() {
         local mod_display
         mod_display=$(get_module_display_name "$mod")
         ui_info "$mod_display"
+
+        # Read all prompts into an array first to avoid stdin conflicts
+        # (gum input reads from stdin, which conflicts with process substitution)
+        local config_lines=()
+        while IFS= read -r line; do
+          [ -n "$line" ] && config_lines+=("$line")
+        done < <(get_module_config_prompts "$mod")
+
         local key prompt default options value
-        while IFS='|' read -r key prompt default options; do
+        for config_line in "${config_lines[@]}"; do
+          IFS='|' read -r key prompt default options <<< "$config_line"
           [ -z "$key" ] && continue
 
           if [ -n "$options" ]; then
@@ -579,7 +588,7 @@ main() {
             esac
           fi
           _set_module_config "${mod}__${key}" "$value"
-        done < <(get_module_config_prompts "$mod")
+        done
         echo ""
       fi
     fi


### PR DESCRIPTION
gum input inside a while-read loop backed by process substitution inherits the pipe's stdin. When the protected branches prompt had an empty default, gum read the next line (the autoUpdateCheck prompt data) as its pre-filled value.

Fix: read all config prompt lines into an array first, then iterate with a for loop so interactive commands get clean stdin from the terminal.

Closes #44