### PR TITLE
#157: remove session name, LOC changes, and cost from statusline

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ cp modules/commands-core/commands/*.md ~/.claude/commands/
 
 ### statusline.sh - Claude Code Session Monitor
 
-Display live session metrics at the bottom of your Claude Code terminal. Shows model, session, directory, git branch, LOC changes, context usage, cost, and rate limits with reset countdowns.
+Display live session metrics at the bottom of your Claude Code terminal. Shows model, directory, git branch, context usage, and rate limits with reset countdowns.
 
 **Usage:**
 
@@ -238,16 +238,13 @@ Or manually add to `~/.claude/settings.json`:
 **Display Example:**
 
 ```
-🧠 O-4.6 | my-session | code main | +42 -7 | ctx:8% | $1.23 | 5h:62% ███░░ 2h26m | 7d:79% ████░ 3d8h
+🧠 O-4.6 | code main | ctx:8% | 5h:62% ███░░ 2h26m | 7d:79% ████░ 3d8h
 ```
 
 **Features:**
 - Model with tier emoji (🧠 Opus, 🐢 Sonnet, ⚠️ Haiku) and abbreviation (O-4.6, S-4.6, H-4.5, etc.)
-- Session name or truncated session ID
 - Current directory and git branch
-- Lines of code added/removed (+N green, -N red)
 - Context window usage (0-100%)
-- Session cost in USD
 - 5-hour rate limit with bar and reset countdown
 - 7-day rate limit with bar and reset countdown
 - Color-coded by usage: green <60%, yellow <85%, red 85%+

--- a/lib/statusline.sh
+++ b/lib/statusline.sh
@@ -1,20 +1,8 @@
 #!/usr/bin/env bash
 # Claude Code status line script
-# Displays: model | session | directory branch | LOC | context usage | cost | 5h & 7d rate limits
+# Displays: model | directory branch | context usage | 5h & 7d rate limits
 
 input=$(cat)
-
-# --- Session ID (first 8 chars) and session name
-session_id=$(echo "$input" | jq -r '.session_id // ""')
-session_name=$(echo "$input" | jq -r '.session_name // ""')
-session_id_short="${session_id:0:8}"
-
-# --- LOC tracking
-lines_added=$(echo "$input" | jq -r '.cost.total_lines_added // 0')
-lines_removed=$(echo "$input" | jq -r '.cost.total_lines_removed // 0')
-
-# --- Cost tracking
-total_cost=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
 
 # --- Model (abbreviated: O-4.6, S-4.6, H-4.5, etc.) with tier indicators
 model_raw=$(echo "$input" | jq -r '.model.display_name // ""')
@@ -97,32 +85,12 @@ if [ -n "$model_abbr" ]; then
   esac
 fi
 
-# Session: name or truncated ID
-if [ -n "$session_name" ]; then
-  sections+=("$(printf "${DIM}%s${RESET}" "$session_name")")
-elif [ -n "$session_id_short" ]; then
-  sections+=("$(printf "${DIM}%s${RESET}" "$session_id_short")")
-fi
-
 # Dir + git branch (combined)
 dir_part="$(printf "${CYAN}%s${RESET}" "$cwd_display")"
 if [ -n "$git_branch" ]; then
   dir_part="${dir_part} $(printf "${YELLOW}%s${RESET}" "$git_branch")"
 fi
 sections+=("$dir_part")
-
-# LOC tracking (+added / -removed)
-if [ "$lines_added" -gt 0 ] || [ "$lines_removed" -gt 0 ]; then
-  loc_part=""
-  if [ "$lines_added" -gt 0 ]; then
-    loc_part="$(printf "${GREEN}+%s${RESET}" "$lines_added")"
-  fi
-  if [ "$lines_removed" -gt 0 ]; then
-    [ -n "$loc_part" ] && loc_part="${loc_part} "
-    loc_part="${loc_part}$(printf "${RED}-%s${RESET}" "$lines_removed")"
-  fi
-  sections+=("$loc_part")
-fi
 
 # Context used (100 - remaining)
 if [ -n "$remaining" ]; then
@@ -136,12 +104,6 @@ if [ -n "$remaining" ]; then
     ctx_color="$RED"
   fi
   sections+=("$(printf "${ctx_color}ctx:${used_int}%%${RESET}")")
-fi
-
-# Session cost
-if [ -n "$total_cost" ] && [ "$total_cost" != "0" ]; then
-  cost_formatted=$(printf '$%.2f' "$total_cost")
-  sections+=("$(printf "${DIM}%s${RESET}" "$cost_formatted")")
 fi
 
 # 5-hour rate limit with bar and reset countdown

--- a/modules/commands-utility/statusline-command.sh
+++ b/modules/commands-utility/statusline-command.sh
@@ -1,20 +1,8 @@
 #!/usr/bin/env bash
 # Claude Code status line script
-# Displays: model | session | directory branch | LOC | context usage | cost | 5h & 7d rate limits
+# Displays: model | directory branch | context usage | 5h & 7d rate limits
 
 input=$(cat)
-
-# --- Session ID (first 8 chars) and session name
-session_id=$(echo "$input" | jq -r '.session_id // ""')
-session_name=$(echo "$input" | jq -r '.session_name // ""')
-session_id_short="${session_id:0:8}"
-
-# --- LOC tracking
-lines_added=$(echo "$input" | jq -r '.cost.total_lines_added // 0')
-lines_removed=$(echo "$input" | jq -r '.cost.total_lines_removed // 0')
-
-# --- Cost tracking
-total_cost=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
 
 # --- Model (abbreviated: O-4.6, S-4.6, H-4.5, etc.) with tier indicators
 model_raw=$(echo "$input" | jq -r '.model.display_name // ""')
@@ -97,32 +85,12 @@ if [ -n "$model_abbr" ]; then
   esac
 fi
 
-# Session: name or truncated ID
-if [ -n "$session_name" ]; then
-  sections+=("$(printf "${DIM}%s${RESET}" "$session_name")")
-elif [ -n "$session_id_short" ]; then
-  sections+=("$(printf "${DIM}%s${RESET}" "$session_id_short")")
-fi
-
 # Dir + git branch (combined)
 dir_part="$(printf "${CYAN}%s${RESET}" "$cwd_display")"
 if [ -n "$git_branch" ]; then
   dir_part="${dir_part} $(printf "${YELLOW}%s${RESET}" "$git_branch")"
 fi
 sections+=("$dir_part")
-
-# LOC tracking (+added / -removed)
-if [ "$lines_added" -gt 0 ] || [ "$lines_removed" -gt 0 ]; then
-  loc_part=""
-  if [ "$lines_added" -gt 0 ]; then
-    loc_part="$(printf "${GREEN}+%s${RESET}" "$lines_added")"
-  fi
-  if [ "$lines_removed" -gt 0 ]; then
-    [ -n "$loc_part" ] && loc_part="${loc_part} "
-    loc_part="${loc_part}$(printf "${RED}-%s${RESET}" "$lines_removed")"
-  fi
-  sections+=("$loc_part")
-fi
 
 # Context used (100 - remaining)
 if [ -n "$remaining" ]; then
@@ -136,12 +104,6 @@ if [ -n "$remaining" ]; then
     ctx_color="$RED"
   fi
   sections+=("$(printf "${ctx_color}ctx:${used_int}%%${RESET}")")
-fi
-
-# Session cost
-if [ -n "$total_cost" ] && [ "$total_cost" != "0" ]; then
-  cost_formatted=$(printf '$%.2f' "$total_cost")
-  sections+=("$(printf "${DIM}%s${RESET}" "$cost_formatted")")
 fi
 
 # 5-hour rate limit with bar and reset countdown


### PR DESCRIPTION
## Summary
- Removed session name/ID, LOC tracking (+N -N), and session cost ($X.XX) from statusline script
- Updated all three copies: lib/statusline.sh, modules/commands-utility/statusline-command.sh, and installed ~/.claude/statusline-command.sh
- Updated README display example and features list

Statusline now shows only: model | directory branch | context % | 5h rate limit | 7d rate limit

Closes #157