### PR TITLE
#200: implement shared types, config persistence, and session management

### DIFF
--- a/modules/agent-manager/src/internal/agent/health.go
+++ b/modules/agent-manager/src/internal/agent/health.go
@@ -1,3 +1,3 @@
 // health.go implements liveness checks for running agents.
-// Epic 2 will implement periodic health polling (process alive, responsive).
+// Health polling will be implemented in Epic 3.
 package agent

--- a/modules/agent-manager/src/internal/agent/manager.go
+++ b/modules/agent-manager/src/internal/agent/manager.go
@@ -1,4 +1,102 @@
 // Package agent provides process lifecycle management for Claude Code agents.
-// manager.go orchestrates discovery, launch, restart, and shutdown of agents.
-// Epic 2 will implement the Manager type and its Watch/Kill/Restart methods.
+// manager.go handles config persistence (CRUD). Process management lives in
+// process.go and will be implemented in a later epic.
 package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/fileutil"
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/types"
+)
+
+// agentsDir returns the path to the agents config directory within dataDir.
+func agentsDir(dataDir string) string {
+	return filepath.Join(dataDir, "agents")
+}
+
+// agentPath returns the JSON file path for a given agentID within dataDir.
+// The caller must validate agentID before calling this function.
+func agentPath(dataDir, agentID string) string {
+	return filepath.Join(agentsDir(dataDir), agentID+".json")
+}
+
+// LoadAgentConfig reads and returns the AgentConfig for agentID from dataDir.
+// Returns os.ErrNotExist (wrapped) if the agent does not exist.
+func LoadAgentConfig(dataDir, agentID string) (*types.AgentConfig, error) {
+	if err := types.ValidateID(agentID); err != nil {
+		return nil, fmt.Errorf("load agent config: %w", err)
+	}
+	path := agentPath(dataDir, agentID)
+	var cfg types.AgentConfig
+	if err := fileutil.ReadJSON(path, &cfg); err != nil {
+		return nil, fmt.Errorf("load agent config %s: %w", agentID, err)
+	}
+	return &cfg, nil
+}
+
+// SaveAgentConfig persists cfg to dataDir/agents/<cfg.ID>.json using an atomic
+// write with 0600 permissions. cfg.Validate() must pass before saving.
+func SaveAgentConfig(dataDir string, cfg *types.AgentConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("save agent config: %w", err)
+	}
+	dir := agentsDir(dataDir)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("save agent config: create agents dir: %w", err)
+	}
+	path := agentPath(dataDir, cfg.ID)
+	if err := fileutil.AtomicWriteJSON(path, cfg, 0600); err != nil {
+		return fmt.Errorf("save agent config %s: %w", cfg.ID, err)
+	}
+	return nil
+}
+
+// DeleteAgentConfig removes the persisted config for agentID from dataDir.
+// Returns nil if the file does not exist (idempotent delete).
+func DeleteAgentConfig(dataDir, agentID string) error {
+	if err := types.ValidateID(agentID); err != nil {
+		return fmt.Errorf("delete agent config: %w", err)
+	}
+	path := agentPath(dataDir, agentID)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("delete agent config %s: %w", agentID, err)
+	}
+	return nil
+}
+
+// ListAgentConfigs returns all AgentConfigs persisted in dataDir/agents/.
+// The order of results is not guaranteed.
+func ListAgentConfigs(dataDir string) ([]*types.AgentConfig, error) {
+	dir := agentsDir(dataDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list agent configs: %w", err)
+	}
+
+	var configs []*types.AgentConfig
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		id := fileutil.Basename(entry.Name())
+		// Skip files whose names are not valid IDs (e.g. stray .tmp files).
+		if err := types.ValidateID(id); err != nil {
+			continue
+		}
+		cfg, err := LoadAgentConfig(dataDir, id)
+		if err != nil {
+			return nil, fmt.Errorf("list agent configs: %w", err)
+		}
+		configs = append(configs, cfg)
+	}
+	return configs, nil
+}

--- a/modules/agent-manager/src/internal/agent/manager_test.go
+++ b/modules/agent-manager/src/internal/agent/manager_test.go
@@ -1,0 +1,194 @@
+package agent_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/agent"
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/types"
+)
+
+func validConfig(id string) *types.AgentConfig {
+	return &types.AgentConfig{
+		ID:         id,
+		Name:       "Test Agent " + id,
+		Command:    "claude",
+		WorkingDir: "/tmp/work",
+		RestartPolicy: types.RestartPolicy{
+			Type:       "on-crash",
+			MaxRetries: 3,
+			BaseDelay:  time.Second,
+		},
+	}
+}
+
+func TestSaveAndLoadAgentConfig_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfg := validConfig("agent-1")
+
+	if err := agent.SaveAgentConfig(dir, cfg); err != nil {
+		t.Fatalf("SaveAgentConfig: %v", err)
+	}
+
+	got, err := agent.LoadAgentConfig(dir, "agent-1")
+	if err != nil {
+		t.Fatalf("LoadAgentConfig: %v", err)
+	}
+	if got.ID != cfg.ID {
+		t.Errorf("ID: got %q, want %q", got.ID, cfg.ID)
+	}
+	if got.Command != cfg.Command {
+		t.Errorf("Command: got %q, want %q", got.Command, cfg.Command)
+	}
+	if got.WorkingDir != cfg.WorkingDir {
+		t.Errorf("WorkingDir: got %q, want %q", got.WorkingDir, cfg.WorkingDir)
+	}
+}
+
+func TestSaveAgentConfig_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	cfg := validConfig("agent-perm")
+
+	if err := agent.SaveAgentConfig(dir, cfg); err != nil {
+		t.Fatalf("SaveAgentConfig: %v", err)
+	}
+
+	path := filepath.Join(dir, "agents", "agent-perm.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected 0600 permissions, got %04o", info.Mode().Perm())
+	}
+}
+
+func TestSaveAgentConfig_InvalidConfigRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfg := validConfig("good-id")
+	cfg.Command = "" // make invalid
+
+	if err := agent.SaveAgentConfig(dir, cfg); err == nil {
+		t.Error("expected error for invalid config, got nil")
+	}
+}
+
+func TestLoadAgentConfig_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	// Create agents dir to avoid a missing-dir error.
+	if err := os.MkdirAll(filepath.Join(dir, "agents"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := agent.LoadAgentConfig(dir, "nonexistent")
+	if err == nil {
+		t.Error("expected error for missing agent, got nil")
+	}
+}
+
+func TestLoadAgentConfig_PathTraversalRejected(t *testing.T) {
+	dir := t.TempDir()
+	malicious := []string{
+		"../secret",
+		"agent/../etc",
+		"agent/sub",
+		"agent id",
+	}
+	for _, id := range malicious {
+		_, err := agent.LoadAgentConfig(dir, id)
+		if err == nil {
+			t.Errorf("expected error for malicious ID %q, got nil", id)
+		}
+	}
+}
+
+func TestDeleteAgentConfig_RemovesFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg := validConfig("agent-del")
+
+	if err := agent.SaveAgentConfig(dir, cfg); err != nil {
+		t.Fatalf("SaveAgentConfig: %v", err)
+	}
+	if err := agent.DeleteAgentConfig(dir, "agent-del"); err != nil {
+		t.Fatalf("DeleteAgentConfig: %v", err)
+	}
+	if _, err := agent.LoadAgentConfig(dir, "agent-del"); err == nil {
+		t.Error("expected error after deletion, got nil")
+	}
+}
+
+func TestDeleteAgentConfig_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	// Delete non-existent agent should not error.
+	if err := os.MkdirAll(filepath.Join(dir, "agents"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.DeleteAgentConfig(dir, "no-such-agent"); err != nil {
+		t.Errorf("expected no error for idempotent delete, got: %v", err)
+	}
+}
+
+func TestDeleteAgentConfig_PathTraversalRejected(t *testing.T) {
+	dir := t.TempDir()
+	if err := agent.DeleteAgentConfig(dir, "../secret"); err == nil {
+		t.Error("expected error for path traversal ID, got nil")
+	}
+}
+
+func TestListAgentConfigs_Empty(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "agents"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	configs, err := agent.ListAgentConfigs(dir)
+	if err != nil {
+		t.Fatalf("ListAgentConfigs: %v", err)
+	}
+	if len(configs) != 0 {
+		t.Errorf("expected 0 configs, got %d", len(configs))
+	}
+}
+
+func TestListAgentConfigs_Multiple(t *testing.T) {
+	dir := t.TempDir()
+	ids := []string{"agent-a", "agent-b", "agent-c"}
+
+	for _, id := range ids {
+		if err := agent.SaveAgentConfig(dir, validConfig(id)); err != nil {
+			t.Fatalf("SaveAgentConfig %s: %v", id, err)
+		}
+	}
+
+	configs, err := agent.ListAgentConfigs(dir)
+	if err != nil {
+		t.Fatalf("ListAgentConfigs: %v", err)
+	}
+	if len(configs) != len(ids) {
+		t.Errorf("expected %d configs, got %d", len(ids), len(configs))
+	}
+
+	found := make(map[string]bool)
+	for _, c := range configs {
+		found[c.ID] = true
+	}
+	for _, id := range ids {
+		if !found[id] {
+			t.Errorf("expected agent %q in list, not found", id)
+		}
+	}
+}
+
+func TestListAgentConfigs_MissingDirReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	// Do NOT create agents dir - should return empty, not error.
+	configs, err := agent.ListAgentConfigs(dir)
+	if err != nil {
+		t.Fatalf("expected no error for missing dir, got: %v", err)
+	}
+	if len(configs) != 0 {
+		t.Errorf("expected 0 configs, got %d", len(configs))
+	}
+}

--- a/modules/agent-manager/src/internal/agent/process.go
+++ b/modules/agent-manager/src/internal/agent/process.go
@@ -1,4 +1,4 @@
 // process.go handles low-level OS process interaction: spawning, signaling,
 // and waiting on Claude Code agent processes.
-// Epic 2 will implement Process wrapping os/exec.Cmd with PID tracking.
+// Process management will be implemented in Epic 3.
 package agent

--- a/modules/agent-manager/src/internal/agent/restart.go
+++ b/modules/agent-manager/src/internal/agent/restart.go
@@ -1,3 +1,3 @@
 // restart.go implements automatic restart logic for crashed agents.
-// Epic 2 will implement backoff-aware restart with configurable limits.
+// Backoff-aware restart will be implemented in Epic 3.
 package agent

--- a/modules/agent-manager/src/internal/agent/state.go
+++ b/modules/agent-manager/src/internal/agent/state.go
@@ -1,3 +1,3 @@
 // state.go defines and transitions agent state (idle, running, crashed, stopping).
-// Epic 2 will implement the AgentState type and state machine transitions.
+// State machine transitions will be implemented in Epic 3.
 package agent

--- a/modules/agent-manager/src/internal/config/config.go
+++ b/modules/agent-manager/src/internal/config/config.go
@@ -1,4 +1,96 @@
 // Package config loads and validates ccgm-agents runtime configuration.
-// Configuration is read from ~/.ccgm/agent-manager.json (or equivalent).
-// Epic 2 will implement Config struct, defaults, and JSON loading.
 package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/fileutil"
+)
+
+const (
+	configFileName = "config.json"
+
+	defaultHealthCheckInterval = 2 * time.Second
+	defaultHangingTimeout      = 60 * time.Second
+	defaultLogMaxSize          = 50 * 1024 * 1024 // 50 MB
+	defaultLogRetentionDays    = 7
+)
+
+// GlobalConfig holds runtime settings for the agent-manager daemon.
+type GlobalConfig struct {
+	DataDir             string        `json:"data_dir"`
+	HealthCheckInterval time.Duration `json:"health_check_interval"`
+	HangingTimeout      time.Duration `json:"hanging_timeout"`
+	LogMaxSize          int64         `json:"log_max_size"`
+	LogRetentionDays    int           `json:"log_retention_days"`
+}
+
+// DefaultConfig returns a GlobalConfig populated with sensible defaults.
+// DataDir defaults to ~/.ccgm/agent-manager.
+func DefaultConfig() *GlobalConfig {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
+	return &GlobalConfig{
+		DataDir:             filepath.Join(home, ".ccgm", "agent-manager"),
+		HealthCheckInterval: defaultHealthCheckInterval,
+		HangingTimeout:      defaultHangingTimeout,
+		LogMaxSize:          defaultLogMaxSize,
+		LogRetentionDays:    defaultLogRetentionDays,
+	}
+}
+
+// LoadConfig reads a GlobalConfig from the JSON file at path.
+// If path does not exist, DefaultConfig is returned (not an error).
+func LoadConfig(path string) (*GlobalConfig, error) {
+	cfg := DefaultConfig()
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return cfg, nil
+	}
+	if err := fileutil.ReadJSON(path, cfg); err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+	return cfg, nil
+}
+
+// SaveConfig writes cfg to path as JSON using an atomic write and 0600 permissions.
+func SaveConfig(cfg *GlobalConfig, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	if err := fileutil.AtomicWriteJSON(path, cfg, 0600); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	return nil
+}
+
+// InitDataDir creates the full directory structure needed by agent-manager
+// under baseDir. Directories are created with 0700 permissions.
+func InitDataDir(baseDir string) error {
+	subdirs := []string{
+		"agents",
+		"sessions",
+		"logs",
+		"history",
+		"state",
+	}
+	if err := fileutil.EnsureDir(baseDir, 0700); err != nil {
+		return fmt.Errorf("init data dir %s: %w", baseDir, err)
+	}
+	for _, sub := range subdirs {
+		dir := filepath.Join(baseDir, sub)
+		if err := fileutil.EnsureDir(dir, 0700); err != nil {
+			return fmt.Errorf("init data dir %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+// ConfigPath returns the default config file path within baseDir.
+func ConfigPath(baseDir string) string {
+	return filepath.Join(baseDir, configFileName)
+}

--- a/modules/agent-manager/src/internal/config/config_test.go
+++ b/modules/agent-manager/src/internal/config/config_test.go
@@ -1,0 +1,151 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/config"
+)
+
+func TestDefaultConfig_NonEmpty(t *testing.T) {
+	cfg := config.DefaultConfig()
+	if cfg == nil {
+		t.Fatal("DefaultConfig returned nil")
+	}
+	if cfg.DataDir == "" {
+		t.Error("DataDir must not be empty")
+	}
+	if cfg.HealthCheckInterval <= 0 {
+		t.Error("HealthCheckInterval must be positive")
+	}
+	if cfg.HangingTimeout <= 0 {
+		t.Error("HangingTimeout must be positive")
+	}
+	if cfg.LogMaxSize <= 0 {
+		t.Error("LogMaxSize must be positive")
+	}
+	if cfg.LogRetentionDays <= 0 {
+		t.Error("LogRetentionDays must be positive")
+	}
+}
+
+func TestSaveAndLoadConfig_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	want := &config.GlobalConfig{
+		DataDir:             "/tmp/ccgm-test",
+		HealthCheckInterval: 5 * time.Second,
+		HangingTimeout:      30 * time.Second,
+		LogMaxSize:          1024 * 1024,
+		LogRetentionDays:    3,
+	}
+
+	if err := config.SaveConfig(want, path); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	got, err := config.LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if got.DataDir != want.DataDir {
+		t.Errorf("DataDir: got %q, want %q", got.DataDir, want.DataDir)
+	}
+	if got.HealthCheckInterval != want.HealthCheckInterval {
+		t.Errorf("HealthCheckInterval: got %v, want %v", got.HealthCheckInterval, want.HealthCheckInterval)
+	}
+	if got.HangingTimeout != want.HangingTimeout {
+		t.Errorf("HangingTimeout: got %v, want %v", got.HangingTimeout, want.HangingTimeout)
+	}
+	if got.LogMaxSize != want.LogMaxSize {
+		t.Errorf("LogMaxSize: got %d, want %d", got.LogMaxSize, want.LogMaxSize)
+	}
+	if got.LogRetentionDays != want.LogRetentionDays {
+		t.Errorf("LogRetentionDays: got %d, want %d", got.LogRetentionDays, want.LogRetentionDays)
+	}
+}
+
+func TestLoadConfig_MissingFileReturnsDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.json")
+
+	cfg, err := config.LoadConfig(path)
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected default config, got nil")
+	}
+}
+
+func TestSaveConfig_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	if err := config.SaveConfig(config.DefaultConfig(), path); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected 0600 permissions, got %04o", info.Mode().Perm())
+	}
+}
+
+func TestInitDataDir_CreatesSubdirectories(t *testing.T) {
+	base := t.TempDir()
+
+	if err := config.InitDataDir(base); err != nil {
+		t.Fatalf("InitDataDir: %v", err)
+	}
+
+	expectedDirs := []string{"agents", "sessions", "logs", "history", "state"}
+	for _, sub := range expectedDirs {
+		dir := filepath.Join(base, sub)
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Errorf("expected directory %s to exist: %v", sub, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("expected %s to be a directory", sub)
+		}
+	}
+}
+
+func TestInitDataDir_Permissions(t *testing.T) {
+	base := t.TempDir()
+
+	if err := config.InitDataDir(base); err != nil {
+		t.Fatalf("InitDataDir: %v", err)
+	}
+
+	for _, sub := range []string{"agents", "sessions", "logs", "history", "state"} {
+		info, err := os.Stat(filepath.Join(base, sub))
+		if err != nil {
+			t.Errorf("stat %s: %v", sub, err)
+			continue
+		}
+		if info.Mode().Perm() != 0700 {
+			t.Errorf("expected 0700 for %s, got %04o", sub, info.Mode().Perm())
+		}
+	}
+}
+
+func TestInitDataDir_Idempotent(t *testing.T) {
+	base := t.TempDir()
+
+	if err := config.InitDataDir(base); err != nil {
+		t.Fatalf("first InitDataDir: %v", err)
+	}
+	if err := config.InitDataDir(base); err != nil {
+		t.Fatalf("second InitDataDir: %v", err)
+	}
+}

--- a/modules/agent-manager/src/internal/fileutil/fileutil.go
+++ b/modules/agent-manager/src/internal/fileutil/fileutil.go
@@ -1,0 +1,67 @@
+// Package fileutil provides safe file I/O helpers for the agent-manager.
+package fileutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// AtomicWriteJSON serializes data as indented JSON and writes it to path using
+// an atomic write: it writes to a .tmp sibling file first, then renames into
+// place. The destination file will have the permissions specified by perm.
+func AtomicWriteJSON(path string, data interface{}, perm os.FileMode) error {
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal JSON for %s: %w", path, err)
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, b, perm); err != nil {
+		return fmt.Errorf("write temp file %s: %w", tmpPath, err)
+	}
+	// Ensure permissions are exact even if the file already existed with
+	// different permissions (WriteFile only sets perms for new files on some
+	// platforms).
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("chmod temp file %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename %s -> %s: %w", tmpPath, path, err)
+	}
+	return nil
+}
+
+// EnsureDir creates dir with the given permissions if it does not already exist.
+func EnsureDir(dir string, perm os.FileMode) error {
+	if err := os.MkdirAll(dir, perm); err != nil {
+		return fmt.Errorf("create directory %s: %w", dir, err)
+	}
+	// Explicitly chmod in case the directory already existed with other perms.
+	if err := os.Chmod(dir, perm); err != nil {
+		return fmt.Errorf("chmod directory %s: %w", dir, err)
+	}
+	return nil
+}
+
+// ReadJSON reads the file at path and unmarshals it into dst.
+func ReadJSON(path string, dst interface{}) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	if err := json.Unmarshal(b, dst); err != nil {
+		return fmt.Errorf("parse JSON %s: %w", path, err)
+	}
+	return nil
+}
+
+// Basename returns the filename of path without directory or extension.
+func Basename(path string) string {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	return base[:len(base)-len(ext)]
+}

--- a/modules/agent-manager/src/internal/fileutil/fileutil_test.go
+++ b/modules/agent-manager/src/internal/fileutil/fileutil_test.go
@@ -1,0 +1,108 @@
+package fileutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/fileutil"
+)
+
+func TestAtomicWriteJSON_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.json")
+
+	type payload struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	want := payload{Name: "test", Value: 42}
+	if err := fileutil.AtomicWriteJSON(path, want, 0600); err != nil {
+		t.Fatalf("AtomicWriteJSON: %v", err)
+	}
+
+	var got payload
+	if err := fileutil.ReadJSON(path, &got); err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	if got != want {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", got, want)
+	}
+}
+
+func TestAtomicWriteJSON_Permissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.json")
+
+	if err := fileutil.AtomicWriteJSON(path, map[string]string{"k": "v"}, 0600); err != nil {
+		t.Fatalf("AtomicWriteJSON: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected 0600 permissions, got %04o", info.Mode().Perm())
+	}
+}
+
+func TestAtomicWriteJSON_NoTmpFileLeftOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.json")
+
+	if err := fileutil.AtomicWriteJSON(path, "hello", 0600); err != nil {
+		t.Fatalf("AtomicWriteJSON: %v", err)
+	}
+
+	tmpPath := path + ".tmp"
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("expected .tmp file to be cleaned up, but it exists")
+	}
+}
+
+func TestEnsureDir_CreatesDirectory(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "a", "b", "c")
+
+	if err := fileutil.EnsureDir(dir, 0700); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("expected directory, got file")
+	}
+}
+
+func TestEnsureDir_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	// Calling twice should not error.
+	if err := fileutil.EnsureDir(dir, 0700); err != nil {
+		t.Fatalf("first EnsureDir: %v", err)
+	}
+	if err := fileutil.EnsureDir(dir, 0700); err != nil {
+		t.Fatalf("second EnsureDir: %v", err)
+	}
+}
+
+func TestBasename(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/foo/bar/baz.json", "baz"},
+		{"agent-1.json", "agent-1"},
+		{"session.json", "session"},
+		{"/path/to/file", "file"},
+	}
+	for _, c := range cases {
+		got := fileutil.Basename(c.path)
+		if got != c.want {
+			t.Errorf("Basename(%q) = %q, want %q", c.path, got, c.want)
+		}
+	}
+}

--- a/modules/agent-manager/src/internal/session/loader.go
+++ b/modules/agent-manager/src/internal/session/loader.go
@@ -1,3 +1,3 @@
-// loader.go discovers and reads Claude Code session files from disk.
-// Epic 2 will implement directory scanning and JSONL parsing of session transcripts.
+// loader.go re-exports session CRUD functions and will house Claude Code
+// session file discovery (JSONL parsing from ~/.claude/projects/) in Epic 3.
 package session

--- a/modules/agent-manager/src/internal/session/session.go
+++ b/modules/agent-manager/src/internal/session/session.go
@@ -1,4 +1,100 @@
-// Package session handles Claude Code session metadata: current task,
-// branch, repo, and context window usage.
-// Epic 2 will implement Session parsing from ~/.claude/projects/.
+// Package session handles persistence of agent session configs.
+// A Session is a named group of agent configs that can be launched together.
 package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/fileutil"
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/types"
+)
+
+// sessionsDir returns the path to the sessions directory within dataDir.
+func sessionsDir(dataDir string) string {
+	return filepath.Join(dataDir, "sessions")
+}
+
+// sessionPath returns the JSON file path for a given sessionID within dataDir.
+// The caller must validate sessionID before calling this function.
+func sessionPath(dataDir, sessionID string) string {
+	return filepath.Join(sessionsDir(dataDir), sessionID+".json")
+}
+
+// LoadSession reads and returns the Session for sessionID from dataDir.
+// Returns an error wrapping os.ErrNotExist if the session does not exist.
+func LoadSession(dataDir, sessionID string) (*types.Session, error) {
+	if err := types.ValidateID(sessionID); err != nil {
+		return nil, fmt.Errorf("load session: %w", err)
+	}
+	path := sessionPath(dataDir, sessionID)
+	var s types.Session
+	if err := fileutil.ReadJSON(path, &s); err != nil {
+		return nil, fmt.Errorf("load session %s: %w", sessionID, err)
+	}
+	return &s, nil
+}
+
+// SaveSession persists s to dataDir/sessions/<s.ID>.json using an atomic
+// write with 0600 permissions. s.Validate() must pass before saving.
+func SaveSession(dataDir string, s *types.Session) error {
+	if err := s.Validate(); err != nil {
+		return fmt.Errorf("save session: %w", err)
+	}
+	dir := sessionsDir(dataDir)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("save session: create sessions dir: %w", err)
+	}
+	path := sessionPath(dataDir, s.ID)
+	if err := fileutil.AtomicWriteJSON(path, s, 0600); err != nil {
+		return fmt.Errorf("save session %s: %w", s.ID, err)
+	}
+	return nil
+}
+
+// DeleteSession removes the persisted session for sessionID from dataDir.
+// Returns nil if the file does not exist (idempotent delete).
+func DeleteSession(dataDir, sessionID string) error {
+	if err := types.ValidateID(sessionID); err != nil {
+		return fmt.Errorf("delete session: %w", err)
+	}
+	path := sessionPath(dataDir, sessionID)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("delete session %s: %w", sessionID, err)
+	}
+	return nil
+}
+
+// ListSessions returns all Sessions persisted in dataDir/sessions/.
+// The order of results is not guaranteed.
+func ListSessions(dataDir string) ([]*types.Session, error) {
+	dir := sessionsDir(dataDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list sessions: %w", err)
+	}
+
+	var sessions []*types.Session
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		id := fileutil.Basename(entry.Name())
+		if err := types.ValidateID(id); err != nil {
+			continue
+		}
+		s, err := LoadSession(dataDir, id)
+		if err != nil {
+			return nil, fmt.Errorf("list sessions: %w", err)
+		}
+		sessions = append(sessions, s)
+	}
+	return sessions, nil
+}

--- a/modules/agent-manager/src/internal/session/session_test.go
+++ b/modules/agent-manager/src/internal/session/session_test.go
@@ -1,0 +1,213 @@
+package session_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/session"
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/types"
+)
+
+func validAgentConfig(id string) types.AgentConfig {
+	return types.AgentConfig{
+		ID:         id,
+		Name:       "Agent " + id,
+		Command:    "claude",
+		WorkingDir: "/tmp/work",
+		RestartPolicy: types.RestartPolicy{
+			Type:       "never",
+			MaxRetries: 0,
+			BaseDelay:  time.Second,
+		},
+	}
+}
+
+func validSession(id string) *types.Session {
+	return &types.Session{
+		ID:          id,
+		Name:        "Session " + id,
+		Description: "test session",
+		Agents:      []types.AgentConfig{validAgentConfig("agent-1")},
+	}
+}
+
+func TestSaveAndLoadSession_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := validSession("session-1")
+
+	if err := session.SaveSession(dir, s); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	got, err := session.LoadSession(dir, "session-1")
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got.ID != s.ID {
+		t.Errorf("ID: got %q, want %q", got.ID, s.ID)
+	}
+	if got.Name != s.Name {
+		t.Errorf("Name: got %q, want %q", got.Name, s.Name)
+	}
+	if got.Description != s.Description {
+		t.Errorf("Description: got %q, want %q", got.Description, s.Description)
+	}
+	if len(got.Agents) != len(s.Agents) {
+		t.Errorf("Agents length: got %d, want %d", len(got.Agents), len(s.Agents))
+	}
+}
+
+func TestSaveSession_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	s := validSession("session-perm")
+
+	if err := session.SaveSession(dir, s); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	path := filepath.Join(dir, "sessions", "session-perm.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected 0600 permissions, got %04o", info.Mode().Perm())
+	}
+}
+
+func TestSaveSession_InvalidSessionRejected(t *testing.T) {
+	dir := t.TempDir()
+	s := validSession("ok-id")
+	s.Name = "" // make invalid
+
+	if err := session.SaveSession(dir, s); err == nil {
+		t.Error("expected error for invalid session, got nil")
+	}
+}
+
+func TestSaveSession_PathTraversalIDRejected(t *testing.T) {
+	dir := t.TempDir()
+	s := validSession("ok-id")
+	s.ID = "../secret"
+
+	if err := session.SaveSession(dir, s); err == nil {
+		t.Error("expected error for path traversal session ID, got nil")
+	}
+}
+
+func TestLoadSession_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "sessions"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := session.LoadSession(dir, "no-such-session")
+	if err == nil {
+		t.Error("expected error for missing session, got nil")
+	}
+}
+
+func TestLoadSession_PathTraversalRejected(t *testing.T) {
+	dir := t.TempDir()
+	malicious := []string{
+		"../secret",
+		"session/../etc",
+		"session/sub",
+	}
+	for _, id := range malicious {
+		_, err := session.LoadSession(dir, id)
+		if err == nil {
+			t.Errorf("expected error for malicious ID %q, got nil", id)
+		}
+	}
+}
+
+func TestDeleteSession_RemovesFile(t *testing.T) {
+	dir := t.TempDir()
+	s := validSession("session-del")
+
+	if err := session.SaveSession(dir, s); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+	if err := session.DeleteSession(dir, "session-del"); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if _, err := session.LoadSession(dir, "session-del"); err == nil {
+		t.Error("expected error after deletion, got nil")
+	}
+}
+
+func TestDeleteSession_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "sessions"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.DeleteSession(dir, "no-such-session"); err != nil {
+		t.Errorf("expected no error for idempotent delete, got: %v", err)
+	}
+}
+
+func TestDeleteSession_PathTraversalRejected(t *testing.T) {
+	dir := t.TempDir()
+	if err := session.DeleteSession(dir, "../secret"); err == nil {
+		t.Error("expected error for path traversal ID, got nil")
+	}
+}
+
+func TestListSessions_Empty(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "sessions"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := session.ListSessions(dir)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("expected 0 sessions, got %d", len(sessions))
+	}
+}
+
+func TestListSessions_Multiple(t *testing.T) {
+	dir := t.TempDir()
+	ids := []string{"session-a", "session-b", "session-c"}
+
+	for _, id := range ids {
+		if err := session.SaveSession(dir, validSession(id)); err != nil {
+			t.Fatalf("SaveSession %s: %v", id, err)
+		}
+	}
+
+	sessions, err := session.ListSessions(dir)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != len(ids) {
+		t.Errorf("expected %d sessions, got %d", len(ids), len(sessions))
+	}
+
+	found := make(map[string]bool)
+	for _, s := range sessions {
+		found[s.ID] = true
+	}
+	for _, id := range ids {
+		if !found[id] {
+			t.Errorf("expected session %q in list, not found", id)
+		}
+	}
+}
+
+func TestListSessions_MissingDirReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	// Do NOT create sessions dir.
+	sessions, err := session.ListSessions(dir)
+	if err != nil {
+		t.Fatalf("expected no error for missing dir, got: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("expected 0 sessions, got %d", len(sessions))
+	}
+}

--- a/modules/agent-manager/src/internal/types/types.go
+++ b/modules/agent-manager/src/internal/types/types.go
@@ -1,3 +1,135 @@
 // Package types defines shared data structures used across the agent-manager.
-// Epic 2 will populate this with Agent, Session, LogEntry, and related types.
 package types
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+)
+
+// validID matches agent and session IDs: alphanumeric, hyphens, underscores.
+var validID = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// AgentStatus represents the lifecycle state of a managed agent process.
+type AgentStatus string
+
+const (
+	StatusRunning    AgentStatus = "running"
+	StatusStopped    AgentStatus = "stopped"
+	StatusCrashed    AgentStatus = "crashed"
+	StatusHanging    AgentStatus = "hanging"
+	StatusRestarting AgentStatus = "restarting"
+)
+
+// RestartPolicy controls how the manager handles agent process exits.
+type RestartPolicy struct {
+	Type       string        `json:"type"`        // "never", "on-crash", "always"
+	MaxRetries int           `json:"max_retries"` // 0 = unlimited
+	BaseDelay  time.Duration `json:"base_delay"`  // exponential backoff base
+}
+
+// Validate returns an error if the restart policy is misconfigured.
+func (r RestartPolicy) Validate() error {
+	switch r.Type {
+	case "never", "on-crash", "always":
+		// valid
+	default:
+		return fmt.Errorf("invalid restart policy type %q: must be never, on-crash, or always", r.Type)
+	}
+	if r.MaxRetries < 0 {
+		return fmt.Errorf("max_retries must be >= 0, got %d", r.MaxRetries)
+	}
+	if r.BaseDelay < 0 {
+		return fmt.Errorf("base_delay must be >= 0, got %s", r.BaseDelay)
+	}
+	return nil
+}
+
+// AgentConfig is the persisted configuration for a single managed agent.
+type AgentConfig struct {
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Command       string            `json:"command"`
+	Args          []string          `json:"args,omitempty"`
+	WorkingDir    string            `json:"working_dir"`
+	Env           map[string]string `json:"env,omitempty"`
+	Model         string            `json:"model,omitempty"`
+	RestartPolicy RestartPolicy     `json:"restart_policy"`
+}
+
+// Validate returns an error if the agent config is missing required fields or
+// contains an invalid ID (which would allow path traversal).
+func (a AgentConfig) Validate() error {
+	if a.ID == "" {
+		return fmt.Errorf("agent ID must not be empty")
+	}
+	if !validID.MatchString(a.ID) {
+		return fmt.Errorf("agent ID %q is invalid: only alphanumeric, hyphens, and underscores are allowed", a.ID)
+	}
+	if a.Command == "" {
+		return fmt.Errorf("agent %q: command must not be empty", a.ID)
+	}
+	if a.WorkingDir == "" {
+		return fmt.Errorf("agent %q: working_dir must not be empty", a.ID)
+	}
+	return a.RestartPolicy.Validate()
+}
+
+// Session is a named, saved grouping of agent configs that can be launched together.
+type Session struct {
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`
+	Description string        `json:"description,omitempty"`
+	Agents      []AgentConfig `json:"agents"`
+}
+
+// Validate returns an error if the session or any of its agent configs are invalid.
+func (s Session) Validate() error {
+	if s.ID == "" {
+		return fmt.Errorf("session ID must not be empty")
+	}
+	if !validID.MatchString(s.ID) {
+		return fmt.Errorf("session ID %q is invalid: only alphanumeric, hyphens, and underscores are allowed", s.ID)
+	}
+	if s.Name == "" {
+		return fmt.Errorf("session %q: name must not be empty", s.ID)
+	}
+	for i, agent := range s.Agents {
+		if err := agent.Validate(); err != nil {
+			return fmt.Errorf("session %q agent[%d]: %w", s.ID, i, err)
+		}
+	}
+	return nil
+}
+
+// AgentState holds the runtime state of an agent managed by the process supervisor.
+type AgentState struct {
+	Config       AgentConfig
+	PID          int
+	Status       AgentStatus
+	StartedAt    time.Time
+	ExitCode     int
+	RestartCount int
+}
+
+// RunRecord is a historical record written after an agent process exits.
+type RunRecord struct {
+	AgentID      string    `json:"agent_id"`
+	StartedAt    time.Time `json:"started_at"`
+	StoppedAt    time.Time `json:"stopped_at"`
+	ExitCode     int       `json:"exit_code"`
+	LastLogLines []string  `json:"last_log_lines"`
+	RestartCount int       `json:"restart_count"`
+}
+
+// ValidateID returns an error if id is empty or contains characters that could
+// allow path traversal when used as a filename.
+func ValidateID(id string) error {
+	if id == "" {
+		return fmt.Errorf("ID must not be empty")
+	}
+	if !validID.MatchString(id) {
+		return fmt.Errorf("ID %q is invalid: only alphanumeric, hyphens, and underscores are allowed", id)
+	}
+	return nil
+}

--- a/modules/agent-manager/src/internal/types/types_test.go
+++ b/modules/agent-manager/src/internal/types/types_test.go
@@ -1,0 +1,225 @@
+package types_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/types"
+)
+
+// --- RestartPolicy.Validate ---
+
+func TestRestartPolicyValidate_ValidTypes(t *testing.T) {
+	for _, typ := range []string{"never", "on-crash", "always"} {
+		rp := types.RestartPolicy{Type: typ, MaxRetries: 3, BaseDelay: time.Second}
+		if err := rp.Validate(); err != nil {
+			t.Errorf("expected valid policy type %q, got error: %v", typ, err)
+		}
+	}
+}
+
+func TestRestartPolicyValidate_InvalidType(t *testing.T) {
+	rp := types.RestartPolicy{Type: "sometimes"}
+	if err := rp.Validate(); err == nil {
+		t.Error("expected error for invalid restart policy type, got nil")
+	}
+}
+
+func TestRestartPolicyValidate_EmptyType(t *testing.T) {
+	rp := types.RestartPolicy{}
+	if err := rp.Validate(); err == nil {
+		t.Error("expected error for empty restart policy type, got nil")
+	}
+}
+
+func TestRestartPolicyValidate_NegativeMaxRetries(t *testing.T) {
+	rp := types.RestartPolicy{Type: "always", MaxRetries: -1}
+	if err := rp.Validate(); err == nil {
+		t.Error("expected error for negative max_retries, got nil")
+	}
+}
+
+func TestRestartPolicyValidate_NegativeBaseDelay(t *testing.T) {
+	rp := types.RestartPolicy{Type: "on-crash", MaxRetries: 0, BaseDelay: -time.Second}
+	if err := rp.Validate(); err == nil {
+		t.Error("expected error for negative base_delay, got nil")
+	}
+}
+
+// --- AgentConfig.Validate ---
+
+func validAgentConfig() types.AgentConfig {
+	return types.AgentConfig{
+		ID:         "agent-1",
+		Name:       "Test Agent",
+		Command:    "claude",
+		WorkingDir: "/tmp/work",
+		RestartPolicy: types.RestartPolicy{
+			Type:       "on-crash",
+			MaxRetries: 3,
+			BaseDelay:  time.Second,
+		},
+	}
+}
+
+func TestAgentConfigValidate_Valid(t *testing.T) {
+	cfg := validAgentConfig()
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("expected valid config, got error: %v", err)
+	}
+}
+
+func TestAgentConfigValidate_EmptyID(t *testing.T) {
+	cfg := validAgentConfig()
+	cfg.ID = ""
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for empty ID, got nil")
+	}
+}
+
+func TestAgentConfigValidate_EmptyCommand(t *testing.T) {
+	cfg := validAgentConfig()
+	cfg.Command = ""
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for empty command, got nil")
+	}
+}
+
+func TestAgentConfigValidate_EmptyWorkingDir(t *testing.T) {
+	cfg := validAgentConfig()
+	cfg.WorkingDir = ""
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for empty working_dir, got nil")
+	}
+}
+
+func TestAgentConfigValidate_PathTraversalID(t *testing.T) {
+	// IDs that could cause path traversal must be rejected.
+	malicious := []string{
+		"../../../etc/passwd",
+		"agent/../secret",
+		"agent/subdir",
+		"agent id",
+		"agent.id",
+		"agent@1",
+	}
+	for _, id := range malicious {
+		cfg := validAgentConfig()
+		cfg.ID = id
+		if err := cfg.Validate(); err == nil {
+			t.Errorf("expected error for malicious ID %q, got nil", id)
+		}
+	}
+}
+
+func TestAgentConfigValidate_ValidIDChars(t *testing.T) {
+	validIDs := []string{
+		"agent1",
+		"agent-1",
+		"agent_1",
+		"Agent1",
+		"AGENT",
+		"a",
+		"a-b-c_d",
+	}
+	for _, id := range validIDs {
+		cfg := validAgentConfig()
+		cfg.ID = id
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("expected valid ID %q, got error: %v", id, err)
+		}
+	}
+}
+
+func TestAgentConfigValidate_InvalidRestartPolicy(t *testing.T) {
+	cfg := validAgentConfig()
+	cfg.RestartPolicy = types.RestartPolicy{Type: "bad"}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for invalid restart policy, got nil")
+	}
+}
+
+// --- Session.Validate ---
+
+func validSession() types.Session {
+	return types.Session{
+		ID:   "session-1",
+		Name: "My Session",
+		Agents: []types.AgentConfig{
+			validAgentConfig(),
+		},
+	}
+}
+
+func TestSessionValidate_Valid(t *testing.T) {
+	s := validSession()
+	if err := s.Validate(); err != nil {
+		t.Errorf("expected valid session, got error: %v", err)
+	}
+}
+
+func TestSessionValidate_EmptyID(t *testing.T) {
+	s := validSession()
+	s.ID = ""
+	if err := s.Validate(); err == nil {
+		t.Error("expected error for empty session ID, got nil")
+	}
+}
+
+func TestSessionValidate_EmptyName(t *testing.T) {
+	s := validSession()
+	s.Name = ""
+	if err := s.Validate(); err == nil {
+		t.Error("expected error for empty session name, got nil")
+	}
+}
+
+func TestSessionValidate_PathTraversalID(t *testing.T) {
+	s := validSession()
+	s.ID = "../secret"
+	if err := s.Validate(); err == nil {
+		t.Error("expected error for path traversal session ID, got nil")
+	}
+}
+
+func TestSessionValidate_InvalidAgent(t *testing.T) {
+	s := validSession()
+	s.Agents[0].Command = ""
+	if err := s.Validate(); err == nil {
+		t.Error("expected error for invalid agent in session, got nil")
+	}
+}
+
+func TestSessionValidate_NoAgents(t *testing.T) {
+	// A session with no agents is allowed (it's a config template).
+	s := validSession()
+	s.Agents = nil
+	if err := s.Validate(); err != nil {
+		t.Errorf("expected valid empty-agent session, got error: %v", err)
+	}
+}
+
+// --- ValidateID ---
+
+func TestValidateID_PathTraversal(t *testing.T) {
+	bad := []string{
+		"../etc",
+		"foo/bar",
+		"foo bar",
+		"",
+	}
+	for _, id := range bad {
+		if err := types.ValidateID(id); err == nil {
+			t.Errorf("expected error for ID %q, got nil", id)
+		}
+	}
+}
+
+func TestValidateID_Valid(t *testing.T) {
+	good := []string{"foo", "foo-bar", "foo_bar", "FOO123"}
+	for _, id := range good {
+		if err := types.ValidateID(id); err != nil {
+			t.Errorf("expected valid ID %q, got error: %v", id, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `internal/types` with `AgentStatus`, `RestartPolicy`, `AgentConfig`, `Session`, `AgentState`, and `RunRecord` types, all with validation methods and path-traversal-safe ID checking
- Implements `internal/config` with `GlobalConfig`, `LoadConfig`, `SaveConfig`, `InitDataDir`, and `DefaultConfig` (defaults to `~/.ccgm/agent-manager`)
- Implements `internal/agent` config CRUD (`LoadAgentConfig`, `SaveAgentConfig`, `DeleteAgentConfig`, `ListAgentConfigs`) - process management deferred to Epic 3
- Implements `internal/session` CRUD (`LoadSession`, `SaveSession`, `DeleteSession`, `ListSessions`)
- Adds `internal/fileutil` with `AtomicWriteJSON` (write to .tmp then rename), `EnsureDir`, `ReadJSON`, and `Basename` helpers

## Security

- All IDs validated against `^[a-zA-Z0-9_-]+$` before use as filenames - prevents path traversal
- All file writes use atomic rename (write .tmp, rename into place)
- Directories created with 0700, files with 0600

## Test plan

- [x] `go test ./...` - all packages pass (types, config, fileutil, agent, session)
- [x] `go vet ./...` - clean
- [x] Permission tests verify 0600 for files, 0700 for dirs
- [x] Path traversal tests verify malicious IDs are rejected at every CRUD entry point
- [x] Idempotent delete tests (delete non-existent returns nil)
- [x] Missing agents/sessions dir returns empty list (not error)

Closes #200