### PR TITLE
Fix: prevent identity files from being reverse-synced by ccgm-sync

### DIFF
--- a/modules/identity/module.json
+++ b/modules/identity/module.json
@@ -9,12 +9,12 @@
     "rules/soul.md": {
       "target": "rules/soul.md",
       "type": "rule",
-      "template": false
+      "template": true
     },
     "rules/human-context.md": {
       "target": "rules/human-context.md",
       "type": "rule",
-      "template": false
+      "template": true
     }
   },
   "tags": ["identity", "personality", "context", "soul"],


### PR DESCRIPTION
## Summary
Mark soul.md and human-context.md as `template: true` in module.json so ccgm-sync.sh skips them during reverse-sync.

## Problem
Without this fix, running `/ccgm-sync` would detect the user's personalized soul.md and human-context.md as "drifted" from the templates, and copy the user's private personal content (name, goals, career plans) into the public CCGM repo.

## Fix
The sync script already skips files marked `template: true` (line 73-74 of ccgm-sync.sh). Setting this flag means:
- Install: template files are copied to `~/.claude/rules/` as starting points
- Sync: they're excluded from reverse-sync, so personal content stays local

## Test Plan
- [x] test-modules.sh passes (540 checks)
- [x] Verified ccgm-sync.sh skips template files (line 73-74)