### PR TITLE
#95: Auto-run /docupdate after CCGM PR merge and dotsync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,3 +97,11 @@ bash tests/test-installer.sh
 ## Branch Workflow
 
 Feature branches from main. PRs with squash merge.
+
+## Post-Merge: Always Run /docupdate
+
+**After every PR merge to this repo**, run `/docupdate` before moving on. This keeps module counts, phase lists, command references, and feature descriptions in sync with the actual codebase.
+
+This also applies after running `/dotsync` - if files changed, docupdate catches any documentation drift introduced by the sync.
+
+This is non-negotiable for this repo because the docs describe the modules themselves. A new module without updated counts or a changed command without updated descriptions silently misleads users.

--- a/modules/commands-utility/commands/dotsync.md
+++ b/modules/commands-utility/commands/dotsync.md
@@ -47,3 +47,9 @@ Tell the user:
 - Which files are unmanaged (not tracked by any CCGM module)
 - Whether changes were committed and pushed
 - The current sync status
+
+### 4. Run /docupdate (if files changed)
+
+If any files were synced back to CCGM (step 2 made changes), run `/docupdate` to catch any documentation drift introduced by those changes.
+
+This ensures module counts, command references, and feature descriptions in README, docs/, and module READMEs stay accurate after every sync.


### PR DESCRIPTION
## Summary

Two changes that make `/docupdate` run automatically after every CCGM sync - no manual trigger needed.

**`CLAUDE.md` - Post-merge rule:**
Added an explicit rule that after every PR merge to this repo, `/docupdate` must run before moving on. Includes the rationale (this repo's docs describe the modules themselves, so drift directly misleads users) and covers the dotsync case too.

**`modules/commands-utility/commands/dotsync.md` - Step 4:**
Added a final step to the dotsync workflow: if files were synced back to CCGM, run `/docupdate` to catch any documentation drift the sync introduced.

**How it works:**
- PR merge via /cpm → CLAUDE.md rule fires → agent runs /docupdate automatically
- /dotsync with changes → Step 4 fires → agent runs /docupdate automatically
- No extra infrastructure, no external triggers, no manual reminders needed

Closes #95