### PR TITLE
#195: update docs for atdd module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Modular configuration system for [Claude Code](https://docs.anthropic.com/en/doc
 
 ## What is CCGM?
 
-CCGM is a curated collection of 37 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
+CCGM is a curated collection of 38 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
 
 Each module is self-contained with its own README, so you can also [copy individual files manually](#manual-installation) without the installer.
 
@@ -93,7 +93,7 @@ For a quick install with a preset:
 |--------|---------|----------|
 | **minimal** | global-claude-md, autonomy, git-workflow | Getting started |
 | **standard** | global-claude-md, autonomy, identity, git-workflow, hooks, settings, commands-core, commands-utility | Most users |
-| **full** | All 37 modules | Power users |
+| **full** | All 38 modules | Power users |
 | **team** | global-claude-md, autonomy, git-workflow, hooks, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification | Teams |
 
 ### Other install options
@@ -134,6 +134,7 @@ For a quick install with a preset:
 | **github-protocols** | workflow | Issue-first workflow, PR conventions, label taxonomy, code review standards | - |
 | **session-logging** | workflow | Structured agent session logging with mandatory triggers and startup command | - |
 | **multi-agent** | workflow | Multi-clone parallel agent work with issue claiming, port allocation, /mawf workflow | session-logging |
+| **atdd** | workflow | Agentic Test-Driven Development. /atdd reads Playwright vision specs, iteratively builds app code until all tests pass, then ships | - |
 | **test-vision** | workflow | Vision-driven e2e test suite generation. /test-vision for full repo analysis + parallel test suite creation. /e2e for single-feature spec generation | browser-automation, multi-agent |
 | **xplan** | workflow | Interactive planning framework: discovery interview, deep research, tech stack sign-off, peer review, parallel agent execution. Requires [/deepresearch](#companion-module-deepresearch) | multi-agent |
 | **remote-server** | workflow | SSH access to a configured remote server with /onremote command for health checks and remote task execution | - |
@@ -259,8 +260,8 @@ The `docs/` directory contains comprehensive documentation:
 | Document | Description |
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
-| [Module Catalog](docs/modules.md) | Detailed reference for all 37 modules |
-| [Commands Reference](docs/commands.md) | All 30 slash commands with usage examples |
+| [Module Catalog](docs/modules.md) | Detailed reference for all 38 modules |
+| [Commands Reference](docs/commands.md) | All 31 slash commands with usage examples |
 | [Hooks Reference](docs/hooks.md) | All 13 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -471,6 +471,38 @@ Clones or reads an external Claude Code configuration repo and identifies patter
 
 ---
 
+## ATDD commands
+
+Installed by the **atdd** module.
+
+---
+
+### /atdd
+
+**Build app code to pass E2E vision specs.**
+
+Reads Playwright vision specs from `e2e/tests/{feature}/`, iteratively builds app code until all tests pass, then ships.
+
+**Phases**:
+1. **Orient** - Read all spec files, establish baseline (X/Y tests passing), create issue and branch
+2. **Red-Green Loop** - Systematically work through failing tests: read test, implement minimum code, re-run, commit incrementally
+3. **Verify** - Run lint, type-check, unit tests
+4. **Ship** - Push and create PR with baseline/final results
+
+**The ATDD contract**: specs are immutable (never modify test files), mocks define the API contract, UI assertions define the design spec.
+
+**Usage**:
+```
+/atdd habits
+/atdd habits --issue 178
+/atdd coaching --issue 180
+/atdd "principles journal" --issue 181
+```
+
+**Installed by**: atdd module
+
+---
+
 ## Test Vision commands
 
 Installed by the **test-vision** module.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,6 @@
 # Module Catalog
 
-CCGM contains 37 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
+CCGM contains 38 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
 
 ## How modules work
 
@@ -432,6 +432,31 @@ Commands installed:
 | `/xplan-resume` | Resume an interrupted plan execution |
 
 **Dependencies**: multi-agent (which depends on session-logging)
+
+---
+
+### atdd
+
+Agentic Test-Driven Development - build app code to pass E2E vision specs.
+
+**Installs**: 1 command file, 1 rule file
+
+**What it does**: Provides a spec-driven development workflow where E2E vision specs (Playwright tests) define target behavior and agents iteratively build app code until all specs pass. The `/atdd` command runs a 4-phase workflow:
+
+- **Phase 1 (Orient)**: Read all spec files, establish baseline (X/Y tests passing), create branch
+- **Phase 2 (Red-Green Loop)**: Systematically work through failing tests - read each test, implement the minimum app code to make it pass, commit incrementally
+- **Phase 3 (Verify)**: Run lint, type-check, and unit tests to ensure clean code
+- **Phase 4 (Ship)**: Push and create PR with baseline/final results
+
+The ATDD contract: specs are immutable (never modify test files), mocks define the API contract, UI assertions define the design spec.
+
+Commands installed:
+
+| Command | Description |
+|---------|-------------|
+| `/atdd` | Build app code to pass vision specs in `e2e/tests/{feature}/` |
+
+**Dependencies**: None
 
 ---
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -46,7 +46,7 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 **Best for**: Power users who want the complete CCGM experience, including multi-agent coordination, brand research, and tech-specific guides.
 
-**Modules (37)**: All modules.
+**Modules (38)**: All modules.
 
 **What you get**: The full suite. Includes multi-agent workflows, planning frameworks, tech-specific patterns (Cloudflare, Supabase, Tailwind, shadcn, MCP development), and specialized commands.
 


### PR DESCRIPTION
## Summary

Documentation updates after merging the atdd module (#193/#194).

- README.md: module count 37->38, commands count 30->31, added atdd to catalog, updated full preset count
- docs/modules.md: module count 37->38, added atdd entry with full description
- docs/commands.md: added /atdd entry under new "ATDD commands" section
- docs/presets.md: full preset count 37->38

Closes #195