### PR TITLE
#55: remove gum dependency, replace with pure bash TUI

### DIFF
--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# CCGM - TUI utilities with gum progressive enhancement
-# If gum is available: styled prompts, spinners, filterable lists
-# If not: ANSI-colored bash fallback
+# CCGM - Pure bash TUI with ANSI escape sequences
+# Arrow-key navigation menus, no external dependencies
 
 # --- Color constants ---
 readonly UI_RED='\033[0;31m'
@@ -14,83 +13,44 @@ readonly UI_BOLD='\033[1m'
 readonly UI_DIM='\033[2m'
 readonly UI_RESET='\033[0m'
 
-# --- Detection ---
-_has_gum() {
-  command -v gum &>/dev/null
-}
-
 _is_non_interactive() {
   [ "${CCGM_NON_INTERACTIVE:-}" = "1" ]
 }
 
 # --- Banner ---
 ui_banner() {
-  if _has_gum; then
-    gum style \
-      --border double \
-      --border-foreground 99 \
-      --padding "1 3" \
-      --margin "1 0" \
-      --align center \
-      "  CCGM  " \
-      "Claude Code God Mode" \
-      "" \
-      "Modular configuration for Claude Code"
-  else
-    echo ""
-    echo -e "${UI_MAGENTA}${UI_BOLD}======================================${UI_RESET}"
-    echo -e "${UI_MAGENTA}${UI_BOLD}            CCGM${UI_RESET}"
-    echo -e "${UI_MAGENTA}${UI_BOLD}      Claude Code God Mode${UI_RESET}"
-    echo -e "${UI_MAGENTA}${UI_BOLD}======================================${UI_RESET}"
-    echo -e "${UI_DIM}  Modular configuration for Claude Code${UI_RESET}"
-    echo ""
-  fi
+  echo ""
+  echo -e "${UI_MAGENTA}${UI_BOLD}======================================${UI_RESET}"
+  echo -e "${UI_MAGENTA}${UI_BOLD}            CCGM${UI_RESET}"
+  echo -e "${UI_MAGENTA}${UI_BOLD}      Claude Code God Mode${UI_RESET}"
+  echo -e "${UI_MAGENTA}${UI_BOLD}======================================${UI_RESET}"
+  echo -e "${UI_DIM}  Modular configuration for Claude Code${UI_RESET}"
+  echo ""
 }
 
 # --- Section header ---
 # Usage: ui_header "Section Title"
 ui_header() {
   local title="$1"
-  if _has_gum; then
-    echo ""
-    gum style --foreground 99 --bold -- "--- $title ---"
-  else
-    echo ""
-    echo -e "${UI_CYAN}${UI_BOLD}--- $title ---${UI_RESET}"
-  fi
+  echo ""
+  echo -e "${UI_CYAN}${UI_BOLD}--- $title ---${UI_RESET}"
 }
 
 # --- Status messages ---
 ui_success() {
-  if _has_gum; then
-    gum style --foreground 2 -- "  $1"
-  else
-    echo -e "${UI_GREEN}  $1${UI_RESET}"
-  fi
+  echo -e "${UI_GREEN}  $1${UI_RESET}"
 }
 
 ui_error() {
-  if _has_gum; then
-    gum style --foreground 1 -- "  $1"
-  else
-    echo -e "${UI_RED}  $1${UI_RESET}"
-  fi
+  echo -e "${UI_RED}  $1${UI_RESET}"
 }
 
 ui_warn() {
-  if _has_gum; then
-    gum style --foreground 3 -- "  $1"
-  else
-    echo -e "${UI_YELLOW}  $1${UI_RESET}"
-  fi
+  echo -e "${UI_YELLOW}  $1${UI_RESET}"
 }
 
 ui_info() {
-  if _has_gum; then
-    gum style --foreground 4 -- "  $1"
-  else
-    echo -e "${UI_BLUE}  $1${UI_RESET}"
-  fi
+  echo -e "${UI_BLUE}  $1${UI_RESET}"
 }
 
 # --- Confirm (yes/no) ---
@@ -105,33 +65,24 @@ ui_confirm() {
     if [ "$default" = "yes" ]; then return 0; else return 1; fi
   fi
 
-  if _has_gum; then
-    if [ "$default" = "yes" ]; then
-      gum confirm --default=yes "$prompt"
-    else
-      gum confirm --default=no "$prompt"
-    fi
-    return $?
+  local yn_hint
+  if [ "$default" = "yes" ]; then
+    yn_hint="[Y/n]"
   else
-    local yn_hint
-    if [ "$default" = "yes" ]; then
-      yn_hint="[Y/n]"
-    else
-      yn_hint="[y/N]"
-    fi
-    while true; do
-      echo -en "${UI_CYAN}? ${UI_RESET}${UI_BOLD}$prompt${UI_RESET} $yn_hint "
-      read -r answer
-      case "${answer,,}" in
-        y|yes) return 0 ;;
-        n|no) return 1 ;;
-        "")
-          if [ "$default" = "yes" ]; then return 0; else return 1; fi
-          ;;
-        *) echo -e "${UI_YELLOW}  Please answer yes or no.${UI_RESET}" ;;
-      esac
-    done
+    yn_hint="[y/N]"
   fi
+  while true; do
+    echo -en "${UI_CYAN}? ${UI_RESET}${UI_BOLD}$prompt${UI_RESET} $yn_hint "
+    read -r answer
+    case "${answer,,}" in
+      y|yes) return 0 ;;
+      n|no) return 1 ;;
+      "")
+        if [ "$default" = "yes" ]; then return 0; else return 1; fi
+        ;;
+      *) echo -e "${UI_YELLOW}  Please answer yes or no.${UI_RESET}" ;;
+    esac
+  done
 }
 
 # --- Text input ---
@@ -146,33 +97,48 @@ ui_input() {
     return 0
   fi
 
-  if _has_gum; then
-    echo -e "${UI_CYAN}? ${UI_RESET}${UI_BOLD}$prompt${UI_RESET}" >&2
-    local args=(--placeholder "$prompt")
-    if [ -n "$default" ]; then
-      args+=(--value "$default")
-    fi
-    local result
-    result=$(gum input "${args[@]}")
-    if [ -z "$result" ] && [ -n "$default" ]; then
-      echo "$default"
-    else
-      echo "$result"
-    fi
-  else
-    local display_default=""
-    if [ -n "$default" ]; then
-      display_default=" ${UI_DIM}($default)${UI_RESET}"
-    fi
-    echo -en "${UI_CYAN}? ${UI_RESET}${UI_BOLD}$prompt${UI_RESET}$display_default: " >&2
-    local answer
-    read -r answer
-    if [ -z "$answer" ] && [ -n "$default" ]; then
-      echo "$default"
-    else
-      echo "$answer"
-    fi
+  local display_default=""
+  if [ -n "$default" ]; then
+    display_default=" ${UI_DIM}($default)${UI_RESET}"
   fi
+  echo -en "${UI_CYAN}? ${UI_RESET}${UI_BOLD}$prompt${UI_RESET}$display_default: " >&2
+  local answer
+  read -r answer
+  if [ -z "$answer" ] && [ -n "$default" ]; then
+    echo "$default"
+  else
+    echo "$answer"
+  fi
+}
+
+# --- Read a single keypress (handles escape sequences for arrow keys) ---
+# Sets global _KEY to: "up", "down", "enter", "space", "a", or the character
+_read_key() {
+  local char
+  IFS= read -rsn1 char < /dev/tty
+
+  case "$char" in
+    $'\x1b')
+      # Escape sequence - read next two chars for arrow keys
+      local seq1 seq2
+      IFS= read -rsn1 -t 0.1 seq1 < /dev/tty
+      IFS= read -rsn1 -t 0.1 seq2 < /dev/tty
+      case "${seq1}${seq2}" in
+        "[A") _KEY="up" ;;
+        "[B") _KEY="down" ;;
+        *)    _KEY="escape" ;;
+      esac
+      ;;
+    "")
+      _KEY="enter"
+      ;;
+    " ")
+      _KEY="space"
+      ;;
+    *)
+      _KEY="$char"
+      ;;
+  esac
 }
 
 # --- Single select ---
@@ -188,27 +154,73 @@ ui_choose() {
     return 0
   fi
 
-  if _has_gum; then
-    echo -e "${UI_CYAN}? ${UI_RESET}${UI_BOLD}$prompt${UI_RESET}" >&2
-    printf '%s\n' "${options[@]}" | gum choose
-  else
-    echo -e "${UI_CYAN}? ${UI_RESET}${UI_BOLD}$prompt${UI_RESET}" >&2
-    local i=1
-    for opt in "${options[@]}"; do
-      echo -e "  ${UI_CYAN}$i)${UI_RESET} $opt" >&2
-      ((i++))
-    done
-    while true; do
-      echo -en "${UI_CYAN}> ${UI_RESET}Enter number (1-${#options[@]}): " >&2
-      local choice
-      read -r choice
-      if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#options[@]}" ]; then
-        echo "${options[$((choice-1))]}"
+  # Save terminal state and enable raw mode on /dev/tty
+  local original_stty
+  original_stty=$(stty -g < /dev/tty)
+  stty -echo -icanon < /dev/tty
+
+  # Restore terminal on exit (works in subshell from $())
+  trap "stty '$original_stty' < /dev/tty 2>/dev/null; printf '\\033[?25h' > /dev/tty" EXIT
+  trap "stty '$original_stty' < /dev/tty 2>/dev/null; printf '\\033[?25h' > /dev/tty; exit 130" INT
+
+  # Hide cursor
+  printf '\033[?25l' > /dev/tty
+
+  # Print prompt
+  printf "${UI_CYAN}? ${UI_RESET}${UI_BOLD}%s${UI_RESET} ${UI_DIM}(arrows navigate, enter selects)${UI_RESET}\n" "$prompt" > /dev/tty
+
+  local selected=0
+  local count=${#options[@]}
+  local i
+
+  # Initial render
+  for ((i = 0; i < count; i++)); do
+    if [ $i -eq $selected ]; then
+      printf "  ${UI_CYAN}${UI_BOLD}▸ %s${UI_RESET}\n" "${options[$i]}" > /dev/tty
+    else
+      printf "    %s\n" "${options[$i]}" > /dev/tty
+    fi
+  done
+
+  while true; do
+    _read_key
+    local moved=false
+
+    case "$_KEY" in
+      up)
+        if [ $selected -gt 0 ]; then
+          selected=$((selected - 1))
+          moved=true
+        fi
+        ;;
+      down)
+        if [ $selected -lt $((count - 1)) ]; then
+          selected=$((selected + 1))
+          moved=true
+        fi
+        ;;
+      enter)
+        # Show cursor
+        printf '\033[?25h' > /dev/tty
+        # Output result to stdout (captured by $())
+        echo "${options[$selected]}"
         return 0
-      fi
-      echo -e "${UI_YELLOW}  Invalid choice, try again.${UI_RESET}" >&2
-    done
-  fi
+        ;;
+    esac
+
+    if [ "$moved" = true ]; then
+      # Move cursor up to top of list and redraw
+      printf "\033[%dA" "$count" > /dev/tty
+      for ((i = 0; i < count; i++)); do
+        printf "\r\033[2K" > /dev/tty
+        if [ $i -eq $selected ]; then
+          printf "  ${UI_CYAN}${UI_BOLD}▸ %s${UI_RESET}\n" "${options[$i]}" > /dev/tty
+        else
+          printf "    %s\n" "${options[$i]}" > /dev/tty
+        fi
+      done
+    fi
+  done
 }
 
 # --- Multi-select ---
@@ -219,32 +231,120 @@ ui_multichoose() {
   shift
   local options=("$@")
 
-  if _has_gum; then
-    echo -e "${UI_CYAN}? ${UI_RESET}${UI_BOLD}$prompt${UI_RESET}" >&2
-    printf '%s\n' "${options[@]}" | gum choose --no-limit
-  else
-    echo -e "${UI_CYAN}? ${UI_RESET}${UI_BOLD}$prompt${UI_RESET}" >&2
-    echo -e "${UI_DIM}  Enter numbers separated by spaces, or 'a' for all${UI_RESET}" >&2
-    local i=1
-    for opt in "${options[@]}"; do
-      echo -e "  ${UI_CYAN}$i)${UI_RESET} $opt" >&2
-      ((i++))
-    done
-    echo -en "${UI_CYAN}> ${UI_RESET}Selection: " >&2
-    local input
-    read -r input
-    if [ "$input" = "a" ] || [ "$input" = "all" ]; then
-      printf '%s\n' "${options[@]}"
-      return 0
+  if _is_non_interactive; then
+    # Return all options in non-interactive mode
+    printf '%s\n' "${options[@]}"
+    return 0
+  fi
+
+  # Save terminal state and enable raw mode on /dev/tty
+  local original_stty
+  original_stty=$(stty -g < /dev/tty)
+  stty -echo -icanon < /dev/tty
+
+  # Restore terminal on exit (works in subshell from $())
+  trap "stty '$original_stty' < /dev/tty 2>/dev/null; printf '\\033[?25h' > /dev/tty" EXIT
+  trap "stty '$original_stty' < /dev/tty 2>/dev/null; printf '\\033[?25h' > /dev/tty; exit 130" INT
+
+  # Hide cursor
+  printf '\033[?25l' > /dev/tty
+
+  # Print prompt
+  printf "${UI_CYAN}? ${UI_RESET}${UI_BOLD}%s${UI_RESET} ${UI_DIM}(arrows navigate, space toggles, a=all, enter confirms)${UI_RESET}\n" "$prompt" > /dev/tty
+
+  local cursor=0
+  local count=${#options[@]}
+  local i
+  local checked=()
+  for ((i = 0; i < count; i++)); do
+    checked+=("false")
+  done
+
+  # Initial render
+  for ((i = 0; i < count; i++)); do
+    local marker="[ ]"
+    [ "${checked[$i]}" = "true" ] && marker="[✓]"
+    if [ $i -eq $cursor ]; then
+      printf "  ${UI_CYAN}${UI_BOLD}▸ %s %s${UI_RESET}\n" "$marker" "${options[$i]}" > /dev/tty
+    else
+      printf "    %s %s\n" "$marker" "${options[$i]}" > /dev/tty
     fi
-    local selected=()
-    for num in $input; do
-      if [[ "$num" =~ ^[0-9]+$ ]] && [ "$num" -ge 1 ] && [ "$num" -le "${#options[@]}" ]; then
-        selected+=("${options[$((num-1))]}")
+  done
+
+  while true; do
+    _read_key
+
+    case "$_KEY" in
+      up)
+        if [ $cursor -gt 0 ]; then
+          cursor=$((cursor - 1))
+        fi
+        ;;
+      down)
+        if [ $cursor -lt $((count - 1)) ]; then
+          cursor=$((cursor + 1))
+        fi
+        ;;
+      space)
+        if [ "${checked[$cursor]}" = "true" ]; then
+          checked[$cursor]="false"
+        else
+          checked[$cursor]="true"
+        fi
+        ;;
+      a)
+        # Toggle all: if all checked, uncheck all; otherwise check all
+        local all_checked=true
+        for ((i = 0; i < count; i++)); do
+          if [ "${checked[$i]}" = "false" ]; then
+            all_checked=false
+            break
+          fi
+        done
+        for ((i = 0; i < count; i++)); do
+          if [ "$all_checked" = true ]; then
+            checked[$i]="false"
+          else
+            checked[$i]="true"
+          fi
+        done
+        ;;
+      enter)
+        # Show cursor
+        printf '\033[?25h' > /dev/tty
+        # Show summary on tty
+        local sel_count=0
+        for ((i = 0; i < count; i++)); do
+          [ "${checked[$i]}" = "true" ] && sel_count=$((sel_count + 1))
+        done
+        printf "  ${UI_GREEN}✓ %d selected${UI_RESET}\n" "$sel_count" > /dev/tty
+        # Output selected items to stdout (captured by $())
+        for ((i = 0; i < count; i++)); do
+          if [ "${checked[$i]}" = "true" ]; then
+            echo "${options[$i]}"
+          fi
+        done
+        return 0
+        ;;
+      *)
+        # Ignore other keys
+        continue
+        ;;
+    esac
+
+    # Redraw menu
+    printf "\033[%dA" "$count" > /dev/tty
+    for ((i = 0; i < count; i++)); do
+      printf "\r\033[2K" > /dev/tty
+      local marker="[ ]"
+      [ "${checked[$i]}" = "true" ] && marker="[✓]"
+      if [ $i -eq $cursor ]; then
+        printf "  ${UI_CYAN}${UI_BOLD}▸ %s %s${UI_RESET}\n" "$marker" "${options[$i]}" > /dev/tty
+      else
+        printf "    %s %s\n" "$marker" "${options[$i]}" > /dev/tty
       fi
     done
-    printf '%s\n' "${selected[@]}"
-  fi
+  done
 }
 
 # --- Spinner ---
@@ -253,25 +353,21 @@ ui_spin() {
   local title="$1"
   shift
 
-  if _has_gum; then
-    gum spin --spinner dot --title "$title" -- "$@"
-  else
-    echo -en "${UI_CYAN}  $title${UI_RESET} " >&2
-    "$@" &>/dev/null &
-    local pid=$!
-    local spin_chars='/-\|'
-    local i=0
-    while kill -0 "$pid" 2>/dev/null; do
-      i=$(( (i+1) % 4 ))
-      printf "\b${spin_chars:$i:1}" >&2
-      sleep 0.1
-    done
-    wait "$pid"
-    local exit_code=$?
-    printf "\b " >&2
-    echo "" >&2
-    return $exit_code
-  fi
+  echo -en "${UI_CYAN}  $title${UI_RESET} " >&2
+  "$@" &>/dev/null &
+  local pid=$!
+  local spin_chars='/-\|'
+  local i=0
+  while kill -0 "$pid" 2>/dev/null; do
+    i=$(( (i+1) % 4 ))
+    printf "\b${spin_chars:$i:1}" >&2
+    sleep 0.1
+  done
+  wait "$pid"
+  local exit_code=$?
+  printf "\b " >&2
+  echo "" >&2
+  return $exit_code
 }
 
 # --- File preview ---
@@ -284,11 +380,7 @@ ui_preview_file() {
 
 # --- Divider ---
 ui_divider() {
-  if _has_gum; then
-    gum style --foreground 240 -- "$(printf '%.0s-' {1..50})"
-  else
-    echo -e "${UI_DIM}$(printf '%.0s-' {1..50})${UI_RESET}"
-  fi
+  echo -e "${UI_DIM}$(printf '%.0s-' {1..50})${UI_RESET}"
 }
 
 # --- List item ---
@@ -296,9 +388,5 @@ ui_divider() {
 ui_list_item() {
   local name="$1"
   local desc="$2"
-  if _has_gum; then
-    gum style -- "  $(gum style --foreground 2 --bold -- "$name")  $desc"
-  else
-    echo -e "  ${UI_GREEN}${UI_BOLD}$name${UI_RESET}  $desc"
-  fi
+  echo -e "  ${UI_GREEN}${UI_BOLD}$name${UI_RESET}  $desc"
 }

--- a/start.sh
+++ b/start.sh
@@ -182,7 +182,6 @@ main() {
   # Define prerequisites: name|required|check_cmd|pkg_name_brew|pkg_name_apt|description
   local -a missing_required=()
   local -a missing_optional=()
-  local has_gum=false
   local has_jq=false
 
   # Check each prerequisite
@@ -231,8 +230,6 @@ main() {
 
   # Optional but recommended
   _check_prereq "gh" "false" "GitHub CLI for issue/PR commands" || true
-  _check_prereq "gum" "false" "enhanced terminal UI" || true
-  if command -v gum &>/dev/null; then has_gum=true; fi
 
   echo ""
 
@@ -327,7 +324,6 @@ main() {
       ui_info "Installing: ${missing_optional[*]}"
       if $pkg_install "${missing_optional[@]}"; then
         ui_success "Optional tools installed"
-        command -v gum &>/dev/null && has_gum=true
       else
         ui_info "Optional install failed - continuing without them"
       fi
@@ -572,7 +568,7 @@ main() {
         ui_info "$mod_display"
 
         # Read all prompts into an array first to avoid stdin conflicts
-        # (gum input reads from stdin, which conflicts with process substitution)
+        # (ui_input uses read, which conflicts with process substitution)
         local config_lines=()
         while IFS= read -r line; do
           [ -n "$line" ] && config_lines+=("$line")


### PR DESCRIPTION
Closes #55

## Summary
- Complete rewrite of `lib/ui.sh` removing all gum usage
- `ui_choose`: arrow-key single-select menu with `▸` indicator, stty raw mode, `/dev/tty` rendering for subshell compatibility
- `ui_multichoose`: arrow-key multi-select with `[✓]`/`[ ]` checkboxes, space toggle, `a` for select-all
- All other ui functions (`ui_banner`, `ui_header`, `ui_success/error/warn/info`, `ui_input`, `ui_confirm`, `ui_spin`, `ui_divider`, `ui_list_item`): stripped to bash/ANSI-only code
- Removed gum from `start.sh` prerequisites
- Function signatures unchanged - all 159 call sites unaffected

## Test plan
- [x] All 247 module tests pass
- [x] Non-interactive mode (`CCGM_NON_INTERACTIVE=1`) works for all functions
- [x] `bash -n` syntax check passes on both files
- [x] Manual test in Terminal.app - arrow-key menus work, no duplicate lines