### PR TITLE
#143: Integrate identity files into startup and log-init commands

### DIFF
--- a/modules/session-logging/commands/log-init.md
+++ b/modules/session-logging/commands/log-init.md
@@ -107,6 +107,21 @@ To get current branch:
 git branch --show-current
 ```
 
+### 4.5 Identity Context (Lightweight)
+
+If a soul.md file exists, read it briefly for tone grounding:
+
+```bash
+SOUL_FILE="$HOME/.claude/rules/soul.md"
+if [ -f "$SOUL_FILE" ]; then
+  echo "identity:soul"
+fi
+```
+
+If the file exists, read it using the Read tool. This primes the session with the AI's personality and communication style. If it does not exist, skip silently.
+
+Do NOT read human-context.md here - log-init is meant to be fast and minimal. The full `/startup` command reads both files.
+
 ### 5. Output Status
 
 Check for sibling sessions in the same repo (other live Claude CLI sessions):

--- a/modules/session-logging/commands/startup.md
+++ b/modules/session-logging/commands/startup.md
@@ -287,6 +287,33 @@ else
 fi
 ```
 
+### 8.5 Identity Context
+
+Check for soul.md and human-context.md identity files. If present, read them to prime the session with personality and user context.
+
+```bash
+SOUL_FILE="$HOME/.claude/rules/soul.md"
+CONTEXT_FILE="$HOME/.claude/rules/human-context.md"
+
+IDENTITY_STATUS=""
+if [ -f "$SOUL_FILE" ] && [ -f "$CONTEXT_FILE" ]; then
+  IDENTITY_STATUS="soul.md + human-context.md loaded"
+elif [ -f "$SOUL_FILE" ]; then
+  IDENTITY_STATUS="soul.md loaded (no human-context.md)"
+elif [ -f "$CONTEXT_FILE" ]; then
+  IDENTITY_STATUS="human-context.md loaded (no soul.md)"
+else
+  IDENTITY_STATUS="not configured"
+fi
+echo "Identity: $IDENTITY_STATUS"
+```
+
+If either file exists, read it using the Read tool. These files define:
+- **soul.md** - AI personality, philosophy, reasoning principles, communication style
+- **human-context.md** - User identity, goals, domain knowledge, working preferences
+
+If neither file exists, skip silently. Do not suggest installing them.
+
 ### 9. Present Session Summary
 
 Display a concise dashboard:
@@ -296,6 +323,7 @@ Session: {agent-id} - {repo-name} - {date}
 Branch: {current-branch}
 Status: {clean/dirty}
 Sync: {N ahead, N behind main}
+Identity: {soul.md + human-context.md loaded | not configured}
 
 Previous Session:
   {Summary of last log entry or "No previous session found"}


### PR DESCRIPTION
## Summary
- `/startup` now reads `soul.md` + `human-context.md` from `~/.claude/rules/` at session start
- `/log-init` now reads `soul.md` only (lightweight priming)
- Both skip gracefully if files don't exist
- Dashboard shows `Identity: soul.md + human-context.md loaded` status line

## Changes
- `modules/session-logging/commands/startup.md` - Added step 8.5 (Identity Context)
- `modules/session-logging/commands/log-init.md` - Added step 4.5 (Identity Context - Lightweight)

## Test Plan
- [x] Startup reads both files when present
- [x] Startup skips when files absent (no error, no suggestion to install)
- [x] Log-init reads soul.md only when present
- [x] Log-init skips when absent

Closes #143