### PR TITLE
#62: Add /cgr command - Clear + Git Rebase

### DIFF
--- a/modules/commands-extra/commands/cgr.md
+++ b/modules/commands-extra/commands/cgr.md
@@ -1,0 +1,74 @@
+---
+description: Clear conversation and rebase on the default branch for a fresh start
+allowed-tools: Bash
+---
+
+# /cgr - Clear + Git Rebase
+
+Start fresh by clearing the conversation context and rebasing on the latest default branch. Use this between tasks to get a clean slate.
+
+## Input
+
+```
+$ARGUMENTS
+```
+
+## Instructions
+
+### 1. Signal Fresh Start
+
+Tell the user you are clearing context and starting fresh. Forget all previous conversation context - treat everything from this point as a brand new session.
+
+### 2. Detect Default Branch
+
+```bash
+# Try remote HEAD first, fall back to common names
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+
+if [ -z "$DEFAULT_BRANCH" ]; then
+  for candidate in main master; do
+    if git rev-parse --verify "origin/$candidate" >/dev/null 2>&1; then
+      DEFAULT_BRANCH="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$DEFAULT_BRANCH" ]; then
+  echo "ERROR: Could not detect default branch"
+  exit 1
+fi
+
+echo "Default branch: $DEFAULT_BRANCH"
+```
+
+### 3. Stash Uncommitted Changes (if any)
+
+```bash
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Stashing uncommitted changes..."
+  git stash push -m "cgr-auto-stash-$(date +%s)"
+fi
+```
+
+### 4. Checkout and Rebase
+
+```bash
+git checkout "$DEFAULT_BRANCH"
+git fetch origin "$DEFAULT_BRANCH"
+git rebase "origin/$DEFAULT_BRANCH"
+```
+
+### 5. Report Status
+
+```bash
+echo ""
+echo "--- Fresh Start ---"
+echo "Branch: $(git branch --show-current)"
+echo "Commit: $(git log --oneline -1)"
+echo "Status: $(git status --short | wc -l | tr -d ' ') files changed"
+echo ""
+echo "Ready for new work."
+```
+
+Display the status to the user and ask what they would like to work on next.

--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -1,7 +1,7 @@
 {
   "name": "commands-extra",
   "displayName": "Extra Commands",
-  "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global).",
+  "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global), /cgr (clear + git rebase).",
   "category": "commands",
   "scope": ["global"],
   "dependencies": [],
@@ -9,8 +9,9 @@
     "commands/audit.md": { "target": "commands/audit.md", "type": "command", "template": false },
     "commands/pwv.md": { "target": "commands/pwv.md", "type": "command", "template": false },
     "commands/walkthrough.md": { "target": "commands/walkthrough.md", "type": "command", "template": false },
-    "commands/promote-rule.md": { "target": "commands/promote-rule.md", "type": "command", "template": false }
+    "commands/promote-rule.md": { "target": "commands/promote-rule.md", "type": "command", "template": false },
+    "commands/cgr.md": { "target": "commands/cgr.md", "type": "command", "template": false }
   },
-  "tags": ["commands", "audit", "verification", "walkthrough"],
+  "tags": ["commands", "audit", "verification", "walkthrough", "git"],
   "configPrompts": []
 }


### PR DESCRIPTION
## What this does

Adds the `/cgr` slash command that clears conversation context and rebases on the default branch. Very useful between tasks when you want a clean start without manually running multiple git commands.

I was doing this manually every time - clear context, find default branch, checkout, fetch, rebase. Now its just `/cgr`.

## How it works

1. **Clear context** - signals Claude to treat everything as fresh session
2. **Detect default branch** - checks `origin/HEAD` first, falls back to `main`/`master`
3. **Stash changes** - if there are uncommitted changes, auto-stashes them so checkout doesnt fail
4. **Checkout + rebase** - switches to default branch and rebases on latest origin
5. **Report status** - shows current branch, latest commit, and working directory state

## Files changed

- `modules/commands-extra/commands/cgr.md` - new command file following same pattern as `/gs`, `/audit`, etc.
- `modules/commands-extra/module.json` - registered the new command in files list, updated description, added "git" tag

## Testing

- `bash tests/test-modules.sh` - 393 passed, 0 failed
- `bash tests/test-no-personal-data.sh` - only pre-existing README clone URLs flagged (not from this change)
- Command follows same frontmatter pattern as existing commands (description + allowed-tools)

Closes #62