### PR TITLE
78: Add tier icons to model indicator in statusline

### DIFF
--- a/lib/statusline.sh
+++ b/lib/statusline.sh
@@ -4,19 +4,19 @@
 
 input=$(cat)
 
-# --- Model (abbreviated: O-4.6, S-4.6, H-4.5, etc.)
+# --- Model (abbreviated: O-4.6, S-4.6, H-4.5, etc.) with tier indicators
 model_raw=$(echo "$input" | jq -r '.model.display_name // ""')
 case "$model_raw" in
-  *"Opus 4.6"*)   model_abbr="O-4.6"; is_latest=true ;;
-  *"Opus 4.5"*)   model_abbr="O-4.5"; is_latest=false ;;
-  *"Opus 4"*)     model_abbr="O-4"; is_latest=false ;;
-  *"Sonnet 4.6"*) model_abbr="S-4.6"; is_latest=false ;;
-  *"Sonnet 4.5"*) model_abbr="S-4.5"; is_latest=false ;;
-  *"Sonnet 4"*)   model_abbr="S-4"; is_latest=false ;;
-  *"Haiku 4.5"*)  model_abbr="H-4.5"; is_latest=false ;;
-  *"Haiku"*)      model_abbr="H"; is_latest=false ;;
-  "")             model_abbr=""; is_latest=false ;;
-  *)              model_abbr=$(echo "$model_raw" | sed 's/Claude //;s/ .*//'); is_latest=false ;;
+  *"Opus 4.6"*)   model_abbr="O-4.6"; model_tier="opus-best" ;;
+  *"Opus 4.5"*)   model_abbr="O-4.5"; model_tier="opus-other" ;;
+  *"Opus 4"*)     model_abbr="O-4"; model_tier="opus-other" ;;
+  *"Sonnet 4.6"*) model_abbr="S-4.6"; model_tier="sonnet" ;;
+  *"Sonnet 4.5"*) model_abbr="S-4.5"; model_tier="sonnet" ;;
+  *"Sonnet 4"*)   model_abbr="S-4"; model_tier="sonnet" ;;
+  *"Haiku 4.5"*)  model_abbr="H-4.5"; model_tier="haiku" ;;
+  *"Haiku"*)      model_abbr="H"; model_tier="haiku" ;;
+  "")             model_abbr=""; model_tier="" ;;
+  *)              model_abbr=$(echo "$model_raw" | sed 's/Claude //;s/ .*//'); model_tier="unknown" ;;
 esac
 
 # --- Directory: immediate dir name only
@@ -65,15 +65,26 @@ make_bar() {
 SEP=$(printf " ${DIM}|${RESET} ")
 sections=()
 
-# Model (abbreviated with warning if not Opus 4.6)
+# Model with tier indicators
 if [ -n "$model_abbr" ]; then
-  if [ "$is_latest" = true ]; then
-    # Opus 4.6: blue, no warning
-    sections+=("$(printf "${BLUE}%s${RESET}" "$model_abbr")")
-  else
-    # Not Opus 4.6: red text with warning icon
-    sections+=("$(printf "${RED}⚠️ %s${RESET}" "$model_abbr")")
-  fi
+  case "$model_tier" in
+    opus-best)
+      # Opus 4.6: brain icon, blue
+      sections+=("$(printf "${BLUE}🧠 %s${RESET}" "$model_abbr")")
+      ;;
+    sonnet)
+      # Sonnet variants: turtle icon
+      sections+=("$(printf "🐢 %s" "$model_abbr")")
+      ;;
+    haiku)
+      # Haiku variants: warning icon, red
+      sections+=("$(printf "${RED}⚠️ %s${RESET}" "$model_abbr")")
+      ;;
+    *)
+      # Other/unknown: no icon
+      sections+=("$(printf "%s" "$model_abbr")")
+      ;;
+  esac
 fi
 
 # Dir + git branch (combined)


### PR DESCRIPTION
Enhance the statusline script with model tier indicators using thematic icons.

Changes:
- Opus 4.6 (highest): 🧠 brain icon in blue
- Sonnet variants (mid): 🐢 turtle icon
- Haiku variants (low): ⚠️ warning icon in red

Display: 🧠 O-4.6 | code | ctx:8% / 🐢 S-4.6 | code | ctx:8% / ⚠️ H-4.5 | code | ctx:8%

Closes #78