### PR TITLE
#189: update docs for test-vision module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Modular configuration system for [Claude Code](https://docs.anthropic.com/en/doc
 
 ## What is CCGM?
 
-CCGM is a curated collection of 36 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
+CCGM is a curated collection of 37 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
 
 Each module is self-contained with its own README, so you can also [copy individual files manually](#manual-installation) without the installer.
 
@@ -93,7 +93,7 @@ For a quick install with a preset:
 |--------|---------|----------|
 | **minimal** | global-claude-md, autonomy, git-workflow | Getting started |
 | **standard** | global-claude-md, autonomy, identity, git-workflow, hooks, settings, commands-core, commands-utility | Most users |
-| **full** | All 36 modules | Power users |
+| **full** | All 37 modules | Power users |
 | **team** | global-claude-md, autonomy, git-workflow, hooks, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification | Teams |
 
 ### Other install options
@@ -134,6 +134,7 @@ For a quick install with a preset:
 | **github-protocols** | workflow | Issue-first workflow, PR conventions, label taxonomy, code review standards | - |
 | **session-logging** | workflow | Structured agent session logging with mandatory triggers and startup command | - |
 | **multi-agent** | workflow | Multi-clone parallel agent work with issue claiming, port allocation, /mawf workflow | session-logging |
+| **test-vision** | workflow | Vision-driven e2e test suite generation. /test-vision for full repo analysis + parallel test suite creation. /e2e for single-feature spec generation | browser-automation, multi-agent |
 | **xplan** | workflow | Interactive planning framework: discovery interview, deep research, tech stack sign-off, peer review, parallel agent execution. Requires [/deepresearch](#companion-module-deepresearch) | multi-agent |
 | **remote-server** | workflow | SSH access to a configured remote server with /onremote command for health checks and remote task execution | - |
 | **self-improving** | workflow | Meta-learning system: /reflect and /consolidate commands, PostToolUse hook (PR merge/issue close reminders), PreCompact hook (pre-compaction capture), prescriptive reflection triggers | - |
@@ -258,8 +259,8 @@ The `docs/` directory contains comprehensive documentation:
 | Document | Description |
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
-| [Module Catalog](docs/modules.md) | Detailed reference for all 36 modules |
-| [Commands Reference](docs/commands.md) | All 28 slash commands with usage examples |
+| [Module Catalog](docs/modules.md) | Detailed reference for all 37 modules |
+| [Commands Reference](docs/commands.md) | All 30 slash commands with usage examples |
 | [Hooks Reference](docs/hooks.md) | All 13 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -471,6 +471,71 @@ Clones or reads an external Claude Code configuration repo and identifies patter
 
 ---
 
+## Test Vision commands
+
+Installed by the **test-vision** module.
+
+---
+
+### /test-vision
+
+**Comprehensive e2e test suite generation.**
+
+Discovers all features in a codebase, interviews the user to validate test cases, generates Playwright infrastructure, dispatches parallel `/e2e` agents, and produces a complete test suite with CI/CD integration.
+
+**Phases**:
+1. **Phase 0** - Codebase discovery (7-source checklist: routes, nav, README, API, tests, stores, forms)
+2. **Phase 1** - Chrome MCP visual discovery (explore running app, identify interactive elements)
+3. **Phase 2** - User interview (validate feature domains, prioritize, confirm auth setup, review delegation)
+4. **Phase 3** - Infrastructure generation (playwright.config.ts, fixtures.ts, auth.setup.ts)
+5. **Phase 4** - Parallel /e2e dispatch (one agent per feature domain, pre-assigned file paths)
+6. **Phase 5** - Integration and validation (test discovery, import paths, duplicates, smoke check)
+7. **Phase 6** - CI/CD workflow generation (GitHub Actions)
+8. **Phase 7** - Summary report
+
+**Flags**:
+- `--skip-chrome` - Skip Chrome MCP visual discovery (code-based only)
+- `--skip-interview` - Use auto-detected defaults without interview
+
+**Usage**:
+```
+/test-vision
+/test-vision --skip-chrome
+/test-vision --skip-interview
+```
+
+**Installed by**: test-vision module
+
+---
+
+### /e2e
+
+**Generate a Playwright e2e spec for a single feature.**
+
+Generates a complete Playwright spec file for one feature, flow, or GitHub issue. Works standalone or as the atomic building block within `/test-vision`.
+
+**Modes**:
+- **Standalone** - Called directly. Runs its own discovery, Chrome MCP exploration, infrastructure setup, and spec generation.
+- **Composed** - Called by `/test-vision`. Receives pre-computed context and skips discovery.
+
+**What it generates**:
+- Three-tier assertions: route loads, structural landmarks, behavioral interactions
+- Direct locators (getByRole, getByText, getByTestId)
+- Graceful credential skipping via auth fixtures
+- Auth provider detection (Better Auth, Supabase, Clerk)
+
+**Usage**:
+```
+/e2e authentication
+/e2e #42
+/e2e /dashboard/settings
+/e2e payments --file e2e/features/payments.spec.ts
+```
+
+**Installed by**: test-vision module
+
+---
+
 ## Self-improving commands
 
 Installed by the **self-improving** module.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,6 @@
 # Module Catalog
 
-CCGM contains 36 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
+CCGM contains 37 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
 
 ## How modules work
 
@@ -432,6 +432,30 @@ Commands installed:
 | `/xplan-resume` | Resume an interrupted plan execution |
 
 **Dependencies**: multi-agent (which depends on session-logging)
+
+---
+
+### test-vision
+
+Vision-driven e2e test suite generation using multi-agent orchestration.
+
+**Installs**: 2 command files
+
+**What it does**: Provides two composable commands for generating comprehensive Playwright e2e test suites:
+
+- **`/test-vision`** - Full repo orchestrator: discovers all features via 7-source checklist + Chrome MCP visual exploration, interviews the user to validate test cases and priorities, generates shared Playwright infrastructure (config, fixtures, auth setup by provider), dispatches parallel `/e2e` agents per feature domain, validates the suite, and generates a CI/CD workflow.
+- **`/e2e`** - Atomic spec generator: generates a single Playwright spec file for a feature, flow, or issue. Works standalone (with its own discovery) or as a building block within `/test-vision`. Supports three-tier assertions for unbuilt features (route loads, structural landmarks, behavioral interactions).
+
+Key design: `/test-vision` composes `/e2e` as its atomic unit. File paths are pre-assigned before dispatch to prevent merge conflicts. Infrastructure is generated before agents are spawned.
+
+Commands installed:
+
+| Command | Description |
+|---------|-------------|
+| `/test-vision` | Full repo e2e test suite generation with parallel agents |
+| `/e2e` | Single-feature Playwright spec generation |
+
+**Dependencies**: browser-automation, multi-agent
 
 ---
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -46,7 +46,7 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 **Best for**: Power users who want the complete CCGM experience, including multi-agent coordination, brand research, and tech-specific guides.
 
-**Modules (35)**: All modules.
+**Modules (37)**: All modules.
 
 **What you get**: The full suite. Includes multi-agent workflows, planning frameworks, tech-specific patterns (Cloudflare, Supabase, Tailwind, shadcn, MCP development), and specialized commands.
 


### PR DESCRIPTION
## Summary

Documentation updates after merging the test-vision module (#186/#188).

- README.md: module count 36->37, commands count 28->30, added test-vision to catalog table, updated full preset count
- docs/modules.md: module count 36->37, added full test-vision entry with description and command table
- docs/commands.md: added /test-vision and /e2e entries under new "Test Vision commands" section
- docs/presets.md: full preset count 35->37

Closes #189