### PR TITLE
#176: upgrade command agent models from haiku to sonnet

### DIFF
--- a/modules/commands-core/commands/commit.md
+++ b/modules/commands-core/commands/commit.md
@@ -7,7 +7,7 @@ allowed-tools: Agent
 
 Use the Agent tool to execute this entire workflow on a cheaper model:
 
-- **model**: haiku
+- **model**: sonnet
 - **description**: commit workflow
 
 Pass the agent all workflow instructions below. Include the received arguments: `$ARGUMENTS`

--- a/modules/commands-core/commands/cpm.md
+++ b/modules/commands-core/commands/cpm.md
@@ -7,7 +7,7 @@ allowed-tools: Agent
 
 Use the Agent tool to execute this entire workflow on a cheaper model:
 
-- **model**: haiku
+- **model**: sonnet
 - **description**: cpm git workflow
 
 Pass the agent all workflow instructions below. Include the received arguments: `$ARGUMENTS`

--- a/modules/commands-core/commands/gs.md
+++ b/modules/commands-core/commands/gs.md
@@ -7,7 +7,7 @@ allowed-tools: Agent
 
 Use the Agent tool to execute this entire workflow on a cheaper model:
 
-- **model**: haiku
+- **model**: sonnet
 - **description**: git status dashboard
 
 Pass the agent all workflow instructions below. Include the received arguments: `$ARGUMENTS`

--- a/modules/commands-core/commands/pr.md
+++ b/modules/commands-core/commands/pr.md
@@ -7,7 +7,7 @@ allowed-tools: Agent
 
 Use the Agent tool to execute this entire workflow on a cheaper model:
 
-- **model**: haiku
+- **model**: sonnet
 - **description**: push and create PR
 
 Pass the agent all workflow instructions below. Include the received arguments: `$ARGUMENTS`

--- a/modules/commands-utility/commands/ccgm-sync.md
+++ b/modules/commands-utility/commands/ccgm-sync.md
@@ -7,7 +7,7 @@ allowed-tools: Agent
 
 Use the Agent tool to execute this entire workflow on a cheaper model:
 
-- **model**: haiku
+- **model**: sonnet
 - **description**: ccgm-sync
 
 Pass the agent all workflow instructions below.

--- a/modules/multi-agent/commands/workspace-setup.md
+++ b/modules/multi-agent/commands/workspace-setup.md
@@ -7,7 +7,7 @@ allowed-tools: Agent
 
 Use the Agent tool to execute this workflow on a cheaper model:
 
-- **model**: haiku
+- **model**: sonnet
 - **description**: workspace setup
 
 Pass the agent all workflow instructions below. Include the received arguments: `$ARGUMENTS`

--- a/modules/xplan/commands/xplan-status.md
+++ b/modules/xplan/commands/xplan-status.md
@@ -8,7 +8,7 @@ argument-hint: [plan-name]
 
 Use the Agent tool to execute this workflow on a cheaper model:
 
-- **model**: haiku
+- **model**: sonnet
 - **description**: xplan status check
 
 Pass the agent all workflow instructions below. Include the received arguments: `$ARGUMENTS`


### PR DESCRIPTION
## Summary

Upgrade 7 command agent models from haiku to sonnet for reliability. Haiku fails under heavy context load (~10k+ tokens from CLAUDE.md rules), producing meta-commentary instead of formatted output.

Commands upgraded: `/gs`, `/xplan-status`, `/cpm`, `/pr`, `/commit`, `/ccgm-sync`, `/workspace-setup`
Commands remaining on haiku: `/log-init`, `/ghi`, `/onremote` (simple, mechanical tasks)

## Test Plan

- [x] All 568 module tests pass
- [x] No personal data leaks
- [x] Verified final model state across all commands

Closes #176