### PR TITLE
#161: Detect orphaned test workers at startup

### DIFF
--- a/modules/hooks/hooks/orphan-process-check.py
+++ b/modules/hooks/hooks/orphan-process-check.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Check for orphaned test worker processes (vitest, jest) at session start.
+
+Orphaned workers occur when a Claude Code session exits mid-test-run. The forked
+worker processes get re-parented to PID 1 (launchd) and run indefinitely, consuming
+RAM and CPU.
+
+This hook runs during startup and warns if orphans are found.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+
+def find_orphaned_test_workers():
+    """Find node processes with PPID 1 that look like test workers."""
+    try:
+        result = subprocess.run(
+            ["ps", "-eo", "pid,ppid,rss,command"],
+            capture_output=True, text=True, timeout=5
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+
+    orphans = []
+    for line in result.stdout.strip().split("\n")[1:]:  # skip header
+        parts = line.split(None, 3)
+        if len(parts) < 4:
+            continue
+
+        pid, ppid, rss_kb, command = parts[0], parts[1], parts[2], parts[3]
+
+        # Only orphaned processes (PPID 1)
+        if ppid != "1":
+            continue
+
+        # Only node processes that look like test workers
+        test_patterns = ["vitest", "jest-worker", "jest_worker", "test-worker"]
+        if not any(p in command.lower() for p in test_patterns):
+            continue
+
+        try:
+            orphans.append({
+                "pid": int(pid),
+                "rss_mb": int(rss_kb) / 1024,
+                "command": command[:80]
+            })
+        except ValueError:
+            continue
+
+    return orphans
+
+
+def main():
+    orphans = find_orphaned_test_workers()
+
+    if not orphans:
+        sys.exit(0)
+
+    total_mb = sum(o["rss_mb"] for o in orphans)
+    pids = [str(o["pid"]) for o in orphans]
+
+    # Output warning via hook result
+    msg = (
+        f"WARNING: {len(orphans)} orphaned test worker(s) found "
+        f"({total_mb:.0f} MB RAM). "
+        f"PIDs: {', '.join(pids[:10])}. "
+        f"Run: kill {' '.join(pids[:10])}"
+    )
+
+    print(json.dumps({
+        "decision": "approve",
+        "reason": msg
+    }))
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/hooks/module.json
+++ b/modules/hooks/module.json
@@ -61,6 +61,11 @@
       "type": "hook",
       "template": false
     },
+    "hooks/orphan-process-check.py": {
+      "target": "hooks/orphan-process-check.py",
+      "type": "hook",
+      "template": false
+    },
     "settings.partial.json": {
       "target": "settings.json",
       "type": "config",

--- a/modules/session-logging/commands/startup.md
+++ b/modules/session-logging/commands/startup.md
@@ -314,6 +314,18 @@ If either file exists, read it using the Read tool. These files define:
 
 If neither file exists, skip silently. Do not suggest installing them.
 
+### 8.6 Orphaned Process Check
+
+Check for orphaned test worker processes (vitest, jest) that may be consuming resources:
+
+```bash
+python3 ~/.claude/hooks/orphan-process-check.py 2>/dev/null
+```
+
+If the script outputs a warning, include it in the session dashboard. The warning includes PIDs and a kill command the user can approve.
+
+If the script is not found or produces no output, skip silently.
+
 ### 9. Present Session Summary
 
 Display a concise dashboard:


### PR DESCRIPTION
## Summary
When a Claude Code session exits mid-test-run, vitest/jest worker processes become orphaned (re-parented to PID 1) and run indefinitely. This was discovered when 18 orphaned vitest workers consumed 14GB RAM and 525% CPU.

## Changes
- `hooks/orphan-process-check.py` - Detects orphaned node test workers (PPID 1, matching vitest/jest patterns). Outputs a warning with PIDs and a kill command.
- `startup.md` - Added step 8.6 that runs the orphan check and surfaces warnings in the session dashboard.
- `hooks/module.json` - Registered the new hook file.

## How it works
1. At `/startup`, the script scans for node processes with PPID 1 that match test worker patterns
2. If found, the dashboard shows: `WARNING: N orphaned test worker(s) found (X MB RAM). PIDs: ... Run: kill ...`
3. User can approve the kill command

## Test Plan
- [x] Script returns no output when no orphans exist
- [x] test-modules.sh passes (563 checks)
- [x] test-no-personal-data.sh passes

Closes #161