### PR TITLE
#203: implement log collection with rotation, export, and parser interface

### DIFF
--- a/modules/agent-manager/src/internal/log/collector.go
+++ b/modules/agent-manager/src/internal/log/collector.go
@@ -1,4 +1,190 @@
-// Package log handles log collection, buffering, and export for agent processes.
-// collector.go reads stdout/stderr streams from running agents into ring buffers.
-// Epic 2 will implement the Collector type and per-agent log buffering.
+// Package log handles log collection, buffering, rotation, and export for
+// agent processes. collector.go reads stdout/stderr streams from running
+// agents, batches lines, and delivers them to the TUI via a send function.
 package log
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"sync"
+	"time"
+)
+
+// DefaultBatchInterval is the interval at which batched log lines are flushed
+// to the send function. 16ms gives ~60fps update cadence for the TUI.
+const DefaultBatchInterval = 16 * time.Millisecond
+
+// LogLine is a single line of output captured from a running agent process.
+type LogLine struct {
+	Text      string
+	IsStderr  bool
+	Timestamp time.Time
+}
+
+// LogLineMsg is the message type delivered to the TUI (via sendFn) containing
+// a batch of log lines from one agent. Using a generic func type keeps this
+// package free of any bubbletea dependency.
+type LogLineMsg struct {
+	AgentID string
+	Lines   []LogLine
+}
+
+// LogCollector reads stdout and stderr from an agent process, batches the
+// lines at a configurable interval, and calls sendFn for each batch. It also
+// writes every line to an optional LogWriter for file persistence.
+//
+// The collectors lifetime is tied to the readers: once both stdout and stderr
+// reach EOF, the collector automatically performs a final flush and exits. The
+// Stop method can be used to cancel the context early when the process is
+// killed; the readers will then be unblocked by the process exiting and
+// closing the pipes from the OS side.
+type LogCollector struct {
+	agentID       string
+	sendFn        func(msg LogLineMsg)
+	batchInterval time.Duration
+	writer        *LogWriter // may be nil
+
+	cancel  context.CancelFunc
+	stopped chan struct{} // closed when the flush goroutine exits
+
+	mu      sync.Mutex
+	pending []LogLine
+}
+
+// NewLogCollector creates a LogCollector for agentID. sendFn is called with
+// each batch of lines (never called with an empty slice). batchInterval
+// controls how often pending lines are flushed; pass 0 to use
+// DefaultBatchInterval. writer may be nil if file persistence is not needed.
+func NewLogCollector(agentID string, sendFn func(LogLineMsg), batchInterval time.Duration, writer *LogWriter) *LogCollector {
+	if batchInterval <= 0 {
+		batchInterval = DefaultBatchInterval
+	}
+	return &LogCollector{
+		agentID:       agentID,
+		sendFn:        sendFn,
+		batchInterval: batchInterval,
+		writer:        writer,
+		stopped:       make(chan struct{}),
+	}
+}
+
+// Start begins reading from stdout and stderr in separate goroutines. Lines
+// are collected into an internal buffer and flushed to sendFn at the
+// configured batchInterval.
+//
+// The flush goroutine exits once both reader goroutines finish (EOF on both
+// pipes) and performs a final flush. Stop cancels the context to signal
+// readers that they should exit on the next line boundary, then waits for the
+// flush goroutine to close.
+//
+// Start may only be called once per LogCollector.
+func (c *LogCollector) Start(ctx context.Context, stdout, stderr io.Reader) {
+	ctx, cancel := context.WithCancel(ctx)
+	c.cancel = cancel
+
+	// readersDone is closed once both reader goroutines have exited.
+	readersDone := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		c.readLines(ctx, stdout, false)
+	}()
+	go func() {
+		defer wg.Done()
+		c.readLines(ctx, stderr, true)
+	}()
+
+	// Close readersDone when both goroutines are done.
+	go func() {
+		wg.Wait()
+		close(readersDone)
+	}()
+
+	// Flush goroutine: drains the pending buffer on a timer, and does one
+	// final flush once both readers have exited.
+	go func() {
+		defer close(c.stopped)
+
+		ticker := time.NewTicker(c.batchInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				c.flush()
+			case <-readersDone:
+				// Both readers finished: final flush and exit.
+				c.flush()
+				return
+			}
+		}
+	}()
+}
+
+// Stop cancels the collection context and blocks until the flush goroutine
+// has performed its final flush and exited. It is safe to call Stop multiple
+// times.
+//
+// Note: reader goroutines blocked inside bufio.Scanner.Scan() cannot be
+// interrupted by context cancellation alone; they will unblock when the
+// underlying pipe is closed (i.e. when the agent process exits). Stop signals
+// that no new lines should be processed after the current one and waits for
+// the natural shutdown path.
+func (c *LogCollector) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+	<-c.stopped
+}
+
+// readLines scans lines from r and appends them to the pending buffer.
+// It exits when the reader returns EOF or an error, or after each scanned
+// line if the context has been cancelled.
+func (c *LogCollector) readLines(ctx context.Context, r io.Reader, isStderr bool) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := LogLine{
+			Text:      scanner.Text(),
+			IsStderr:  isStderr,
+			Timestamp: time.Now(),
+		}
+
+		// Write to file immediately (before batching for TUI).
+		if c.writer != nil {
+			// Best-effort: ignore write errors so a disk issue does not kill the TUI.
+			_ = c.writer.Write(line)
+		}
+
+		c.mu.Lock()
+		c.pending = append(c.pending, line)
+		c.mu.Unlock()
+
+		// Check context after each line so we stop promptly when cancelled.
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+	}
+}
+
+// flush takes ownership of pending lines and calls sendFn if there are any.
+func (c *LogCollector) flush() {
+	c.mu.Lock()
+	if len(c.pending) == 0 {
+		c.mu.Unlock()
+		return
+	}
+	lines := c.pending
+	c.pending = nil
+	c.mu.Unlock()
+
+	c.sendFn(LogLineMsg{
+		AgentID: c.agentID,
+		Lines:   lines,
+	})
+}

--- a/modules/agent-manager/src/internal/log/collector_test.go
+++ b/modules/agent-manager/src/internal/log/collector_test.go
@@ -1,0 +1,247 @@
+package log_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/log"
+)
+
+// pipePair returns (writer, reader) backed by an io.Pipe.
+func pipePair() (*io.PipeWriter, *io.PipeReader) {
+	r, w := io.Pipe()
+	return w, r
+}
+
+func TestCollector_ReceivesBatchedLines(t *testing.T) {
+	var mu sync.Mutex
+	var received []log.LogLineMsg
+
+	sendFn := func(msg log.LogLineMsg) {
+		mu.Lock()
+		received = append(received, msg)
+		mu.Unlock()
+	}
+
+	stdoutW, stdoutR := pipePair()
+	stderrW, stderrR := pipePair()
+
+	c := log.NewLogCollector("agent-1", sendFn, 16*time.Millisecond, nil)
+	c.Start(context.Background(), stdoutR, stderrR)
+
+	// Write several lines quickly - they should all arrive eventually.
+	lines := []string{"line1", "line2", "line3"}
+	for _, l := range lines {
+		_, err := io.WriteString(stdoutW, l+"\n")
+		if err != nil {
+			t.Fatalf("write line: %v", err)
+		}
+	}
+
+	// Close both pipes so both reader goroutines reach EOF and the collector
+	// performs its final flush.
+	stdoutW.Close()
+	stderrW.Close()
+	c.Stop() // blocks until final flush
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Collect all lines across all batches.
+	var allLines []log.LogLine
+	for _, msg := range received {
+		if msg.AgentID != "agent-1" {
+			t.Errorf("unexpected agent ID %q in message", msg.AgentID)
+		}
+		allLines = append(allLines, msg.Lines...)
+	}
+
+	if len(allLines) != len(lines) {
+		t.Fatalf("expected %d lines total, got %d", len(lines), len(allLines))
+	}
+	for i, want := range lines {
+		if allLines[i].Text != want {
+			t.Errorf("line[%d]: got %q, want %q", i, allLines[i].Text, want)
+		}
+	}
+}
+
+func TestCollector_StdoutStderrSeparated(t *testing.T) {
+	var mu sync.Mutex
+	var received []log.LogLineMsg
+
+	sendFn := func(msg log.LogLineMsg) {
+		mu.Lock()
+		received = append(received, msg)
+		mu.Unlock()
+	}
+
+	stdoutW, stdoutR := pipePair()
+	stderrW, stderrR := pipePair()
+
+	c := log.NewLogCollector("agent-sep", sendFn, 16*time.Millisecond, nil)
+	c.Start(context.Background(), stdoutR, stderrR)
+
+	_, _ = io.WriteString(stdoutW, "out-line\n")
+	_, _ = io.WriteString(stderrW, "err-line\n")
+
+	stdoutW.Close()
+	stderrW.Close()
+	c.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	var gotOut, gotErr int
+	for _, msg := range received {
+		for _, line := range msg.Lines {
+			if line.Text == "out-line" && !line.IsStderr {
+				gotOut++
+			}
+			if line.Text == "err-line" && line.IsStderr {
+				gotErr++
+			}
+		}
+	}
+
+	if gotOut != 1 {
+		t.Errorf("expected 1 stdout line, got %d", gotOut)
+	}
+	if gotErr != 1 {
+		t.Errorf("expected 1 stderr line, got %d", gotErr)
+	}
+}
+
+func TestCollector_ContextCancellationStopsCollection(t *testing.T) {
+	var mu sync.Mutex
+	var totalLines int
+
+	sendFn := func(msg log.LogLineMsg) {
+		mu.Lock()
+		totalLines += len(msg.Lines)
+		mu.Unlock()
+	}
+
+	stdoutW, stdoutR := pipePair()
+	stderrW, stderrR := pipePair()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := log.NewLogCollector("agent-ctx", sendFn, 16*time.Millisecond, nil)
+	c.Start(ctx, stdoutR, stderrR)
+
+	_, _ = io.WriteString(stdoutW, "before-cancel\n")
+
+	// Cancel context after giving readers time to process the line.
+	// Then close pipes so readers can unblock and exit.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	stdoutW.Close()
+	stderrW.Close()
+
+	// Stop should return promptly once pipes are closed.
+	done := make(chan struct{})
+	go func() {
+		c.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good: Stop returned promptly.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return within 2 seconds after context cancellation")
+	}
+}
+
+func TestCollector_ConcurrentReadersNoRace(t *testing.T) {
+	// This test is designed to surface data races when run with -race.
+	var mu sync.Mutex
+	var total int
+
+	sendFn := func(msg log.LogLineMsg) {
+		mu.Lock()
+		total += len(msg.Lines)
+		mu.Unlock()
+	}
+
+	stdoutW, stdoutR := pipePair()
+	stderrW, stderrR := pipePair()
+
+	c := log.NewLogCollector("agent-race", sendFn, 8*time.Millisecond, nil)
+	c.Start(context.Background(), stdoutR, stderrR)
+
+	// Write from multiple goroutines concurrently.
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = io.WriteString(stdoutW, strings.Repeat("x", 64)+"\n")
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = io.WriteString(stderrW, strings.Repeat("e", 64)+"\n")
+		}()
+	}
+	wg.Wait()
+
+	// Close both pipes before calling Stop so readers unblock.
+	stdoutW.Close()
+	stderrW.Close()
+	c.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if total != 20 {
+		t.Errorf("expected 20 lines total, got %d", total)
+	}
+}
+
+func TestCollector_BatchInterval_LinesBatchedTogether(t *testing.T) {
+	// Use a long batch interval so all lines written quickly are in one batch.
+	const interval = 200 * time.Millisecond
+
+	var mu sync.Mutex
+	var batches []int // number of lines per batch
+
+	sendFn := func(msg log.LogLineMsg) {
+		mu.Lock()
+		batches = append(batches, len(msg.Lines))
+		mu.Unlock()
+	}
+
+	stdoutW, stdoutR := pipePair()
+	stderrW, stderrR := pipePair()
+
+	c := log.NewLogCollector("agent-batch", sendFn, interval, nil)
+	c.Start(context.Background(), stdoutR, stderrR)
+
+	// Write 5 lines quickly - they should all land in one batch before the
+	// first tick fires (interval is 200ms, writes are nearly instantaneous).
+	for i := 0; i < 5; i++ {
+		_, _ = io.WriteString(stdoutW, "line\n")
+	}
+
+	// Close both pipes so readers reach EOF, triggering the final flush.
+	stdoutW.Close()
+	stderrW.Close()
+	c.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// All 5 lines should have arrived across one or more batches.
+	total := 0
+	for _, n := range batches {
+		total += n
+	}
+	if total != 5 {
+		t.Errorf("expected 5 lines across all batches, got %d", total)
+	}
+}

--- a/modules/agent-manager/src/internal/log/export.go
+++ b/modules/agent-manager/src/internal/log/export.go
@@ -1,3 +1,57 @@
-// export.go provides log export functionality: saving agent logs to files.
-// Epic 2 will implement export-to-file commands triggered from the TUI.
+// export.go exports agent log files to a single plain-text output file.
+// It combines previous.log (if present) followed by latest.log so the
+// resulting file is in chronological order.
 package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// ExportLogs reads latest.log and (if present) previous.log from logDir and
+// writes their combined contents to outputPath. previous.log is written first
+// so the output file is in chronological order.
+//
+// The output file is created with 0600 permissions. If outputPath already
+// exists it is overwritten.
+func ExportLogs(logDir string, outputPath string) error {
+	out, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("export logs: create output file %s: %w", outputPath, err)
+	}
+	defer out.Close()
+
+	// Write previous.log first (older data), if it exists.
+	prevPath := filepath.Join(logDir, previousLogName)
+	if err := appendFile(out, prevPath); err != nil {
+		return fmt.Errorf("export logs: append previous.log: %w", err)
+	}
+
+	// Write latest.log (newer data).
+	latestPath := filepath.Join(logDir, latestLogName)
+	if err := appendFile(out, latestPath); err != nil {
+		return fmt.Errorf("export logs: append latest.log: %w", err)
+	}
+
+	return nil
+}
+
+// appendFile copies the contents of srcPath to dst. If srcPath does not
+// exist, the function returns nil (the file is simply skipped).
+func appendFile(dst io.Writer, srcPath string) error {
+	f, err := os.Open(srcPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("open %s: %w", srcPath, err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(dst, f); err != nil {
+		return fmt.Errorf("copy %s: %w", srcPath, err)
+	}
+	return nil
+}

--- a/modules/agent-manager/src/internal/log/export_test.go
+++ b/modules/agent-manager/src/internal/log/export_test.go
@@ -1,0 +1,157 @@
+package log_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/log"
+)
+
+// writeLogFile is a test helper that creates logDir/filename containing body.
+func writeLogFile(t *testing.T, logDir, filename, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(logDir, filename), []byte(body), 0600); err != nil {
+		t.Fatalf("writeLogFile %s: %v", filename, err)
+	}
+}
+
+func TestExportLogs_CombinesLatestAndPrevious(t *testing.T) {
+	logDir := t.TempDir()
+	outDir := t.TempDir()
+
+	writeLogFile(t, logDir, "previous.log", "previous-line\n")
+	writeLogFile(t, logDir, "latest.log", "latest-line\n")
+
+	outPath := filepath.Join(outDir, "export.txt")
+	if err := log.ExportLogs(logDir, outPath); err != nil {
+		t.Fatalf("ExportLogs: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read export: %v", err)
+	}
+
+	combined := string(data)
+	if !strings.Contains(combined, "previous-line") {
+		t.Error("export missing content from previous.log")
+	}
+	if !strings.Contains(combined, "latest-line") {
+		t.Error("export missing content from latest.log")
+	}
+
+	// previous.log should appear before latest.log (chronological order).
+	prevIdx := strings.Index(combined, "previous-line")
+	latestIdx := strings.Index(combined, "latest-line")
+	if prevIdx >= latestIdx {
+		t.Errorf("expected previous-line before latest-line in export; prevIdx=%d latestIdx=%d", prevIdx, latestIdx)
+	}
+}
+
+func TestExportLogs_OnlyLatestLog(t *testing.T) {
+	logDir := t.TempDir()
+	outDir := t.TempDir()
+
+	writeLogFile(t, logDir, "latest.log", "only-latest\n")
+
+	outPath := filepath.Join(outDir, "export.txt")
+	if err := log.ExportLogs(logDir, outPath); err != nil {
+		t.Fatalf("ExportLogs: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read export: %v", err)
+	}
+	if !strings.Contains(string(data), "only-latest") {
+		t.Error("export missing content from latest.log")
+	}
+}
+
+func TestExportLogs_EmptyLogDir_ProducesEmptyFile(t *testing.T) {
+	logDir := t.TempDir()
+	outDir := t.TempDir()
+
+	outPath := filepath.Join(outDir, "export.txt")
+	if err := log.ExportLogs(logDir, outPath); err != nil {
+		t.Fatalf("ExportLogs on empty dir: %v", err)
+	}
+
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("stat export: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Errorf("expected empty export file, got %d bytes", info.Size())
+	}
+}
+
+func TestExportLogs_OutputFilePermissions(t *testing.T) {
+	logDir := t.TempDir()
+	outDir := t.TempDir()
+
+	writeLogFile(t, logDir, "latest.log", "some log content\n")
+
+	outPath := filepath.Join(outDir, "export.txt")
+	if err := log.ExportLogs(logDir, outPath); err != nil {
+		t.Fatalf("ExportLogs: %v", err)
+	}
+
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("stat output: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("expected 0600 permissions on export file, got %04o", perm)
+	}
+}
+
+func TestExportLogs_WriterIntegration(t *testing.T) {
+	// Write lines through LogWriter, then export and verify output.
+	logDir := t.TempDir()
+	outDir := t.TempDir()
+
+	w, err := log.NewLogWriter(logDir, 1024*1024)
+	if err != nil {
+		t.Fatalf("NewLogWriter: %v", err)
+	}
+
+	lines := []log.LogLine{
+		{Text: "first", IsStderr: false, Timestamp: time.Now()},
+		{Text: "second", IsStderr: true, Timestamp: time.Now()},
+	}
+	for _, l := range lines {
+		if err := w.Write(l); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	outPath := filepath.Join(outDir, "integration-export.txt")
+	if err := log.ExportLogs(logDir, outPath); err != nil {
+		t.Fatalf("ExportLogs: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read export: %v", err)
+	}
+
+	combined := string(data)
+	for _, l := range lines {
+		if !strings.Contains(combined, l.Text) {
+			t.Errorf("export missing line %q", l.Text)
+		}
+	}
+	if !strings.Contains(combined, "[stdout]") {
+		t.Error("export missing [stdout] stream indicator")
+	}
+	if !strings.Contains(combined, "[stderr]") {
+		t.Error("export missing [stderr] stream indicator")
+	}
+}

--- a/modules/agent-manager/src/internal/log/parser.go
+++ b/modules/agent-manager/src/internal/log/parser.go
@@ -1,3 +1,33 @@
-// parser.go parses structured log formats produced by Claude Code agents.
-// Epic 2 will implement JSONL log entry parsing and filtering by level/timestamp.
+// parser.go defines an interface for log line parsing. The initial
+// implementation is a no-op stub; a v2 token-aware parser can satisfy the
+// same interface without changing call sites.
 package log
+
+// LogParser parses a raw log line into a ParsedLine. Implementations may
+// extract token counts, context usage, or other structured fields from the
+// line text.
+type LogParser interface {
+	ParseLine(line string) *ParsedLine
+}
+
+// ParsedLine holds the result of parsing a single log line.
+// Fields set to -1 indicate that the value could not be determined.
+type ParsedLine struct {
+	Raw          string
+	TokenCount   int     // -1 if unknown
+	ContextUsage float64 // -1 if unknown
+}
+
+// NoOpParser implements LogParser by returning a ParsedLine with the raw text
+// and sentinel values for unknown fields. It is safe for concurrent use.
+type NoOpParser struct{}
+
+// ParseLine returns a ParsedLine with TokenCount and ContextUsage set to -1,
+// indicating that no structured parsing was performed.
+func (p *NoOpParser) ParseLine(line string) *ParsedLine {
+	return &ParsedLine{
+		Raw:          line,
+		TokenCount:   -1,
+		ContextUsage: -1,
+	}
+}

--- a/modules/agent-manager/src/internal/log/writer.go
+++ b/modules/agent-manager/src/internal/log/writer.go
@@ -1,3 +1,187 @@
-// writer.go writes captured agent log streams to disk in the agent-log repo format.
-// Epic 2 will implement structured log file creation and rotation.
+// writer.go writes captured agent log lines to disk with simple rotation.
+// When latest.log exceeds maxSize, it is renamed to previous.log and a new
+// latest.log is opened. CleanupOldHistory removes files older than a
+// configurable number of days from a history directory.
 package log
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	latestLogName   = "latest.log"
+	previousLogName = "previous.log"
+)
+
+// LogWriter writes LogLines to a rotating log file pair (latest.log /
+// previous.log) under baseDir. All file access is serialised by mu.
+type LogWriter struct {
+	baseDir     string
+	maxSize     int64
+	mu          sync.Mutex
+	currentFile *os.File
+	currentSize int64
+}
+
+// NewLogWriter creates baseDir if needed, opens (or creates) latest.log, and
+// returns a ready-to-use LogWriter. File permissions are 0600; directories
+// are created with 0700.
+func NewLogWriter(baseDir string, maxSize int64) (*LogWriter, error) {
+	if err := os.MkdirAll(baseDir, 0700); err != nil {
+		return nil, fmt.Errorf("log writer: create dir %s: %w", baseDir, err)
+	}
+	// Explicitly set permissions in case the directory already existed.
+	if err := os.Chmod(baseDir, 0700); err != nil {
+		return nil, fmt.Errorf("log writer: chmod dir %s: %w", baseDir, err)
+	}
+
+	w := &LogWriter{
+		baseDir: baseDir,
+		maxSize: maxSize,
+	}
+	if err := w.openLatest(); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+// Write appends line to latest.log as a formatted text entry, rotating first
+// if the current file has reached maxSize.
+func (w *LogWriter) Write(line LogLine) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.currentSize >= w.maxSize {
+		if err := w.rotateLocked(); err != nil {
+			return fmt.Errorf("log writer: rotate: %w", err)
+		}
+	}
+
+	stream := "stdout"
+	if line.IsStderr {
+		stream = "stderr"
+	}
+	entry := fmt.Sprintf("[%s] [%s] %s\n",
+		line.Timestamp.UTC().Format(time.RFC3339),
+		stream,
+		line.Text,
+	)
+
+	n, err := fmt.Fprint(w.currentFile, entry)
+	if err != nil {
+		return fmt.Errorf("log writer: write: %w", err)
+	}
+	w.currentSize += int64(n)
+	return nil
+}
+
+// Rotate explicitly renames latest.log to previous.log and opens a fresh
+// latest.log. The old previous.log is overwritten if present.
+func (w *LogWriter) Rotate() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.rotateLocked()
+}
+
+// rotateLocked performs the rename and open without acquiring mu. The caller
+// must hold mu.
+func (w *LogWriter) rotateLocked() error {
+	if w.currentFile != nil {
+		if err := w.currentFile.Close(); err != nil {
+			return fmt.Errorf("close latest.log: %w", err)
+		}
+		w.currentFile = nil
+	}
+
+	latestPath := filepath.Join(w.baseDir, latestLogName)
+	prevPath := filepath.Join(w.baseDir, previousLogName)
+
+	// Rename latest -> previous (overwrites any existing previous.log).
+	if _, err := os.Stat(latestPath); err == nil {
+		if err := os.Rename(latestPath, prevPath); err != nil {
+			return fmt.Errorf("rename latest.log to previous.log: %w", err)
+		}
+	}
+
+	return w.openLatestLocked()
+}
+
+// Close flushes and closes the underlying log file.
+func (w *LogWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.currentFile == nil {
+		return nil
+	}
+	err := w.currentFile.Close()
+	w.currentFile = nil
+	return err
+}
+
+// openLatest opens latest.log for appending, creating it if necessary.
+// Acquires mu internally; used only during construction.
+func (w *LogWriter) openLatest() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.openLatestLocked()
+}
+
+// openLatestLocked opens latest.log without acquiring mu. The caller must hold mu.
+func (w *LogWriter) openLatestLocked() error {
+	path := filepath.Join(w.baseDir, latestLogName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("log writer: open latest.log: %w", err)
+	}
+	// Ensure permissions on existing files.
+	if err := os.Chmod(path, 0600); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("log writer: chmod latest.log: %w", err)
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return fmt.Errorf("log writer: stat latest.log: %w", err)
+	}
+
+	w.currentFile = f
+	w.currentSize = info.Size()
+	return nil
+}
+
+// CleanupOldHistory removes files inside historyDir whose modification time
+// is older than retentionDays days. It does not recurse into subdirectories.
+func CleanupOldHistory(historyDir string, retentionDays int) error {
+	entries, err := os.ReadDir(historyDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("cleanup history: read dir %s: %w", historyDir, err)
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -retentionDays)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			// File may have been removed between ReadDir and Info; skip it.
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			path := filepath.Join(historyDir, entry.Name())
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("cleanup history: remove %s: %w", path, err)
+			}
+		}
+	}
+	return nil
+}

--- a/modules/agent-manager/src/internal/log/writer_test.go
+++ b/modules/agent-manager/src/internal/log/writer_test.go
@@ -1,0 +1,211 @@
+package log_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/log"
+)
+
+func TestWriter_BasicWrite(t *testing.T) {
+	dir := t.TempDir()
+	w, err := log.NewLogWriter(dir, 1024*1024) // 1 MB
+	if err != nil {
+		t.Fatalf("NewLogWriter: %v", err)
+	}
+	defer w.Close()
+
+	line := log.LogLine{Text: "hello world", IsStderr: false, Timestamp: time.Now()}
+	if err := w.Write(line); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "latest.log"))
+	if err != nil {
+		t.Fatalf("read latest.log: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty latest.log after write")
+	}
+}
+
+func TestWriter_RotationTriggersAtMaxSize(t *testing.T) {
+	dir := t.TempDir()
+	// Set a very small maxSize so rotation triggers after the first write.
+	const maxSize = 10 // bytes
+	w, err := log.NewLogWriter(dir, maxSize)
+	if err != nil {
+		t.Fatalf("NewLogWriter: %v", err)
+	}
+	defer w.Close()
+
+	// First write: fits within maxSize.
+	line1 := log.LogLine{Text: "aaa", IsStderr: false, Timestamp: time.Now()}
+	if err := w.Write(line1); err != nil {
+		t.Fatalf("Write line1: %v", err)
+	}
+
+	// Second write: triggers rotation (previous size >= maxSize).
+	line2 := log.LogLine{Text: "bbb", IsStderr: false, Timestamp: time.Now()}
+	if err := w.Write(line2); err != nil {
+		t.Fatalf("Write line2: %v", err)
+	}
+
+	// previous.log must exist after rotation.
+	if _, err := os.Stat(filepath.Join(dir, "previous.log")); err != nil {
+		t.Errorf("expected previous.log to exist after rotation: %v", err)
+	}
+
+	// latest.log must also exist (newly created after rotation).
+	if _, err := os.Stat(filepath.Join(dir, "latest.log")); err != nil {
+		t.Errorf("expected latest.log to exist after rotation: %v", err)
+	}
+}
+
+func TestWriter_RotationCreatesPreviousLog(t *testing.T) {
+	dir := t.TempDir()
+	w, err := log.NewLogWriter(dir, 50)
+	if err != nil {
+		t.Fatalf("NewLogWriter: %v", err)
+	}
+	defer w.Close()
+
+	// Write enough to fill the budget.
+	for i := 0; i < 5; i++ {
+		line := log.LogLine{Text: "rotation-test", IsStderr: false, Timestamp: time.Now()}
+		_ = w.Write(line)
+	}
+
+	// Explicitly rotate to ensure previous.log is created.
+	if err := w.Rotate(); err != nil {
+		t.Fatalf("Rotate: %v", err)
+	}
+
+	prevPath := filepath.Join(dir, "previous.log")
+	if _, err := os.Stat(prevPath); os.IsNotExist(err) {
+		t.Error("previous.log does not exist after explicit Rotate")
+	}
+}
+
+func TestWriter_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	w, err := log.NewLogWriter(dir, 1024*1024)
+	if err != nil {
+		t.Fatalf("NewLogWriter: %v", err)
+	}
+	defer w.Close()
+
+	line := log.LogLine{Text: "perm-test", IsStderr: false, Timestamp: time.Now()}
+	if err := w.Write(line); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Check log file permissions.
+	latestPath := filepath.Join(dir, "latest.log")
+	info, err := os.Stat(latestPath)
+	if err != nil {
+		t.Fatalf("stat latest.log: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("latest.log: expected 0600, got %04o", perm)
+	}
+
+	// Check directory permissions.
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0700 {
+		t.Errorf("log dir: expected 0700, got %04o", perm)
+	}
+}
+
+func TestWriter_RotationPreviousLogOverwritten(t *testing.T) {
+	dir := t.TempDir()
+	w, err := log.NewLogWriter(dir, 1024*1024)
+	if err != nil {
+		t.Fatalf("NewLogWriter: %v", err)
+	}
+
+	// Write first batch, rotate, write second batch, rotate again.
+	// The second rotation should overwrite previous.log.
+	_ = w.Write(log.LogLine{Text: "first-batch", IsStderr: false, Timestamp: time.Now()})
+	if err := w.Rotate(); err != nil {
+		t.Fatalf("first Rotate: %v", err)
+	}
+
+	_ = w.Write(log.LogLine{Text: "second-batch", IsStderr: false, Timestamp: time.Now()})
+	if err := w.Rotate(); err != nil {
+		t.Fatalf("second Rotate: %v", err)
+	}
+	w.Close()
+
+	data, err := os.ReadFile(filepath.Join(dir, "previous.log"))
+	if err != nil {
+		t.Fatalf("read previous.log: %v", err)
+	}
+	// After second rotation, previous.log should contain the second batch only.
+	if string(data) == "" {
+		t.Error("previous.log should not be empty after second rotation")
+	}
+}
+
+func TestCleanupOldHistory_RemovesOldFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create an "old" file by backdating its mtime.
+	oldFile := filepath.Join(dir, "old.log")
+	if err := os.WriteFile(oldFile, []byte("old"), 0600); err != nil {
+		t.Fatalf("create old file: %v", err)
+	}
+	past := time.Now().AddDate(0, 0, -10) // 10 days ago
+	if err := os.Chtimes(oldFile, past, past); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	// Create a recent file.
+	newFile := filepath.Join(dir, "new.log")
+	if err := os.WriteFile(newFile, []byte("new"), 0600); err != nil {
+		t.Fatalf("create new file: %v", err)
+	}
+
+	if err := log.CleanupOldHistory(dir, 7); err != nil {
+		t.Fatalf("CleanupOldHistory: %v", err)
+	}
+
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Error("expected old file to be removed")
+	}
+	if _, err := os.Stat(newFile); err != nil {
+		t.Error("expected new file to still exist")
+	}
+}
+
+func TestCleanupOldHistory_MissingDirIsNoop(t *testing.T) {
+	if err := log.CleanupOldHistory("/tmp/does-not-exist-ccgm-test", 7); err != nil {
+		t.Errorf("expected no error for missing dir, got: %v", err)
+	}
+}
+
+func TestCleanupOldHistory_PreservesRecentFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write two recent files.
+	for _, name := range []string{"a.log", "b.log"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("data"), 0600); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	if err := log.CleanupOldHistory(dir, 7); err != nil {
+		t.Fatalf("CleanupOldHistory: %v", err)
+	}
+
+	for _, name := range []string{"a.log", "b.log"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("expected %s to still exist: %v", name, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `internal/log/collector.go`: `LogCollector` reads stdout/stderr via `bufio.Scanner` goroutines, batches lines at a configurable interval (default 16ms), and delivers them via a `sendFn func(LogLineMsg)` abstraction (no bubbletea import)
- Implements `internal/log/writer.go`: `LogWriter` appends `LogLine` entries to `latest.log` with automatic rotation to `previous.log` when `maxSize` is exceeded; `CleanupOldHistory` removes files older than `retentionDays` days
- Implements `internal/log/export.go`: `ExportLogs` combines `previous.log` + `latest.log` into a single chronological plain-text file
- Implements `internal/log/parser.go`: `LogParser` interface + `NoOpParser` stub for future token-monitoring v2

## Integration

`LogCollector` accepts an optional `*LogWriter`; each line is written to disk immediately before being batched for the TUI. The `sendFn` abstraction keeps the `log` package free of bubbletea.

## Test plan

- [x] `go test -race ./internal/log/...` - all tests pass with race detector
- [x] `go test -race ./...` - full suite green
- [x] `go vet ./...` - no issues
- Collector: batching, stdout/stderr separation, context cancellation, concurrent readers (-race), batch interval behaviour
- Writer: basic write, rotation trigger, previous.log creation, 0600/0700 permissions, overwrite on second rotation, CleanupOldHistory (removes old, preserves recent, noop on missing dir)
- Export: combined output order, latest-only, empty dir, permissions, integration with LogWriter