### PR TITLE
#134: Add /deepresearch dependency note to xplan

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For a quick install with a preset:
 | **github-protocols** | workflow | Issue-first workflow, PR conventions, label taxonomy, code review standards | - |
 | **session-logging** | workflow | Structured agent session logging with mandatory triggers and startup command | - |
 | **multi-agent** | workflow | Multi-clone parallel agent work with issue claiming, port allocation, /mawf workflow | session-logging |
-| **xplan** | workflow | Interactive planning framework: discovery interview, deep research, tech stack sign-off, peer review, parallel agent execution | multi-agent |
+| **xplan** | workflow | Interactive planning framework: discovery interview, deep research, tech stack sign-off, peer review, parallel agent execution. Requires [/deepresearch](#companion-module-deepresearch) | multi-agent |
 | **remote-server** | workflow | SSH access to a configured remote server with /onremote command for health checks and remote task execution | - |
 | **self-improving** | workflow | Meta-learning: extract experience from tasks, identify patterns, update memory, improve across sessions | - |
 | **subagent-patterns** | workflow | Subagent dispatch: task decomposition, spec-driven delegation, two-stage review, parallel coordination | - |

--- a/modules/xplan/README.md
+++ b/modules/xplan/README.md
@@ -38,6 +38,21 @@ Companion commands:
 ## Dependencies
 
 - **multi-agent**: Required for parallel agent execution during research, review, and implementation phases
+- **[lem-deepresearch](https://github.com/lucasmccomb/lem-deepresearch)** (companion install): xplan's Phase 1 delegates research to the `/deepresearch` command, which is not part of CCGM - it lives in a standalone repo with its own installer
+
+### /deepresearch - required for research phase
+
+xplan's research phase (Phase 1) spawns an agent that runs `/deepresearch` to produce a comprehensive research.md. Without it, xplan cannot complete its research step.
+
+`/deepresearch` uses a local pipeline - Ollama (qwen2.5:72b) for query generation and fact extraction, SearXNG (self-hosted Docker) for web search, and a single Anthropic API call (Sonnet) for synthesis. It requires Docker, Ollama (~40GB model), and a Python venv, which the installer handles.
+
+```bash
+git clone https://github.com/lucasmccomb/lem-deepresearch.git
+cd lem-deepresearch
+./install.sh
+```
+
+See the [lem-deepresearch README](https://github.com/lucasmccomb/lem-deepresearch) for manual setup, prerequisites, and troubleshooting.
 
 ## Manual Installation
 


### PR DESCRIPTION
## Summary

xplan delegates its research phase (Phase 1) to `/deepresearch`, but this wasn't documented anywhere in the xplan module.

## Changes

- **README.md** (root) - Added "Requires /deepresearch" note to xplan row in module catalog table, linking to the companion module section
- **modules/xplan/README.md** - Added `/deepresearch` as a companion dependency with a section explaining what it is, why xplan needs it, and how to install it

## Test plan

- [x] `test-modules.sh` passes (468/468)
- [x] `test-no-personal-data.sh` passes

Closes #134