### PR TITLE
#191: add GitHub Sponsors FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [lucasmccomb]


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` pointing to `lucasmccomb` GitHub Sponsors profile
- Enables the Sponsor button on the repo

Closes #191