### PR TITLE
#116: fix stale module counts, team preset, and missing /log-init docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For a quick install with a preset:
 | **minimal** | autonomy, git-workflow | Getting started |
 | **standard** | autonomy, git-workflow, hooks, settings, commands-core, commands-utility | Most users |
 | **full** | All 28 modules | Power users |
-| **team** | standard + github-protocols, code-quality | Teams |
+| **team** | autonomy, git-workflow, hooks, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification | Teams |
 
 ### Other install options
 
@@ -160,7 +160,7 @@ Config files use placeholders that are expanded during installation:
 | `__USERNAME__` | GitHub username | hooks |
 | `__CODE_DIR__` | Code workspace directory | settings |
 | `__LOG_REPO__` | Agent log repo name | session-logging |
-| `__TIMEZONE__` | Your timezone | session-logging |
+| `__TIMEZONE__` | Your timezone | - |
 | `__DEFAULT_MODE__` | Permission mode (ask/dontAsk) | settings |
 
 ## Manual Installation
@@ -230,7 +230,7 @@ The `docs/` directory contains comprehensive documentation:
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
 | [Module Catalog](docs/modules.md) | Detailed reference for all 28 modules |
-| [Commands Reference](docs/commands.md) | All 24 slash commands with usage examples |
+| [Commands Reference](docs/commands.md) | All 25 slash commands with usage examples |
 | [Hooks Reference](docs/hooks.md) | All 10 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -589,3 +589,24 @@ Automatically runs at session start (if auto-startup is enabled) or can be invok
 ```
 
 **Installed by**: session-logging module
+
+---
+
+### /log-init
+
+**Lightweight log initialization.**
+
+Faster alternative to `/startup` - initializes session logging without the full git status check, issue list, or release check. Use when you want a quick log entry at the start of a session without the full dashboard.
+
+**What it does**:
+1. Derives agent identity from directory name
+2. Pulls latest session logs
+3. Creates today's log file if it doesn't exist
+4. Reports log path and any sibling agent sessions
+
+**Usage**:
+```
+/log-init
+```
+
+**Installed by**: session-logging module

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,7 +41,7 @@ The installer offers four presets, or you can select modules one by one:
 | **minimal** | Core autonomy + git workflow rules | Trying CCGM for the first time |
 | **standard** | Minimal + hooks, settings, core commands | Most individual developers |
 | **team** | Standard + github-protocols, code-quality, debugging, verification | Teams with shared repos |
-| **full** | All 25 modules | Power users who want everything |
+| **full** | All 28 modules | Power users who want everything |
 
 See [Presets](presets.md) for detailed breakdowns.
 
@@ -141,7 +141,7 @@ Removes only CCGM-installed files (tracked via a manifest). Your personal files 
 
 ## Next steps
 
-- [Module Catalog](modules.md) - explore all 25 modules in detail
+- [Module Catalog](modules.md) - explore all 28 modules in detail
 - [Commands Reference](commands.md) - learn every slash command
 - [Hooks Reference](hooks.md) - understand the workflow automation
 - [Configuration](configuration.md) - customize CCGM after installation


### PR DESCRIPTION
Closes #116

## Changes

- **`docs/getting-started.md`**: Two references to "25 modules" updated to 28
- **`README.md`**: Team preset row now lists exact modules from `presets/team.json` instead of the inaccurate "standard + github-protocols, code-quality" shorthand
- **`README.md`**: Commands Reference count updated from 24 to 25
- **`README.md`**: `__TIMEZONE__` "Used By" corrected to "-" (variable is defined in template.sh but not currently used by any module file)
- **`docs/commands.md`**: Added `/log-init` section (the 25th command, installed by session-logging module, was missing from the reference)