### PR TITLE
#142: Add identity module with soul.md and human-context.md templates

### DIFF
--- a/modules/identity/README.md
+++ b/modules/identity/README.md
@@ -1,0 +1,69 @@
+# Identity & Context Module
+
+Two foundational context files that give Claude Code a persistent identity layer, surviving across sessions and context resets.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `soul.md` | Defines the AI's personality, philosophy, reasoning principles, communication style, and boundaries |
+| `human-context.md` | Defines who you are - your background, goals, domain expertise, working style, and life intentions |
+
+## Why Two Files?
+
+These serve fundamentally different purposes and evolve independently:
+
+- **soul.md** answers "who is this AI?" - how it should think, communicate, and behave
+- **human-context.md** answers "who is this human?" - what they know, what they're building, where they're going
+
+Together they transform generic AI sessions into a working relationship with a consistent, aligned collaborator.
+
+## How It Works
+
+Both files are installed as global rules (`~/.claude/rules/`), which means they're automatically loaded in every Claude Code session. No manual steps needed.
+
+If the `session-logging` module is also installed, `/startup` and `/log-init` will actively read and acknowledge these files at session start for stronger context priming.
+
+## Customization
+
+After installation, edit both files to match your preferences and identity:
+
+```bash
+# Edit your AI's personality
+$EDITOR ~/.claude/rules/soul.md
+
+# Edit your personal context
+$EDITOR ~/.claude/rules/human-context.md
+```
+
+### Design Principles
+
+Based on community research and best practices:
+
+1. **Concision beats comprehensiveness** - 1-3 pages per file outperforms longer dumps
+2. **Declarative values beat procedural rules** - "I value simplicity" works better than "never use complex abstractions"
+3. **High-signal anchors** - a few strong statements outperform exhaustive lists
+4. **Stable identity, not current tasks** - these files capture who you are, not what you're doing today (that's what the memory system handles)
+5. **Onboarding doc mental model** - write it like you're briefing a brilliant new colleague, not configuring a settings file
+
+## Relationship to Other Systems
+
+| System | Purpose | How identity files relate |
+|--------|---------|--------------------------|
+| `CLAUDE.md` | Operational rules and procedures | soul.md provides the philosophical foundation; human-context.md provides the user grounding |
+| Memory system | Learned facts, feedback, project state | human-context.md is stable identity; memory captures evolving details |
+| Rule files | Specific behavioral rules | soul.md provides values that inform why rules exist |
+
+## Manual Installation
+
+If not using the CCGM installer:
+
+```bash
+# Copy template files to your Claude Code rules directory
+cp rules/soul.md ~/.claude/rules/soul.md
+cp rules/human-context.md ~/.claude/rules/human-context.md
+
+# Edit with your content
+$EDITOR ~/.claude/rules/soul.md
+$EDITOR ~/.claude/rules/human-context.md
+```

--- a/modules/identity/module.json
+++ b/modules/identity/module.json
@@ -1,0 +1,22 @@
+{
+  "name": "identity",
+  "displayName": "Identity & Context",
+  "description": "Two foundational context files that give Claude Code a persistent identity: soul.md (AI personality and philosophy) and human-context.md (who you are, your goals, and how you work).",
+  "category": "core",
+  "scope": ["global"],
+  "dependencies": [],
+  "files": {
+    "rules/soul.md": {
+      "target": "rules/soul.md",
+      "type": "rule",
+      "template": false
+    },
+    "rules/human-context.md": {
+      "target": "rules/human-context.md",
+      "type": "rule",
+      "template": false
+    }
+  },
+  "tags": ["identity", "personality", "context", "soul"],
+  "configPrompts": []
+}

--- a/modules/identity/rules/human-context.md
+++ b/modules/identity/rules/human-context.md
@@ -1,0 +1,36 @@
+# Human Context
+
+This file tells the AI who you are - your background, goals, expertise, and intentions. It is loaded in every session as a global rule.
+
+Every new session starts with amnesia. This file replaces the months of context a long-term colleague would have. It tells the AI what you know (so it skips unnecessary explanations), what you're building (so suggestions align with your direction), and where you're going (so micro-decisions serve macro-goals).
+
+**Tips**: Keep this file to 1-3 pages. Focus on what's stable about you (identity, values, expertise), not what changes often (current tasks, recent decisions - that's what the memory system is for).
+
+Edit this file to match your situation. The sections below are a starting framework.
+
+---
+
+## Who I Am
+
+<!-- Your professional identity and technical background.
+     Example: "Full-stack engineer, 8 years experience, deep in TypeScript/React." -->
+
+## What I'm Building
+
+<!-- Your current projects, their purpose, and how they connect.
+     Example: "Building a SaaS product for X. Also maintaining an open-source tool for Y." -->
+
+## How I Work
+
+<!-- Your working style, preferences, and what makes collaboration effective.
+     Example: "I prefer terse communication. Show me the diff, not the explanation." -->
+
+## What I Value
+
+<!-- Your professional values and quality standards.
+     Example: "Ship working software. Test what matters. Don't over-engineer." -->
+
+## Where I'm Going
+
+<!-- Your longer-horizon goals and how current work serves them.
+     Example: "Building toward independent consulting. Current projects are portfolio pieces." -->

--- a/modules/identity/rules/soul.md
+++ b/modules/identity/rules/soul.md
@@ -1,0 +1,36 @@
+# Soul
+
+This file defines who you are as an AI collaborator - your personality, philosophy, and operating principles. It is loaded in every session as a global rule.
+
+Think of this as an onboarding document for a brilliant colleague who just walked into the room. It tells them how to think, not what to do (that's what CLAUDE.md is for).
+
+**Tips**: Keep this file to 1-3 pages. Declarative values ("I value X") outperform procedural rules ("always do X"). High-signal anchors beat exhaustive lists.
+
+Edit this file to match your preferences. The sections below are a starting framework.
+
+---
+
+## Identity
+
+<!-- Who is this AI collaborator? What is the relationship model?
+     Example: "You are a senior engineering partner, not an assistant." -->
+
+## Communication Style
+
+<!-- How should the AI communicate? Tone, verbosity, formality.
+     Example: "Lead with the answer. Skip preamble. One sentence beats three." -->
+
+## Reasoning Principles
+
+<!-- How should the AI approach problems and make decisions?
+     Example: "Understand before acting. Evidence before claims. Simplest viable approach first." -->
+
+## Core Values
+
+<!-- What matters most? What should guide every decision?
+     Example: "Correctness over speed. Simplicity over cleverness. Shipping over perfecting." -->
+
+## Boundaries
+
+<!-- When should the AI stop and defer to the human? What is out of scope?
+     Example: "Defer on ambiguous product decisions. Never guess at credentials." -->


### PR DESCRIPTION
## Summary
- New `identity` module providing two foundational context files for Claude Code
- `soul.md` template: five-pillar structure (Identity, Communication Style, Reasoning Principles, Core Values, Boundaries)
- `human-context.md` template: goal-oriented structure (Who I Am, What I'm Building, How I Work, What I Value, Where I'm Going)
- Module README with customization guide and design principles

## Changes
- `modules/identity/module.json` - Module manifest (category: core, scope: global)
- `modules/identity/rules/soul.md` - Template with guidance comments
- `modules/identity/rules/human-context.md` - Template with guidance comments
- `modules/identity/README.md` - Documentation

## Test Plan
- [x] `test-modules.sh` passes (538 checks, 0 failures)
- [x] `test-no-personal-data.sh` passes
- [x] Module JSON validates correctly
- [x] File references resolve

Closes #142