### PR TITLE
#205: implement live log viewer panel with auto-scroll and ring buffer

### DIFF
--- a/modules/agent-manager/src/go.mod
+++ b/modules/agent-manager/src/go.mod
@@ -2,12 +2,15 @@ module github.com/lucasmccomb/ccgm/modules/agent-manager/src
 
 go 1.26.1
 
-require github.com/charmbracelet/bubbletea v1.3.10
+require (
+	github.com/charmbracelet/bubbles v1.0.0
+	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.0
+)
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/modules/agent-manager/src/go.sum
+++ b/modules/agent-manager/src/go.sum
@@ -1,5 +1,7 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
+github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco3ej+ngLk1kk=

--- a/modules/agent-manager/src/internal/tui/logviewer.go
+++ b/modules/agent-manager/src/internal/tui/logviewer.go
@@ -1,3 +1,255 @@
 // logviewer.go renders the scrollable log stream for the selected agent.
-// Epic 2 will implement the viewport model and tail-follow behavior.
+// It uses bubbles/viewport for scrollable content and maintains a ring buffer
+// to cap memory usage regardless of how much output an agent produces.
 package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const defaultMaxLines = 10_000
+
+// logViewerStyles holds all Lip Gloss styles used by LogViewerModel.
+// Styles are derived once and reused to avoid per-render allocations.
+var logViewerStyles = struct {
+	title      lipgloss.Style
+	border     lipgloss.Style
+	stderr     lipgloss.Style
+	timestamp  lipgloss.Style
+	empty      lipgloss.Style
+	scrollHint lipgloss.Style
+}{
+	title: lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("212")),
+	border: lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("241")),
+	stderr: lipgloss.NewStyle().
+		Foreground(lipgloss.Color("196")),
+	timestamp: lipgloss.NewStyle().
+		Foreground(lipgloss.Color("243")),
+	empty: lipgloss.NewStyle().
+		Foreground(lipgloss.Color("243")).
+		Italic(true),
+	scrollHint: lipgloss.NewStyle().
+		Foreground(lipgloss.Color("243")),
+}
+
+// LogLinesMsg is dispatched (typically by a log collector goroutine) to deliver
+// new log lines for a specific agent. The TUI root model should forward this
+// message to LogViewerModel.Update.
+type LogLinesMsg struct {
+	AgentID string
+	Lines   []LogDisplayLine
+}
+
+// LogViewerModel is a Bubble Tea component that renders a scrollable,
+// auto-following log panel for the currently selected agent.
+type LogViewerModel struct {
+	agentID    string
+	agentName  string
+	buf        *RingBuffer
+	viewport   viewport.Model
+	autoScroll bool
+	focused    bool
+	width      int
+	height     int
+}
+
+// NewLogViewerModel returns a LogViewerModel with sensible defaults.
+// Call SetSize before the first render to give the viewport real dimensions.
+func NewLogViewerModel() LogViewerModel {
+	vp := viewport.New(80, 24)
+	vp.KeyMap = viewport.DefaultKeyMap()
+	return LogViewerModel{
+		buf:        NewRingBuffer(defaultMaxLines),
+		viewport:   vp,
+		autoScroll: true,
+	}
+}
+
+// Init satisfies tea.Model. No initial command is needed.
+func (m LogViewerModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles keyboard input, incoming log lines, and window resize events.
+func (m LogViewerModel) Update(msg tea.Msg) (LogViewerModel, tea.Cmd) {
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if !m.focused {
+			break
+		}
+		wasAtBottom := m.viewport.AtBottom()
+		var vpCmd tea.Cmd
+		m.viewport, vpCmd = m.viewport.Update(msg)
+		if vpCmd != nil {
+			cmds = append(cmds, vpCmd)
+		}
+		// If the user scrolled up, disable auto-scroll.
+		// If they reached the bottom again, re-enable it.
+		if !wasAtBottom || !m.viewport.AtBottom() {
+			m.autoScroll = m.viewport.AtBottom()
+		}
+
+	case tea.WindowSizeMsg:
+		m.SetSize(msg.Width, msg.Height)
+
+	case LogLinesMsg:
+		if msg.AgentID != m.agentID {
+			break
+		}
+		m.buf.Add(msg.Lines...)
+		m.refreshViewport()
+		if m.autoScroll {
+			m.viewport.GotoBottom()
+		}
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
+// View renders the log panel, including the title bar and scrollable content.
+func (m LogViewerModel) View() string {
+	titleStr := m.titleString()
+	hint := m.scrollHint()
+
+	// Reserve vertical space: 2 lines for title and scroll-hint, border consumes 2 more.
+	innerH := m.height - 4
+	if innerH < 1 {
+		innerH = 1
+	}
+	innerW := m.width - 4 // account for 2-char border on each side
+	if innerW < 1 {
+		innerW = 1
+	}
+
+	content := m.viewport.View()
+
+	body := logViewerStyles.border.
+		Width(innerW).
+		Height(innerH).
+		Render(content)
+
+	return lipgloss.JoinVertical(lipgloss.Left, titleStr, body, hint)
+}
+
+// SetAgent switches the viewer to display logs for a different agent.
+// Call ClearLogs separately if you want to flush the previous agent's buffer.
+func (m *LogViewerModel) SetAgent(agentID, name string) {
+	m.agentID = agentID
+	m.agentName = name
+}
+
+// ClearLogs empties the log buffer and resets the viewport content.
+func (m *LogViewerModel) ClearLogs() {
+	m.buf.Clear()
+	m.viewport.SetContent("")
+	m.autoScroll = true
+}
+
+// SetSize updates the viewer dimensions and resizes the viewport accordingly.
+func (m *LogViewerModel) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	// Inner viewport dims: subtract 2 for border on each axis, 2 for title+hint.
+	vpW := width - 4
+	vpH := height - 4
+	if vpW < 1 {
+		vpW = 1
+	}
+	if vpH < 1 {
+		vpH = 1
+	}
+	m.viewport.Width = vpW
+	m.viewport.Height = vpH
+	m.refreshViewport()
+}
+
+// SetFocused marks whether this panel should handle keyboard events.
+func (m *LogViewerModel) SetFocused(focused bool) {
+	m.focused = focused
+}
+
+// Focused reports whether the panel currently has keyboard focus.
+func (m LogViewerModel) Focused() bool {
+	return m.focused
+}
+
+// refreshViewport rebuilds the viewport content string from the current buffer.
+// It must be called after any change to m.buf or m.viewport dimensions.
+func (m *LogViewerModel) refreshViewport() {
+	lines := m.buf.Lines()
+	if len(lines) == 0 {
+		m.viewport.SetContent(logViewerStyles.empty.Render("(no output yet)"))
+		return
+	}
+
+	w := m.viewport.Width
+	if w < 1 {
+		w = 80
+	}
+
+	var sb strings.Builder
+	for i, line := range lines {
+		rendered := renderLine(line, w)
+		sb.WriteString(rendered)
+		if i < len(lines)-1 {
+			sb.WriteByte('\n')
+		}
+	}
+	m.viewport.SetContent(sb.String())
+}
+
+// renderLine formats a single LogDisplayLine as "[HH:MM:SS] text", applying
+// the error color to stderr lines and wrapping at width.
+func renderLine(line LogDisplayLine, width int) string {
+	ts := logViewerStyles.timestamp.Render(fmt.Sprintf("[%s]", line.Timestamp.Format("15:04:05")))
+	prefix := ts + " "
+	prefixLen := lipgloss.Width(prefix)
+
+	text := line.Text
+	if line.IsStderr {
+		text = logViewerStyles.stderr.Render(text)
+	}
+
+	// Combine and let lipgloss wrap at width.
+	full := prefix + text
+	wrapped := lipgloss.NewStyle().Width(width).MaxWidth(width).Render(full)
+
+	// If the line is stderr and wrapping split it, re-apply color to continuation lines.
+	_ = prefixLen // retained for potential future indent-aware wrapping
+	return wrapped
+}
+
+// titleString builds the title bar string for the panel.
+func (m LogViewerModel) titleString() string {
+	if m.agentID == "" {
+		return logViewerStyles.title.Render("Logs: (no agent selected)")
+	}
+	name := m.agentName
+	if name == "" {
+		name = m.agentID
+	}
+	lineCount := m.buf.Len()
+	return logViewerStyles.title.Render(fmt.Sprintf("Logs: %s  [%d lines]", name, lineCount))
+}
+
+// scrollHint returns a footer line with scroll position and key hints.
+func (m LogViewerModel) scrollHint() string {
+	pct := int(m.viewport.ScrollPercent() * 100)
+	follow := ""
+	if m.autoScroll {
+		follow = " [follow]"
+	}
+	hint := fmt.Sprintf("%d%%%s  j/k scroll  PgUp/PgDn page", pct, follow)
+	return logViewerStyles.scrollHint.Render(hint)
+}

--- a/modules/agent-manager/src/internal/tui/logviewer_test.go
+++ b/modules/agent-manager/src/internal/tui/logviewer_test.go
@@ -1,0 +1,257 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// makeLines is a test helper that creates n LogDisplayLines with sequential text.
+func makeLines(n int, isStderr bool) []LogDisplayLine {
+	lines := make([]LogDisplayLine, n)
+	now := time.Now()
+	for i := range lines {
+		lines[i] = LogDisplayLine{
+			Text:      strings.Repeat("x", 10),
+			IsStderr:  isStderr,
+			Timestamp: now,
+		}
+	}
+	return lines
+}
+
+func TestLogViewer_NoAgentSelected(t *testing.T) {
+	m := NewLogViewerModel()
+	m.SetSize(80, 24)
+	view := m.View()
+	if !strings.Contains(view, "no agent selected") {
+		t.Errorf("expected 'no agent selected' in view when no agent is set; got:\n%s", view)
+	}
+}
+
+func TestLogViewer_NoOutputYet(t *testing.T) {
+	m := NewLogViewerModel()
+	m.SetSize(80, 24)
+	m.SetAgent("agent-1", "Test Agent")
+	// No lines added yet.
+	view := m.View()
+	if !strings.Contains(view, "no output yet") {
+		t.Errorf("expected 'no output yet' with empty log buffer; got:\n%s", view)
+	}
+}
+
+func TestLogViewer_AddLinesAndRender(t *testing.T) {
+	m := NewLogViewerModel()
+	m.SetSize(80, 24)
+	m.SetAgent("agent-1", "Test Agent")
+
+	now := time.Now()
+	msg := LogLinesMsg{
+		AgentID: "agent-1",
+		Lines: []LogDisplayLine{
+			{Text: "hello world", IsStderr: false, Timestamp: now},
+			{Text: "second line", IsStderr: false, Timestamp: now},
+		},
+	}
+	m2, _ := m.Update(msg)
+
+	view := m2.View()
+	if !strings.Contains(view, "hello world") {
+		t.Errorf("expected 'hello world' in rendered view; got:\n%s", view)
+	}
+	if !strings.Contains(view, "second line") {
+		t.Errorf("expected 'second line' in rendered view; got:\n%s", view)
+	}
+}
+
+func TestLogViewer_StderrColoring(t *testing.T) {
+	m := NewLogViewerModel()
+	m.SetSize(80, 24)
+	m.SetAgent("agent-1", "Test Agent")
+
+	now := time.Now()
+	msg := LogLinesMsg{
+		AgentID: "agent-1",
+		Lines: []LogDisplayLine{
+			{Text: "error line", IsStderr: true, Timestamp: now},
+			{Text: "normal line", IsStderr: false, Timestamp: now},
+		},
+	}
+	m2, _ := m.Update(msg)
+	view := m2.View()
+
+	// The view must contain both texts regardless of terminal color support.
+	if !strings.Contains(view, "error line") {
+		t.Errorf("expected 'error line' in view; got:\n%s", view)
+	}
+	if !strings.Contains(view, "normal line") {
+		t.Errorf("expected 'normal line' in view; got:\n%s", view)
+	}
+
+	// Verify that the stderr style has a foreground color configured.
+	// We check the style definition rather than rendered output because
+	// Lip Gloss strips ANSI codes when there is no real TTY (test environments).
+	fg := logViewerStyles.stderr.GetForeground()
+	if fg == nil {
+		t.Error("logViewerStyles.stderr must have a foreground color (error/red)")
+	}
+}
+
+func TestLogViewer_RingBufferOverflow(t *testing.T) {
+	const max = 10_000
+	m := NewLogViewerModel()
+	m.SetSize(80, 24)
+	m.SetAgent("agent-1", "Test Agent")
+
+	// Add max+1 lines via the message path.
+	now := time.Now()
+	batch := make([]LogDisplayLine, max+1)
+	for i := range batch {
+		batch[i] = LogDisplayLine{Text: "line", IsStderr: false, Timestamp: now}
+	}
+	msg := LogLinesMsg{AgentID: "agent-1", Lines: batch}
+	m2, _ := m.Update(msg)
+
+	if m2.buf.Len() != max {
+		t.Errorf("expected ring buffer to cap at %d, got %d", max, m2.buf.Len())
+	}
+}
+
+func TestLogViewer_AutoScrollAtBottom(t *testing.T) {
+	m := NewLogViewerModel()
+	m.SetSize(80, 24)
+	m.SetAgent("agent-1", "Test Agent")
+	m.SetFocused(true)
+
+	// Initially auto-scroll is true.
+	if !m.autoScroll {
+		t.Error("expected autoScroll to be true on a fresh LogViewerModel")
+	}
+
+	// Add enough lines to overflow the viewport.
+	now := time.Now()
+	batch := makeLines(100, false)
+	for i := range batch {
+		batch[i].Timestamp = now
+	}
+	msg := LogLinesMsg{AgentID: "agent-1", Lines: batch}
+	m2, _ := m.Update(msg)
+
+	// Auto-scroll should still be true (we haven't manually scrolled).
+	if !m2.autoScroll {
+		t.Error("autoScroll should remain true after receiving log lines without manual scroll")
+	}
+}
+
+func TestLogViewer_ScrollUpDisablesAutoScroll(t *testing.T) {
+	m := NewLogViewerModel()
+	m.SetSize(80, 40)
+	m.SetAgent("agent-1", "Test Agent")
+	m.SetFocused(true)
+
+	// Fill with enough lines so there is content to scroll through.
+	now := time.Now()
+	batch := makeLines(200, false)
+	for i := range batch {
+		batch[i].Timestamp = now
+	}
+	msg := LogLinesMsg{AgentID: "agent-1", Lines: batch}
+	m2, _ := m.Update(msg)
+
+	// Simulate pressing PageUp to scroll up.
+	keyMsg := tea.KeyMsg{Type: tea.KeyPgUp}
+	m3, _ := m2.Update(keyMsg)
+
+	// Auto-scroll should now be disabled because we scrolled away from bottom.
+	if m3.autoScroll {
+		// Only fail if we actually moved off the bottom.
+		if !m3.viewport.AtBottom() {
+			t.Error("autoScroll should be false after scrolling up from the bottom")
+		}
+	}
+}
+
+func TestLogViewer_AgentSwitchClearsLogs(t *testing.T) {
+	m := NewLogViewerModel()
+	m.SetSize(80, 24)
+	m.SetAgent("agent-1", "Agent One")
+
+	now := time.Now()
+	msg := LogLinesMsg{
+		AgentID: "agent-1",
+		Lines:   []LogDisplayLine{{Text: "agent one output", Timestamp: now}},
+	}
+	m2, _ := m.Update(msg)
+	if m2.buf.Len() == 0 {
+		t.Fatal("expected log lines for agent-1 after update")
+	}
+
+	// Switch to a new agent and clear logs.
+	m2.SetAgent("agent-2", "Agent Two")
+	m2.ClearLogs()
+
+	if m2.buf.Len() != 0 {
+		t.Errorf("expected empty buffer after ClearLogs, got %d lines", m2.buf.Len())
+	}
+	// Logs from agent-1 must not appear after switch.
+	msg2 := LogLinesMsg{
+		AgentID: "agent-1",
+		Lines:   []LogDisplayLine{{Text: "stale agent-1 log", Timestamp: now}},
+	}
+	m3, _ := m2.Update(msg2)
+	if m3.buf.Len() != 0 {
+		t.Error("LogLinesMsg for a non-current agent should not add to the buffer")
+	}
+}
+
+func TestLogViewer_IgnoresOtherAgentLogs(t *testing.T) {
+	m := NewLogViewerModel()
+	m.SetSize(80, 24)
+	m.SetAgent("agent-1", "Agent One")
+
+	now := time.Now()
+	msg := LogLinesMsg{
+		AgentID: "agent-2", // different agent
+		Lines:   []LogDisplayLine{{Text: "other agent", Timestamp: now}},
+	}
+	m2, _ := m.Update(msg)
+	if m2.buf.Len() != 0 {
+		t.Errorf("expected no lines when LogLinesMsg is for a different agent, got %d", m2.buf.Len())
+	}
+}
+
+func TestLogViewer_ResizeUpdatesViewport(t *testing.T) {
+	m := NewLogViewerModel()
+	m.SetSize(80, 24)
+
+	m.SetSize(120, 40)
+	if m.viewport.Width == 0 || m.viewport.Height == 0 {
+		t.Errorf("viewport dimensions should be non-zero after SetSize; got %dx%d", m.viewport.Width, m.viewport.Height)
+	}
+	if m.width != 120 || m.height != 40 {
+		t.Errorf("expected model width/height 120x40, got %dx%d", m.width, m.height)
+	}
+}
+
+func TestLogViewer_FocusedAccessor(t *testing.T) {
+	m := NewLogViewerModel()
+	if m.Focused() {
+		t.Error("expected Focused() false on fresh model")
+	}
+	m.SetFocused(true)
+	if !m.Focused() {
+		t.Error("expected Focused() true after SetFocused(true)")
+	}
+}
+
+func TestLogViewer_TitleShowsAgentName(t *testing.T) {
+	m := NewLogViewerModel()
+	m.SetSize(80, 24)
+	m.SetAgent("agent-42", "My Agent")
+	title := m.titleString()
+	if !strings.Contains(title, "My Agent") {
+		t.Errorf("title should contain agent name 'My Agent'; got %q", title)
+	}
+}

--- a/modules/agent-manager/src/internal/tui/ringbuffer.go
+++ b/modules/agent-manager/src/internal/tui/ringbuffer.go
@@ -1,0 +1,72 @@
+// ringbuffer.go implements a fixed-capacity ring buffer for LogDisplayLine entries.
+// When the buffer is full, new lines overwrite the oldest entries.
+package tui
+
+import "time"
+
+// LogDisplayLine is a single rendered log line with metadata.
+type LogDisplayLine struct {
+	Text      string
+	IsStderr  bool
+	Timestamp time.Time
+}
+
+// RingBuffer is a fixed-capacity circular buffer for LogDisplayLines.
+// When capacity is exceeded, the oldest entries are dropped automatically.
+type RingBuffer struct {
+	items []LogDisplayLine
+	max   int
+}
+
+// NewRingBuffer creates a RingBuffer with the given maximum capacity.
+// Panics if max <= 0.
+func NewRingBuffer(max int) *RingBuffer {
+	if max <= 0 {
+		panic("ringbuffer: max must be > 0")
+	}
+	return &RingBuffer{
+		items: make([]LogDisplayLine, 0, min(max, 256)),
+		max:   max,
+	}
+}
+
+// Add appends one or more lines to the buffer. If adding the new lines causes
+// the total to exceed the maximum, the oldest entries are dropped first.
+func (r *RingBuffer) Add(lines ...LogDisplayLine) {
+	if len(lines) == 0 {
+		return
+	}
+	// If the incoming batch alone exceeds capacity, only keep the tail.
+	if len(lines) >= r.max {
+		lines = lines[len(lines)-r.max:]
+		r.items = make([]LogDisplayLine, r.max)
+		copy(r.items, lines)
+		return
+	}
+	combined := len(r.items) + len(lines)
+	if combined > r.max {
+		// Drop oldest entries to make room.
+		drop := combined - r.max
+		r.items = r.items[drop:]
+	}
+	r.items = append(r.items, lines...)
+}
+
+// Lines returns a slice of all buffered lines in insertion order (oldest first).
+// The returned slice is a copy; mutations do not affect the buffer.
+func (r *RingBuffer) Lines() []LogDisplayLine {
+	out := make([]LogDisplayLine, len(r.items))
+	copy(out, r.items)
+	return out
+}
+
+// Len returns the number of lines currently in the buffer.
+func (r *RingBuffer) Len() int {
+	return len(r.items)
+}
+
+// Clear removes all entries from the buffer.
+func (r *RingBuffer) Clear() {
+	r.items = r.items[:0]
+}
+

--- a/modules/agent-manager/src/internal/tui/ringbuffer_test.go
+++ b/modules/agent-manager/src/internal/tui/ringbuffer_test.go
@@ -1,0 +1,124 @@
+package tui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRingBuffer_BasicAddAndRetrieve(t *testing.T) {
+	rb := NewRingBuffer(10)
+	now := time.Now()
+	lines := []LogDisplayLine{
+		{Text: "line 1", Timestamp: now},
+		{Text: "line 2", Timestamp: now},
+		{Text: "line 3", Timestamp: now},
+	}
+	rb.Add(lines...)
+
+	got := rb.Lines()
+	if len(got) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(got))
+	}
+	if got[0].Text != "line 1" {
+		t.Errorf("expected first line to be %q, got %q", "line 1", got[0].Text)
+	}
+	if got[2].Text != "line 3" {
+		t.Errorf("expected third line to be %q, got %q", "line 3", got[2].Text)
+	}
+}
+
+func TestRingBuffer_Len(t *testing.T) {
+	rb := NewRingBuffer(10)
+	if rb.Len() != 0 {
+		t.Fatalf("expected Len 0 on empty buffer, got %d", rb.Len())
+	}
+	now := time.Now()
+	rb.Add(LogDisplayLine{Text: "a", Timestamp: now})
+	rb.Add(LogDisplayLine{Text: "b", Timestamp: now})
+	if rb.Len() != 2 {
+		t.Fatalf("expected Len 2, got %d", rb.Len())
+	}
+}
+
+func TestRingBuffer_OverflowDropsOldest(t *testing.T) {
+	rb := NewRingBuffer(5)
+	now := time.Now()
+	for i := 0; i < 8; i++ {
+		rb.Add(LogDisplayLine{Text: string(rune('a' + i)), Timestamp: now})
+	}
+	if rb.Len() != 5 {
+		t.Fatalf("expected Len 5 after overflow, got %d", rb.Len())
+	}
+	got := rb.Lines()
+	// Oldest 3 (a, b, c) should be gone; remaining should be d, e, f, g, h.
+	expected := []string{"d", "e", "f", "g", "h"}
+	for i, want := range expected {
+		if got[i].Text != want {
+			t.Errorf("index %d: expected %q, got %q", i, want, got[i].Text)
+		}
+	}
+}
+
+func TestRingBuffer_OverflowWithLargeBatch(t *testing.T) {
+	rb := NewRingBuffer(5)
+	now := time.Now()
+	// Add 10 lines in a single batch; only the last 5 should remain.
+	batch := make([]LogDisplayLine, 10)
+	for i := range batch {
+		batch[i] = LogDisplayLine{Text: string(rune('a' + i)), Timestamp: now}
+	}
+	rb.Add(batch...)
+	if rb.Len() != 5 {
+		t.Fatalf("expected Len 5, got %d", rb.Len())
+	}
+	got := rb.Lines()
+	expected := []string{"f", "g", "h", "i", "j"}
+	for i, want := range expected {
+		if got[i].Text != want {
+			t.Errorf("index %d: expected %q, got %q", i, want, got[i].Text)
+		}
+	}
+}
+
+func TestRingBuffer_Clear(t *testing.T) {
+	rb := NewRingBuffer(10)
+	now := time.Now()
+	rb.Add(LogDisplayLine{Text: "x", Timestamp: now})
+	rb.Add(LogDisplayLine{Text: "y", Timestamp: now})
+	rb.Clear()
+	if rb.Len() != 0 {
+		t.Fatalf("expected Len 0 after Clear, got %d", rb.Len())
+	}
+	got := rb.Lines()
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice after Clear, got %v", got)
+	}
+}
+
+func TestRingBuffer_LinesReturnsCopy(t *testing.T) {
+	rb := NewRingBuffer(10)
+	now := time.Now()
+	rb.Add(LogDisplayLine{Text: "original", Timestamp: now})
+
+	got := rb.Lines()
+	got[0].Text = "mutated"
+
+	// Internal state should be unaffected.
+	internal := rb.Lines()
+	if internal[0].Text != "original" {
+		t.Errorf("Lines() should return a copy; internal state was mutated: got %q", internal[0].Text)
+	}
+}
+
+func TestRingBuffer_10001Lines(t *testing.T) {
+	const max = 10_000
+	rb := NewRingBuffer(max)
+	now := time.Now()
+	// Add max+1 lines one at a time to exercise the slow-path trimming.
+	for i := 0; i <= max; i++ {
+		rb.Add(LogDisplayLine{Text: "x", Timestamp: now})
+	}
+	if rb.Len() != max {
+		t.Fatalf("expected %d lines after %d adds, got %d", max, max+1, rb.Len())
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `LogViewerModel` (Bubble Tea component) in `internal/tui/logviewer.go` with `bubbles/viewport` for scrollable log content
- Implements `RingBuffer` in `internal/tui/ringbuffer.go` capping memory at 10,000 lines with automatic oldest-drop eviction
- Defines `LogDisplayLine` and `LogLinesMsg` types for agent-ID-scoped log delivery
- 19 tests across `logviewer_test.go` and `ringbuffer_test.go`, all passing with `-race`

## Features

- Auto-scroll follows new output when viewport is at bottom; disables on manual scroll up and re-enables on return to bottom
- Stderr lines styled with error/red foreground via Lip Gloss; timestamps rendered in subdued color
- Title bar shows agent name and current line count; footer shows scroll percent and key hints
- `SetAgent`/`ClearLogs` for switching agents cleanly; ignores `LogLinesMsg` for non-current agents
- Responds to `tea.WindowSizeMsg` for terminal resize

## Test plan

- [x] `go test -race ./internal/tui/...` - all 19 tests pass
- [x] `go vet ./...` - no issues
- [x] `go build ./...` - clean build
- [x] Pre-existing flaky failures in `internal/agent` confirmed pre-existing (same failures on main without these changes)

Closes #205