### PR TITLE
#204: implement agent list dashboard panel with vim-style navigation

### DIFF
--- a/modules/agent-manager/src/go.mod
+++ b/modules/agent-manager/src/go.mod
@@ -6,6 +6,7 @@ require github.com/charmbracelet/bubbletea v1.3.10
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/charmbracelet/bubbles v1.0.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect

--- a/modules/agent-manager/src/go.sum
+++ b/modules/agent-manager/src/go.sum
@@ -1,5 +1,7 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
+github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco3ej+ngLk1kk=

--- a/modules/agent-manager/src/internal/tui/agentlist.go
+++ b/modules/agent-manager/src/internal/tui/agentlist.go
@@ -1,3 +1,313 @@
-// agentlist.go renders the scrollable list of running agents in the left pane.
-// Epic 2 will implement the bubbles/list.Model integration with agent data.
+// agentlist.go implements the scrollable agent list panel for the left pane.
 package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/types"
+)
+
+// AgentSelectedMsg is emitted when the user presses enter on an agent row.
+type AgentSelectedMsg struct {
+	AgentID string
+}
+
+// AgentListUpdatedMsg carries a fresh snapshot of agent list items to the model.
+type AgentListUpdatedMsg struct {
+	Agents []AgentListItem
+}
+
+// AgentListItem is the display representation of a single managed agent.
+type AgentListItem struct {
+	ID           string
+	Name         string
+	Status       types.AgentStatus
+	Uptime       time.Duration
+	PID          int
+	RestartCount int
+}
+
+// AgentListModel is the Bubble Tea component for the agent list panel.
+type AgentListModel struct {
+	agents    []AgentListItem
+	cursor    int
+	filter    string
+	filtering bool
+	width     int
+	height    int
+	focused   bool
+}
+
+// NewAgentListModel returns an empty, unfocused agent list model.
+func NewAgentListModel() AgentListModel {
+	return AgentListModel{}
+}
+
+// Init satisfies the tea.Model interface. No I/O needed on startup.
+func (m AgentListModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles key input, window resizes, and agent list refreshes.
+func (m AgentListModel) Update(msg tea.Msg) (AgentListModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+
+	case AgentListUpdatedMsg:
+		m.SetAgents(msg.Agents)
+
+	case tea.KeyMsg:
+		if m.filtering {
+			return m.updateFilter(msg)
+		}
+		return m.updateNav(msg)
+	}
+	return m, nil
+}
+
+// updateFilter handles key input while the filter input is active.
+func (m AgentListModel) updateFilter(msg tea.KeyMsg) (AgentListModel, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.filtering = false
+		m.filter = ""
+		m.clampCursor()
+	case "backspace":
+		if len(m.filter) > 0 {
+			m.filter = m.filter[:len(m.filter)-1]
+			m.clampCursor()
+		}
+	default:
+		if msg.Type == tea.KeyRunes {
+			m.filter += string(msg.Runes)
+			m.clampCursor()
+		}
+	}
+	return m, nil
+}
+
+// updateNav handles key input during normal (non-filter) navigation.
+func (m AgentListModel) updateNav(msg tea.KeyMsg) (AgentListModel, tea.Cmd) {
+	visible := m.visibleAgents()
+
+	switch msg.String() {
+	case "k", "up":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "j", "down":
+		if m.cursor < len(visible)-1 {
+			m.cursor++
+		}
+	case "/":
+		m.filtering = true
+		m.filter = ""
+	case "enter":
+		if agent, ok := m.SelectedAgent(); ok {
+			return m, func() tea.Msg {
+				return AgentSelectedMsg{AgentID: agent.ID}
+			}
+		}
+	}
+	return m, nil
+}
+
+// View renders the agent list panel as a string.
+func (m AgentListModel) View() string {
+	visible := m.visibleAgents()
+
+	var sb strings.Builder
+
+	// Title bar
+	title := "Agents"
+	if m.filter != "" {
+		title = fmt.Sprintf("Agents [%s]", m.filter)
+	}
+	sb.WriteString(TitleStyle.Render(title))
+	sb.WriteString("\n")
+
+	// Filter mode prompt
+	if m.filtering {
+		sb.WriteString(fmt.Sprintf("Filter: %s_\n", m.filter))
+	}
+
+	// Empty state
+	if len(visible) == 0 {
+		if m.filter != "" {
+			sb.WriteString("(no agents match filter)\n")
+		} else {
+			sb.WriteString("(no agents)\n")
+		}
+		return m.wrapBorder(sb.String())
+	}
+
+	// Column header
+	header := fmt.Sprintf("%-20s  %-13s  %-8s  %-7s  %-8s",
+		"Name", "Status", "Uptime", "PID", "Restarts")
+	sb.WriteString(HeaderStyle.Render(header))
+	sb.WriteString("\n")
+
+	// Agent rows
+	for i, agent := range visible {
+		row := fmt.Sprintf("%-20s  %-13s  %-8s  %-7s  %-8s",
+			truncate(agent.Name, 20),
+			m.renderStatus(agent.Status),
+			formatUptime(agent.Uptime),
+			formatPID(agent.PID),
+			fmt.Sprintf("%d", agent.RestartCount),
+		)
+		if i == m.cursor {
+			sb.WriteString(SelectedStyle.Render(row))
+		} else {
+			sb.WriteString(row)
+		}
+		sb.WriteString("\n")
+	}
+
+	// Filter count hint
+	if m.filter != "" {
+		sb.WriteString(fmt.Sprintf("\n%d/%d shown", len(visible), len(m.agents)))
+	}
+
+	return m.wrapBorder(sb.String())
+}
+
+// SetAgents replaces the agent list and clamps the cursor.
+func (m *AgentListModel) SetAgents(agents []AgentListItem) {
+	m.agents = agents
+	m.clampCursor()
+}
+
+// SetSize updates the panel dimensions.
+func (m *AgentListModel) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+// SetFocused marks the panel as focused or unfocused (affects border color).
+func (m *AgentListModel) SetFocused(focused bool) {
+	m.focused = focused
+}
+
+// SelectedAgent returns the agent under the cursor, if any.
+func (m AgentListModel) SelectedAgent() (AgentListItem, bool) {
+	visible := m.visibleAgents()
+	if len(visible) == 0 || m.cursor < 0 || m.cursor >= len(visible) {
+		return AgentListItem{}, false
+	}
+	return visible[m.cursor], true
+}
+
+// Focused reports whether this panel has keyboard focus.
+func (m AgentListModel) Focused() bool {
+	return m.focused
+}
+
+// visibleAgents returns the subset of agents that match the current filter.
+func (m AgentListModel) visibleAgents() []AgentListItem {
+	if m.filter == "" {
+		return m.agents
+	}
+	lower := strings.ToLower(m.filter)
+	var out []AgentListItem
+	for _, a := range m.agents {
+		if strings.Contains(strings.ToLower(a.Name), lower) {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// clampCursor keeps the cursor within the bounds of the visible agent list.
+func (m *AgentListModel) clampCursor() {
+	visible := m.visibleAgents()
+	if len(visible) == 0 {
+		m.cursor = 0
+		return
+	}
+	if m.cursor >= len(visible) {
+		m.cursor = len(visible) - 1
+	}
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
+}
+
+// wrapBorder wraps content in the appropriate border style based on focus.
+func (m AgentListModel) wrapBorder(content string) string {
+	style := InactiveBorderStyle
+	if m.focused {
+		style = ActiveBorderStyle
+	}
+	if m.width > 0 {
+		// Subtract 2 for the border characters on each side.
+		inner := m.width - 2
+		if inner > 0 {
+			style = style.Width(inner)
+		}
+	}
+	return style.Render(content)
+}
+
+// renderStatus returns a colored status indicator string.
+func (m AgentListModel) renderStatus(status types.AgentStatus) string {
+	dot := "●"
+	switch status {
+	case types.StatusRunning:
+		return StatusRunning.Render(dot + " running")
+	case types.StatusHanging:
+		return StatusHanging.Render(dot + " hanging")
+	case types.StatusCrashed:
+		return StatusCrashed.Render(dot + " crashed")
+	case types.StatusStopped:
+		return StatusStopped.Render(dot + " stopped")
+	case types.StatusRestarting:
+		return StatusRestarting.Render(dot + " restarting")
+	default:
+		return lipgloss.NewStyle().Render(dot + " " + string(status))
+	}
+}
+
+// formatUptime converts a duration to a human-readable short string.
+func formatUptime(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	s := int(d.Seconds()) % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh%02dm", h, m)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%dm%02ds", m, s)
+	}
+	return fmt.Sprintf("%ds", s)
+}
+
+// formatPID returns a dash when the PID is 0 (agent not running).
+func formatPID(pid int) string {
+	if pid == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d", pid)
+}
+
+// truncate shortens s to max runes, appending "..." if needed.
+func truncate(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
+}

--- a/modules/agent-manager/src/internal/tui/agentlist_test.go
+++ b/modules/agent-manager/src/internal/tui/agentlist_test.go
@@ -1,0 +1,373 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/types"
+)
+
+// helpers
+
+func makeItem(id, name string, status types.AgentStatus, pid int) AgentListItem {
+	return AgentListItem{
+		ID:           id,
+		Name:         name,
+		Status:       status,
+		PID:          pid,
+		Uptime:       10 * time.Second,
+		RestartCount: 0,
+	}
+}
+
+func pressKey(m AgentListModel, key string) (AgentListModel, tea.Cmd) {
+	return m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)})
+}
+
+func pressSpecial(m AgentListModel, keyType tea.KeyType) (AgentListModel, tea.Cmd) {
+	return m.Update(tea.KeyMsg{Type: keyType})
+}
+
+// --- rendering tests ---
+
+func TestView_NoAgents(t *testing.T) {
+	m := NewAgentListModel()
+	view := m.View()
+	if !strings.Contains(view, "(no agents)") {
+		t.Errorf("expected '(no agents)' in view, got:\n%s", view)
+	}
+}
+
+func TestView_ShowsAgentNames(t *testing.T) {
+	m := NewAgentListModel()
+	m.SetAgents([]AgentListItem{
+		makeItem("a1", "worker-alpha", types.StatusRunning, 1001),
+		makeItem("a2", "worker-beta", types.StatusCrashed, 0),
+	})
+	view := m.View()
+	if !strings.Contains(view, "worker-alpha") {
+		t.Errorf("expected 'worker-alpha' in view, got:\n%s", view)
+	}
+	if !strings.Contains(view, "worker-beta") {
+		t.Errorf("expected 'worker-beta' in view, got:\n%s", view)
+	}
+}
+
+func TestView_AllStatuses(t *testing.T) {
+	statuses := []types.AgentStatus{
+		types.StatusRunning,
+		types.StatusHanging,
+		types.StatusCrashed,
+		types.StatusStopped,
+		types.StatusRestarting,
+	}
+	for _, status := range statuses {
+		m := NewAgentListModel()
+		m.SetAgents([]AgentListItem{makeItem("a1", "agent", status, 100)})
+		view := m.View()
+		// Each status name should appear somewhere in the rendered view.
+		if !strings.Contains(view, string(status)) {
+			t.Errorf("status %q not found in view:\n%s", status, view)
+		}
+	}
+}
+
+func TestView_ShowsHeader(t *testing.T) {
+	m := NewAgentListModel()
+	m.SetAgents([]AgentListItem{makeItem("a1", "x", types.StatusRunning, 1)})
+	view := m.View()
+	if !strings.Contains(view, "Name") {
+		t.Errorf("expected 'Name' column header in view, got:\n%s", view)
+	}
+}
+
+func TestView_EmptyFilter(t *testing.T) {
+	m := NewAgentListModel()
+	m.SetAgents([]AgentListItem{makeItem("a1", "alpha", types.StatusRunning, 1)})
+	// Activate filter, type something that matches nothing.
+	m, _ = pressKey(m, "/")
+	// Now we are in filter mode
+	for _, ch := range "zzz" {
+		m.filter += string(ch)
+	}
+	view := m.View()
+	if !strings.Contains(view, "no agents match filter") {
+		t.Errorf("expected 'no agents match filter', got:\n%s", view)
+	}
+}
+
+// --- navigation tests ---
+
+func TestNavigation_JDown(t *testing.T) {
+	m := NewAgentListModel()
+	m.SetAgents([]AgentListItem{
+		makeItem("a1", "alpha", types.StatusRunning, 1),
+		makeItem("a2", "beta", types.StatusRunning, 2),
+		makeItem("a3", "gamma", types.StatusRunning, 3),
+	})
+	if m.cursor != 0 {
+		t.Fatalf("expected cursor at 0, got %d", m.cursor)
+	}
+	m, _ = pressKey(m, "j")
+	if m.cursor != 1 {
+		t.Errorf("expected cursor at 1 after j, got %d", m.cursor)
+	}
+	m, _ = pressKey(m, "j")
+	if m.cursor != 2 {
+		t.Errorf("expected cursor at 2 after second j, got %d", m.cursor)
+	}
+	// Should not go past end
+	m, _ = pressKey(m, "j")
+	if m.cursor != 2 {
+		t.Errorf("expected cursor to stay at 2 (end of list), got %d", m.cursor)
+	}
+}
+
+func TestNavigation_KUp(t *testing.T) {
+	m := NewAgentListModel()
+	m.SetAgents([]AgentListItem{
+		makeItem("a1", "alpha", types.StatusRunning, 1),
+		makeItem("a2", "beta", types.StatusRunning, 2),
+	})
+	m.cursor = 1
+	m, _ = pressKey(m, "k")
+	if m.cursor != 0 {
+		t.Errorf("expected cursor at 0 after k, got %d", m.cursor)
+	}
+	// Should not go below 0
+	m, _ = pressKey(m, "k")
+	if m.cursor != 0 {
+		t.Errorf("expected cursor to stay at 0, got %d", m.cursor)
+	}
+}
+
+func TestNavigation_ArrowKeys(t *testing.T) {
+	m := NewAgentListModel()
+	m.SetAgents([]AgentListItem{
+		makeItem("a1", "alpha", types.StatusRunning, 1),
+		makeItem("a2", "beta", types.StatusRunning, 2),
+	})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if m.cursor != 1 {
+		t.Errorf("expected cursor 1 after Down, got %d", m.cursor)
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.cursor != 0 {
+		t.Errorf("expected cursor 0 after Up, got %d", m.cursor)
+	}
+}
+
+// --- filter tests ---
+
+func TestFilter_EnterAndExit(t *testing.T) {
+	m := NewAgentListModel()
+	m.SetAgents([]AgentListItem{makeItem("a1", "alpha", types.StatusRunning, 1)})
+
+	if m.filtering {
+		t.Fatal("should not be filtering initially")
+	}
+
+	// Enter filter mode via /
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
+	if !m.filtering {
+		t.Fatal("expected filtering=true after /")
+	}
+
+	// Type some characters
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("al")})
+	if m.filter != "al" {
+		t.Errorf("expected filter='al', got %q", m.filter)
+	}
+
+	// Escape exits filter mode and clears filter
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.filtering {
+		t.Error("expected filtering=false after Esc")
+	}
+	if m.filter != "" {
+		t.Errorf("expected filter cleared after Esc, got %q", m.filter)
+	}
+}
+
+func TestFilter_Narrows(t *testing.T) {
+	m := NewAgentListModel()
+	m.SetAgents([]AgentListItem{
+		makeItem("a1", "alpha", types.StatusRunning, 1),
+		makeItem("a2", "beta", types.StatusRunning, 2),
+		makeItem("a3", "alpine", types.StatusRunning, 3),
+	})
+
+	m.filtering = true
+	m.filter = "al"
+
+	visible := m.visibleAgents()
+	if len(visible) != 2 {
+		t.Errorf("expected 2 visible agents with filter 'al', got %d", len(visible))
+	}
+	names := map[string]bool{}
+	for _, a := range visible {
+		names[a.Name] = true
+	}
+	if !names["alpha"] {
+		t.Error("expected 'alpha' in filtered results")
+	}
+	if !names["alpine"] {
+		t.Error("expected 'alpine' in filtered results")
+	}
+	if names["beta"] {
+		t.Error("did not expect 'beta' in filtered results")
+	}
+}
+
+func TestFilter_CaseInsensitive(t *testing.T) {
+	m := NewAgentListModel()
+	m.SetAgents([]AgentListItem{
+		makeItem("a1", "Worker-Alpha", types.StatusRunning, 1),
+	})
+	m.filtering = true
+	m.filter = "worker"
+	visible := m.visibleAgents()
+	if len(visible) != 1 {
+		t.Errorf("expected 1 result for case-insensitive filter, got %d", len(visible))
+	}
+}
+
+func TestFilter_Backspace(t *testing.T) {
+	m := NewAgentListModel()
+	m.SetAgents([]AgentListItem{makeItem("a1", "alpha", types.StatusRunning, 1)})
+	m.filtering = true
+	m.filter = "alp"
+
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if m.filter != "al" {
+		t.Errorf("expected filter='al' after backspace, got %q", m.filter)
+	}
+}
+
+// --- SelectedAgent tests ---
+
+func TestSelectedAgent_Empty(t *testing.T) {
+	m := NewAgentListModel()
+	_, ok := m.SelectedAgent()
+	if ok {
+		t.Error("expected SelectedAgent to return false for empty list")
+	}
+}
+
+func TestSelectedAgent_ReturnsCorrect(t *testing.T) {
+	m := NewAgentListModel()
+	items := []AgentListItem{
+		makeItem("a1", "alpha", types.StatusRunning, 1),
+		makeItem("a2", "beta", types.StatusStopped, 0),
+	}
+	m.SetAgents(items)
+	m.cursor = 1
+
+	agent, ok := m.SelectedAgent()
+	if !ok {
+		t.Fatal("expected SelectedAgent to return true")
+	}
+	if agent.ID != "a2" {
+		t.Errorf("expected agent ID 'a2', got %q", agent.ID)
+	}
+}
+
+func TestSelectedAgent_EnterEmitsMsg(t *testing.T) {
+	m := NewAgentListModel()
+	m.SetAgents([]AgentListItem{makeItem("a1", "alpha", types.StatusRunning, 1)})
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected a command from enter key, got nil")
+	}
+	msg := cmd()
+	sel, ok := msg.(AgentSelectedMsg)
+	if !ok {
+		t.Fatalf("expected AgentSelectedMsg, got %T", msg)
+	}
+	if sel.AgentID != "a1" {
+		t.Errorf("expected AgentID 'a1', got %q", sel.AgentID)
+	}
+}
+
+// --- resize tests ---
+
+func TestSetSize(t *testing.T) {
+	m := NewAgentListModel()
+	m.SetSize(100, 40)
+	if m.width != 100 || m.height != 40 {
+		t.Errorf("expected width=100 height=40, got %d %d", m.width, m.height)
+	}
+}
+
+func TestWindowSizeMsg(t *testing.T) {
+	m := NewAgentListModel()
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	if m.width != 80 || m.height != 24 {
+		t.Errorf("expected width=80 height=24 after WindowSizeMsg, got %d %d", m.width, m.height)
+	}
+}
+
+func TestAgentListUpdatedMsg(t *testing.T) {
+	m := NewAgentListModel()
+	msg := AgentListUpdatedMsg{
+		Agents: []AgentListItem{makeItem("a1", "alpha", types.StatusRunning, 1)},
+	}
+	m, _ = m.Update(msg)
+	if len(m.agents) != 1 {
+		t.Errorf("expected 1 agent after AgentListUpdatedMsg, got %d", len(m.agents))
+	}
+}
+
+// --- focused border test ---
+
+func TestFocused(t *testing.T) {
+	m := NewAgentListModel()
+	if m.Focused() {
+		t.Error("expected unfocused initially")
+	}
+	m.SetFocused(true)
+	if !m.Focused() {
+		t.Error("expected focused after SetFocused(true)")
+	}
+}
+
+// --- format helpers ---
+
+func TestFormatUptime(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{45 * time.Second, "45s"},
+		{90 * time.Second, "1m30s"},
+		{3700 * time.Second, "1h01m"},
+	}
+	for _, c := range cases {
+		got := formatUptime(c.d)
+		if got != c.want {
+			t.Errorf("formatUptime(%v) = %q, want %q", c.d, got, c.want)
+		}
+	}
+}
+
+func TestFormatPID(t *testing.T) {
+	if formatPID(0) != "-" {
+		t.Error("expected '-' for PID 0")
+	}
+	if formatPID(1234) != "1234" {
+		t.Errorf("expected '1234', got %q", formatPID(1234))
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if truncate("hello", 10) != "hello" {
+		t.Error("short string should not be truncated")
+	}
+	if truncate("hello world", 8) != "hello..." {
+		t.Errorf("expected 'hello...', got %q", truncate("hello world", 8))
+	}
+}

--- a/modules/agent-manager/src/internal/tui/keys.go
+++ b/modules/agent-manager/src/internal/tui/keys.go
@@ -1,3 +1,38 @@
-// keys.go defines the key bindings for the TUI using bubbletea/key.
-// Epic 2 will implement all key maps: navigation, agent control, log scrolling.
+// keys.go defines the key bindings for the TUI using bubbles/key.
 package tui
+
+import "github.com/charmbracelet/bubbles/key"
+
+// KeyMap holds all named key bindings for the agent manager TUI.
+type KeyMap struct {
+	Up       key.Binding
+	Down     key.Binding
+	Enter    key.Binding
+	Filter   key.Binding
+	Escape   key.Binding
+	Quit     key.Binding
+	Help     key.Binding
+	Stop     key.Binding
+	Restart  key.Binding
+	Kill     key.Binding
+	New      key.Binding
+	Tab      key.Binding
+	Export   key.Binding
+}
+
+// DefaultKeyMap is the key map used when no other map is configured.
+var DefaultKeyMap = KeyMap{
+	Up:      key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/↑", "up")),
+	Down:    key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j/↓", "down")),
+	Enter:   key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+	Filter:  key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "filter")),
+	Escape:  key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+	Quit:    key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
+	Help:    key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+	Stop:    key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "stop")),
+	Restart: key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "restart")),
+	Kill:    key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "kill")),
+	New:     key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
+	Tab:     key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "switch panel")),
+	Export:  key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export logs")),
+}

--- a/modules/agent-manager/src/internal/tui/styles.go
+++ b/modules/agent-manager/src/internal/tui/styles.go
@@ -1,3 +1,24 @@
 // styles.go defines lipgloss styles used throughout the TUI.
-// Epic 2 will implement the full design system: colors, borders, typography.
 package tui
+
+import "github.com/charmbracelet/lipgloss"
+
+var (
+	// Panel borders
+	ActiveBorderStyle   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("62"))
+	InactiveBorderStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("240"))
+
+	// Status colors
+	StatusRunning    = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))  // green
+	StatusHanging    = lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // yellow/orange
+	StatusCrashed    = lipgloss.NewStyle().Foreground(lipgloss.Color("196")) // red
+	StatusStopped    = lipgloss.NewStyle().Foreground(lipgloss.Color("240")) // gray
+	StatusRestarting = lipgloss.NewStyle().Foreground(lipgloss.Color("33"))  // blue
+
+	// Table
+	HeaderStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("252"))
+	SelectedStyle = lipgloss.NewStyle().Background(lipgloss.Color("237")).Bold(true)
+
+	// Title
+	TitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("62")).Padding(0, 1)
+)


### PR DESCRIPTION
## Summary

- Implements `styles.go` with Lip Gloss styles for panel borders, status colors, table headers, and selection highlight
- Implements `keys.go` with `KeyMap` struct and `DefaultKeyMap` covering all navigation, agent control, and filter bindings using `bubbles/key`
- Implements `agentlist.go` with `AgentListModel` - a full Bubble Tea component for the left-pane agent list

## Features

- Table view with columns: Name, Status, Uptime, PID, Restarts
- Color-coded status indicators (green running, yellow hanging, red crashed, gray stopped, blue restarting)
- vim-style j/k navigation with arrow key support
- `/` to enter filter mode with case-insensitive name filtering, `Esc` to exit
- Selected row highlight via `SelectedStyle`
- `AgentSelectedMsg` emitted on Enter keypress
- `AgentListUpdatedMsg` for receiving fresh agent snapshots from the manager
- Active/inactive border styles via `SetFocused`
- `SetSize` + `tea.WindowSizeMsg` for responsive layout

## Test plan

- [x] 22 tests covering: empty state, all status renders, j/k/arrow navigation, boundary clamping, filter enter/exit/backspace/case-insensitive, SelectedAgent empty/correct, Enter emits AgentSelectedMsg, resize via SetSize and WindowSizeMsg, AgentListUpdatedMsg, focused state, formatUptime, formatPID, truncate
- [x] `go test -race ./...` passes (all packages)
- [x] `go vet ./...` clean
- [x] Closes #204