### PR TITLE
#58: add auto-startup SessionStart hook to session-logging module

### DIFF
--- a/modules/session-logging/README.md
+++ b/modules/session-logging/README.md
@@ -11,6 +11,7 @@ This module establishes a centralized logging system where Claude Code agents re
 - **Context preservation**: Capture details that do not fit in git commits or issues
 - **Work tracking**: Record completed work, blockers, and decisions made
 - **Remote backup**: All logs are git-tracked with a GitHub remote
+- **Auto-startup**: Automatically run `/startup` on new sessions (works in VS Code, Cursor, and desktop app)
 
 ## Files
 
@@ -19,6 +20,8 @@ This module establishes a centralized logging system where Claude Code agents re
 | `rules/session-logging.md` | rule | Mandatory log triggers and living documents protocol |
 | `log-system.md` | doc | Full logging system documentation |
 | `commands/startup.md` | command | Session startup protocol (/startup) |
+| `hooks/auto-startup.py` | hook | SessionStart hook that auto-runs /startup |
+| `settings.partial.json` | config | Hook wiring for SessionStart event |
 
 ## Configuration
 
@@ -26,6 +29,7 @@ During installation, you will be prompted for:
 
 - **Agent log repo name**: The name of the git repository for storing agent logs (e.g., `yourname-agent-logs`)
 - **Create log repo now**: Whether to create the log repo immediately via `gh` CLI
+- **Auto-run /startup**: Whether to automatically run `/startup` on new sessions (default: yes). This works across all Claude Code clients including VS Code, Cursor, and the desktop app. Can be toggled later via `CCGM_AUTO_STARTUP` in `~/.claude/.ccgm.env`.
 
 ## Dependencies
 
@@ -56,13 +60,48 @@ cp log-system.md ~/.claude/log-system.md
 # Copy the startup command
 mkdir -p ~/.claude/commands
 cp commands/startup.md ~/.claude/commands/startup.md
+
+# Copy the auto-startup hook
+mkdir -p ~/.claude/hooks
+cp hooks/auto-startup.py ~/.claude/hooks/auto-startup.py
 ```
 
-### 3. Configure Paths
+### 3. Configure the Hook
+
+Add the SessionStart hook to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/auto-startup.py",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 4. Enable/Disable Auto-Startup
+
+Add or update in `~/.claude/.ccgm.env`:
+
+```bash
+CCGM_AUTO_STARTUP=true   # or false to disable
+```
+
+### 5. Configure Paths
 
 After copying, update the log repo path references in the rule file and log-system.md to point to your actual log repository location (e.g., `~/code/your-agent-logs/`).
 
-### 4. Add to CLAUDE.md (Optional)
+### 6. Add to CLAUDE.md (Optional)
 
 Add a reference to the session logging rule in your global CLAUDE.md:
 

--- a/modules/session-logging/hooks/auto-startup.py
+++ b/modules/session-logging/hooks/auto-startup.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+SessionStart hook that instructs Claude to run /startup on new sessions.
+
+When a fresh session starts (source == "startup"), prints an instruction to
+stdout which gets injected into Claude's context. This works across all
+Claude Code clients (terminal, VS Code, Cursor, desktop app).
+
+Can be disabled by setting CCGM_AUTO_STARTUP=false in ~/.claude/.ccgm.env
+"""
+import json
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+
+
+def is_enabled():
+    """Check if auto-startup is enabled in .ccgm.env."""
+    if not ENV_FILE.exists():
+        return False
+    try:
+        with open(ENV_FILE) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("CCGM_AUTO_STARTUP="):
+                    value = line.split("=", 1)[1].strip().lower()
+                    return value in ("true", "1", "yes")
+    except (OSError, IOError):
+        pass
+    return False
+
+
+def main():
+    # Read stdin (required by hook contract)
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, not resume or compact
+    source = hook_input.get("source", "")
+    if source != "startup":
+        return
+
+    if not is_enabled():
+        return
+
+    # Print instruction to stdout - this gets injected into Claude's context
+    print("<auto-startup>")
+    print("Run the /startup command now to initialize this session.")
+    print("</auto-startup>")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/session-logging/module.json
+++ b/modules/session-logging/module.json
@@ -1,14 +1,16 @@
 {
   "name": "session-logging",
   "displayName": "Session Logging",
-  "description": "Structured agent session logging system with mandatory log triggers, log repo management, and session startup command.",
+  "description": "Structured agent session logging system with mandatory log triggers, log repo management, session startup command, and auto-startup hook.",
   "category": "workflow",
   "scope": ["global"],
   "dependencies": [],
   "files": {
     "rules/session-logging.md": { "target": "rules/session-logging.md", "type": "rule", "template": false },
     "log-system.md": { "target": "log-system.md", "type": "doc", "template": false },
-    "commands/startup.md": { "target": "commands/startup.md", "type": "command", "template": false }
+    "commands/startup.md": { "target": "commands/startup.md", "type": "command", "template": false },
+    "hooks/auto-startup.py": { "target": "hooks/auto-startup.py", "type": "hook", "template": false },
+    "settings.partial.json": { "target": "settings.json", "type": "config", "merge": true, "template": false }
   },
   "tags": ["logging", "session", "agent", "coordination"],
   "configPrompts": [
@@ -21,6 +23,12 @@
       "key": "createLogRepo",
       "prompt": "Create the agent log repo now? (requires gh CLI)",
       "default": "no",
+      "options": ["yes", "no"]
+    },
+    {
+      "key": "autoStartup",
+      "prompt": "Auto-run /startup on new sessions? (works in VS Code, Cursor, and desktop app too)",
+      "default": "yes",
       "options": ["yes", "no"]
     }
   ]

--- a/modules/session-logging/settings.partial.json
+++ b/modules/session-logging/settings.partial.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/auto-startup.py",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/start.sh
+++ b/start.sh
@@ -725,6 +725,12 @@ main() {
   case "$auto_update_raw" in
     yes|true|1) auto_update_check="true" ;;
   esac
+  local auto_startup_raw
+  auto_startup_raw=$(_get_module_config "session-logging__autoStartup" "yes")
+  local auto_startup="false"
+  case "$auto_startup_raw" in
+    yes|true|1) auto_startup="true" ;;
+  esac
   local env_entries=(
     "CCGM_HOME=${HOME}"
     "CCGM_USERNAME=${github_username}"
@@ -733,6 +739,7 @@ main() {
     "CCGM_TIMEZONE=${timezone}"
     "CCGM_DEFAULT_MODE=${default_mode}"
     "CCGM_AUTO_UPDATE_CHECK=${auto_update_check}"
+    "CCGM_AUTO_STARTUP=${auto_startup}"
   )
 
   # Add module-specific configs
@@ -740,7 +747,7 @@ main() {
   while [ $cfg_idx -lt ${#MODULE_CONFIG_KEYS[@]} ]; do
     local cfg_key="${MODULE_CONFIG_KEYS[$cfg_idx]}"
     case "$cfg_key" in
-      *__LOG_REPO__*|*__defaultMode__*|*__autoUpdateCheck__*) cfg_idx=$((cfg_idx + 1)); continue ;;
+      *__LOG_REPO__*|*__defaultMode__*|*__autoUpdateCheck__*|*__autoStartup__*) cfg_idx=$((cfg_idx + 1)); continue ;;
     esac
     env_entries+=("CCGM_MODULE_${cfg_key}=${MODULE_CONFIG_VALS[$cfg_idx]}")
     cfg_idx=$((cfg_idx + 1))


### PR DESCRIPTION
## Summary

- Adds a `SessionStart` hook to the session-logging module that auto-runs `/startup` on fresh sessions
- Works across all Claude Code clients (terminal, VS Code, Cursor, desktop app) since hooks are processed by the engine, not the UI layer
- Toggleable via `CCGM_AUTO_STARTUP` in `~/.claude/.ccgm.env`

## Changes

- **New**: `modules/session-logging/hooks/auto-startup.py` - Python hook that reads stdin JSON, checks `source == "startup"`, and outputs an instruction to Claude's context
- **New**: `modules/session-logging/settings.partial.json` - Wires the hook to the `SessionStart` event
- **Modified**: `modules/session-logging/module.json` - Added new file entries and `autoStartup` config prompt (default: yes)
- **Modified**: `start.sh` - Added `CCGM_AUTO_STARTUP` env var extraction and skip filter
- **Modified**: `modules/session-logging/README.md` - Documented new files, config, and manual install steps

## Test Plan

- [x] `bash tests/test-modules.sh` passes (249/249)
- [x] `bash tests/test-no-personal-data.sh` - pre-existing README issue only, no new leaks
- [ ] Manual: Run `./start.sh` in temp dir, confirm autoStartup prompt appears
- [ ] Manual: After installing, open Claude Code in desktop app and verify auto `/startup`

Closes #58