### PR TITLE
#184: update docs for copycat module and orphan-process-check hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Modular configuration system for [Claude Code](https://docs.anthropic.com/en/doc
 
 ## What is CCGM?
 
-CCGM is a curated collection of 35 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
+CCGM is a curated collection of 36 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
 
 Each module is self-contained with its own README, so you can also [copy individual files manually](#manual-installation) without the installer.
 
@@ -93,7 +93,7 @@ For a quick install with a preset:
 |--------|---------|----------|
 | **minimal** | global-claude-md, autonomy, git-workflow | Getting started |
 | **standard** | global-claude-md, autonomy, identity, git-workflow, hooks, settings, commands-core, commands-utility | Most users |
-| **full** | All 35 modules | Power users |
+| **full** | All 36 modules | Power users |
 | **team** | global-claude-md, autonomy, git-workflow, hooks, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification | Teams |
 
 ### Other install options
@@ -124,6 +124,7 @@ For a quick install with a preset:
 | **commands-extra** | commands | /audit (codebase audit), /pwv (Playwright verify), /walkthrough, /promote-rule | - |
 | **commands-utility** | commands | /cws-submit (Chrome Web Store walkthrough), /ccgm-sync (sync config to CCGM + lem-deepresearch), /user-test (browser user testing) | - |
 | **documentation** | commands | /docupdate (comprehensive documentation audit: README, TOC, onboarding, packages, module coverage) | - |
+| **copycat** | commands | /copycat (analyze external Claude Code config repos for CCGM improvements) | - |
 | **debugging** | commands | /debug (structured root-cause debugging with Opus) | - |
 | **brand-naming** | commands | /brand (full naming pipeline with word exploration, domain/trademark/app store checks) and /brand-check (single-name deep verification) | - |
 | **editorial-critique** | commands | /editorial-critique - 8-pass editorial review of long-form writing: prose craft, AI-tell detection, argument, conciseness, accuracy, structure, impact, grammar. Scored report with auto-fix | - |
@@ -257,9 +258,9 @@ The `docs/` directory contains comprehensive documentation:
 | Document | Description |
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
-| [Module Catalog](docs/modules.md) | Detailed reference for all 35 modules |
-| [Commands Reference](docs/commands.md) | All 27 slash commands with usage examples |
-| [Hooks Reference](docs/hooks.md) | All 12 hooks explained - what they do and when they fire |
+| [Module Catalog](docs/modules.md) | Detailed reference for all 36 modules |
+| [Commands Reference](docs/commands.md) | All 28 slash commands with usage examples |
+| [Hooks Reference](docs/hooks.md) | All 13 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |
 | [Configuration](docs/configuration.md) | Customization, template variables, settings overrides |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -442,6 +442,35 @@ Performs thorough availability checking for one or more specific names.
 
 ---
 
+## Copycat commands
+
+Installed by the **copycat** module.
+
+---
+
+### /copycat
+
+**Analyze external Claude Code config repos for CCGM improvements.**
+
+Clones or reads an external Claude Code configuration repo and identifies patterns, rules, commands, and techniques worth incorporating into CCGM.
+
+**Phases**:
+1. **Acquire**: Clone from GitHub URL or read from local path
+2. **Discover**: Map all config files (CLAUDE.md, rules, commands, hooks, settings, MCP)
+3. **Analyze**: 4 parallel agents examine rules, commands, hooks/settings, and architecture patterns
+4. **Rank**: Score findings by impact (1-5) and effort (1-5), sort into priority groups
+5. **Walkthrough**: Present findings interactively, group by group (High Priority, Quick Wins, Worth Considering)
+6. **Implement**: Create GitHub issues for approved findings
+
+**Usage**:
+```
+/copycat owner/repo
+/copycat https://github.com/someone/claude-config
+/copycat ~/code/some-local-repo
+```
+
+---
+
 ## Self-improving commands
 
 Installed by the **self-improving** module.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -18,7 +18,7 @@ Hooks are registered in `settings.json` under the `hooks` key. Each hook specifi
 
 ## Installed hooks
 
-The **hooks** module installs 9 hooks, 2 Python libraries, and a settings partial. The **session-logging** module installs 1 additional hook. The **self-improving** module installs 2 additional hooks. Total: 12 hooks across 3 modules.
+The **hooks** module installs 10 hooks, 2 Python libraries, and a settings partial. The **session-logging** module installs 1 additional hook. The **self-improving** module installs 2 additional hooks. Total: 13 hooks across 3 modules.
 
 ---
 
@@ -195,6 +195,24 @@ Validates Supabase migration file timestamps before a commit is created, prevent
 **Why this matters**: Duplicate migration timestamps cause `supabase db push` to get confused - the CLI cannot distinguish the files and one gets permanently stuck as "local only." Catching this before commit prevents hard-to-debug migration state issues.
 
 **Resolution**: When a duplicate is detected, rename one file to a unique timestamp (increment by 1 second) before committing.
+
+---
+
+### orphan-process-check.py
+
+**Type**: SessionStart
+**Module**: hooks
+**Can block**: No (warning only)
+
+Detects orphaned test worker processes (vitest, jest) left behind when a previous Claude Code session exited mid-test-run.
+
+**How it works**:
+1. Scans running processes for node processes with PPID 1 (re-parented to launchd/init)
+2. Filters for test worker patterns: vitest, jest-worker, jest_worker, test-worker
+3. If orphans are found, reports their PIDs and total RAM usage
+4. Suggests a `kill` command to clean them up
+
+**Why this matters**: Orphaned test workers run indefinitely after a session crash, consuming RAM and CPU. They accumulate over time and can slow down the machine. Catching them at session start prevents resource waste.
 
 ---
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,6 @@
 # Module Catalog
 
-CCGM contains 35 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
+CCGM contains 36 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
 
 ## How modules work
 
@@ -310,6 +310,22 @@ Structured root-cause debugging with Opus delegation.
 **What it does**: Enforces a disciplined debugging workflow (reproduce, hypothesize, instrument, diagnose, fix, verify) using Opus for deep root-cause analysis. Invoked automatically by the `systematic-debugging` module's routing rule.
 
 For `/deepresearch`, see [lem-deepresearch](https://github.com/lucasmccomb/lem-deepresearch) (installed separately).
+
+**Dependencies**: None
+
+---
+
+### copycat
+
+Analyze external Claude Code configuration repos to find useful patterns worth adopting into CCGM.
+
+**Installs**: 1 command file
+
+| Command | Description |
+|---------|-------------|
+| `/copycat` | Analyze an external Claude Code config repo and walk through what's worth incorporating into CCGM |
+
+**What it does**: Accepts a GitHub URL or local path to any Claude Code config repo. Clones/reads the repo, spawns 4 parallel analysis agents (rules, commands, hooks/settings, architecture patterns), compares each finding against CCGM's existing modules, ranks by impact and effort, and walks you through findings interactively. Creates GitHub issues for approved improvements.
 
 **Dependencies**: None
 


### PR DESCRIPTION
Closes #184 (docupdate follow-up)

## Summary

Post-merge documentation update after adding the copycat module.

## Changes

- **README.md**: Updated module count (35 -> 36), command count (27 -> 28), hook count (12 -> 13), added copycat to module catalog table
- **docs/modules.md**: Updated module count, added copycat entry in commands category
- **docs/commands.md**: Added /copycat command section with usage examples
- **docs/hooks.md**: Updated hook count (12 -> 13), added orphan-process-check.py documentation (was previously undocumented)

## Test plan

- [x] `test-modules.sh` - 584 passed, 0 failed
- [x] `test-no-personal-data.sh` - PASS