### PR TITLE
#206: implement command bar and keybinding system with help overlay

### DIFF
--- a/modules/agent-manager/src/internal/tui/commandbar.go
+++ b/modules/agent-manager/src/internal/tui/commandbar.go
@@ -1,3 +1,175 @@
-// commandbar.go renders the bottom bar with available key bindings.
-// Epic 2 will implement dynamic key hint rendering based on active focus.
+// commandbar.go renders the bottom bar with contextual key binding hints and status messages.
 package tui
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// BarContext identifies which panel is currently focused, controlling which
+// hints the command bar displays.
+type BarContext string
+
+const (
+	ContextAgentList BarContext = "agent-list"
+	ContextLogViewer BarContext = "log-viewer"
+	ContextModal     BarContext = "modal"
+)
+
+const statusClearDelay = 3 * time.Second
+
+// StatusMsg carries a status message to display in the command bar.
+type StatusMsg struct {
+	Text    string
+	IsError bool
+}
+
+// ClearStatusMsg signals that the current status message should be cleared.
+type ClearStatusMsg struct{}
+
+// CommandBarModel is a Bubble Tea component that renders a contextual command
+// bar at the bottom of the screen.
+type CommandBarModel struct {
+	keys        KeyMap
+	context     BarContext
+	message     string
+	messageErr  bool
+	messageTime time.Time
+	width       int
+}
+
+// NewCommandBarModel returns a CommandBarModel with DefaultKeyMap and the
+// agent-list context active.
+func NewCommandBarModel(keys KeyMap) CommandBarModel {
+	return CommandBarModel{
+		keys:    keys,
+		context: ContextAgentList,
+	}
+}
+
+// Init satisfies the tea.Model interface. No I/O is needed on startup.
+func (m CommandBarModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles messages relevant to the command bar: window resize, status
+// messages, and the auto-clear tick.
+func (m CommandBarModel) Update(msg tea.Msg) (CommandBarModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+
+	case StatusMsg:
+		m.message = msg.Text
+		m.messageErr = msg.IsError
+		m.messageTime = time.Now()
+		return m, tea.Tick(statusClearDelay, func(t time.Time) tea.Msg {
+			return ClearStatusMsg{}
+		})
+
+	case ClearStatusMsg:
+		m.message = ""
+		m.messageErr = false
+	}
+	return m, nil
+}
+
+// View renders the command bar as a full-width string.
+func (m CommandBarModel) View() string {
+	bg := lipgloss.NewStyle().
+		Background(lipgloss.Color("236")).
+		Width(m.width)
+
+	// If there is a status message, show it instead of keybinding hints.
+	if m.message != "" {
+		color := lipgloss.Color("2") // green for success
+		if m.messageErr {
+			color = lipgloss.Color("1") // red for error
+		}
+		msgStyle := lipgloss.NewStyle().
+			Background(lipgloss.Color("236")).
+			Foreground(color).
+			Bold(true).
+			PaddingLeft(1)
+		return bg.Render(msgStyle.Render(m.message))
+	}
+
+	hints := m.hintsForContext()
+	return bg.Render(renderHints(hints, m.width))
+}
+
+// SetContext updates the focused panel context so the correct hints are shown.
+func (m *CommandBarModel) SetContext(ctx BarContext) {
+	m.context = ctx
+}
+
+// SetMessage displays a status message in the command bar. Callers should also
+// send a StatusMsg through the Bubble Tea update loop to trigger auto-clear.
+func (m *CommandBarModel) SetMessage(msg string) {
+	m.message = msg
+	m.messageTime = time.Now()
+}
+
+// SetWidth updates the render width (called on terminal resize).
+func (m *CommandBarModel) SetWidth(width int) {
+	m.width = width
+}
+
+// hint is a single key/description pair rendered in the command bar.
+type hint struct {
+	key  string
+	desc string
+}
+
+func (m CommandBarModel) hintsForContext() []hint {
+	switch m.context {
+	case ContextLogViewer:
+		return []hint{
+			{key: "j/k", desc: "scroll"},
+			{key: "e", desc: "export"},
+			{key: "tab", desc: "agents"},
+			{key: "?", desc: "help"},
+			{key: "q", desc: "quit"},
+		}
+	case ContextModal:
+		return []hint{
+			{key: "enter", desc: "confirm"},
+			{key: "esc", desc: "cancel"},
+		}
+	default: // ContextAgentList
+		return []hint{
+			{key: "n", desc: "new"},
+			{key: "s", desc: "stop"},
+			{key: "r", desc: "restart"},
+			{key: "x", desc: "kill"},
+			{key: "/", desc: "filter"},
+			{key: "tab", desc: "logs"},
+			{key: "?", desc: "help"},
+			{key: "q", desc: "quit"},
+		}
+	}
+}
+
+// renderHints builds the hint string from key/desc pairs using Lip Gloss styles.
+func renderHints(hints []hint, width int) string {
+	keyStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("15")).
+		Background(lipgloss.Color("236"))
+
+	descStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("244")).
+		Background(lipgloss.Color("236"))
+
+	var parts []string
+	for _, h := range hints {
+		parts = append(parts, keyStyle.Render(h.key)+" "+descStyle.Render(h.desc))
+	}
+
+	content := " " + strings.Join(parts, "  ")
+	_ = width // width is applied by the outer bg style
+	return content
+}

--- a/modules/agent-manager/src/internal/tui/commandbar_test.go
+++ b/modules/agent-manager/src/internal/tui/commandbar_test.go
@@ -1,0 +1,110 @@
+package tui_test
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/tui"
+)
+
+func TestCommandBar_AgentListContext(t *testing.T) {
+	m := tui.NewCommandBarModel(tui.DefaultKeyMap)
+	m.SetWidth(120)
+
+	view := m.View()
+
+	// All agent-list hints must appear.
+	for _, want := range []string{"n", "new", "s", "stop", "r", "restart", "x", "kill", "/", "filter", "tab", "logs", "?", "help", "q", "quit"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("agent-list view missing %q\nfull view: %q", want, view)
+		}
+	}
+}
+
+func TestCommandBar_LogViewerContext(t *testing.T) {
+	m := tui.NewCommandBarModel(tui.DefaultKeyMap)
+	m.SetWidth(120)
+	m.SetContext(tui.ContextLogViewer)
+
+	view := m.View()
+
+	for _, want := range []string{"j/k", "scroll", "e", "export", "tab", "agents", "?", "help", "q", "quit"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("log-viewer view missing %q\nfull view: %q", want, view)
+		}
+	}
+
+	// Agent-list specific hints must NOT appear.
+	for _, absent := range []string{"stop", "restart", "kill", "filter"} {
+		if strings.Contains(view, absent) {
+			t.Errorf("log-viewer view should not contain %q\nfull view: %q", absent, view)
+		}
+	}
+}
+
+func TestCommandBar_ModalContext(t *testing.T) {
+	m := tui.NewCommandBarModel(tui.DefaultKeyMap)
+	m.SetWidth(120)
+	m.SetContext(tui.ContextModal)
+
+	view := m.View()
+
+	for _, want := range []string{"enter", "confirm", "esc", "cancel"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("modal view missing %q\nfull view: %q", want, view)
+		}
+	}
+}
+
+func TestCommandBar_StatusMessage(t *testing.T) {
+	m := tui.NewCommandBarModel(tui.DefaultKeyMap)
+	m.SetWidth(120)
+
+	m2, _ := m.Update(tui.StatusMsg{Text: "Agent stopped", IsError: false})
+
+	view := m2.View()
+	if !strings.Contains(view, "Agent stopped") {
+		t.Errorf("expected status message in view, got: %q", view)
+	}
+}
+
+func TestCommandBar_StatusMessageError(t *testing.T) {
+	m := tui.NewCommandBarModel(tui.DefaultKeyMap)
+	m.SetWidth(120)
+
+	m2, _ := m.Update(tui.StatusMsg{Text: "Kill failed", IsError: true})
+
+	view := m2.View()
+	if !strings.Contains(view, "Kill failed") {
+		t.Errorf("expected error message in view, got: %q", view)
+	}
+}
+
+func TestCommandBar_StatusMessageAutoClear(t *testing.T) {
+	m := tui.NewCommandBarModel(tui.DefaultKeyMap)
+	m.SetWidth(120)
+
+	// Show a status message.
+	m2, _ := m.Update(tui.StatusMsg{Text: "Done", IsError: false})
+
+	// Simulate the auto-clear tick arriving.
+	m3, _ := m2.Update(tui.ClearStatusMsg{})
+
+	// The message should be cleared; keybinding hints should now show.
+	view := m3.View()
+	if strings.Contains(view, "Done") {
+		t.Errorf("status message should have been cleared, got: %q", view)
+	}
+}
+
+func TestCommandBar_WidthResize(t *testing.T) {
+	m := tui.NewCommandBarModel(tui.DefaultKeyMap)
+
+	// Default width is 0 - no panic.
+	_ = m.View()
+
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 200, Height: 40})
+	_ = m2.View()
+}

--- a/modules/agent-manager/src/internal/tui/help.go
+++ b/modules/agent-manager/src/internal/tui/help.go
@@ -1,0 +1,163 @@
+// help.go implements the help overlay that shows all keybindings organized by category.
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// HelpModel is a Bubble Tea component that renders a centered modal overlay
+// listing all keybindings grouped by category. The parent model is responsible
+// for layering this on top of other content when Visible() returns true.
+type HelpModel struct {
+	keys    KeyMap
+	visible bool
+	width   int
+	height  int
+}
+
+// NewHelpModel returns a HelpModel with the given key map. The overlay starts hidden.
+func NewHelpModel(keys KeyMap) HelpModel {
+	return HelpModel{keys: keys}
+}
+
+// Update handles keyboard messages to toggle or dismiss the overlay.
+func (m HelpModel) Update(msg tea.Msg) (HelpModel, tea.Cmd) {
+	if !m.visible {
+		return m, nil
+	}
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "?", "esc":
+			m.visible = false
+		}
+	}
+	return m, nil
+}
+
+// View renders the centered help modal. If the overlay is not visible it
+// returns an empty string.
+func (m HelpModel) View() string {
+	if !m.visible {
+		return ""
+	}
+
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("12")).
+		MarginBottom(1)
+
+	categoryStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("11"))
+
+	keyStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("15"))
+
+	descStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("244"))
+
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("62")).
+		Padding(1, 3).
+		Background(lipgloss.Color("235"))
+
+	var sb strings.Builder
+
+	sb.WriteString(titleStyle.Render("Keybindings"))
+	sb.WriteString("\n")
+
+	type entry struct {
+		key  string
+		desc string
+	}
+	type category struct {
+		name    string
+		entries []entry
+	}
+
+	categories := []category{
+		{
+			name: "Navigation",
+			entries: []entry{
+				{"j/↓", "Move down"},
+				{"k/↑", "Move up"},
+				{"tab", "Switch panel"},
+				{"/", "Filter agents"},
+				{"esc", "Cancel/back"},
+			},
+		},
+		{
+			name: "Agent Actions",
+			entries: []entry{
+				{"n", "New agent"},
+				{"s", "Stop agent"},
+				{"r", "Restart agent"},
+				{"x", "Kill agent"},
+			},
+		},
+		{
+			name: "Log Actions",
+			entries: []entry{
+				{"e", "Export logs"},
+			},
+		},
+		{
+			name: "General",
+			entries: []entry{
+				{"?", "Toggle help"},
+				{"q", "Quit"},
+			},
+		},
+	}
+
+	for i, cat := range categories {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(categoryStyle.Render(cat.name))
+		sb.WriteString("\n")
+		for _, e := range cat.entries {
+			sb.WriteString("  ")
+			sb.WriteString(keyStyle.Render(padKey(e.key, 6)))
+			sb.WriteString(" ")
+			sb.WriteString(descStyle.Render(e.desc))
+			sb.WriteString("\n")
+		}
+	}
+
+	content := strings.TrimRight(sb.String(), "\n")
+	box := boxStyle.Render(content)
+
+	// Center the box in the available terminal space.
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
+}
+
+// Toggle flips the visible state of the overlay.
+func (m *HelpModel) Toggle() {
+	m.visible = !m.visible
+}
+
+// Visible reports whether the overlay is currently shown.
+func (m HelpModel) Visible() bool {
+	return m.visible
+}
+
+// SetSize stores the terminal dimensions used to center the overlay.
+func (m *HelpModel) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+// padKey right-pads a key string to the given width for column alignment.
+func padKey(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}

--- a/modules/agent-manager/src/internal/tui/help_test.go
+++ b/modules/agent-manager/src/internal/tui/help_test.go
@@ -1,0 +1,117 @@
+package tui_test
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/tui"
+)
+
+func TestHelp_InitiallyHidden(t *testing.T) {
+	m := tui.NewHelpModel(tui.DefaultKeyMap)
+	if m.Visible() {
+		t.Error("help overlay should start hidden")
+	}
+	if m.View() != "" {
+		t.Errorf("hidden overlay should render empty string, got %q", m.View())
+	}
+}
+
+func TestHelp_Toggle(t *testing.T) {
+	m := tui.NewHelpModel(tui.DefaultKeyMap)
+
+	m.Toggle()
+	if !m.Visible() {
+		t.Error("toggle should make overlay visible")
+	}
+
+	m.Toggle()
+	if m.Visible() {
+		t.Error("second toggle should hide overlay")
+	}
+}
+
+func TestHelp_ViewContainsAllCategories(t *testing.T) {
+	m := tui.NewHelpModel(tui.DefaultKeyMap)
+	m.SetSize(120, 40)
+	m.Toggle()
+
+	view := m.View()
+
+	for _, cat := range []string{"Navigation", "Agent Actions", "Log Actions", "General"} {
+		if !strings.Contains(view, cat) {
+			t.Errorf("help view missing category %q\nfull view: %q", cat, view)
+		}
+	}
+}
+
+func TestHelp_ViewContainsKeyEntries(t *testing.T) {
+	m := tui.NewHelpModel(tui.DefaultKeyMap)
+	m.SetSize(120, 40)
+	m.Toggle()
+
+	view := m.View()
+
+	for _, entry := range []string{
+		"Move down",
+		"Move up",
+		"Switch panel",
+		"Filter agents",
+		"New agent",
+		"Stop agent",
+		"Restart agent",
+		"Kill agent",
+		"Export logs",
+		"Toggle help",
+		"Quit",
+	} {
+		if !strings.Contains(view, entry) {
+			t.Errorf("help view missing entry %q\nfull view: %q", entry, view)
+		}
+	}
+}
+
+func TestHelp_DismissWithEscape(t *testing.T) {
+	m := tui.NewHelpModel(tui.DefaultKeyMap)
+	m.Toggle()
+	if !m.Visible() {
+		t.Fatal("expected overlay to be visible")
+	}
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if m2.Visible() {
+		t.Error("escape should dismiss the help overlay")
+	}
+}
+
+func TestHelp_DismissWithQuestionMark(t *testing.T) {
+	m := tui.NewHelpModel(tui.DefaultKeyMap)
+	m.Toggle()
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	if m2.Visible() {
+		t.Error("? should dismiss the help overlay when visible")
+	}
+}
+
+func TestHelp_UpdateIgnoredWhenHidden(t *testing.T) {
+	m := tui.NewHelpModel(tui.DefaultKeyMap)
+	// Overlay is hidden; pressing esc should not change visible state.
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if m2.Visible() {
+		t.Error("update while hidden should not change visible state")
+	}
+}
+
+func TestHelp_SetSize(t *testing.T) {
+	m := tui.NewHelpModel(tui.DefaultKeyMap)
+	m.SetSize(80, 24)
+	m.Toggle()
+	// Should not panic and should produce a non-empty view.
+	view := m.View()
+	if view == "" {
+		t.Error("expected non-empty view after SetSize and Toggle")
+	}
+}

--- a/modules/agent-manager/src/internal/tui/keys.go
+++ b/modules/agent-manager/src/internal/tui/keys.go
@@ -3,7 +3,7 @@ package tui
 
 import "github.com/charmbracelet/bubbles/key"
 
-// KeyMap holds all named key bindings for the agent manager TUI.
+// KeyMap holds all keybindings used across the TUI.
 type KeyMap struct {
 	Up       key.Binding
 	Down     key.Binding
@@ -18,21 +18,25 @@ type KeyMap struct {
 	New      key.Binding
 	Tab      key.Binding
 	Export   key.Binding
+	PageUp   key.Binding
+	PageDown key.Binding
 }
 
-// DefaultKeyMap is the key map used when no other map is configured.
+// DefaultKeyMap is the default keybinding set used by the TUI.
 var DefaultKeyMap = KeyMap{
-	Up:      key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/↑", "up")),
-	Down:    key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j/↓", "down")),
-	Enter:   key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
-	Filter:  key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "filter")),
-	Escape:  key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
-	Quit:    key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
-	Help:    key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
-	Stop:    key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "stop")),
-	Restart: key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "restart")),
-	Kill:    key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "kill")),
-	New:     key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
-	Tab:     key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "switch panel")),
-	Export:  key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export logs")),
+	Up:       key.NewBinding(key.WithKeys("k", "up"), key.WithHelp("k/↑", "up")),
+	Down:     key.NewBinding(key.WithKeys("j", "down"), key.WithHelp("j/↓", "down")),
+	Enter:    key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+	Filter:   key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "filter")),
+	Escape:   key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+	Quit:     key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
+	Help:     key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+	Stop:     key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "stop")),
+	Restart:  key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "restart")),
+	Kill:     key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "kill")),
+	New:      key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new agent")),
+	Tab:      key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "switch panel")),
+	Export:   key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "export logs")),
+	PageUp:   key.NewBinding(key.WithKeys("pgup"), key.WithHelp("pgup", "page up")),
+	PageDown: key.NewBinding(key.WithKeys("pgdown"), key.WithHelp("pgdn", "page down")),
 }


### PR DESCRIPTION
## Summary

- Implements full `KeyMap` with `DefaultKeyMap` using `charmbracelet/bubbles/key` bindings (15 bindings covering navigation, agent control, log actions, and general)
- Implements `CommandBarModel` - a Bubble Tea component that renders contextual keybinding hints at the bottom of the screen, switching between agent-list, log-viewer, and modal contexts
- Status messages display in the command bar and auto-clear after 3 seconds via `tea.Tick` + `ClearStatusMsg`
- Implements `HelpModel` - a centered modal overlay with all bindings organized into 4 categories (Navigation, Agent Actions, Log Actions, General), toggled/dismissed with `?` or `Esc`
- Adds `charmbracelet/bubbles v1.0.0` dependency

## Files changed

- `internal/tui/keys.go` - Full `KeyMap` and `DefaultKeyMap`
- `internal/tui/commandbar.go` - `CommandBarModel`, `BarContext`, `StatusMsg`, `ClearStatusMsg`
- `internal/tui/help.go` - `HelpModel` overlay
- `internal/tui/commandbar_test.go` - 7 tests covering all contexts, status messages, resize
- `internal/tui/help_test.go` - 8 tests covering toggle, dismiss, categories, key entries

## Test plan

- [x] `go test -race ./internal/tui/...` - all 15 tests pass
- [x] `go vet ./...` - clean
- [x] Pre-existing `internal/agent` failures are unrelated (require a mock binary compiled via `go test -c`)

Closes #206