### PR TITLE
#50: Check for Claude Code installation as first prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ CCGM places files into `~/.claude/` (global) or `.claude/` (project-level):
 
 ## Requirements
 
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`npm install -g @anthropic-ai/claude-code`)
 - macOS or Linux
 - bash 4+ or zsh
 - git
 
-The installer checks for additional tools (jq, Python 3, gh CLI, gum) and offers to install any that are missing.
+The installer checks for Claude Code, additional tools (jq, Python 3, gh CLI, gum), and offers to install any that are missing.
 
 ## Install
 

--- a/start.sh
+++ b/start.sh
@@ -206,6 +206,23 @@ main() {
     fi
   }
 
+  # Check for Claude Code first
+  if command -v claude &>/dev/null; then
+    ui_success "claude: installed"
+  else
+    echo ""
+    ui_warn "Claude Code is not installed."
+    ui_info "CCGM configures Claude Code, so you'll need it installed to use these configs."
+    ui_info "Install: npm install -g @anthropic-ai/claude-code"
+    ui_info "  Docs: https://docs.anthropic.com/en/docs/claude-code"
+    echo ""
+    if ! ui_confirm "Continue installing CCGM configs anyway?"; then
+      ui_info "Install Claude Code first, then re-run ./start.sh"
+      exit 0
+    fi
+    echo ""
+  fi
+
   # Required prerequisites
   _check_prereq "git" "true" "version control" || true
   _check_prereq "python3" "true" "needed for hooks module" || true


### PR DESCRIPTION
## Summary
CCGM configures Claude Code, but the installer never checked if Claude Code was actually installed.

## Changes
- Checks for `claude` binary before other prerequisites
- If missing, shows install instructions and asks whether to continue anyway
- Updated README requirements to list Claude Code first

Closes #50