### PR TITLE
#92: Update xplan docs to reflect interactive overhaul

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Instructions for Claude Code when working on the CCGM (Claude Code God Mode) rep
 
 ## What This Repo Is
 
-CCGM is a modular Claude Code configuration system. It contains 27 modules that users can selectively install to configure Claude Code's behavior, hooks, commands, and permissions.
+CCGM is a modular Claude Code configuration system. It contains 28 modules that users can selectively install to configure Claude Code's behavior, hooks, commands, and permissions.
 
 ## Repository Structure
 
@@ -19,7 +19,7 @@ ccgm/
 │   ├── merge.sh        # settings.json merge via jq
 │   ├── modules.sh      # Module discovery + deps
 │   └── backup.sh       # Backup/restore
-├── modules/            # 15 self-contained modules
+├── modules/            # 28 self-contained modules
 │   └── {name}/
 │       ├── module.json # Manifest
 │       ├── README.md   # Module docs

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Modular configuration system for [Claude Code](https://docs.anthropic.com/en/doc
 - [Module Catalog](#module-catalog)
 - [Customization](#customization)
 - [Manual Installation](#manual-installation)
+- [Utilities](#utilities)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
+- [License](#license)
 
 ## What is CCGM?
 
@@ -124,7 +126,7 @@ For a quick install with a preset:
 | **github-protocols** | workflow | Issue-first workflow, PR conventions, label taxonomy, code review standards | - |
 | **session-logging** | workflow | Structured agent session logging with mandatory triggers and startup command | - |
 | **multi-agent** | workflow | Multi-clone parallel agent work with issue claiming, port allocation, /mawf workflow | session-logging |
-| **xplan** | workflow | Deep research + planning + execution framework with parallel agent waves | multi-agent |
+| **xplan** | workflow | Interactive planning framework: discovery interview, deep research, tech stack sign-off, peer review, parallel agent execution | multi-agent |
 | **self-improving** | workflow | Meta-learning: extract experience from tasks, identify patterns, update memory, improve across sessions | - |
 | **subagent-patterns** | workflow | Subagent dispatch: task decomposition, spec-driven delegation, two-stage review, parallel coordination | - |
 | **code-quality** | patterns | Code standards, testing requirements, error handling, security, build verification | - |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -453,25 +453,35 @@ Installed by the **xplan**, **multi-agent**, and **session-logging** modules.
 
 ### /xplan
 
-**Deep research, planning, and execution framework.**
+**Interactive deep research, planning, and execution framework.**
 
-An 8-phase autonomous framework for tackling complex projects, from initial research through implementation.
+A human-in-the-loop planning framework that interviews you upfront, researches your concept deeply, proposes tech stack and architecture for your sign-off, creates a parallelized execution plan, reviews it with specialized agents, and executes via parallel agents.
 
-**Phases**:
-1. **Parse input** - understand the project, create plan directory
-2. **Deep research** - spawn parallel research agents (configurable preset: Full, Technical Only, Lite, Custom)
-3. **Build model** - synthesize research into a contextual understanding
-4. **Create plan** - design parallelized execution plan with epics and dependency waves
-5. **Peer review** - specialized agents review for architecture, security, UX, and feasibility
-6. **Interactive walkthrough** - present plan to user for feedback and decisions
-7. **Execute** - spawn parallel agents for each wave of work
-8. **Complete** - audit results, run retrospective
+**Phases** (interactive mode):
+- **Phase 0** - Parse input, create plan directory
+- **Phase 0.5** - Discovery interview: confirm core concept, choose research depth (Full / Technical Only / Market & Product / Lite / Custom)
+- **Phase 1** - Deep research via parallel specialized agents
+- **Phase 1.5** - Research review: business viability assessment, confirm to proceed
+- **Phase 2** - Naming ideation (optional)
+- **Phase 2.5** - Tech stack sign-off: propose stack, get approval
+- **Phase 2.6** - Scope sign-off: approve epic structure
+- **Phase 2.7** - Multi-agent setup review
+- **Phase 3** - Plan creation with parallelized epics and dependency waves
+- **Phase 4** - Peer review by security, architecture, and business logic agents
+- **Phase 5** - Write plan.md
+- **Phase 6** - Final confirmation gate before execution
+- **Phase 7** - Execute via parallel agents in separate clones
+- **Phase 8** - Verification, audit, and retrospective
 
-This command explicitly overrides autonomy rules - all phases require user confirmation before proceeding.
+**Flags**:
+- `--repo <path>` - Analyze and plan work for an existing repo
+- `--light` - Skip interactive interview phases (Phases 0.5, 1.5, 2.5, 2.6, 2.7); uses minimal clarification + traditional walkthrough instead
 
 **Usage**:
 ```
 /xplan "Build a SaaS dashboard with auth, billing, and analytics"
+/xplan "Add dark mode to my app" --repo ~/code/myapp
+/xplan "Build a CLI tool" --light
 /xplan  # Will ask for project description interactively
 ```
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,6 @@
 # Module Catalog
 
-CCGM contains 27 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
+CCGM contains 28 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
 
 ## How modules work
 
@@ -297,16 +297,21 @@ Deep research, planning, and execution framework for complex projects.
 
 **Installs**: 3 command files
 
-**What it does**: An 8-phase framework for tackling large projects:
+**What it does**: An interactive, human-in-the-loop planning framework:
 
-1. **Parse input** and create plan directory
-2. **Deep research** via parallel specialized agents (market research, technical analysis, competitive review, user research)
-3. **Build contextual model** from research findings
-4. **Create parallelized execution plan** with epics and dependency waves
-5. **Peer review** by specialized agents (architecture, security, UX, feasibility)
-6. **Interactive walkthrough** with the user for feedback and decisions
-7. **Autonomous execution** via parallel agents in separate clones
-8. **Completion audit** and retrospective
+- **Phase 0** - Parse input, create plan directory
+- **Phase 0.5** - Discovery interview: confirm concept, choose research depth
+- **Phase 1** - Deep research via parallel agents (Full / Technical Only / Market & Product / Lite / Custom presets)
+- **Phase 1.5** - Research review with business viability assessment; confirm to proceed
+- **Phase 2** - Naming ideation (optional)
+- **Phase 2.5/2.6/2.7** - Tech stack sign-off, scope sign-off, multi-agent setup review
+- **Phase 3** - Plan creation with parallelized epics and dependency waves
+- **Phase 4** - Peer review by security, architecture, and business logic agents
+- **Phase 5-6** - Write plan.md, final confirmation gate
+- **Phase 7** - Execute via parallel agents in separate clones
+- **Phase 8** - Verification, audit, and retrospective
+
+Use `--light` to skip the interview phases and use a traditional walkthrough instead.
 
 Commands installed:
 

--- a/modules/xplan/README.md
+++ b/modules/xplan/README.md
@@ -1,19 +1,27 @@
 # xplan
 
-Deep research + planning + execution framework for new projects. Spawns parallel research agents, creates comprehensive plans with review, walks the user through interactively, and executes via parallel agent waves.
+Interactive deep research + planning + execution framework for new projects. Interviews you upfront, researches deeply, proposes tech stack and scope for your sign-off, creates a parallelized execution plan with peer review, and executes via parallel agents.
 
 ## What This Module Does
 
-xplan is a comprehensive 8-phase framework for taking a project idea from concept to working code:
+xplan is a human-in-the-loop planning framework with mandatory confirmation gates throughout:
 
-1. **Parse Input & Setup** - Create plan directory, check templates, analyze existing repos
-2. **Deep Research** - Spawn 4-7 parallel research agents covering domain, technical, competitive, UX, data, and business facets
-3. **Naming Ideation** - (Optional) Brainstorm names with domain availability checks
-4. **Plan Review** - Spawn security, architecture, and business logic review agents
-5. **Write Plan** - Comprehensive plan.md with epics, waves, and execution strategy
-6. **Walkthrough** - Interactive section-by-section walkthrough with the user (mandatory)
-7. **Execution** - Create repo, issues, and spawn parallel agents per wave
-8. **Verification & Retrospective** - Full audit, retro, optional template generation
+- **Phase 0** - Parse input, create plan directory
+- **Phase 0.5** - Discovery interview: confirm core concept, choose research depth
+- **Phase 1** - Deep research via parallel agents (configurable preset: Full / Technical Only / Market & Product / Lite / Custom)
+- **Phase 1.5** - Research review with business viability assessment; confirm to proceed
+- **Phase 2** - Naming ideation (optional, with domain availability checks)
+- **Phase 2.5** - Tech stack sign-off: propose stack, get approval
+- **Phase 2.6** - Scope sign-off: approve epic structure and wave breakdown
+- **Phase 2.7** - Multi-agent setup review
+- **Phase 3** - Create parallelized plan with epics and dependency waves
+- **Phase 4** - Peer review by security, architecture, and business logic agents
+- **Phase 5** - Write comprehensive plan.md
+- **Phase 6** - Final confirmation gate before execution
+- **Phase 7** - Create repo, issues, and spawn parallel agents per wave
+- **Phase 8** - Verification, audit, retrospective, optional template generation
+
+**`--light` flag**: Skips Phases 0.5, 1.5, 2.5, 2.6, and 2.7. Uses minimal clarification + traditional section-by-section walkthrough instead of the interview-driven flow. Equivalent to old xplan behavior.
 
 Companion commands:
 - **/xplan-status** - Check progress on a running or completed plan
@@ -55,4 +63,4 @@ Optional: Create a templates directory for reusable plan patterns:
 mkdir -p ~/code/plans/_templates
 ```
 
-After installation, invoke with `/xplan <project concept or idea>` or `/xplan <idea> --repo <existing-repo-path>`.
+After installation, invoke with `/xplan <project concept or idea>`, `/xplan <idea> --repo <existing-repo-path>`, or `/xplan <idea> --light` to skip interactive interview phases.


### PR DESCRIPTION
## Summary

Documentation audit (`/docupdate`) after the xplan interactive overhaul in #88 found that docs hadn't been updated to match.

**xplan docs updated** (`docs/commands.md`, `docs/modules.md`, `modules/xplan/README.md`):
- "8-phase autonomous framework" -> interactive, human-in-the-loop framework with 14 phases (0-8 with sub-phases)
- Full phase list now matches actual command: Phase 0.5 discovery interview, Phase 1.5 research review, Phases 2.5/2.6/2.7 sign-offs, Phase 6 final gate
- `--light` flag documented (skips interview phases, uses traditional walkthrough)
- Research depth presets documented (Full / Technical Only / Market & Product / Lite / Custom)
- UX peer review agent removed (was removed in the overhaul, docs still listed it)
- Usage examples updated with `--light` and `--repo` flags

**Minor fixes:**
- `README.md` xplan catalog row clarifies "interactive" nature
- `README.md` TOC adds missing Utilities and License entries
- `docs/modules.md` module count: 27 -> 28
- `CLAUDE.md` module count: 27 -> 28, directory comment: 15 -> 28

Closes #92