### PR TITLE
#90: Fix stale docs after documentation module addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Modular configuration system for [Claude Code](https://docs.anthropic.com/en/doc
 
 ## What is CCGM?
 
-CCGM is a curated collection of 27 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
+CCGM is a curated collection of 28 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
 
 Each module is self-contained with its own README, so you can also [copy individual files manually](#manual-installation) without the installer.
 
@@ -90,7 +90,7 @@ For a quick install with a preset:
 |--------|---------|----------|
 | **minimal** | autonomy, git-workflow | Getting started |
 | **standard** | autonomy, git-workflow, hooks, settings, commands-core, commands-utility | Most users |
-| **full** | All 27 modules | Power users |
+| **full** | All 28 modules | Power users |
 | **team** | standard + github-protocols, code-quality | Teams |
 
 ### Other install options
@@ -118,6 +118,7 @@ For a quick install with a preset:
 | **commands-core** | commands | /commit, /pr, /cpm (commit-PR-merge), /gs (git status), /ghi (create issue) | - |
 | **commands-extra** | commands | /audit (codebase audit), /pwv (Playwright verify), /walkthrough, /promote-rule | - |
 | **commands-utility** | commands | /cgr (clear + checkout + rebase), /cws-submit (Chrome Web Store walkthrough), /dotsync (sync config to CCGM), /user-test (browser user testing) | - |
+| **documentation** | commands | /docupdate (comprehensive documentation audit: README, TOC, onboarding, packages, module coverage) | - |
 | **deep-research** | commands | /deepresearch (multi-channel research across 15+ platforms) and /debug (structured root-cause debugging with Opus) | - |
 | **brand-naming** | commands | /brand (full naming pipeline with word exploration, domain/trademark/app store checks) and /brand-check (single-name deep verification) | - |
 | **github-protocols** | workflow | Issue-first workflow, PR conventions, label taxonomy, code review standards | - |
@@ -226,8 +227,8 @@ The `docs/` directory contains comprehensive documentation:
 | Document | Description |
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
-| [Module Catalog](docs/modules.md) | Detailed reference for all 27 modules |
-| [Commands Reference](docs/commands.md) | All 23 slash commands with usage examples |
+| [Module Catalog](docs/modules.md) | Detailed reference for all 28 modules |
+| [Commands Reference](docs/commands.md) | All 24 slash commands with usage examples |
 | [Hooks Reference](docs/hooks.md) | All 10 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |

--- a/modules/deep-research/README.md
+++ b/modules/deep-research/README.md
@@ -53,5 +53,6 @@ cp commands/debug.md ~/.claude/commands/debug.md
 
 ## Dependencies
 
-- Agent Reach (recommended for `/deepresearch`) - provides `mcporter` CLI for Exa, Reddit, GitHub, YouTube, Twitter channels
+- `mcporter` (optional, for Exa semantic search in `/deepresearch`) - install via npm: `npm install -g mcporter`
+- `yt-dlp` (optional, for YouTube metadata in `/deepresearch`) - install via brew: `brew install yt-dlp`
 - Opus model access (for `/debug` delegation)

--- a/modules/documentation/README.md
+++ b/modules/documentation/README.md
@@ -1,0 +1,42 @@
+# Documentation Update
+
+Provides the `/docupdate` slash command for comprehensive documentation auditing and updating. Works in any codebase type (npm, Cargo, Python, Ruby, Go, monorepo).
+
+## Command
+
+### `/docupdate [--scope <area>] [--dry-run]`
+
+Spawns 4 parallel audit agents to find every gap between your documentation and actual codebase state, then applies targeted surgical fixes.
+
+**What it audits:**
+- README accuracy (packages, features, commands, setup steps, versions, internal links)
+- Table of contents vs actual headings (anchor slugs, order, missing entries)
+- Onboarding/setup flow (prerequisites, env vars, setup steps, documented scripts)
+- Module and feature coverage (source dirs vs docs, undocumented new additions)
+
+**Flags:**
+- `--scope readme|toc|onboarding|all` - Limit to specific audit areas (default: all)
+- `--dry-run` - Print the gap report without making any changes
+
+**Usage:**
+```
+/docupdate                    # Full audit and fix
+/docupdate --dry-run          # Report gaps without making changes
+/docupdate --scope toc        # TOC only
+/docupdate --scope readme     # README only
+```
+
+## Manual Installation
+
+```bash
+cp commands/docupdate.md ~/.claude/commands/docupdate.md
+```
+
+## How It Works
+
+1. **Discover** - Detects project type and finds all documentation files
+2. **Audit** - Runs 4 agents in parallel, each focused on one area
+3. **Report** - Synthesizes findings into Critical / Missing / Stale / TOC / Minor categories
+4. **Confirm** - Asks which fixes to apply
+5. **Fix** - Makes targeted edits matching existing voice and formatting
+6. **Summary** - Lists every file changed and any gaps left for manual review


### PR DESCRIPTION
## Summary

Found by running /docupdate --dry-run on the CCGM repo itself after adding the documentation module in #89.

- Updated module count from 27 to 28 (3 occurrences in README.md)
- Updated slash command count from 23 to 24 (README.md)
- Added `documentation` module row to the Module Catalog table
- Created `modules/documentation/README.md` (was missing, all other modules have one)
- Removed stale Agent Reach reference from `modules/deep-research/README.md` (Agent Reach was removed in #85)

Closes #90