### PR TITLE
#48: Fix option numbering in choose/multichoose fallbacks

### DIFF
--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -196,6 +196,7 @@ ui_choose() {
     local i=1
     for opt in "${options[@]}"; do
       echo -e "  ${UI_CYAN}$i)${UI_RESET} $opt" >&2
+      ((i++))
     done
     while true; do
       echo -en "${UI_CYAN}> ${UI_RESET}Enter number (1-${#options[@]}): " >&2
@@ -227,6 +228,7 @@ ui_multichoose() {
     local i=1
     for opt in "${options[@]}"; do
       echo -e "  ${UI_CYAN}$i)${UI_RESET} $opt" >&2
+      ((i++))
     done
     echo -en "${UI_CYAN}> ${UI_RESET}Selection: " >&2
     local input


### PR DESCRIPTION
## Summary
Counter variable `i` was never incremented in the non-gum fallback loops for `ui_choose` and `ui_multichoose`, so all options displayed as `1)`.

## Changes
- Added `((i++))` to both loops in `lib/ui.sh`

Closes #48