### PR TITLE
#118: add explicit AskUserQuestion JSON format to xplan command

### DIFF
--- a/modules/xplan/commands/xplan.md
+++ b/modules/xplan/commands/xplan.md
@@ -41,6 +41,28 @@ The orchestrator (this session) stays on the current model for all synthesis, ar
 
 **Preferred**: Use `AskUserQuestion` for structured prompts with options.
 
+**CRITICAL: `AskUserQuestion` parameter format** - The `questions` parameter MUST be a JSON array of objects, never a string. Each object requires `question` (string), `header` (string, max 12 chars), `options` (array of `{label, description}` objects, 2-4 items), and `multiSelect` (boolean). Example:
+
+```json
+{
+  "questions": [
+    {
+      "question": "What level of research should I run?",
+      "header": "Research",
+      "options": [
+        {"label": "Full (Recommended)", "description": "All research agents in parallel"},
+        {"label": "Technical Only", "description": "Technical Architecture + Data & Infrastructure"},
+        {"label": "Lite", "description": "Domain + Technical Architecture only"},
+        {"label": "Custom", "description": "Pick individual research agents"}
+      ],
+      "multiSelect": false
+    }
+  ]
+}
+```
+
+When the pseudo-code below shows `question:` / `options:` blocks, always translate them into this structured format. Never pass a raw string to `questions`.
+
 **Fallback (if AskUserQuestion is blocked)**: Present the same question and options as regular text output, then **STOP and wait for the user to type their response**. Do NOT guess defaults. Do NOT proceed without the user's answer. The user can always respond by typing in the conversation.
 
 Example fallback format:


### PR DESCRIPTION
## Summary

xplan's pseudo-YAML shorthand for `AskUserQuestion` calls (`question: "..."`, `options: - "..."`) is ambiguous enough that the LLM sometimes passes a raw string to the `questions` parameter instead of the required array-of-objects structure, causing:

```
InputValidationError: AskUserQuestion failed due to the following issue:
The parameter `questions` type is expected as `array` but provided as `string`
```

Adds an explicit JSON schema example to the xplan command showing the exact `AskUserQuestion` parameter format, placed in the "How to Ask the User" section so it's seen before any pseudo-code blocks.

Closes #118

## Test Plan

- [ ] Run `/xplan` and verify AskUserQuestion prompts render correctly without InputValidationError