### PR TITLE
#72: add comprehensive documentation for public-facing readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Modular configuration system for [Claude Code](https://docs.anthropic.com/en/doc
 - [Module Catalog](#module-catalog)
 - [Customization](#customization)
 - [Manual Installation](#manual-installation)
+- [Documentation](#documentation)
 - [Contributing](#contributing)
 
 ## What is CCGM?
@@ -170,6 +171,21 @@ cp modules/autonomy/rules/autonomy.md ~/.claude/rules/
 mkdir -p ~/.claude/commands
 cp modules/commands-core/commands/*.md ~/.claude/commands/
 ```
+
+## Documentation
+
+The `docs/` directory contains comprehensive documentation:
+
+| Document | Description |
+|----------|-------------|
+| [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
+| [Module Catalog](docs/modules.md) | Detailed reference for all 25 modules |
+| [Commands Reference](docs/commands.md) | All 17 slash commands with usage examples |
+| [Hooks Reference](docs/hooks.md) | All 9 hooks explained - what they do and when they fire |
+| [Presets](docs/presets.md) | Preset breakdowns and recommendations |
+| [Installer](docs/installer.md) | How the installer works, updating, uninstalling |
+| [Configuration](docs/configuration.md) | Customization, template variables, settings overrides |
+| [Multi-Agent System](docs/multi-agent.md) | Parallel agent coordination, port allocation, issue tracking |
 
 ## Contributing
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,411 @@
+# Commands Reference
+
+CCGM installs slash commands as `.md` files in `~/.claude/commands/`. Each file contains a description, the list of tools the command may use, and detailed instructions that Claude follows when the command is invoked.
+
+Commands are invoked by typing `/command-name` in a Claude Code session.
+
+## Core commands
+
+Installed by the **commands-core** module.
+
+---
+
+### /commit
+
+**Stage all changes and commit with conventional format.**
+
+Stages all modified and untracked files, runs the project's verification suite (lint, type-check, tests, build), and creates a commit with a formatted message.
+
+**Commit message format**: `#{issue_number}: {description}`
+
+The issue number is extracted from the branch name. If the branch is `42-add-login-form`, the commit message will start with `#42:`.
+
+**What happens**:
+1. Stages all changes (`git add`)
+2. Runs the project's full verification suite
+3. If verification passes, creates the commit
+4. If verification fails, fixes the issues and retries
+
+**Usage**:
+```
+/commit
+```
+
+---
+
+### /pr
+
+**Push branch and create a pull request.**
+
+Runs verification, rebases on the base branch, pushes, and creates a PR with proper formatting.
+
+**What happens**:
+1. Runs the project's full verification suite
+2. Rebases on `origin/main` (or the project's base branch)
+3. Pushes the branch with `--force-with-lease` if needed
+4. Checks for PR templates (repo root, `.github/`, org `.github` repo)
+5. Creates a PR using the template format, with `Closes #{issue}` in the body
+6. Reports the PR URL
+
+**Usage**:
+```
+/pr
+```
+
+---
+
+### /cpm
+
+**One-shot: commit, create PR, and merge.**
+
+The complete workflow in a single command. Commits changes, creates a PR, and squash-merges it.
+
+**What happens**:
+1. Stages all changes
+2. Runs full verification suite
+3. Creates a commit with conventional format
+4. Rebases on `origin/main`
+5. Pushes the branch
+6. Creates a PR (using template if available)
+7. Squash-merges the PR
+8. Closes the associated issue
+9. Returns to main branch and pulls
+10. Reports the final state
+
+**Usage**:
+```
+/cpm
+```
+
+---
+
+### /gs
+
+**Git status dashboard.**
+
+Displays a formatted overview of the current repository state.
+
+**What it shows**:
+- Current branch and remote tracking status
+- Ahead/behind counts relative to main
+- Working directory state (modified, staged, untracked files)
+- Open pull requests
+- Recommended next action based on the current state
+
+**Usage**:
+```
+/gs
+```
+
+---
+
+### /ghi
+
+**Create a GitHub issue with labels.**
+
+Interactively creates a GitHub issue with appropriate type labels.
+
+**What happens**:
+1. Asks for the issue type (feature, bug, refactor, chore, documentation, human-agent)
+2. Asks for the title and description
+3. Creates missing labels if they don't exist on the repo
+4. Structures the issue body based on type (features get acceptance criteria, bugs get reproduction steps)
+5. Creates the issue and returns the URL
+
+**Usage**:
+```
+/ghi
+```
+
+---
+
+## Extra commands
+
+Installed by the **commands-extra** module.
+
+---
+
+### /audit
+
+**Multi-phase codebase audit.**
+
+Runs a comprehensive audit across 8 categories using parallel specialized agents, then optionally applies auto-fixes and creates GitHub issues for manual findings.
+
+**Audit categories**:
+1. Security (injection, auth, secrets, dependencies)
+2. Dependencies (outdated, unused, duplicated, license issues)
+3. Code quality (complexity, duplication, naming, dead code)
+4. Architecture (coupling, layering, circular dependencies)
+5. TypeScript/React (type safety, component patterns, hooks usage)
+6. Testing (coverage gaps, test quality, missing edge cases)
+7. Documentation (outdated docs, missing API docs)
+8. Performance (bundle size, render performance, memory leaks)
+
+**Severity levels**: Critical, High, Medium, Low
+
+**Usage**:
+```
+/audit                         # Full audit, all categories
+/audit security                # Single category
+/audit security,testing        # Multiple categories
+/audit --fix                   # Auto-fix applicable findings
+/audit --no-issues             # Skip GitHub issue creation
+```
+
+---
+
+### /pwv
+
+**Playwright visual verification.**
+
+Launches a headless browser to verify that a page renders correctly, checking for console errors and network failures.
+
+**What happens**:
+1. Ensures a dev server is running (starts one if needed)
+2. Navigates to the specified URL
+3. Takes screenshots (desktop and optionally mobile viewports)
+4. Checks the browser console for JavaScript errors
+5. Checks network requests for failed API calls
+6. Reports findings with screenshots
+
+**Usage**:
+```
+/pwv                           # Verify localhost default page
+/pwv https://localhost:5173    # Specific URL
+/pwv /dashboard                # Specific route
+/pwv /dashboard --mobile       # Include mobile viewport
+/pwv --dark                    # Test dark mode
+```
+
+---
+
+### /walkthrough
+
+**Step-by-step guided mode.**
+
+Breaks a complex task into discrete steps and presents them one at a time, waiting for user confirmation before proceeding.
+
+**Behavior**:
+- Shows progress as "Step N/Total"
+- Presents one step at a time with clear instructions
+- Waits for user to confirm completion, ask questions, or provide information
+- Never skips ahead or presents multiple steps
+- Incorporates user-provided information (API keys, URLs, etc.) into subsequent steps
+
+**Trigger words**: "walk me through", "guide me through", "step me through", or `/walkthrough`
+
+**Usage**:
+```
+/walkthrough
+walk me through deploying to Cloudflare
+```
+
+---
+
+### /promote-rule
+
+**Review and promote repo rules to global.**
+
+Scans the current repo's CLAUDE.md for rules that could be promoted to the global `~/.claude/CLAUDE.md`.
+
+**What happens**:
+1. Reads the repo's CLAUDE.md
+2. Looks for `<!-- CANDIDATE:GLOBAL -->` markers
+3. Identifies implicit candidates (rules that aren't project-specific)
+4. Checks the global CLAUDE.md for duplicates
+5. Presents candidates for approval
+6. Applies approved promotions
+
+**Usage**:
+```
+/promote-rule              # Interactive review
+/promote-rule --all        # Show all candidates without filtering
+/promote-rule --dry-run    # Preview without making changes
+```
+
+---
+
+## Brand commands
+
+Installed by the **brand-naming** module.
+
+---
+
+### /brand
+
+**Full naming pipeline.**
+
+Comprehensive brand name research using parallel word exploration, name generation, and multi-source verification.
+
+**Phases**:
+1. **Input**: Gather naming preferences (industry, vibe, constraints)
+2. **Word exploration**: 4 parallel research agents query Datamuse, ConceptNet, Big Huge Thesaurus, and philosophical/etymological sources
+3. **Name generation**: Generate 150-250 candidates across 6 categories (single words, compounds, vowel-dropped, invented/neo-Latin, philosophical/classical, word+TLD combos)
+4. **Domain checks**: Verify domain availability via Instant Domain Search MCP or DNS/whois fallback
+5. **Trademark screening**: USPTO and WIPO trademark pre-search
+6. **App store and social checks**: Apple App Store, Google Play, GitHub, Twitter/X, Instagram, and more
+7. **Scoring**: Rate candidates across 8 criteria and produce a final ranked report
+
+**Usage**:
+```
+/brand
+/brand "AI productivity tool for developers"
+```
+
+---
+
+### /brand-check
+
+**Deep verification of a single brand name.**
+
+Performs thorough availability checking for one or more specific names.
+
+**Checks performed**:
+- Domain availability across all specified TLDs (default: .ai, .io, .com, .life, .work, .app, .co, .dev, .org, .net)
+- USPTO and WIPO trademark search
+- Apple App Store and Google Play search
+- Social handle availability (GitHub, Twitter/X, Instagram, Reddit, YouTube, TikTok, LinkedIn, ProductHunt)
+- Existing business/product search
+
+**Usage**:
+```
+/brand-check acmecorp
+/brand-check "acme corp" "acme labs" "acme ai"    # Compare multiple names
+```
+
+---
+
+## Workflow commands
+
+Installed by the **xplan**, **multi-agent**, and **session-logging** modules.
+
+---
+
+### /xplan
+
+**Deep research, planning, and execution framework.**
+
+An 8-phase autonomous framework for tackling complex projects, from initial research through implementation.
+
+**Phases**:
+1. **Parse input** - understand the project, create plan directory
+2. **Deep research** - spawn parallel research agents (configurable preset: Full, Technical Only, Lite, Custom)
+3. **Build model** - synthesize research into a contextual understanding
+4. **Create plan** - design parallelized execution plan with epics and dependency waves
+5. **Peer review** - specialized agents review for architecture, security, UX, and feasibility
+6. **Interactive walkthrough** - present plan to user for feedback and decisions
+7. **Execute** - spawn parallel agents for each wave of work
+8. **Complete** - audit results, run retrospective
+
+This command explicitly overrides autonomy rules - all phases require user confirmation before proceeding.
+
+**Usage**:
+```
+/xplan "Build a SaaS dashboard with auth, billing, and analytics"
+/xplan  # Will ask for project description interactively
+```
+
+**Installed by**: xplan module
+
+---
+
+### /xplan-status
+
+**Check progress on a running or completed xplan.**
+
+Reads the plan's `progress.md`, checks live GitHub issue and PR states, inspects clone states, and shows wave completion.
+
+**Usage**:
+```
+/xplan-status
+```
+
+**Installed by**: xplan module
+
+---
+
+### /xplan-resume
+
+**Resume an interrupted xplan execution.**
+
+Reconstructs context from plan files (`progress.md`, `plan.md`, `decisions.md`, `research.md`), verifies live state vs checkpoint, handles in-flight work, and continues execution.
+
+**Usage**:
+```
+/xplan-resume
+```
+
+**Installed by**: xplan module
+
+---
+
+### /mawf
+
+**Multi-Agent Workflow.**
+
+Takes unstructured feedback or a list of tasks, parses them into typed GitHub issues, plans agent allocation by dependency wave, spawns parallel agents, monitors progress, and reports final state.
+
+**What happens**:
+1. Parses input into individual work items
+2. Creates GitHub issues for each item
+3. Plans waves (groups of independent issues that can run in parallel)
+4. Spawns agents in separate clones for each wave
+5. Monitors progress and handles failures
+6. Merges results and syncs clones between waves
+7. Reports final state
+
+**Usage**:
+```
+/mawf "Fix the login bug, add dark mode toggle, update the API docs"
+```
+
+**Installed by**: multi-agent module
+
+---
+
+### /workspace-setup
+
+**Create workspace-based multi-agent directory structure.**
+
+Sets up isolated workspace directories with multiple clones for parallel agent work.
+
+**What it creates**:
+- N clones of the repo per workspace
+- `.env.clone` files with agent identity and port assignments
+- GitHub labels for each workspace and clone
+- Workspace-level CLAUDE.md for coordinator agents
+- Log directory structure
+
+**Usage**:
+```
+/workspace-setup my-repo
+```
+
+**Installed by**: multi-agent module
+
+---
+
+### /startup
+
+**Session initialization.**
+
+Automatically runs at session start (if auto-startup is enabled) or can be invoked manually. Provides full context for beginning a work session.
+
+**What it does**:
+1. Derives agent identity from directory name
+2. Pulls latest session logs and reads today's entries
+3. Reads other agents' logs for cross-agent awareness
+4. Creates today's log file if it doesn't exist
+5. Checks git status, syncs with remote
+6. Lists open PRs and issues
+7. Queries the tracking dashboard for claimed/unclaimed work
+8. Checks sibling clones for what other agents are doing
+9. Checks for Claude Code updates
+10. Presents a session dashboard with recommended next action
+
+**Usage**:
+```
+/startup
+```
+
+**Installed by**: session-logging module

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,125 @@
+# Configuration
+
+After installing CCGM, you can customize its behavior without modifying CCGM files directly.
+
+## Adding personal rules
+
+Create your own rule files in `~/.claude/rules/`. CCGM will never overwrite files it didn't install.
+
+```bash
+# Create a personal rule file
+cat > ~/.claude/rules/personal.md << 'EOF'
+# My Personal Rules
+
+- Always use TypeScript strict mode
+- Prefer functional components over class components
+- Use pnpm instead of npm
+EOF
+```
+
+Claude Code automatically loads all `.md` files from `rules/` at session start.
+
+## Overriding settings
+
+Claude Code supports a local override file for settings:
+
+```bash
+# ~/.claude/settings.local.json
+{
+  "permissions": {
+    "defaultMode": "dontAsk"
+  }
+}
+```
+
+This file takes precedence over `settings.json` for the keys it defines. CCGM does not manage `settings.local.json`.
+
+## MCP servers
+
+MCP (Model Context Protocol) server configuration lives in `~/.claude/mcp.json`, which is not managed by CCGM. Configure your MCP servers there independently.
+
+## Template variables
+
+During installation, CCGM expands placeholder tokens in configuration files. These are only relevant during the install process - they don't affect runtime behavior.
+
+| Variable | Description | Where it's used |
+|----------|-------------|-----------------|
+| `__HOME__` | Your home directory path (e.g., `/Users/jane`) | `settings.json` - path patterns in allow/deny lists |
+| `__USERNAME__` | GitHub username (e.g., `janedoe`) | `enforce-git-workflow.py` - direct-to-main repo allowlist |
+| `__CODE_DIR__` | Code workspace directory (e.g., `~/code`) | `settings.json` - path patterns, port registry |
+| `__LOG_REPO__` | Agent log repo name (e.g., `agent-logs`) | Session logging - log file paths |
+| `__TIMEZONE__` | Your timezone (e.g., `America/New_York`) | Session logging documentation |
+| `__DEFAULT_MODE__` | Permission mode: `ask` or `dontAsk` | `settings.json` - `defaultMode` field |
+
+Values are collected during installation and stored in `~/.claude/.ccgm.env`. They are applied via `sed` substitution when files are copied.
+
+## The CCGM environment file
+
+`~/.claude/.ccgm.env` stores all configuration values collected during installation:
+
+```bash
+# Example contents
+CCGM_USERNAME=janedoe
+CCGM_CODE_DIR=/Users/jane/code
+CCGM_TIMEZONE=America/New_York
+CCGM_DEFAULT_MODE=ask
+CCGM_LOG_REPO=agent-logs
+CCGM_AUTO_UPDATE_CHECK=true
+CCGM_AUTO_STARTUP=true
+```
+
+Some hooks read values from this file at runtime:
+- `ccgm-update-check.py` reads `CCGM_AUTO_UPDATE_CHECK`
+- `auto-startup.py` reads `CCGM_AUTO_STARTUP`
+
+## The CCGM manifest
+
+`~/.claude/.ccgm-manifest.json` records what was installed, when, and how. It is used by `update.sh` and `uninstall.sh`.
+
+```json
+{
+  "version": "1.0.0",
+  "timestamp": "2026-03-29T12:00:00Z",
+  "preset": "standard",
+  "scope": "global",
+  "linkMode": false,
+  "modules": ["autonomy", "git-workflow", "settings", "hooks", "commands-core"],
+  "files": [
+    "~/.claude/rules/autonomy.md",
+    "~/.claude/rules/git-workflow.md",
+    "~/.claude/commands/commit.md"
+  ],
+  "ccgmRoot": "/Users/jane/ccgm"
+}
+```
+
+## Module configuration prompts
+
+Some modules ask questions during installation that affect their behavior:
+
+| Module | Prompt | Options | Effect |
+|--------|--------|---------|--------|
+| **settings** | Permission mode | `ask` / `dontAsk` | Controls whether Claude asks before running tools or auto-approves |
+| **hooks** | Protected branches | Custom list | Additional branch names to protect from direct commits |
+| **hooks** | Auto update check | yes / no | Whether to check for CCGM updates once daily |
+| **session-logging** | Log repo name | Text input | Name of the git repo for session logs |
+| **session-logging** | Create log repo | yes / no | Whether to initialize the log repo during install |
+| **session-logging** | Auto startup | yes / no | Whether to auto-run `/startup` at session start |
+| **brand-naming** | Add MCP server | yes / no | Whether to add Instant Domain Search MCP server to `mcp.json` |
+
+## Customizing hooks
+
+CCGM hooks are Python scripts in `~/.claude/hooks/`. They are registered in `settings.json` under the `hooks` key. If you need to modify a hook's behavior:
+
+1. If using copy mode: edit the hook file directly in `~/.claude/hooks/`
+2. If using link mode: the file is a symlink to the CCGM repo, so edit it there
+
+To disable a specific hook without uninstalling, remove its entry from the `hooks` section in `settings.json`.
+
+## Scope precedence
+
+When both global (`~/.claude/`) and project (`.claude/`) configurations exist, Claude Code merges them with project-level taking precedence. This means:
+
+- Project rules override global rules with the same filename
+- Project settings override global settings for matching keys
+- Both sets of hooks run (project hooks in addition to global hooks)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,147 @@
+# Getting Started
+
+This guide walks through installing CCGM, choosing modules, and running your first session.
+
+## Prerequisites
+
+CCGM requires:
+
+- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** - the CLI tool from Anthropic (`npm install -g @anthropic-ai/claude-code`)
+- **macOS or Linux** - Windows is not supported
+- **bash 4+** or **zsh**
+- **git** - for cloning and version tracking
+- **Python 3** - hooks are written in Python
+- **jq** - for JSON manipulation during settings merge
+
+Optional but recommended:
+
+- **[GitHub CLI](https://cli.github.com/)** (`gh`) - enables auto-detection of your GitHub username, issue management commands, and PR workflows
+- **[gum](https://github.com/charmbracelet/gum)** - prettier interactive menus (the installer falls back to pure bash if gum is not available)
+
+The installer checks for all prerequisites and offers to install missing tools using your system's package manager (Homebrew on macOS, apt/dnf/pacman on Linux).
+
+## Installation
+
+### 1. Clone and run
+
+```bash
+git clone https://github.com/YOUR_USERNAME/ccgm.git
+cd ccgm
+./start.sh
+```
+
+The interactive installer handles everything from here.
+
+### 2. Choose a preset (or pick modules individually)
+
+The installer offers four presets, or you can select modules one by one:
+
+| Preset | What you get | Best for |
+|--------|-------------|----------|
+| **minimal** | Core autonomy + git workflow rules | Trying CCGM for the first time |
+| **standard** | Minimal + hooks, settings, core commands | Most individual developers |
+| **team** | Standard + github-protocols, code-quality, debugging, verification | Teams with shared repos |
+| **full** | All 25 modules | Power users who want everything |
+
+See [Presets](presets.md) for detailed breakdowns.
+
+### 3. Answer configuration prompts
+
+Depending on which modules you selected, the installer may ask:
+
+- **GitHub username** - auto-detected from `gh api user` if GitHub CLI is installed
+- **Code directory** - where your projects live (default: `~/code`)
+- **Timezone** - auto-detected from system settings
+- **Permission mode** - `ask` (confirm before risky actions) or `dontAsk` (full auto-approval)
+
+### 4. Restart Claude Code
+
+After installation, start a new Claude Code session. Your new rules, commands, and hooks will be active immediately.
+
+## Install scopes
+
+CCGM can install to two locations:
+
+| Scope | Path | Effect |
+|-------|------|--------|
+| **Global** | `~/.claude/` | Applies to all projects and all Claude Code environments |
+| **Project** | `.claude/` in current directory | Applies only to the current project |
+
+```bash
+./start.sh                    # Interactive scope selection
+./start.sh --scope global     # Global only
+./start.sh --scope project    # Project only
+```
+
+Global installation is the most common choice. Project-level installation is useful when you want different rules for a specific repo, or when sharing configuration with a team via version control.
+
+## Install modes
+
+| Mode | Flag | Behavior |
+|------|------|----------|
+| **Copy** (default) | - | Copies files to `~/.claude/`. Independent of the CCGM repo after install. |
+| **Link** | `--link` | Creates symlinks to the CCGM repo. Changes to the repo are reflected immediately. Best for CCGM developers. |
+
+## Your first session
+
+After installation, start Claude Code:
+
+```bash
+claude
+```
+
+If you installed the **session-logging** module, Claude will automatically run the `/startup` command, which:
+
+1. Identifies your agent and repo context
+2. Pulls and reads session logs
+3. Checks git status, open PRs, and open issues
+4. Presents a dashboard with recommended next actions
+
+If you installed **commands-core**, you now have these slash commands available:
+
+- `/gs` - Git status dashboard
+- `/commit` - Stage and commit with conventional format
+- `/pr` - Push and create a pull request
+- `/cpm` - One-shot commit + PR + merge workflow
+- `/ghi` - Create a GitHub issue
+
+Try `/gs` to see your project status at a glance.
+
+## Non-interactive installation
+
+For CI environments or agent-driven setup:
+
+```bash
+CCGM_NON_INTERACTIVE=1 \
+  CCGM_USERNAME="your-github-username" \
+  CCGM_CODE_DIR="$HOME/code" \
+  CCGM_TIMEZONE="America/New_York" \
+  ./start.sh --preset standard
+```
+
+See [Installer](installer.md) for the full list of environment variables.
+
+## Updating
+
+```bash
+cd /path/to/ccgm
+./update.sh
+```
+
+The updater fetches the latest changes, shows what changed, and offers to re-run the installer with your existing configuration. See [Installer - Updating](installer.md#updating) for details.
+
+## Uninstalling
+
+```bash
+cd /path/to/ccgm
+./uninstall.sh
+```
+
+Removes only CCGM-installed files (tracked via a manifest). Your personal files in `~/.claude/` are left untouched. See [Installer - Uninstalling](installer.md#uninstalling) for details.
+
+## Next steps
+
+- [Module Catalog](modules.md) - explore all 25 modules in detail
+- [Commands Reference](commands.md) - learn every slash command
+- [Hooks Reference](hooks.md) - understand the workflow automation
+- [Configuration](configuration.md) - customize CCGM after installation

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,217 @@
+# Hooks Reference
+
+CCGM hooks are Python scripts that Claude Code executes at specific points in its workflow. They automate enforcement, provide warnings, and track state.
+
+## How hooks work
+
+Claude Code supports four hook types:
+
+| Hook type | When it fires | Can block? |
+|-----------|---------------|------------|
+| **PreToolUse** | Before a tool call is executed | Yes - can approve, deny, or modify |
+| **PostToolUse** | After a tool call completes | No - advisory only |
+| **UserPromptSubmit** | When the user submits a message | No - can inject context |
+| **SessionStart** | When a new session begins | No - can inject context |
+
+Hooks are registered in `settings.json` under the `hooks` key. Each hook specifies its type, an optional matcher (e.g., `Bash` to only fire on Bash tool calls), and the command to run.
+
+## Installed hooks
+
+The **hooks** module installs 8 hooks. The **session-logging** module installs 1 additional hook.
+
+---
+
+### enforce-git-workflow.py
+
+**Type**: PreToolUse:Bash
+**Module**: hooks
+**Can block**: Yes
+
+The most critical hook. Enforces branch protection and commit message formatting.
+
+**What it blocks**:
+- Commits directly to protected branches (main, master, develop, dev, staging, prod, production, release, trunk, stag)
+- Commits without the `#N:` issue prefix format (e.g., `#42: add login form`)
+- Pushes to protected branches
+
+**Escape hatches**:
+- `sync:` prefix in commit messages bypasses format check (for non-issue commits like syncing docs)
+- `ALLOW_MAIN_COMMIT=1` environment variable disables all checks (emergency use)
+- Repos listed in `DIRECT_TO_MAIN_REPOS` skip all checks (configured during install with your username)
+
+**Custom protected branches**: During installation, you can specify additional branch names to protect. These are stored in `~/.claude/git-flow-protected-branches.json`.
+
+---
+
+### enforce-issue-workflow.py
+
+**Type**: UserPromptSubmit
+**Module**: hooks
+**Can block**: No (context injection only)
+
+Detects when the user asks Claude to do implementation work (keywords: update, fix, add, create, implement, build, etc.) and injects a workflow reminder into Claude's context.
+
+**Injected reminder**:
+- Check for an existing GitHub issue (or create one)
+- Create a feature branch from the issue
+- Implement the changes
+- Commit with issue prefix
+- Create a pull request
+
+If the working directory has a `.claude/logs/` directory (indicating multi-agent setup), an additional coordination reminder is injected to read other agents' logs.
+
+---
+
+### auto-approve-bash.py
+
+**Type**: PreToolUse:Bash
+**Module**: hooks
+**Can block**: Yes (approve or pass-through)
+
+Enforces Bash command permissions from `settings.json`. This is a workaround for Claude Code bugs where the VS Code extension ignores configured permissions and piped commands bypass the allowlist.
+
+**How it works**:
+1. Reads `allow` and `deny` patterns for `Bash` from `settings.json`
+2. Applies deny-first logic: if the command matches a deny pattern, it passes through (letting Claude Code handle the denial)
+3. If the command matches an allow pattern, it auto-approves
+4. Otherwise, passes through for Claude Code's default handling
+
+**Pattern matching**: Supports prefix matching and `*` wildcard. For example, `git status*` matches `git status`, `git status --short`, etc.
+
+---
+
+### auto-approve-file-ops.py
+
+**Type**: PreToolUse (matches Read, Edit, Write)
+**Module**: hooks
+**Can block**: Yes (approve or pass-through)
+
+Enforces path-based permissions for file read/edit/write operations. Another workaround for Claude Code permission bugs.
+
+**How it works**:
+1. Reads `allow` patterns for Read, Edit, and Write tools from `settings.json`
+2. Extracts the file path from the tool call input
+3. If the path matches a glob pattern in the allow list, auto-approves
+4. Otherwise, passes through for default handling
+
+---
+
+### ccgm-update-check.py
+
+**Type**: PreToolUse (any tool, fires once per day)
+**Module**: hooks
+**Can block**: No (advisory only)
+
+Checks once per day whether the CCGM repository has upstream updates.
+
+**How it works**:
+1. Reads the CCGM root directory from `~/.claude/.ccgm-manifest.json`
+2. Checks a daily flag file in `/tmp` to avoid repeated checks
+3. If not checked today: runs `git fetch` in the CCGM repo and compares HEAD to `origin/main`
+4. If updates are available: prints a notification to stderr with the number of new commits
+5. Creates the daily flag file to prevent further checks today
+
+**Configuration**: Enabled/disabled via `CCGM_AUTO_UPDATE_CHECK` in `~/.claude/.ccgm.env`.
+
+---
+
+### port-check.py
+
+**Type**: PreToolUse:Bash (dev server commands only)
+**Module**: hooks
+**Can block**: No (advisory only)
+
+Detects dev server launch commands and warns about port conflicts.
+
+**Commands detected**: `vite`, `wrangler dev`, `npm run dev`, `pnpm dev`, `next dev`, `npx vite`, and similar patterns.
+
+**How it works**:
+1. Reads port assignments from `~/.claude/port-registry.json` and `.env.clone`
+2. Checks if the expected port is already in use via `lsof`
+3. Warns if the command uses a port different from the clone's assigned port
+4. Warns if another process is already listening on the expected port
+
+This hook is advisory only - it never blocks commands. It exists to prevent port collisions when multiple agents run dev servers simultaneously.
+
+---
+
+### agent-tracking-pre.py
+
+**Type**: PreToolUse:Bash
+**Module**: hooks
+**Can block**: No (advisory only)
+
+Warns when a `git checkout -b {N}-*` command is about to claim an issue that's already claimed by another agent.
+
+**How it works**:
+1. Only activates in multi-clone repos (checks for `.env.clone`)
+2. Detects branch creation commands that follow the `{issue-number}-description` pattern
+3. Reads the tracking CSV via `agent_tracking.py`
+4. If the issue is already claimed by a different agent, prints a warning
+
+Never blocks, never writes to tracking. The actual claim happens in the post-hook after the command succeeds.
+
+---
+
+### agent-tracking-post.py
+
+**Type**: PostToolUse:Bash
+**Module**: hooks
+**Can block**: No (post-execution)
+
+All tracking CSV writes happen in this hook, after commands succeed. This is the engine of the multi-agent issue tracking system.
+
+**Commands intercepted**:
+
+| Command pattern | Action | Status transition |
+|----------------|--------|-------------------|
+| `git checkout -b {N}-*` | `claim_issue()` | -> `claimed` |
+| `git commit -m "#N: ..."` (first) | `update_status()` | `claimed` -> `in-progress` |
+| `git commit -m "#N: ..."` (subsequent) | `update_heartbeat()` | Timestamp only (throttled to 30 min) |
+| `gh pr create` | `update_status()` | -> `pr-created` |
+| `gh pr merge` | `update_status()` | -> `merged` |
+| `gh issue close N` | `update_status()` | -> `closed` |
+
+**Concurrency model**: Uses git commit + `pull --rebase` + push for the tracking CSV. Different-row edits auto-resolve during rebase since each agent modifies only its own rows.
+
+Only activates in multi-clone repos. Skips tracking for commits to the log repo itself.
+
+---
+
+### auto-startup.py
+
+**Type**: SessionStart
+**Module**: session-logging
+**Can block**: No (context injection)
+
+Triggers the `/startup` command at the beginning of each new session.
+
+**How it works**:
+1. Only fires on fresh session starts (source == "startup"), not on resume or context compaction
+2. Prints `<auto-startup>Run the /startup command now to initialize this session.</auto-startup>` to stdout
+3. Claude Code picks up this output and Claude executes the `/startup` command
+
+**Configuration**: Enabled/disabled via `CCGM_AUTO_STARTUP` in `~/.claude/.ccgm.env`.
+
+## Agent tracking library
+
+The hooks module also installs `lib/agent_tracking.py`, a Python module and CLI tool used by the tracking hooks.
+
+**Storage**: `~/code/{log-repo}/{repo}/tracking.csv`
+
+**CSV fields**: `issue, agent, status, branch, pr, epic, title, claimed_at, updated_at`
+
+**Status lifecycle**: `claimed` -> `in-progress` -> `pr-created` -> `merged` / `closed`
+
+**CLI usage** (used by `/startup` command):
+
+```bash
+# List all tracked issues for a repo
+python3 ~/.claude/lib/agent_tracking.py list --repo my-repo
+
+# Garbage-collect stale claims (not updated in N days)
+python3 ~/.claude/lib/agent_tracking.py gc --repo my-repo
+
+# Import from label-based tracking (migration from legacy system)
+python3 ~/.claude/lib/agent_tracking.py import --repo my-repo
+```

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -1,0 +1,183 @@
+# Installer
+
+The CCGM installer (`start.sh`) is an interactive bash script that handles prerequisite checking, module selection, dependency resolution, file installation, and verification.
+
+## Installation flow
+
+The installer runs 15 sequential steps:
+
+### Step 1: Welcome
+
+Displays a banner with the CCGM name and version.
+
+### Step 2: Prerequisites
+
+Checks for required and optional tools:
+
+| Tool | Required | Purpose |
+|------|----------|---------|
+| `claude` | Yes | Claude Code CLI |
+| `git` | Yes | Version control |
+| `python3` | Yes | Hook scripts |
+| `jq` | Yes | JSON manipulation for settings merge |
+| `gh` | No | GitHub CLI for auto-detecting username, issue/PR commands |
+| `gum` | No | Prettier interactive menus (falls back to bash) |
+
+If a required tool is missing, the installer detects your package manager (Homebrew, apt, dnf, or pacman) and offers to install it. On macOS without Homebrew, it offers to install Homebrew first.
+
+### Step 3: Configuration
+
+Collects user-specific values:
+
+- **GitHub username** - auto-detected via `gh api user` if GitHub CLI is installed, otherwise prompted
+- **Code directory** - defaults to `~/code`
+- **Timezone** - auto-detected from system settings
+
+### Step 4: Scope selection
+
+Choose where to install:
+
+- **Global** (`~/.claude/`) - applies to all projects
+- **Project** (`.claude/` in current directory) - applies only here
+- **Both** - installs to both locations
+
+### Step 5: Module selection
+
+Choose a preset (minimal, standard, full, team) or select individual modules from a checkbox menu. The menu groups modules by category (core, commands, workflow, patterns, tech-specific).
+
+### Step 6: Dependency resolution
+
+Automatically adds any modules required by your selection. Uses a depth-first topological sort with cycle detection. Reports any automatically added dependencies.
+
+For example, selecting `xplan` automatically adds `multi-agent` (its dependency), which adds `session-logging` (multi-agent's dependency).
+
+### Step 7: Module config prompts
+
+Each module can define `configPrompts` in its `module.json`. The installer asks these questions and stores answers for template expansion. See [Configuration - Module configuration prompts](configuration.md#module-configuration-prompts) for the full list.
+
+### Step 8: Preview
+
+Shows a complete list of files that will be created or overwritten, grouped by module. This is the last chance to review before changes are made.
+
+### Step 9: Confirm
+
+A single yes/no gate. Answering no exits without making changes.
+
+### Step 10: Backup
+
+Creates a timestamped backup of existing `~/.claude/` contents to `~/.claude/backups/ccgm-YYYYMMDD-HHMMSS/`. Only backs up files that CCGM will overwrite.
+
+### Step 11: Install
+
+Processes each file according to its type:
+
+| File type | Behavior |
+|-----------|----------|
+| **copy** (default) | Copies the file to the target location. Template variables are expanded via `sed`. |
+| **link** | Creates a symlink to the source file in the CCGM repo. Only available with `--link` flag. |
+| **merge** | Deep-merges JSON into the existing `settings.json` using `jq`. Arrays like `allow` and `deny` are deduplicated. Hook arrays are concatenated. |
+
+Also writes `~/.claude/.ccgm.env` with all collected configuration values.
+
+### Step 12: Manifest
+
+Writes `~/.claude/.ccgm-manifest.json` recording:
+- Version, timestamp, preset name
+- Scope and link mode
+- List of installed modules and files
+- Backup paths
+- Path to the CCGM repository (`ccgmRoot`)
+
+This manifest is used by `update.sh` and `uninstall.sh` to know what was installed.
+
+### Step 13: Verification
+
+Checks that all installed files exist on disk, scans for unexpanded `__PLACEHOLDER__` tokens (indicating a template expansion failure), and validates `settings.json` as valid JSON via `jq`.
+
+### Step 14: Shell alias
+
+Optionally adds `alias ccgm="claude /startup"` to `~/.zshrc` or `~/.bashrc`. Detects existing aliases to avoid duplicates.
+
+### Step 15: Next steps
+
+Displays a summary with instructions to restart Claude Code and begin using the installed modules.
+
+## Settings merge
+
+The settings merge (`lib/merge.sh`) deserves special attention because `settings.json` is shared between CCGM modules.
+
+When multiple modules contribute to `settings.json` (via `settings.partial.json` files with `"merge": true`), the installer deep-merges them using a custom `jq` function:
+
+- **`allow` and `deny` arrays**: Entries are concatenated and deduplicated with `unique`
+- **`hooks` object**: Hook event arrays (PreToolUse, PostToolUse, etc.) are concatenated
+- **`enabledPlugins`**: Deep-merged
+- **Other keys**: Standard JSON merge (later values override earlier)
+
+This means each module can add its own permissions and hooks without overwriting what other modules installed.
+
+## Updating
+
+```bash
+cd /path/to/ccgm
+./update.sh
+```
+
+The updater performs these steps:
+
+1. **Fetch** - runs `git fetch origin` to check for upstream changes
+2. **Compare** - shows the commit log between your local HEAD and `origin/main`
+3. **Categorize** - groups changed files by type (modules, presets, installer, other)
+4. **Pull** - offers to `git pull --ff-only` to update the local repo
+5. **Re-install** - offers to re-run the installer using the same preset, scope, and link mode recorded in the manifest
+6. **Drift check** - compares installed files against source files to detect local modifications (for non-template, non-merge files)
+
+## Uninstalling
+
+```bash
+cd /path/to/ccgm
+./uninstall.sh
+```
+
+The uninstaller:
+
+1. Reads `.ccgm-manifest.json` to find the exact files that were installed
+2. Creates a safety backup before removing anything
+3. Removes each file (handles both regular files and symlinks)
+4. Removes `.ccgm-manifest.json` and `.ccgm.env`
+5. Cleans up empty `rules/`, `commands/`, and `hooks/` directories
+6. Offers to restore from the safety backup if you change your mind
+
+Only CCGM-installed files are removed. Personal files you created in `~/.claude/` are untouched.
+
+## Installer library
+
+The installer is split into library files in `lib/`:
+
+| File | Purpose |
+|------|---------|
+| `lib/ui.sh` | Pure-bash ANSI TUI with colored output, menus, and progress indicators. No external dependencies (gum is optional for prettier menus). |
+| `lib/modules.sh` | Module discovery (scans `modules/` for `module.json` files), dependency resolution (topological sort), and preset loading. |
+| `lib/template.sh` | Template variable expansion via `sed`. Handles macOS and Linux `sed` differences. |
+| `lib/merge.sh` | Deep JSON merge for `settings.json` using `jq`. Special handling for arrays and hook objects. |
+| `lib/backup.sh` | Timestamped backup and restore of `~/.claude/` contents. |
+
+## Non-interactive mode
+
+Set environment variables to skip all prompts:
+
+```bash
+CCGM_NON_INTERACTIVE=1 \
+  CCGM_USERNAME="github-user" \
+  CCGM_CODE_DIR="$HOME/code" \
+  CCGM_TIMEZONE="America/New_York" \
+  ./start.sh --preset standard
+```
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CCGM_NON_INTERACTIVE` | Set to `1` to skip all prompts | - |
+| `CCGM_USERNAME` | GitHub username | auto-detected via `gh` |
+| `CCGM_CODE_DIR` | Code workspace directory | `~/code` |
+| `CCGM_TIMEZONE` | Timezone | auto-detected |
+
+All module config prompts use their default values in non-interactive mode.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,538 @@
+# Module Catalog
+
+CCGM contains 25 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
+
+## How modules work
+
+A module installs one or more of these file types:
+
+| File type | Location | How Claude uses it |
+|-----------|----------|-------------------|
+| **Rules** (`rules/*.md`) | `~/.claude/rules/` | Loaded automatically at session start. Guides Claude's behavior. |
+| **Commands** (`commands/*.md`) | `~/.claude/commands/` | Available as `/command-name` slash commands. |
+| **Hooks** (`hooks/*.py`) | `~/.claude/hooks/` | Triggered by Claude Code events (tool calls, session start, etc.). |
+| **Settings** (`settings.*.json`) | `~/.claude/settings.json` | Deep-merged into the permissions configuration. |
+| **Docs** (`*.md` reference files) | `~/.claude/` | Reference documentation accessible to Claude. |
+| **Config** (`*.json` config files) | `~/.claude/` | Configuration data read by hooks or commands. |
+
+## Category: core
+
+These modules form the foundation. The **standard** preset includes all four.
+
+---
+
+### autonomy
+
+Configures Claude as a fully autonomous Staff-level engineer who executes tasks end-to-end without unnecessary questions.
+
+**Installs**: `rules/autonomy.md`
+
+**What it does**: Sets the core operating principle of "do it, don't describe it." Instead of presenting steps for the user to follow, Claude runs commands, fixes problems, chains operations, and debugs issues itself. The rule defines clear boundaries for when to act vs when to ask (credentials, third-party dashboards, ambiguous product decisions, destructive actions).
+
+Also defines a post-task "call to action" pattern: after finishing work, Claude prompts for next steps rather than just summarizing.
+
+**Dependencies**: None
+
+---
+
+### git-workflow
+
+Git conventions covering sync safety, branching strategy, commit attribution, and PR workflows.
+
+**Installs**: `rules/git-workflow.md`
+
+**What it does**: Establishes six critical rules:
+
+1. **No AI attribution** - never add Co-Authored-By trailers or "Generated with Claude" to commits, PRs, or git metadata
+2. **PR template detection** - before creating PRs, check the repo and org for PR templates and use them
+3. **Sync before history changes** - always `git fetch` before rebase, filter-branch, or reset
+4. **Rebase by default** - use rebase instead of merge for feature branches
+5. **Never stash** - commit instead; stashes are invisible and easy to lose
+6. **Return to main after merge** - checkout main and pull after PRs are merged
+
+**Dependencies**: None
+
+---
+
+### settings
+
+Base `settings.json` with 800+ pre-configured tool permission entries.
+
+**Installs**: `settings.base.json` (merged into `settings.json`)
+
+**What it does**: Provides a comprehensive permissions configuration for Claude Code:
+
+- **Allow list**: 800+ tool commands pre-approved for auto-execution (git operations, npm/pnpm commands, file operations in safe paths, common CLI tools)
+- **Deny list**: Dangerous commands blocked (force push to main, `rm -rf /`, dropping databases, etc.)
+- **Default mode**: Configurable as `ask` (confirm before risky tools) or `dontAsk` (auto-approve everything not denied)
+
+**Config prompts**: Permission mode (`ask` or `dontAsk`)
+
+**Template variables**: `__HOME__`, `__CODE_DIR__`, `__DEFAULT_MODE__`
+
+**Dependencies**: None
+
+---
+
+### hooks
+
+Python hooks that automate and enforce development workflows.
+
+**Installs**: 8 hook scripts, 1 Python library, settings.json fragment
+
+This module installs the most hooks of any module. See [Hooks Reference](hooks.md) for detailed documentation of each hook.
+
+**Hooks installed**:
+
+| Hook | Type | Purpose |
+|------|------|---------|
+| `enforce-git-workflow.py` | PreToolUse:Bash | Blocks commits/pushes to protected branches, enforces `#N:` commit format |
+| `enforce-issue-workflow.py` | UserPromptSubmit | Reminds Claude to follow issue-first workflow |
+| `auto-approve-bash.py` | PreToolUse:Bash | Enforces bash permissions from settings.json |
+| `auto-approve-file-ops.py` | PreToolUse | Enforces path-based read/edit/write permissions |
+| `ccgm-update-check.py` | PreToolUse | Daily check for CCGM upstream updates |
+| `port-check.py` | PreToolUse:Bash | Warns about dev server port conflicts |
+| `agent-tracking-pre.py` | PreToolUse:Bash | Warns when claiming already-claimed issues |
+| `agent-tracking-post.py` | PostToolUse:Bash | Records issue claims, status transitions in tracking CSV |
+
+**Config prompts**: Protected branches (custom list), auto update check (yes/no)
+
+**Template variables**: `__USERNAME__`
+
+**Dependencies**: settings
+
+---
+
+## Category: commands
+
+Slash commands that extend Claude Code with new capabilities.
+
+---
+
+### commands-core
+
+Essential slash commands for daily development workflow.
+
+**Installs**: 5 command files
+
+| Command | Description |
+|---------|-------------|
+| `/commit` | Stage all changes and commit with conventional format |
+| `/pr` | Push branch and create a pull request |
+| `/cpm` | One-shot commit + PR + merge workflow |
+| `/gs` | Git status dashboard |
+| `/ghi` | Create a GitHub issue with labels |
+
+See [Commands Reference](commands.md) for detailed usage of each command.
+
+**Dependencies**: None
+
+---
+
+### commands-extra
+
+Additional slash commands for code quality and guided workflows.
+
+**Installs**: 4 command files
+
+| Command | Description |
+|---------|-------------|
+| `/audit` | Multi-phase codebase audit across 8 categories |
+| `/pwv` | Playwright visual verification |
+| `/walkthrough` | Step-by-step guided mode |
+| `/promote-rule` | Review and promote repo rules to global |
+
+See [Commands Reference](commands.md) for detailed usage of each command.
+
+**Dependencies**: None
+
+---
+
+### brand-naming
+
+Research tools for naming products, companies, or projects.
+
+**Installs**: 2 command files
+
+| Command | Description |
+|---------|-------------|
+| `/brand` | Full naming pipeline with word exploration, generation, and multi-source verification |
+| `/brand-check` | Deep verification of a single name across domains, trademarks, app stores, and social |
+
+**Config prompts**: Whether to add the Instant Domain Search MCP server to `mcp.json`
+
+**Dependencies**: None
+
+---
+
+## Category: workflow
+
+Development workflow patterns and coordination systems.
+
+---
+
+### github-protocols
+
+Issue-first workflow, PR conventions, label taxonomy, and code review standards.
+
+**Installs**: `rules/github-protocols.md`, `github-repo-protocols.md` (reference doc)
+
+**What it does**: Establishes a structured development workflow:
+
+- **Issue-first**: Every code change starts with an issue
+- **Label taxonomy**: Consistent labels for type (feature, bug, refactor), priority, and status
+- **PR conventions**: Branch naming, PR description format, review checklist
+- **Code review standards**: What to look for, how to give feedback
+- **Rule promotion**: Instructions for identifying repo-specific rules that should become global
+
+**Dependencies**: None
+
+---
+
+### session-logging
+
+Structured agent session logging with mandatory triggers, log management, and auto-startup.
+
+**Installs**: `rules/session-logging.md`, `log-system.md` (reference doc), `commands/startup.md`, `hooks/auto-startup.py`, settings.json fragment
+
+**What it does**: Creates a system for tracking work across sessions:
+
+- **Session logs**: Markdown files in a dedicated log repo (`~/code/{log-repo}/`)
+- **Mandatory triggers**: Logs must be updated after commits, PR creation, PR merge, issue close, and before context compaction
+- **Agent identity**: Each clone gets a unique agent ID derived from its directory name
+- **Auto-startup**: A SessionStart hook automatically runs `/startup` to initialize each session
+- **Cross-agent awareness**: Agents read each other's logs to avoid duplicate work
+
+The `/startup` command is the primary interface. It pulls logs, checks git status, queries the tracking dashboard, checks for Claude Code updates, and presents a session dashboard.
+
+**Config prompts**: Log repo name, whether to create the log repo, whether to enable auto-startup
+
+**Dependencies**: None
+
+---
+
+### multi-agent
+
+Multi-clone architecture for running multiple Claude agents in parallel on the same repo.
+
+**Installs**: `rules/multi-agent.md`, `multi-agent-system.md` (reference doc), `commands/mawf.md`, `commands/workspace-setup.md`, `port-registry.json`
+
+**What it does**: Enables parallel development with multiple Claude Code instances:
+
+- **Clone organization**: Two models supported - workspace model (`{repo}-workspaces/{repo}-wX/{repo}-wX-cY/`) and flat model (`{repo}-repos/{repo}-N/`)
+- **Port allocation**: Each clone gets unique ports via `port-registry.json` and `.env.clone` to prevent dev server collisions
+- **Issue claiming**: Agents claim issues via the tracking CSV, preventing duplicate work
+- **Workspace setup**: `/workspace-setup` creates isolated workspace directories with clones, labels, and agent identity files
+
+Commands installed:
+
+| Command | Description |
+|---------|-------------|
+| `/mawf` | Multi-Agent Workflow - parse feedback into issues, spawn parallel agents |
+| `/workspace-setup` | Create workspace directory structure for a repo |
+
+**Dependencies**: session-logging
+
+---
+
+### xplan
+
+Deep research, planning, and execution framework for complex projects.
+
+**Installs**: 3 command files
+
+**What it does**: An 8-phase framework for tackling large projects:
+
+1. **Parse input** and create plan directory
+2. **Deep research** via parallel specialized agents (market research, technical analysis, competitive review, user research)
+3. **Build contextual model** from research findings
+4. **Create parallelized execution plan** with epics and dependency waves
+5. **Peer review** by specialized agents (architecture, security, UX, feasibility)
+6. **Interactive walkthrough** with the user for feedback and decisions
+7. **Autonomous execution** via parallel agents in separate clones
+8. **Completion audit** and retrospective
+
+Commands installed:
+
+| Command | Description |
+|---------|-------------|
+| `/xplan` | Launch the full planning and execution pipeline |
+| `/xplan-status` | Check progress on a running or completed plan |
+| `/xplan-resume` | Resume an interrupted plan execution |
+
+**Dependencies**: multi-agent (which depends on session-logging)
+
+---
+
+### self-improving
+
+Meta-learning patterns for improving across sessions.
+
+**Installs**: `rules/self-improving.md`
+
+**What it does**: Instructs Claude to reflect on completed tasks and extract reusable lessons:
+
+- **Reflection loop**: After completing work, extract observations, distill into rules, write to memory, consolidate periodically
+- **What to capture**: Non-obvious decisions, surprising root causes, patterns that worked, user preferences
+- **What to skip**: Obvious patterns, one-time fixes, already-documented conventions
+- **Confidence levels**: High (save immediately), medium (note for confirmation), low (watch for patterns)
+
+**Dependencies**: None
+
+---
+
+### subagent-patterns
+
+Methodology for decomposing tasks and delegating to subagents.
+
+**Installs**: `rules/subagent-patterns.md`
+
+**What it does**: Provides a structured approach to using Claude Code's Agent tool:
+
+- **When to use subagents**: Parallel independent research, parallel implementation across files, isolated exploration
+- **Task decomposition**: How to write specs for subagents (context, deliverable, constraints, success criteria)
+- **Dispatch patterns**: Parallel research with aggregation, parallel implementation with separate clones
+- **Two-stage review**: First check spec compliance, then check code quality
+- **Coordination rules**: No shared mutable state, aggregate results in the parent, report failures immediately
+
+**Dependencies**: None
+
+---
+
+## Category: patterns
+
+Reusable development patterns and methodologies.
+
+---
+
+### code-quality
+
+Code standards, testing requirements, error handling, security practices, and build verification.
+
+**Installs**: `rules/code-quality.md`
+
+**What it does**: A comprehensive code quality ruleset covering:
+
+- **Dependency minimization**: Prefer built-in over library over framework
+- **Migration validation**: PostgreSQL reserved keyword quoting, idempotent patterns, local testing
+- **Component patterns**: Functional React/TypeScript components, path aliases
+- **Testing**: What to test (features, edge cases, bug fixes, complex logic)
+- **Error handling**: Frontend (error boundaries, toasts) and backend (centralized middleware, no leaked internals)
+- **Security**: Input sanitization, upload validation, no committed secrets, RLS
+- **Build verification**: Pre-push only (not after every change), CI parity
+- **Living documents**: When and how to update README.md and project-story.md after merges
+
+**Dependencies**: None
+
+---
+
+### browser-automation
+
+Browser tool selection hierarchy and verification workflows.
+
+**Installs**: `rules/browser-automation.md`
+
+**What it does**: Establishes rules for when and how to use browser automation:
+
+- **Tool selection hierarchy**: WebMCP tools > Chrome extension > Playwright
+- **Verification priority**: CLI tools > MCP servers > API calls > WebMCP > browser automation
+- **When browser IS appropriate**: Visual layout verification, client-side interactivity testing, OAuth flows, screenshots
+- **UI verification workflow**: Get browser context, navigate, wait, check errors, screenshot
+- **Deployment verification**: Never test until deployment is actually complete
+
+**Dependencies**: None
+
+---
+
+### common-mistakes
+
+Eight documented anti-patterns extracted from real mistakes.
+
+**Installs**: `rules/common-mistakes.md`
+
+**What it does**: Prevents Claude from repeating known failure patterns:
+
+1. **Shallow directory exploration** - always use two-method verification in monorepos
+2. **Dependency blindness** - check open PRs before creating branches
+3. **ESLint Fast Refresh violations** - never mix component and non-component exports
+4. **Suggesting already-tried solutions** - assume the user already tried the obvious
+5. **Premature solutions** - check linter configs and existing patterns first
+6. **Git multi-clone confusion** - branch from `origin/main`, check sibling clones
+7. **Cloudflare Pages vs Workers** - know which product to use
+8. **CF Pages without Git integration** - always connect for auto-deploy
+
+**Dependencies**: None
+
+---
+
+### frontend-design
+
+Principles for building distinctive, production-grade web interfaces.
+
+**Installs**: `rules/frontend-design.md`
+
+**What it does**: Guides Claude away from generic AI-generated aesthetics toward intentional design:
+
+- **Typography**: Establish clear hierarchy, use 2-3 font sizes max per component
+- **Color systems**: WCAG AA compliance, semantic color tokens, purposeful contrast
+- **Spatial composition**: Consistent spacing scale, intentional whitespace
+- **Motion**: Purposeful animations (feedback, orientation, delight), not decoration
+- **What to avoid**: Default framework styles, generic card grids, excessive gradients
+- **Implementation checklist**: Questions to ask before writing UI code
+
+**Dependencies**: None
+
+---
+
+### systematic-debugging
+
+Structured 4-phase root cause investigation methodology.
+
+**Installs**: `rules/systematic-debugging.md`
+
+**What it does**: Prevents scattered debugging by enforcing a systematic process:
+
+1. **Investigate**: Read the actual error, identify the exact failure point
+2. **Analyze**: Look for patterns, check recent changes, trace data flow
+3. **Hypothesize**: Form testable theories, rank by likelihood
+4. **Implement**: Fix the root cause (not symptoms), verify the fix, check for regressions
+
+Also includes a "three-strike rule": if you try three approaches without progress, step back and reassess your understanding of the problem.
+
+**Dependencies**: None
+
+---
+
+### test-driven-development
+
+Strict red-green-refactor TDD discipline.
+
+**Installs**: `rules/test-driven-development.md`
+
+**What it does**: Enforces TDD when writing new code:
+
+- **Red**: Write a failing test first
+- **Green**: Write the minimum code to make it pass
+- **Refactor**: Clean up without changing behavior
+- **For features**: Test the public API, not implementation details
+- **For bug fixes**: Write a test that reproduces the bug before fixing it
+- **When TDD applies**: New features, bug fixes, complex logic, refactoring
+- **Rationalizations to reject**: "This is too simple to test," "I'll add tests later," "The types guarantee correctness"
+
+**Dependencies**: None
+
+---
+
+### verification
+
+Evidence-before-claims methodology for confirming work is done.
+
+**Installs**: `rules/verification.md`
+
+**What it does**: Prevents Claude from claiming completion without proof:
+
+- **5-step process**: Plan verification, execute commands, read full output, evaluate results, report honestly
+- **Evidence table**: What evidence to provide for each claim type (bug fix, feature, deployment, etc.)
+- **Fresh-run requirement**: Always re-execute verification commands rather than relying on earlier output
+- **Honest reporting**: If verification fails, say so - never claim success without evidence
+
+**Dependencies**: None
+
+---
+
+## Category: tech-specific
+
+Guides for specific technologies and platforms.
+
+---
+
+### cloudflare
+
+Cloudflare Pages and Workers deployment guide.
+
+**Installs**: `rules/cloudflare.md`
+
+**What it does**: Prevents common Cloudflare deployment mistakes:
+
+- **Pages vs Workers**: Comparison table for choosing the right product
+- **Git integration**: Always connect Pages projects to GitHub for auto-deploy
+- **Red flags**: How to detect a misconfigured Pages project
+- **Fix steps**: What to do when Git integration is missing
+
+**Dependencies**: None
+
+---
+
+### supabase
+
+Supabase API key terminology, environment variables, and migration workflow.
+
+**Installs**: `rules/supabase.md`
+
+**What it does**: Ensures correct Supabase terminology and practices:
+
+- **Key terminology**: Publishable key (not "anon key"), secret key (not "service_role key")
+- **Environment variables**: Correct naming conventions for client and server
+- **Circuit breaker**: Rules to prevent tripping Supabase connection pooler lockouts
+- **Migration workflow**: References the code-quality module for validation details
+
+**Dependencies**: None
+
+---
+
+### mcp-development
+
+Guide for building MCP (Model Context Protocol) servers.
+
+**Installs**: `rules/mcp-development.md`
+
+**What it does**: Provides patterns for building MCP servers:
+
+- **Language choice**: TypeScript for ecosystem breadth, Python for data/ML
+- **Transport**: stdio for local, Streamable HTTP for remote
+- **Tool naming**: `{service}_{action}_{resource}` convention
+- **Input schemas**: Required vs optional fields, enum types, validation
+- **Error handling**: Structured error responses, retry guidance
+- **Testing**: MCP Inspector for interactive testing
+- **Quality checklist**: Pre-publish verification steps
+
+**Dependencies**: None
+
+---
+
+### shadcn
+
+Patterns for using shadcn/ui components in React projects.
+
+**Installs**: `rules/shadcn.md`
+
+**What it does**: Establishes conventions for shadcn/ui usage:
+
+- **Composition over custom**: Use existing components before building new ones
+- **Semantic theming**: Use `bg-primary` not `bg-blue-500`; define tokens in CSS variables
+- **Form architecture**: Use React Hook Form + Zod, wrap in `<Form>`, use `<FormField>` components
+- **Layout patterns**: Prefer `flex` + `gap` over margins, use `size-*` for square elements
+- **Accessibility**: ARIA labels, keyboard navigation, focus management
+- **CLI workflow**: Use `npx shadcn@latest add {component}` to install components
+
+**Dependencies**: None
+
+---
+
+### tailwind
+
+Tailwind CSS v4 design system patterns.
+
+**Installs**: `rules/tailwind.md`
+
+**What it does**: Guides Tailwind v4 usage (CSS-first configuration, not the deprecated `tailwind.config.ts`):
+
+- **CSS-first config**: All configuration in CSS using `@theme`, `@custom-variant`, and `@utility`
+- **Design token hierarchy**: Primitive (raw values), semantic (contextual names), component (specific elements)
+- **Color system**: OKLCH for perceptual uniformity, CSS custom properties for theming
+- **CVA variants**: Use class-variance-authority for component variant management
+- **Dark mode**: `@custom-variant dark (&:where(.dark, .dark *))` pattern
+- **Responsive**: Mobile-first with `sm:`, `md:`, `lg:` breakpoints
+- **v3 to v4 migration**: Mapping table for changed utility names
+
+**Dependencies**: None

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -1,0 +1,214 @@
+# Multi-Agent System
+
+The multi-agent system enables running multiple Claude Code instances in parallel on the same repository. Each instance works in its own clone of the repo, claims issues to avoid duplicate work, and uses assigned ports to prevent dev server collisions.
+
+## When to use multi-agent
+
+Multi-agent is useful when:
+- You have multiple independent GitHub issues to complete
+- Issues don't block each other (no sequential dependencies)
+- You want to parallelize development work
+- You're working on a project with a large backlog
+
+## Clone organization models
+
+CCGM supports two directory layouts for multi-clone repos.
+
+### Workspace model (recommended)
+
+```
+~/code/my-repo-workspaces/
+├── my-repo-w0/                    # Workspace 0
+│   ├── my-repo-w0-c0/             # Clone 0 (agent-w0-c0)
+│   ├── my-repo-w0-c1/             # Clone 1 (agent-w0-c1)
+│   ├── my-repo-w0-c2/             # Clone 2 (agent-w0-c2)
+│   └── my-repo-w0-c3/             # Clone 3 (agent-w0-c3)
+├── my-repo-w1/                    # Workspace 1
+│   ├── my-repo-w1-c0/
+│   └── ...
+```
+
+Each workspace is an isolated group of 4 clones. A coordinator agent runs in the workspace directory and delegates tasks to sub-agents in its clones.
+
+Create workspaces with `/workspace-setup`:
+```
+/workspace-setup my-repo
+```
+
+### Flat clone model (simpler)
+
+```
+~/code/my-repo-repos/
+├── my-repo-0/                     # Clone 0 (agent-0)
+├── my-repo-1/                     # Clone 1 (agent-1)
+├── my-repo-2/                     # Clone 2 (agent-2)
+└── my-repo-3/                     # Clone 3 (agent-3)
+```
+
+All clones are siblings in one directory. Simpler to set up but no isolation between agents.
+
+## Agent identity
+
+Each clone has a unique agent ID derived from its directory name:
+
+| Directory | Agent ID |
+|-----------|----------|
+| `my-repo-w0-c2` | `agent-w0-c2` |
+| `my-repo-3` | `agent-3` |
+| `my-repo` (no number) | `agent-0` |
+
+The agent ID is also stored in `.env.clone`:
+
+```bash
+AGENT_ID=agent-w0-c2
+WORKSPACE_NUM=0
+CLONE_NUM=2
+FRONTEND_PORT=3102
+BACKEND_PORT=3103
+```
+
+## Port allocation
+
+Each clone gets unique ports to prevent dev server collisions.
+
+### How ports are assigned
+
+Ports are managed in `~/.claude/port-registry.json`:
+
+```json
+{
+  "my-repo": {
+    "basePort": 3100,
+    "clones": 4
+  }
+}
+```
+
+Each repo gets a 16-port block. Within that block, each clone gets 2 ports (frontend + backend):
+
+| Clone | Frontend | Backend |
+|-------|----------|---------|
+| Clone 0 | basePort + 0 | basePort + 1 |
+| Clone 1 | basePort + 2 | basePort + 3 |
+| Clone 2 | basePort + 4 | basePort + 5 |
+| Clone 3 | basePort + 6 | basePort + 7 |
+
+### Using ports
+
+Always read ports from `.env.clone` before starting a dev server:
+
+```bash
+FRONTEND_PORT=$(grep 'FRONTEND_PORT=' .env.clone | cut -d= -f2)
+pnpm dev -- --port ${FRONTEND_PORT}
+```
+
+The `port-check.py` hook warns if you start a dev server on the wrong port or if the port is already in use.
+
+## Issue tracking
+
+The multi-agent system uses a CSV-based tracking system to coordinate which agent is working on which issue.
+
+### Tracking file
+
+Located at `~/code/{log-repo}/{repo}/tracking.csv` with fields:
+
+```
+issue,agent,status,branch,pr,epic,title,claimed_at,updated_at
+42,agent-w0-c1,in-progress,42-add-login,,,"Add login form",2026-03-29T10:00:00,2026-03-29T11:30:00
+43,agent-w0-c2,pr-created,43-dark-mode,#87,,"Add dark mode",2026-03-29T10:05:00,2026-03-29T11:45:00
+```
+
+### Status lifecycle
+
+```
+claimed -> in-progress -> pr-created -> merged
+                                     -> closed
+```
+
+### Automatic tracking
+
+Hooks automatically update the tracking CSV:
+
+1. **`git checkout -b 42-add-login`** -> Issue #42 claimed by this agent
+2. **`git commit -m "#42: initial scaffold"`** -> Status transitions to `in-progress`
+3. **Subsequent commits** -> Heartbeat updated (throttled to every 30 minutes)
+4. **`gh pr create`** -> Status transitions to `pr-created`
+5. **`gh pr merge`** -> Status transitions to `merged`
+6. **`gh issue close 42`** -> Status transitions to `closed`
+
+No manual tracking updates are needed. The hooks handle everything.
+
+### Viewing tracking state
+
+The `/startup` command shows the tracking dashboard. You can also query it directly:
+
+```bash
+python3 ~/.claude/lib/agent_tracking.py list --repo my-repo
+```
+
+### Stale claim cleanup
+
+If an agent abandons work without updating tracking:
+
+```bash
+python3 ~/.claude/lib/agent_tracking.py gc --repo my-repo
+```
+
+This finds claims not updated in the last 24 hours and flags them as stale.
+
+## Session logging
+
+Each agent maintains its own session log in the log repo:
+
+```
+~/code/{log-repo}/
+└── my-repo/
+    └── 20260329/
+        ├── agent-w0-c0.md
+        ├── agent-w0-c1.md
+        └── agent-w0-c2.md
+```
+
+At session start, agents read each other's logs to understand:
+- Which issues other agents have claimed
+- What branches they created
+- Blockers or decisions that might affect shared work
+
+## Workflows
+
+### /mawf - Multi-Agent Workflow
+
+Takes unstructured feedback, splits it into GitHub issues, and spawns parallel agents:
+
+```
+/mawf "Fix the login bug, add dark mode, update API docs"
+```
+
+This creates issues, plans dependency waves, spawns agents in separate clones, monitors progress, and reports results.
+
+### /workspace-setup - Create workspace structure
+
+Creates the directory structure, clones, `.env.clone` files, and GitHub labels:
+
+```
+/workspace-setup my-repo
+```
+
+### /xplan - Planning and execution
+
+For larger projects, `/xplan` handles the full lifecycle from research through parallel execution:
+
+```
+/xplan "Build a SaaS dashboard with auth and billing"
+```
+
+## Concurrency safety
+
+The tracking CSV uses git's merge mechanism for concurrency:
+
+1. Agent modifies only its own rows
+2. After writing, runs `git commit && git pull --rebase && git push`
+3. Different-row edits auto-resolve during rebase
+4. Same-row conflicts (rare) require manual resolution
+
+This is safe for typical multi-agent workflows where each agent works on different issues.

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -1,0 +1,77 @@
+# Presets
+
+Presets are named collections of modules for quick installation. Each preset is a JSON array in the `presets/` directory listing module names.
+
+## Available presets
+
+### minimal
+
+**Best for**: Trying CCGM for the first time, or environments where you want light-touch guidance with no hooks or settings changes.
+
+**Modules (2)**:
+- `autonomy` - configures Claude as a fully autonomous engineer
+- `git-workflow` - git conventions (sync, rebase, no AI attribution)
+
+**What you get**: Two behavior rule files in `rules/`. No hooks, no commands, no settings.json changes.
+
+### standard
+
+**Best for**: Most individual developers. The recommended starting point.
+
+**Modules (5)**:
+- Everything in **minimal**, plus:
+- `settings` - base `settings.json` with 800+ pre-configured tool permissions
+- `hooks` - Python hooks for workflow enforcement (branch protection, commit format, auto-approval)
+- `commands-core` - essential slash commands (`/commit`, `/pr`, `/cpm`, `/gs`, `/ghi`)
+
+**What you get**: Rules, hooks, commands, and a permissions configuration that lets Claude operate effectively while keeping guardrails on destructive operations.
+
+### team
+
+**Best for**: Teams with shared repositories who want consistent practices across contributors.
+
+**Modules (9)**:
+- Everything in **standard**, plus:
+- `github-protocols` - issue-first workflow, PR conventions, label taxonomy, code review standards
+- `code-quality` - code standards, testing requirements, error handling, security, build verification
+- `systematic-debugging` - structured 4-phase debugging methodology
+- `verification` - evidence-before-claims, fresh execution requirement
+
+**What you get**: Everything in standard, plus rules that enforce consistent development practices across a team.
+
+### full
+
+**Best for**: Power users who want the complete CCGM experience, including multi-agent coordination, brand research, and tech-specific guides.
+
+**Modules (25)**: All modules.
+
+**What you get**: The full suite. Includes multi-agent workflows, planning frameworks, tech-specific patterns (Cloudflare, Supabase, Tailwind, shadcn, MCP development), and specialized commands.
+
+## Dependency resolution
+
+When you select a module that depends on other modules, the installer automatically includes the dependencies. For example:
+
+- Selecting `xplan` automatically adds `multi-agent` and `session-logging`
+- Selecting `hooks` automatically adds `settings`
+
+You don't need to manually track dependencies. The installer resolves them using topological sorting and reports any additions.
+
+## Using presets from the command line
+
+```bash
+./start.sh --preset minimal
+./start.sh --preset standard
+./start.sh --preset full
+./start.sh --preset team
+```
+
+Combine with scope and link flags:
+
+```bash
+./start.sh --preset standard --scope global
+./start.sh --preset full --link
+```
+
+## Custom module selection
+
+If none of the presets match your needs, the installer offers a checkbox-style menu where you can select individual modules. This is the default when no `--preset` flag is provided.


### PR DESCRIPTION
## Summary

- Added 8 documentation files in `docs/` covering every aspect of CCGM: modules, commands, hooks, presets, installer, configuration, and multi-agent system
- Updated README.md with a Documentation section linking to all docs

## New files

| Document | Content |
|----------|---------|
| `docs/getting-started.md` | Installation walkthrough, prerequisites, first session, scopes, install modes |
| `docs/modules.md` | All 25 modules - descriptions, installed files, config prompts, dependencies |
| `docs/commands.md` | All 17 slash commands with behavior, what happens, and usage examples |
| `docs/hooks.md` | All 9 hooks - type, blocking behavior, how they work, configuration |
| `docs/presets.md` | All 4 presets with module lists, target audience, dependency resolution |
| `docs/installer.md` | All 15 installer steps, settings merge, update/uninstall, non-interactive mode |
| `docs/configuration.md` | Customization, template variables, manifest, scope precedence |
| `docs/multi-agent.md` | Clone models, agent identity, port allocation, issue tracking, workflows |

## Test plan

- [x] `bash tests/test-modules.sh` - 398 passed, 0 failed
- [x] `bash tests/test-no-personal-data.sh` - no new personal data (pre-existing README clone URLs are the only flags)
- [x] All docs cross-reference correctly
- [x] No personal data in new files

Closes #72