### PR TITLE
#214: add Terraform infrastructure for Hetzner Cloud

### DIFF
--- a/modules/cloud-dispatch/terraform/.gitignore
+++ b/modules/cloud-dispatch/terraform/.gitignore
@@ -1,0 +1,14 @@
+# Terraform state - contains sensitive data and should never be committed
+*.tfstate
+*.tfstate.backup
+
+# Terraform working directory
+.terraform/
+.terraform.lock.hcl
+
+# Variable files - contain secrets (API tokens, IPs, keys)
+terraform.tfvars
+*.auto.tfvars
+
+# Plan output files
+*.tfplan

--- a/modules/cloud-dispatch/terraform/main.tf
+++ b/modules/cloud-dispatch/terraform/main.tf
@@ -1,0 +1,87 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.45"
+    }
+  }
+}
+
+provider "hcloud" {
+  token = var.hcloud_token
+}
+
+# Firewall restricts inbound SSH to the orchestrator IP only.
+# VMs provisioned by cloud-dispatch are tagged with this firewall
+# so that only the orchestrating machine can reach them.
+resource "hcloud_firewall" "agent_firewall" {
+  name = "${var.project_name}-firewall"
+
+  # Allow inbound SSH from orchestrator only
+  rule {
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "22"
+    source_ips  = [var.orchestrator_ip]
+    description = "Allow SSH from orchestrator machine only"
+  }
+
+  # Allow all outbound traffic (further restricted by iptables on each VM)
+  rule {
+    direction       = "out"
+    protocol        = "tcp"
+    port            = "any"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    direction       = "out"
+    protocol        = "udp"
+    port            = "any"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    direction       = "out"
+    protocol        = "icmp"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+# SSH key uploaded to Hetzner so VMs can be provisioned with it.
+# This is the orchestrator's public key - private key stays on the MacBook.
+resource "hcloud_ssh_key" "dispatch_key" {
+  name       = "${var.project_name}-key"
+  public_key = var.ssh_public_key
+}
+
+# Private network for agent VMs.
+# VMs don't require internal communication, but having a private network
+# avoids routing through the public internet if VM-to-VM communication
+# is ever needed. Each datacenter location gets its own subnet.
+resource "hcloud_network" "agent_network" {
+  name     = "${var.project_name}-network"
+  ip_range = "10.0.0.0/16"
+}
+
+resource "hcloud_network_subnet" "fsn1" {
+  network_id   = hcloud_network.agent_network.id
+  type         = "cloud"
+  network_zone = "eu-central"
+  ip_range     = "10.0.1.0/24"
+}
+
+resource "hcloud_network_subnet" "nbg1" {
+  network_id   = hcloud_network.agent_network.id
+  type         = "cloud"
+  network_zone = "eu-central"
+  ip_range     = "10.0.2.0/24"
+}
+
+resource "hcloud_network_subnet" "hel1" {
+  network_id   = hcloud_network.agent_network.id
+  type         = "cloud"
+  network_zone = "eu-central"
+  ip_range     = "10.0.3.0/24"
+}

--- a/modules/cloud-dispatch/terraform/outputs.tf
+++ b/modules/cloud-dispatch/terraform/outputs.tf
@@ -1,0 +1,31 @@
+output "firewall_id" {
+  description = "ID of the agent firewall resource. Pass this when creating VMs so they inherit the SSH restriction."
+  value       = hcloud_firewall.agent_firewall.id
+}
+
+output "ssh_key_id" {
+  description = "ID of the SSH key resource in Hetzner. Pass this when creating VMs so the orchestrator can connect."
+  value       = hcloud_ssh_key.dispatch_key.id
+}
+
+output "network_id" {
+  description = "ID of the private agent network. Pass this when creating VMs to attach them to the private network."
+  value       = hcloud_network.agent_network.id
+}
+
+output "next_steps" {
+  description = "Guidance for using these resources."
+  value       = <<-EOT
+    Infrastructure is ready. To provision agent VMs, use the hcloud CLI or cloud-dispatch scripts:
+
+      hcloud server create \
+        --name <agent-name> \
+        --type cx22 \
+        --image <packer-snapshot-id> \
+        --ssh-key ${hcloud_ssh_key.dispatch_key.id} \
+        --firewall ${hcloud_firewall.agent_firewall.id} \
+        --network ${hcloud_network.agent_network.id}
+
+    VMs are ephemeral - destroy them after each session to avoid charges.
+  EOT
+}

--- a/modules/cloud-dispatch/terraform/terraform.tfvars.example
+++ b/modules/cloud-dispatch/terraform/terraform.tfvars.example
@@ -1,0 +1,11 @@
+# Copy this file to terraform.tfvars and fill in your values.
+# DO NOT commit terraform.tfvars - it is excluded by .gitignore.
+#
+# Get your public IP: curl -s https://ifconfig.me
+
+hcloud_token    = "your-hetzner-api-token"
+orchestrator_ip = "203.0.113.10/32"
+ssh_public_key  = "ssh-ed25519 AAAA... your-key-comment"
+
+# Optional: override the default resource name prefix
+# project_name = "ccgm-dispatch"

--- a/modules/cloud-dispatch/terraform/variables.tf
+++ b/modules/cloud-dispatch/terraform/variables.tf
@@ -1,0 +1,26 @@
+variable "hcloud_token" {
+  description = "Hetzner Cloud API token (read/write). Found in Hetzner Cloud Console > Security > API Tokens."
+  type        = string
+  sensitive   = true
+}
+
+variable "orchestrator_ip" {
+  description = "IP address of the orchestrating MacBook in CIDR notation (e.g. 203.0.113.10/32). Only this IP is allowed inbound SSH access to agent VMs."
+  type        = string
+
+  validation {
+    condition     = can(cidrhost(var.orchestrator_ip, 0))
+    error_message = "orchestrator_ip must be a valid CIDR block (e.g. 203.0.113.10/32)."
+  }
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key for VM access. The corresponding private key must remain on the orchestrating machine. Paste the full public key string (e.g. 'ssh-ed25519 AAAA...')."
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name prefix used for naming Hetzner resources."
+  type        = string
+  default     = "ccgm-dispatch"
+}


### PR DESCRIPTION
Closes #214

## Summary

- `main.tf`: Hetzner firewall (SSH inbound from orchestrator IP only, all outbound allowed), SSH key resource, private network with subnets for fsn1/nbg1/hel1
- `variables.tf`: Four input variables (hcloud_token, orchestrator_ip with CIDR validation, ssh_public_key, project_name) - all sensitive values parameterized
- `outputs.tf`: firewall_id, ssh_key_id, network_id, and a next_steps guidance output with the hcloud CLI command for VM provisioning
- `.gitignore`: Excludes tfstate, tfstate.backup, .terraform/, .terraform.lock.hcl, terraform.tfvars, *.auto.tfvars, *.tfplan
- `terraform.tfvars.example`: Safe-to-commit example file with placeholder values

## Test plan

- [ ] `terraform validate` passes (requires Hetzner account - validated HCL structure manually; terraform not installed locally)
- [ ] `terraform plan` shows hcloud_firewall, hcloud_ssh_key, hcloud_network, and 3 hcloud_network_subnet resources
- [ ] Firewall inbound rule references `var.orchestrator_ip` - no hardcoded IPs
- [ ] `terraform.tfvars` is excluded by `.gitignore`
- [ ] Personal data check passes (`bash tests/test-no-personal-data.sh`)