### PR TITLE
#104: gs - add sibling sessions section

### DIFF
--- a/modules/commands-core/commands/gs.md
+++ b/modules/commands-core/commands/gs.md
@@ -77,6 +77,23 @@ gh pr list --state open --limit 10 2>/dev/null
 
 If any PRs are from the current branch, highlight them.
 
+### 5.5 Sibling Sessions
+
+Check for other Claude Code sessions working in the same repository:
+
+```bash
+python3 ~/.claude/lib/agent_sessions.py --repo "$(git remote get-url origin 2>/dev/null | xargs basename | sed 's/\.git$//')" --exclude-cwd "$PWD" --text 2>/dev/null
+```
+
+If any sessions are found, include them in the dashboard under "Sibling Sessions". If none found, omit this section entirely to keep the output clean.
+
+Dashboard format when siblings exist:
+```
+Sibling Sessions (same repo):
+  agent-w0-c2 | branch: 44-update-onboarding | up: 3h (ttys003)
+  agent-w0-c3 | branch: 45-fix-payments      | up: 45m (ttys009)
+```
+
 ### 6. Uncommitted Changes Summary
 
 If there are uncommitted changes, provide a brief summary:
@@ -120,6 +137,10 @@ Recent Commits:
 
 Open PRs:
   #{number} {title} ({branch})
+  ...
+
+Sibling Sessions (same repo):   <- only if siblings exist
+  {agent_id} | branch: {branch} | up: {uptime} ({tty})
   ...
 
 Changes:


### PR DESCRIPTION
Closes #104

## Changes

Added a 'Sibling Sessions' section (step 5.5) to /gs that shows other live Claude CLI sessions working in the same repository. The section is hidden when no siblings are present to keep the output clean.

- New step 5.5 runs `agent_sessions.py` with `--repo` and `--exclude-cwd` flags
- Filters to same repo only (not all sessions on the machine)
- Dashboard format updated to include the section between Open PRs and Changes
- Section is conditionally omitted when no siblings are found