### PR TITLE
#84: Remove Agent Reach and replace with safe standalone tools

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -320,19 +320,18 @@ Installed by the **deep-research** module.
 
 **Deep multi-channel research across 15+ platforms.**
 
-Spawns parallel research agents to gather comprehensive information from web search, GitHub, Reddit, Twitter/X, YouTube, and other platforms via Agent Reach integration.
+Spawns parallel research agents to gather comprehensive information from web search, GitHub, Reddit, YouTube, and other platforms using standalone tools (curl, gh, mcporter, yt-dlp, WebSearch).
 
 **Research channels**:
-- Web search (Exa)
-- GitHub (repos, issues, discussions)
-- Reddit (subreddits, threads)
-- Twitter/X
-- YouTube
-- Hacker News, LinkedIn, ProductHunt, and more
+- Web search (Exa via mcporter, WebSearch)
+- GitHub (repos, issues, discussions via gh CLI)
+- Reddit (JSON API via curl)
+- YouTube (metadata via yt-dlp)
+- Any web page (Jina Reader via curl)
 
 **What happens**:
 1. Breaks the research question into parallel sub-queries
-2. Spawns agents per channel via Agent Reach
+2. Spawns agents per channel using standalone CLI tools
 3. Aggregates and deduplicates findings
 4. Synthesizes into a structured report with sources
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -193,12 +193,12 @@ Multi-channel research and structured debugging commands powered by specialized 
 
 | Command | Description |
 |---------|-------------|
-| `/deepresearch` | Deep multi-channel research across 15+ platforms using Agent Reach and web search |
+| `/deepresearch` | Deep multi-channel research using parallel agents and web search |
 | `/debug` | Structured root-cause debugging with Opus - reproduce, hypothesize, instrument, diagnose, fix, verify |
 
 **What it does**: Provides two high-powered research and investigation commands:
 
-- **/deepresearch**: Spawns parallel research agents across web search, GitHub, Reddit, Twitter/X, YouTube, and other platforms via the Agent Reach integration. Produces a structured report with findings, sources, and synthesis.
+- **/deepresearch**: Spawns parallel research agents across web search, GitHub, Reddit, YouTube, and other platforms. Produces a structured report with findings, sources, and synthesis.
 - **/debug**: Enforces a disciplined debugging workflow (reproduce → hypothesize → instrument → diagnose → fix → verify) using Opus for deep root-cause analysis. Invoked automatically by the `systematic-debugging` module's routing rule.
 
 **Dependencies**: None

--- a/modules/brand-naming/commands/brand-check.md
+++ b/modules/brand-naming/commands/brand-check.md
@@ -197,34 +197,31 @@ Interpret HTTP codes:
 - 301/302 = taken (redirect to profile)
 - 429 = rate limited (note as "unknown")
 
-### Agent Reach: Direct Twitter Search
+### Twitter/X Search
 
 ```bash
-bird search "NAME" -n 5
-bird search "from:NAME OR @NAME" -n 5
-# Fallback if bird CLI unavailable:
-# mcporter call 'exa.web_search_exa(query: "site:twitter.com NAME", numResults: 3)'
+WebSearch: "NAME" site:twitter.com OR site:x.com
 ```
 
 Check for active accounts, brands, or influencers using the name.
 
-### Agent Reach: Direct Reddit Search
+### Reddit Search
 
 ```bash
-curl -s "https://www.reddit.com/search.json?q=NAME&limit=5" -H "User-Agent: agent-reach/1.0" | jq '.data.children[].data | {title, selftext: .selftext[:300], subreddit, score}'
+curl -s "https://www.reddit.com/search.json?q=NAME&limit=5" -H "User-Agent: research-agent/1.0" | jq '.data.children[].data | {title, selftext: .selftext[:300], subreddit, score}'
 ```
 
 Look for subreddits, communities, or products with the name.
 
-### Agent Reach: Direct YouTube Search
+### YouTube Search
 
 ```bash
-~/.agent-reach-venv/bin/yt-dlp --dump-json "ytsearch3:NAME" 2>/dev/null | jq '[.[] | {title, channel, view_count, webpage_url}]'
+yt-dlp --dump-json "ytsearch3:NAME" 2>/dev/null | jq '[.[] | {title, channel, view_count, webpage_url}]'
 ```
 
 Check for channels or prominent content using the name.
 
-### Agent Reach: Direct GitHub Search
+### GitHub Search
 
 ```bash
 gh search repos "NAME" --limit 5
@@ -244,7 +241,7 @@ WebSearch: "NAME" company OR startup OR app -site:github.com
 
 Is there an existing company, product, or notable entity using this name?
 
-### Agent Reach: Deep Web Presence Check
+### Deep Web Presence Check (Exa)
 
 ```bash
 mcporter call 'exa.web_search_exa(query: "NAME company startup app product", numResults: 5)'

--- a/modules/brand-naming/commands/brand.md
+++ b/modules/brand-naming/commands/brand.md
@@ -275,7 +275,7 @@ If no Marker API credentials, use WebSearch:
 WebSearch: "CANDIDATE NAME" site:tsdr.uspto.gov OR site:tmsearch.uspto.gov
 ```
 
-### Agent Reach: Deep Brand Collision Check
+### Deep Brand Collision Check (Exa)
 ```bash
 mcporter call 'exa.web_search_exa(query: "CANDIDATE brand company startup app", numResults: 5)'
 ```
@@ -321,38 +321,33 @@ curl -s -o /dev/null -w "%{http_code}" "https://github.com/CANDIDATE"
 curl -s -o /dev/null -w "%{http_code}" "https://www.reddit.com/user/CANDIDATE"
 ```
 
-### Agent Reach: Direct GitHub Search
+### GitHub Search
 ```bash
 gh search repos "CANDIDATE" --limit 5
 ```
 
-### Agent Reach: Direct Twitter Search
+### Twitter/X Search
 ```bash
-bird search "CANDIDATE" -n 5
-# Fallback if bird not configured: mcporter call 'exa.web_search_exa(query: "site:twitter.com CANDIDATE", numResults: 3)'
+WebSearch: "CANDIDATE" site:twitter.com OR site:x.com
 ```
 
-### Agent Reach: Direct Reddit Search
+### Reddit Search
 ```bash
-curl -s "https://www.reddit.com/search.json?q=CANDIDATE&limit=5" -H "User-Agent: agent-reach/1.0" | jq '.data.children[].data | {title, selftext: .selftext[:300], subreddit, score}'
+curl -s "https://www.reddit.com/search.json?q=CANDIDATE&limit=5" -H "User-Agent: research-agent/1.0" | jq '.data.children[].data | {title, selftext: .selftext[:300], subreddit, score}'
 ```
 
-### Agent Reach: Direct YouTube Search
+### YouTube Search
 ```bash
-~/.agent-reach-venv/bin/yt-dlp --dump-json "ytsearch3:CANDIDATE" 2>/dev/null | jq '[.[] | {title, channel, view_count, webpage_url}]'
+yt-dlp --dump-json "ytsearch3:CANDIDATE" 2>/dev/null | jq '[.[] | {title, channel, view_count, webpage_url}]'
 ```
 
-### Brand Sentiment (Agent Reach)
+### Brand Sentiment
 
-Search Reddit and Twitter for existing associations with the name:
+Search Reddit for existing associations with the name:
 ```bash
-curl -s "https://www.reddit.com/search.json?q=CANDIDATE&sort=top&limit=5" -H "User-Agent: agent-reach/1.0" | jq '.data.children[].data | {title, selftext: .selftext[:200], score}'
+curl -s "https://www.reddit.com/search.json?q=CANDIDATE&sort=top&limit=5" -H "User-Agent: research-agent/1.0" | jq '.data.children[].data | {title, selftext: .selftext[:200], score}'
 ```
 Look for: negative associations, controversial usage, strong existing brands using the name.
-```bash
-# If bird is configured:
-bird search "CANDIDATE" -n 10
-```
 
 Or if FindME CLI is installed:
 ```bash

--- a/modules/commands-extra/commands/audit.md
+++ b/modules/commands-extra/commands/audit.md
@@ -16,14 +16,14 @@ When spawning audit category agents in Phase 3, set model to **sonnet** in the A
 ## Audit Categories
 
 1. **Security** - Secrets in code, exposed API keys, missing input sanitization, SQL injection risks, XSS vulnerabilities, insecure dependencies
-   **Optional: Internet-powered vulnerability checks (Agent Reach)**
+   **Optional: Internet-powered vulnerability checks**
    For each dependency in package.json or lock file, agents can check:
    - CVE databases: `WebSearch: "{package}@{version} vulnerability CVE security advisory"`
    - GitHub Security Advisories: `gh api graphql -f query='{ securityVulnerabilities(first:5, package:"{package}") { nodes { advisory { summary severity } } } }'`
    - Known vulnerabilities: `WebFetch` on `https://registry.npmjs.org/-/npm/v1/security/advisories?package={package}`
    These checks are supplementary - the audit works without internet access too.
 2. **Dependencies** - Outdated packages, unused dependencies, duplicate packages, missing lock files, version conflicts
-   **Optional: Internet-powered deprecation checks (Agent Reach)**
+   **Optional: Internet-powered deprecation checks**
    For key dependencies, agents can verify maintenance status:
    - Check if repo is archived: `gh repo view {owner}/{package} --json isArchived 2>/dev/null`
    - Check for deprecation notices: `WebSearch: "{package} deprecated alternative migration"`

--- a/modules/deep-research/commands/deepresearch.md
+++ b/modules/deep-research/commands/deepresearch.md
@@ -1,12 +1,12 @@
 ---
-description: Deep multi-channel research using Agent Reach + web search across 15+ platforms
+description: Deep multi-channel research using web search across multiple platforms
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, WebSearch, WebFetch, AskUserQuestion
 argument-hint: <topic> [--depth full|technical|market|lite|custom] [--output <path>] [--repo <path>] [--plan-dir <path>] [--extend <prior-research-path>]
 ---
 
 # /deepresearch - Deep Multi-Channel Research
 
-A standalone research skill that spawns parallel agents to research a topic across the internet using Agent Reach channels (Reddit, GitHub, YouTube, Exa, web, RSS, Twitter) alongside WebSearch/WebFetch. Produces a comprehensive research.md.
+A standalone research skill that spawns parallel agents to research a topic across the internet using multiple channels (Reddit, GitHub, YouTube, Exa, web, RSS) alongside WebSearch/WebFetch. Produces a comprehensive research.md.
 
 **Can be used:**
 - Standalone: `/deepresearch "dark mode browser extensions"` - writes to `~/code/docs/research/`
@@ -130,12 +130,12 @@ Pass these targeted sub-questions to each agent instead of (or alongside) the br
 Launch the selected research agents in **parallel** using the Task tool. Each agent gets:
 1. The topic/concept to research
 2. Its targeted sub-questions from Phase 1.5
-3. The Agent Reach Quick Reference (below)
+3. The Internet Research Tools reference (below)
 4. Output size rules
 5. Depth-appropriate channel intensity guidance
 6. Prior research context (if `--extend` was provided)
 
-### Agent Reach Quick Reference
+### Internet Research Tools Reference
 
 Include this reference block in EVERY research agent's Task prompt:
 
@@ -168,8 +168,8 @@ Best for: reading specific URLs, article content
 Fallback: WebFetch
 
 **Reddit (community sentiment, user discussions)**
-curl -s "https://www.reddit.com/search.json?q=QUERY&limit=5" -H "User-Agent: agent-reach/1.0" | jq '.data.children[].data | {title, selftext: .selftext[:500], url, score, num_comments}'
-curl -s "https://www.reddit.com/r/SUBREDDIT/hot.json?limit=5" -H "User-Agent: agent-reach/1.0" | jq '.data.children[].data | {title, selftext: .selftext[:500], url, score}'
+curl -s "https://www.reddit.com/search.json?q=QUERY&limit=5" -H "User-Agent: research-agent/1.0" | jq '.data.children[].data | {title, selftext: .selftext[:500], url, score, num_comments}'
+curl -s "https://www.reddit.com/r/SUBREDDIT/hot.json?limit=5" -H "User-Agent: research-agent/1.0" | jq '.data.children[].data | {title, selftext: .selftext[:500], url, score}'
 Fallback: mcporter call 'exa.web_search_exa(query: "site:reddit.com QUERY")'
 
 **GitHub (code, repos, issues)**
@@ -178,17 +178,13 @@ gh search code "QUERY" --language LANG --limit 10
 gh repo view OWNER/REPO
 Fallback: WebSearch "site:github.com QUERY"
 
-**YouTube (video transcripts, tutorials) - MUST filter output**
-~/.agent-reach-venv/bin/yt-dlp --dump-json "ytsearch3:QUERY" 2>/dev/null | jq '[.[] | {title, description: .description[:300], duration, view_count, webpage_url}]'
+**YouTube (video metadata, tutorials) - MUST filter output**
+yt-dlp --dump-json "ytsearch3:QUERY" 2>/dev/null | jq '[.[] | {title, description: .description[:300], duration, view_count, webpage_url}]'
 Fallback: WebSearch "site:youtube.com QUERY"
-
-**Twitter/X (real-time discussions, developer sentiment) - if configured**
-bird search "QUERY" -n 10
-bird read URL_OR_ID
-Fallback: mcporter call 'exa.web_search_exa(query: "site:twitter.com QUERY")'
+SECURITY: Never use --cookies-from-browser flag (accesses macOS keychain to decrypt all browser cookies)
 
 **RSS Feeds**
-~/.agent-reach-venv/bin/python3 -c "
+python3 -c "
 import feedparser
 feed = feedparser.parse('FEED_URL')
 for e in feed.entries[:5]:
@@ -274,7 +270,6 @@ Channels to prioritize:
 - Reddit for user reviews and complaints (search r/SaaS, relevant subreddits)
 - Exa for deep-web competitive intelligence
 - GitHub for open-source alternatives (stars, activity, issues)
-- Twitter/bird for brand sentiment and user discussions
 
 ---
 
@@ -343,7 +338,6 @@ Channels to prioritize:
 - WebSearch for pricing pages and business model articles
 - Reddit (r/SaaS, r/startups, r/Entrepreneur) for pricing discussions
 - Exa for deep business analysis content
-- Twitter/bird for pricing sentiment
 
 ---
 
@@ -356,7 +350,7 @@ Analyze the existing repo at `{REPO_PATH}`. Deep dive into:
 - Test coverage and testing patterns
 - Current state (open issues, recent PRs, active branches)
 
-This agent does NOT use Agent Reach channels. It uses: Read, Glob, Grep, Bash (for git commands, gh CLI).
+This agent does NOT use internet channels. It uses: Read, Glob, Grep, Bash (for git commands, gh CLI).
 
 ---
 

--- a/modules/deep-research/module.json
+++ b/modules/deep-research/module.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-research",
   "displayName": "Deep Research & Debugging",
-  "description": "/deepresearch (multi-channel research across 15+ platforms using parallel agents) and /debug (structured root-cause debugging with Opus delegation).",
+  "description": "/deepresearch (multi-channel research using parallel agents) and /debug (structured root-cause debugging with Opus delegation).",
   "category": "commands",
   "scope": ["global"],
   "dependencies": [],

--- a/modules/multi-agent/commands/mawf.md
+++ b/modules/multi-agent/commands/mawf.md
@@ -56,7 +56,7 @@ Does this look right? Should I adjust anything before creating these?
 
 Wait for user confirmation before proceeding.
 
-### Phase 2.5: Optional Context Research (Agent Reach)
+### Phase 2.5: Optional Context Research
 
 When feedback references external issues, competitors, or community discussions, verify and enrich with real data before creating issues. This step is **optional** and should only run when feedback explicitly references external context. Skip entirely for purely internal feedback.
 
@@ -70,7 +70,7 @@ When feedback references external issues, competitors, or community discussions,
   gh search issues "{error message or bug description}" --limit 5
   ```
   ```bash
-  curl -s "https://www.reddit.com/search.json?q={error or issue}&limit=3" -H "User-Agent: agent-reach/1.0" | jq '.data.children[].data | {title, url, score}'
+  curl -s "https://www.reddit.com/search.json?q={error or issue}&limit=3" -H "User-Agent: research-agent/1.0" | jq '.data.children[].data | {title, url, score}'
   ```
 
 - **User references a library or tool**: Check its current status

--- a/modules/xplan/commands/xplan.md
+++ b/modules/xplan/commands/xplan.md
@@ -132,7 +132,7 @@ Read the file ~/code/claude-dotfiles/commands/deepresearch.md and follow its ins
 Topic: {concept from Phase 0}
 Arguments: --depth {user's selection from 1.0} --plan-dir ~/code/plans/{concept-name} {--repo REPO_PATH if provided}
 
-Execute the full /deepresearch workflow: parse arguments, spawn parallel research agents with Agent Reach internet access, synthesize findings, and write research.md to the plan directory.
+Execute the full /deepresearch workflow: parse arguments, spawn parallel research agents with internet access, synthesize findings, and write research.md to the plan directory.
 ```
 
 **Important**: Pass the depth selection from 1.0 via the `--depth` flag so /deepresearch skips its own interactive question (prevents double-prompting).
@@ -150,7 +150,7 @@ If research.md does not exist, the research agent failed. Re-spawn it or ask the
 Read the research.md and confirm it contains:
 - Executive Summary
 - Key Insights (with real data, not just LLM knowledge)
-- Sources section with actual URLs (Agent Reach should have populated this)
+- Sources section with actual URLs (research agents should have populated this)
 
 If the Sources section is empty, the research agents did not use internet channels. Note this but proceed.
 


### PR DESCRIPTION
## Summary

Removes all Agent Reach references from CCGM skills and docs. Agent Reach was found to have multiple security issues during an audit:

- **CRITICAL**: `cookie_extract.py` uses `browser_cookie3` to decrypt ALL Chrome cookies via macOS keychain
- **HIGH**: Downloads and executes unverified shell scripts (`curl | bash` from NodeSource)
- **HIGH**: `pip install` from unverified git repos with no version pinning or hash verification
- **MEDIUM**: SKILL.md injection surface - `install`/`doctor` commands write to `~/.claude/skills/`
- **MEDIUM**: 180+ packages in shared venv (735MB) expanding attack surface
- **MEDIUM**: Instructed agents to use `yt-dlp --cookies-from-browser chrome` (keychain access)

## Changes

Research skills now use safe standalone tools directly:
- `yt-dlp` (installed via brew)
- `mcporter` + Exa search (unchanged, already safe)
- `curl` for Jina Reader and Reddit API
- `gh` CLI for GitHub search
- `WebSearch`/`WebFetch` (built-in Claude Code tools)
- `feedparser` via minimal `~/.research-tools-venv/` (32 packages vs 180+)

Removed:
- All "Agent Reach" branding/headers from skill files
- `bird` CLI (Twitter - required cookie auth)
- `~/.agent-reach-venv/` references (paths now use system tools)
- `User-Agent: agent-reach/1.0` headers (replaced with `research-agent/1.0`)

Files updated:
- `modules/deep-research/commands/deepresearch.md`
- `modules/deep-research/module.json`
- `modules/brand-naming/commands/brand.md`
- `modules/brand-naming/commands/brand-check.md`
- `modules/multi-agent/commands/mawf.md`
- `modules/xplan/commands/xplan.md`
- `modules/commands-extra/commands/audit.md`
- `docs/modules.md`
- `docs/commands.md`

Closes #84