### PR TITLE
#97: add /log-init command and delegate logging to Haiku

### DIFF
--- a/modules/session-logging/commands/log-init.md
+++ b/modules/session-logging/commands/log-init.md
@@ -1,0 +1,123 @@
+---
+description: Log initialization - create today's log without full session startup
+allowed-tools: Agent
+---
+
+# /log-init - Log Initialization
+
+Use the Agent tool to execute this workflow on a cheaper model:
+
+- **model**: haiku
+- **description**: log initialization
+
+Pass the agent all workflow instructions below.
+
+After the agent completes, relay its brief status line to the user exactly as received. Then wait for the user's next instruction.
+
+---
+
+## Workflow Instructions
+
+Initialize session logging only. Faster than /startup - no git status, no issue check, no release check.
+
+### 1. Derive Agent Identity
+
+```bash
+# Agent identity from directory name (supports both workspace and flat clone models)
+WC_MATCH=$(basename "$PWD" | grep -oP 'w\d+-c\d+$')
+if [ -n "$WC_MATCH" ]; then
+  AGENT_ID="agent-${WC_MATCH}"
+elif [ -f .env.clone ] && grep -q 'AGENT_ID=' .env.clone 2>/dev/null; then
+  AGENT_ID=$(grep 'AGENT_ID=' .env.clone | cut -d= -f2)
+else
+  AGENT_NUM=$(basename "$PWD" | grep -oE '[0-9]+$' || echo "0")
+  AGENT_ID="agent-${AGENT_NUM}"
+fi
+echo "Agent: ${AGENT_ID}"
+
+# Repo name from git remote
+REPO_NAME=$(git remote get-url origin 2>/dev/null | xargs basename | sed 's/\.git$//')
+echo "Repo: ${REPO_NAME}"
+
+# Today's date
+TODAY=$(date +%Y%m%d)
+echo "Date: ${TODAY}"
+```
+
+### 2. Pull Log Repo
+
+```bash
+LOG_REPO="$HOME/code/{log-repo-name}"
+cd "$LOG_REPO" && git pull --rebase 2>/dev/null | tail -1
+```
+
+Check for today's log file:
+
+```bash
+LOG_DIR="${LOG_REPO}/${REPO_NAME}/${TODAY}"
+LOG_FILE="${LOG_DIR}/${AGENT_ID}.md"
+
+if [ -f "$LOG_FILE" ]; then
+  echo "status:existing"
+else
+  echo "status:new"
+  find "${LOG_REPO}/${REPO_NAME}" -name "${AGENT_ID}.md" -type f | sort | tail -1
+fi
+```
+
+If today's log exists, read it briefly (last 20 lines only) for minimal context. If not, note the most recent log date for reference.
+
+### 3. Freshness Check
+
+```bash
+cd "$LOG_REPO"
+LAST_COMMIT=$(git log -1 --format="%ct" 2>/dev/null || echo "0")
+NOW=$(date +%s)
+DIFF_MINUTES=$(( (NOW - LAST_COMMIT) / 60 ))
+
+if [ "$DIFF_MINUTES" -gt 60 ]; then
+  git add -A
+  if ! git diff --cached --quiet; then
+    git commit -m "${AGENT_ID}: auto-sync" && git pull --rebase && git push
+  fi
+fi
+```
+
+### 4. Create Today's Log (if needed)
+
+**IMPORTANT: Parallel execution safety** - Run `mkdir -p` as its own step, never grouped with git commands in the same parallel call.
+
+```bash
+mkdir -p "$LOG_DIR"
+```
+
+If today's log does not exist, create it:
+
+```markdown
+# {agent-id} - {YYYYMMDD} - {repo-name}
+
+## Session Start
+- **Time**: {HH:MM}
+- **Branch**: `{current-branch}`
+- **State**: {Clean / dirty / in-progress on #XX}
+```
+
+To get current branch:
+```bash
+git branch --show-current
+```
+
+### 5. Output Status
+
+Print exactly one line:
+
+```
+Log: {agent-id} @ {log-file-path} [new | existing]
+```
+
+Example:
+```
+Log: agent-0 @ ~/code/{log-repo-name}/my-repo/20260404/agent-0.md [new]
+```
+
+That is all. No dashboard, no recommendations, no issue list.

--- a/modules/session-logging/commands/startup.md
+++ b/modules/session-logging/commands/startup.md
@@ -1,19 +1,24 @@
 ---
 description: Session startup - check logs, git status, open issues, and orient
-allowed-tools: Bash, Read, Glob, Grep
+allowed-tools: Agent
 ---
 
 # /startup - Session Startup
 
+Use the Agent tool to execute this entire workflow on a cheaper model:
+
+- **model**: haiku
+- **description**: session startup
+
+Pass the agent all workflow instructions below.
+
+After the agent completes, relay its session summary dashboard to the user exactly as received. Then wait for the user's next instruction.
+
+---
+
+## Workflow Instructions
+
 Initialize a new session by checking logs, git status, open issues, and establishing context.
-
-## Input
-
-```
-$ARGUMENTS
-```
-
-## Instructions
 
 ### 1. Derive Agent Identity
 

--- a/modules/session-logging/module.json
+++ b/modules/session-logging/module.json
@@ -9,6 +9,7 @@
     "rules/session-logging.md": { "target": "rules/session-logging.md", "type": "rule", "template": false },
     "log-system.md": { "target": "log-system.md", "type": "doc", "template": false },
     "commands/startup.md": { "target": "commands/startup.md", "type": "command", "template": false },
+    "commands/log-init.md": { "target": "commands/log-init.md", "type": "command", "template": false },
     "hooks/auto-startup.py": { "target": "hooks/auto-startup.py", "type": "hook", "template": false },
     "settings.partial.json": { "target": "settings.json", "type": "config", "merge": true, "template": false }
   },


### PR DESCRIPTION
## Summary

- Adds `/log-init` command: lightweight alternative to `/startup` that only initializes session logging (steps 1-4: identity, pull, freshness check, create log). Delegates to Haiku via Agent tool.
- Updates `/startup` source to use Haiku delegation (matching the installed version that was updated previously but never synced back to source).
- Adds `log-init.md` to `module.json` so it installs with the session-logging module.

## Changes

- `modules/session-logging/commands/log-init.md` - new command
- `modules/session-logging/commands/startup.md` - updated to use `allowed-tools: Agent` + Haiku delegation (was `Bash, Read, Glob, Grep`)
- `modules/session-logging/module.json` - added `log-init.md` entry

## Usage After This PR

After installing/updating with CCGM, users can:
- Run `claude /log-init` for fast log-only initialization (update `ccgm` alias)
- Run `claude /startup` for full 11-step session startup (keep `ccgms` alias)

Both commands delegate their work to Haiku, keeping Opus/Sonnet tokens for actual work.

## Test Plan

- [ ] Run `bash tests/test-modules.sh` - passes (399/399)
- [ ] Run `bash tests/test-no-personal-data.sh` - clean for changed files (pre-existing README.md issue unrelated to this PR)
- [ ] Verify `/log-init` creates today's log via `claude /log-init` in a project directory
- [ ] Verify output is a single status line, not a full dashboard

Closes #97