### PR TITLE
#215: add VM lifecycle scripts

### DIFF
--- a/modules/cloud-dispatch/lib/common.sh
+++ b/modules/cloud-dispatch/lib/common.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# common.sh - Shared utilities for CCGM cloud-dispatch VM lifecycle scripts
+# Source this file from all other cloud-dispatch scripts.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Server type for agent VMs (CCX63: 48 vCPU, 192 GB RAM)
+CCGM_SERVER_TYPE="${CCGM_SERVER_TYPE:-ccx63}"
+
+# Datacenter locations, in round-robin order for VM placement
+# exported so sourcing scripts see it without shellcheck SC2034 false-positives
+export CCGM_LOCATIONS=("fsn1" "nbg1" "hel1")
+
+# Snapshot label selector used to find the latest golden image
+export CCGM_IMAGE_LABEL="${CCGM_IMAGE_LABEL:-purpose=ccgm-agent}"
+
+# SSH key name as stored in Hetzner (set by Terraform)
+export CCGM_SSH_KEY_NAME="${CCGM_SSH_KEY_NAME:-ccgm-dispatch-key}"
+
+# Firewall name as created by Terraform
+export CCGM_FIREWALL_NAME="${CCGM_FIREWALL_NAME:-ccgm-dispatch-firewall}"
+
+# VM name prefix and pattern
+export CCGM_VM_PREFIX="ccgm-agent"
+export CCGM_VM_PATTERN="ccgm-agent-*"
+
+# Number of agent users per VM
+export CCGM_AGENTS_PER_VM=4
+
+# SSH identity file for dispatch connections
+export CCGM_SSH_KEY="${CCGM_SSH_KEY:-${HOME}/.ssh/ccgm-dispatch-session}"
+
+# ControlMaster socket directory
+export CCGM_SSH_CTL_DIR="/tmp"
+
+# Minimum free disk space (GB) required for a VM to be healthy
+export CCGM_MIN_DISK_GB=20
+
+# Minimum free memory (MB) per agent slot for a VM to be healthy
+export CCGM_MIN_MEM_MB_PER_AGENT=4096
+
+# ---------------------------------------------------------------------------
+# Color output helpers
+# ---------------------------------------------------------------------------
+
+# Detect whether we have a terminal that supports color
+if [[ -t 1 ]] && [[ "${TERM:-}" != "dumb" ]]; then
+  _COLOR_RESET=$'\033[0m'
+  _COLOR_RED=$'\033[0;31m'
+  _COLOR_GREEN=$'\033[0;32m'
+  _COLOR_YELLOW=$'\033[0;33m'
+  _COLOR_CYAN=$'\033[0;36m'
+  _COLOR_BOLD=$'\033[1m'
+else
+  _COLOR_RESET=''
+  _COLOR_RED=''
+  _COLOR_GREEN=''
+  _COLOR_YELLOW=''
+  _COLOR_CYAN=''
+  _COLOR_BOLD=''
+fi
+
+# ---------------------------------------------------------------------------
+# Logging utilities
+# ---------------------------------------------------------------------------
+
+log_info() {
+  echo "${_COLOR_CYAN}[INFO]${_COLOR_RESET}  $(date '+%Y-%m-%dT%H:%M:%S') $*" >&2
+}
+
+log_success() {
+  echo "${_COLOR_GREEN}[OK]${_COLOR_RESET}    $(date '+%Y-%m-%dT%H:%M:%S') $*" >&2
+}
+
+log_warn() {
+  echo "${_COLOR_YELLOW}[WARN]${_COLOR_RESET}  $(date '+%Y-%m-%dT%H:%M:%S') $*" >&2
+}
+
+log_error() {
+  echo "${_COLOR_RED}[ERROR]${_COLOR_RESET} $(date '+%Y-%m-%dT%H:%M:%S') $*" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Prerequisite check
+# ---------------------------------------------------------------------------
+
+# require_cmd <command> - exits with error if <command> is not found in PATH
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    log_error "Required command not found: ${cmd}"
+    log_error "Install it and retry."
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# VM naming convention
+# ---------------------------------------------------------------------------
+
+# vm_name <location> <index>
+# Returns a deterministic VM name: ccgm-agent-<location>-<index>
+# e.g. vm_name fsn1 0 -> ccgm-agent-fsn1-0
+vm_name() {
+  local location="$1"
+  local index="$2"
+  echo "${CCGM_VM_PREFIX}-${location}-${index}"
+}
+
+# ---------------------------------------------------------------------------
+# SSH configuration
+# ---------------------------------------------------------------------------
+
+# ssh_config_snippet - prints an SSH config Host block for ccgm-agent-* VMs.
+# Append this to ~/.ssh/config or write to a dedicated include file.
+ssh_config_snippet() {
+  cat <<'EOF'
+Host ccgm-agent-*
+  User root
+  IdentityFile ~/.ssh/ccgm-dispatch-session
+  StrictHostKeyChecking accept-new
+  ControlMaster auto
+  ControlPath /tmp/ccgm-ssh-%r@%h:%p
+  ControlPersist 600
+  ServerAliveInterval 30
+  ServerAliveCountMax 3
+  BatchMode yes
+  ConnectTimeout 10
+EOF
+}
+
+# ssh_opts - common SSH options array, suitable for use with ssh/scp.
+# Usage: ssh "${ssh_opts[@]}" root@<ip> <command>
+ssh_opts() {
+  echo \
+    -i "${CCGM_SSH_KEY}" \
+    -o StrictHostKeyChecking=accept-new \
+    -o ControlMaster=auto \
+    -o "ControlPath=${CCGM_SSH_CTL_DIR}/ccgm-ssh-%r@%h:%p" \
+    -o ControlPersist=600 \
+    -o ServerAliveInterval=30 \
+    -o ServerAliveCountMax=3 \
+    -o BatchMode=yes \
+    -o ConnectTimeout=10
+}
+
+# ---------------------------------------------------------------------------
+# Hetzner helpers
+# ---------------------------------------------------------------------------
+
+# latest_image_id - returns the snapshot ID of the most recent ccgm-agent image.
+# Selects by label type=ccgm-agent, sorted by created date descending.
+latest_image_id() {
+  hcloud image list \
+    --type snapshot \
+    --selector "${CCGM_IMAGE_LABEL}" \
+    --output json \
+    | python3 -c "
+import json, sys
+images = json.load(sys.stdin)
+if not images:
+    print('', end='')
+    sys.exit(0)
+images.sort(key=lambda x: x.get('created', ''), reverse=True)
+print(images[0]['id'])
+"
+}
+
+# wait_for_vm_running <vm-name> [timeout_secs]
+# Polls hcloud until the VM is in 'running' state or timeout is reached.
+wait_for_vm_running() {
+  local name="$1"
+  local timeout="${2:-120}"
+  local elapsed=0
+  local interval=5
+
+  log_info "Waiting for ${name} to reach 'running' state (timeout ${timeout}s)..."
+  while [[ ${elapsed} -lt ${timeout} ]]; do
+    local status
+    status=$(hcloud server describe "${name}" --output json 2>/dev/null \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('status','unknown'))" \
+      || echo "unknown")
+
+    if [[ "${status}" == "running" ]]; then
+      log_success "${name} is running."
+      return 0
+    fi
+    sleep "${interval}"
+    elapsed=$(( elapsed + interval ))
+  done
+
+  log_error "${name} did not reach 'running' within ${timeout}s (last status: ${status:-unknown})."
+  return 1
+}
+
+# wait_for_ssh <ip> [timeout_secs]
+# Retries SSH connection until it succeeds or timeout is reached.
+wait_for_ssh() {
+  local ip="$1"
+  local timeout="${2:-120}"
+  local elapsed=0
+  local interval=5
+
+  log_info "Waiting for SSH on ${ip} (timeout ${timeout}s)..."
+  while [[ ${elapsed} -lt ${timeout} ]]; do
+    # ssh_opts returns space-separated options; read into array to avoid word splitting
+    # shellcheck disable=SC2206
+    read -ra _ssh_wait_opts <<< "$(ssh_opts)"
+    if ssh "${_ssh_wait_opts[@]}" "root@${ip}" "true" 2>/dev/null; then
+      log_success "SSH is reachable on ${ip}."
+      return 0
+    fi
+    sleep "${interval}"
+    elapsed=$(( elapsed + interval ))
+  done
+
+  log_error "SSH on ${ip} did not become reachable within ${timeout}s."
+  return 1
+}
+
+# vm_ip <vm-name> - prints the public IPv4 address of a named VM.
+vm_ip() {
+  local name="$1"
+  hcloud server describe "${name}" --output json \
+    | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+nets = d.get('public_net', {})
+ipv4 = nets.get('ipv4', {})
+print(ipv4.get('ip', ''))
+"
+}
+
+# ---------------------------------------------------------------------------
+# Trap / cleanup registration
+# ---------------------------------------------------------------------------
+
+# cleanup_fns is an array of function names to call on EXIT.
+# Use register_cleanup to add entries.
+declare -a _cleanup_fns=()
+
+register_cleanup() {
+  _cleanup_fns+=("$1")
+}
+
+_run_cleanup() {
+  for fn in "${_cleanup_fns[@]+"${_cleanup_fns[@]}"}"; do
+    "${fn}" || true
+  done
+}
+
+trap '_run_cleanup' EXIT

--- a/modules/cloud-dispatch/lib/vm-create.sh
+++ b/modules/cloud-dispatch/lib/vm-create.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# vm-create.sh - Create CCGM agent VMs from the golden image snapshot.
+#
+# Usage:
+#   vm-create.sh [count] [--type TYPE] [--image IMAGE_ID]
+#
+# Arguments:
+#   count        Number of VMs to create (default: 3)
+#
+# Options:
+#   --type TYPE       Server type (default: ccx63)
+#   --image IMAGE_ID  Snapshot ID to use (default: latest ccgm-agent snapshot)
+#
+# Environment:
+#   HCLOUD_TOKEN  Hetzner Cloud API token (required)
+#
+# VMs are named ccgm-agent-<location>-<index> and spread round-robin across
+# the configured datacenter locations (fsn1, nbg1, hel1 by default).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+
+COUNT=3
+SERVER_TYPE="${CCGM_SERVER_TYPE}"
+IMAGE_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --type)
+      SERVER_TYPE="$2"; shift 2 ;;
+    --image)
+      IMAGE_ID="$2"; shift 2 ;;
+    --*)
+      log_error "Unknown option: $1"; exit 1 ;;
+    *)
+      COUNT="$1"; shift ;;
+  esac
+done
+
+if ! [[ "${COUNT}" =~ ^[0-9]+$ ]] || [[ "${COUNT}" -lt 1 ]]; then
+  log_error "count must be a positive integer, got: ${COUNT}"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+
+require_cmd hcloud
+require_cmd python3
+
+if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+  log_error "HCLOUD_TOKEN is not set. Export it before running this script."
+  exit 1
+fi
+
+# Resolve image ID if not provided
+if [[ -z "${IMAGE_ID}" ]]; then
+  log_info "Resolving latest ccgm-agent snapshot..."
+  IMAGE_ID="$(latest_image_id)"
+  if [[ -z "${IMAGE_ID}" ]]; then
+    log_error "No snapshot found matching label '${CCGM_IMAGE_LABEL}'."
+    log_error "Build the golden image first with: packer build packer/agent-image.pkr.hcl"
+    exit 1
+  fi
+  log_info "Using snapshot ID: ${IMAGE_ID}"
+fi
+
+# Resolve SSH key and firewall IDs from Hetzner
+log_info "Resolving SSH key '${CCGM_SSH_KEY_NAME}'..."
+SSH_KEY_ID="$(hcloud ssh-key describe "${CCGM_SSH_KEY_NAME}" --output json \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")"
+
+log_info "Resolving firewall '${CCGM_FIREWALL_NAME}'..."
+FIREWALL_ID="$(hcloud firewall describe "${CCGM_FIREWALL_NAME}" --output json \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")"
+
+# ---------------------------------------------------------------------------
+# Create VMs
+# ---------------------------------------------------------------------------
+
+log_info "Creating ${COUNT} VM(s) with type=${SERVER_TYPE}, image=${IMAGE_ID}..."
+
+declare -a CREATED_NAMES=()
+declare -a FAILED_NAMES=()
+
+for (( i=0; i<COUNT; i++ )); do
+  location="${CCGM_LOCATIONS[$(( i % ${#CCGM_LOCATIONS[@]} ))]}"
+  name="$(vm_name "${location}" "${i}")"
+
+  log_info "Creating ${name} in ${location}..."
+
+  if hcloud server create \
+    --name "${name}" \
+    --type "${SERVER_TYPE}" \
+    --image "${IMAGE_ID}" \
+    --location "${location}" \
+    --ssh-key "${SSH_KEY_ID}" \
+    --firewall "${FIREWALL_ID}" \
+    --output json >/dev/null 2>&1; then
+    CREATED_NAMES+=("${name}")
+    log_success "Created ${name}."
+  else
+    FAILED_NAMES+=("${name}")
+    log_error "Failed to create ${name}."
+  fi
+done
+
+if [[ ${#FAILED_NAMES[@]} -gt 0 ]]; then
+  log_warn "Some VMs failed to create: ${FAILED_NAMES[*]}"
+fi
+
+if [[ ${#CREATED_NAMES[@]} -eq 0 ]]; then
+  log_error "No VMs were created successfully."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Wait for VMs to be running and SSH-reachable
+# ---------------------------------------------------------------------------
+
+declare -a READY_NAMES=()
+declare -a UNREADY_NAMES=()
+
+for name in "${CREATED_NAMES[@]}"; do
+  if wait_for_vm_running "${name}" 120; then
+    ip="$(vm_ip "${name}")"
+    if wait_for_ssh "${ip}" 120; then
+      READY_NAMES+=("${name}")
+    else
+      UNREADY_NAMES+=("${name}")
+      log_warn "${name} (${ip}): VM running but SSH unreachable."
+    fi
+  else
+    UNREADY_NAMES+=("${name}")
+    log_warn "${name}: did not reach running state in time."
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "${_COLOR_BOLD}==== VM Create Summary ====${_COLOR_RESET}"
+echo ""
+
+if [[ ${#READY_NAMES[@]} -gt 0 ]]; then
+  echo "${_COLOR_GREEN}Ready:${_COLOR_RESET}"
+  for name in "${READY_NAMES[@]}"; do
+    ip="$(vm_ip "${name}")"
+    location="$(hcloud server describe "${name}" --output json \
+      | python3 -c "import json,sys; print(json.load(sys.stdin)['datacenter']['location']['name'])")"
+    printf "  %-30s  %-15s  %s\n" "${name}" "${ip}" "${location}"
+  done
+fi
+
+if [[ ${#UNREADY_NAMES[@]} -gt 0 ]]; then
+  echo ""
+  echo "${_COLOR_YELLOW}Not ready (manual intervention may be needed):${_COLOR_RESET}"
+  for name in "${UNREADY_NAMES[@]}"; do
+    printf "  %s\n" "${name}"
+  done
+fi
+
+if [[ ${#FAILED_NAMES[@]} -gt 0 ]]; then
+  echo ""
+  echo "${_COLOR_RED}Failed to create:${_COLOR_RESET}"
+  for name in "${FAILED_NAMES[@]}"; do
+    printf "  %s\n" "${name}"
+  done
+fi
+
+echo ""
+
+if [[ ${#UNREADY_NAMES[@]} -gt 0 ]] || [[ ${#FAILED_NAMES[@]} -gt 0 ]]; then
+  exit 1
+fi

--- a/modules/cloud-dispatch/lib/vm-destroy.sh
+++ b/modules/cloud-dispatch/lib/vm-destroy.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# vm-destroy.sh - Terminate CCGM agent VMs.
+#
+# Usage:
+#   vm-destroy.sh --all [--force]
+#   vm-destroy.sh [--force] <vm-name> [<vm-name>...]
+#
+# Options:
+#   --all    Destroy all VMs matching the ccgm-agent-* pattern
+#   --force  Skip confirmation prompt
+#
+# After destruction, removes SSH known_hosts entries and ControlMaster sockets
+# for each destroyed VM.
+#
+# Environment:
+#   HCLOUD_TOKEN  Hetzner Cloud API token (required)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+
+DESTROY_ALL=false
+FORCE=false
+declare -a TARGET_NAMES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      DESTROY_ALL=true; shift ;;
+    --force)
+      FORCE=true; shift ;;
+    --*)
+      log_error "Unknown option: $1"; exit 1 ;;
+    *)
+      TARGET_NAMES+=("$1"); shift ;;
+  esac
+done
+
+if [[ "${DESTROY_ALL}" == "false" ]] && [[ ${#TARGET_NAMES[@]} -eq 0 ]]; then
+  echo "Usage: $0 --all [--force]" >&2
+  echo "       $0 [--force] <vm-name> [<vm-name>...]" >&2
+  exit 1
+fi
+
+if [[ "${DESTROY_ALL}" == "true" ]] && [[ ${#TARGET_NAMES[@]} -gt 0 ]]; then
+  log_error "--all and explicit VM names are mutually exclusive."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+
+require_cmd hcloud
+require_cmd python3
+
+if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+  log_error "HCLOUD_TOKEN is not set. Export it before running this script."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve targets
+# ---------------------------------------------------------------------------
+
+if [[ "${DESTROY_ALL}" == "true" ]]; then
+  log_info "Listing all VMs matching pattern '${CCGM_VM_PATTERN}'..."
+  mapfile -t TARGET_NAMES < <(
+    hcloud server list --output json \
+      | python3 -c "
+import json, sys, fnmatch
+servers = json.load(sys.stdin)
+pattern = '${CCGM_VM_PATTERN}'
+for s in servers:
+    if fnmatch.fnmatch(s['name'], pattern):
+        print(s['name'])
+" \
+    || true
+  )
+
+  if [[ ${#TARGET_NAMES[@]} -eq 0 ]]; then
+    log_info "No VMs matching '${CCGM_VM_PATTERN}' found. Nothing to destroy."
+    exit 0
+  fi
+fi
+
+log_info "Targets: ${TARGET_NAMES[*]}"
+
+# ---------------------------------------------------------------------------
+# Collect IPs before deletion (needed for known_hosts cleanup)
+# ---------------------------------------------------------------------------
+
+declare -A VM_IPS=()
+
+for name in "${TARGET_NAMES[@]}"; do
+  ip="$(vm_ip "${name}" 2>/dev/null || true)"
+  if [[ -n "${ip}" ]]; then
+    VM_IPS["${name}"]="${ip}"
+  else
+    log_warn "Could not resolve IP for ${name}; known_hosts cleanup may be incomplete."
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Confirmation prompt
+# ---------------------------------------------------------------------------
+
+if [[ "${FORCE}" == "false" ]]; then
+  echo ""
+  echo "${_COLOR_YELLOW}The following VMs will be permanently destroyed:${_COLOR_RESET}"
+  for name in "${TARGET_NAMES[@]}"; do
+    ip="${VM_IPS[${name}]:-unknown}"
+    printf "  %-30s  %s\n" "${name}" "${ip}"
+  done
+  echo ""
+  read -r -p "Type 'yes' to confirm: " CONFIRM
+  if [[ "${CONFIRM}" != "yes" ]]; then
+    log_info "Aborted."
+    exit 0
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Destroy VMs
+# ---------------------------------------------------------------------------
+
+declare -a DESTROYED_NAMES=()
+declare -a FAILED_NAMES=()
+
+for name in "${TARGET_NAMES[@]}"; do
+  log_info "Destroying ${name}..."
+  if hcloud server delete "${name}" 2>/dev/null; then
+    DESTROYED_NAMES+=("${name}")
+    log_success "Destroyed ${name}."
+  else
+    FAILED_NAMES+=("${name}")
+    log_error "Failed to destroy ${name}."
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Clean up SSH artifacts
+# ---------------------------------------------------------------------------
+
+for name in "${DESTROYED_NAMES[@]}"; do
+  ip="${VM_IPS[${name}]:-}"
+
+  # Remove known_hosts entry for the IP
+  if [[ -n "${ip}" ]] && [[ -f "${HOME}/.ssh/known_hosts" ]]; then
+    ssh-keygen -R "${ip}" >/dev/null 2>&1 || true
+    log_info "Removed ${ip} from ~/.ssh/known_hosts."
+  fi
+
+  # Remove ControlMaster socket files matching this VM
+  if [[ -n "${ip}" ]]; then
+    # Socket path pattern: /tmp/ccgm-ssh-root@<ip>:<port>
+    find "${CCGM_SSH_CTL_DIR}" -maxdepth 1 -name "ccgm-ssh-root@${ip}:*" -exec rm -f {} \; 2>/dev/null || true
+  fi
+
+  # Also clean by name-based socket pattern if present
+  find "${CCGM_SSH_CTL_DIR}" -maxdepth 1 -name "ccgm-ssh-*${name}*" -exec rm -f {} \; 2>/dev/null || true
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "${_COLOR_BOLD}==== VM Destroy Summary ====${_COLOR_RESET}"
+echo ""
+
+if [[ ${#DESTROYED_NAMES[@]} -gt 0 ]]; then
+  echo "${_COLOR_GREEN}Destroyed:${_COLOR_RESET}"
+  for name in "${DESTROYED_NAMES[@]}"; do
+    printf "  %s\n" "${name}"
+  done
+fi
+
+if [[ ${#FAILED_NAMES[@]} -gt 0 ]]; then
+  echo ""
+  echo "${_COLOR_RED}Failed to destroy:${_COLOR_RESET}"
+  for name in "${FAILED_NAMES[@]}"; do
+    printf "  %s\n" "${name}"
+  done
+  exit 1
+fi
+
+echo ""

--- a/modules/cloud-dispatch/lib/vm-health.sh
+++ b/modules/cloud-dispatch/lib/vm-health.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# vm-health.sh - Health check CCGM agent VMs.
+#
+# Usage:
+#   vm-health.sh                  Check all ccgm-agent-* VMs
+#   vm-health.sh --all            Same as above
+#   vm-health.sh <vm-name> [...]  Check specific VM(s) by name
+#
+# Per-VM checks:
+#   - SSH reachability (timeout 10s)
+#   - `claude --version` returns successfully
+#   - Free disk space > 20 GB
+#   - Free memory > 4 GB per agent slot (CCGM_AGENTS_PER_VM slots)
+#   - Agent users exist (agent-0 through agent-3)
+#   - iptables rules active (non-empty ruleset)
+#
+# Reports HEALTHY / DEGRADED / UNREACHABLE per VM.
+# Exit code: 0 if all VMs are HEALTHY, 1 if any DEGRADED or UNREACHABLE.
+#
+# Environment:
+#   HCLOUD_TOKEN  Hetzner Cloud API token (required)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+
+declare -a TARGET_NAMES=()
+CHECK_ALL=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      CHECK_ALL=true; shift ;;
+    --*)
+      log_error "Unknown option: $1"; exit 1 ;;
+    *)
+      TARGET_NAMES+=("$1"); shift ;;
+  esac
+done
+
+# Default: check all if no targets specified
+if [[ ${#TARGET_NAMES[@]} -eq 0 ]]; then
+  CHECK_ALL=true
+fi
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+
+require_cmd hcloud
+require_cmd ssh
+require_cmd python3
+
+if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+  log_error "HCLOUD_TOKEN is not set. Export it before running this script."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve target list
+# ---------------------------------------------------------------------------
+
+if [[ "${CHECK_ALL}" == "true" ]]; then
+  log_info "Discovering ccgm-agent-* VMs..."
+  mapfile -t TARGET_NAMES < <(
+    hcloud server list --output json \
+      | python3 -c "
+import json, sys, fnmatch
+servers = json.load(sys.stdin)
+for s in sorted(servers, key=lambda x: x['name']):
+    if fnmatch.fnmatch(s['name'], '${CCGM_VM_PATTERN}'):
+        print(s['name'])
+" \
+    || true
+  )
+
+  if [[ ${#TARGET_NAMES[@]} -eq 0 ]]; then
+    log_info "No ccgm-agent-* VMs found."
+    exit 0
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Health check helpers
+# ---------------------------------------------------------------------------
+
+# Run a remote command on a VM, capturing output. Returns the exit code.
+_remote() {
+  local ip="$1"
+  shift
+  # shellcheck disable=SC2206
+  read -ra opts <<< "$(ssh_opts)"
+  ssh "${opts[@]}" -o ConnectTimeout=10 "root@${ip}" "$@" 2>/dev/null
+}
+
+# check_ssh <ip> - returns 0 if SSH is reachable within 10s
+check_ssh() {
+  local ip="$1"
+  # shellcheck disable=SC2206
+  read -ra opts <<< "$(ssh_opts)"
+  ssh "${opts[@]}" -o ConnectTimeout=10 "root@${ip}" "true" 2>/dev/null
+}
+
+# check_claude <ip> - returns 0 if `claude --version` succeeds
+check_claude() {
+  _remote "$1" "claude --version" >/dev/null 2>&1
+}
+
+# check_disk <ip> - returns 0 if free space on / exceeds CCGM_MIN_DISK_GB
+check_disk() {
+  local ip="$1"
+  local free_kb
+  free_kb="$(_remote "${ip}" "df -k / | awk 'NR==2{print \$4}'")" || return 1
+  local free_gb=$(( free_kb / 1024 / 1024 ))
+  [[ "${free_gb}" -ge "${CCGM_MIN_DISK_GB}" ]]
+}
+
+# check_memory <ip> - returns 0 if free memory satisfies per-agent requirement
+check_memory() {
+  local ip="$1"
+  local free_mb
+  free_mb="$(_remote "${ip}" "free -m | awk '/^Mem:/{print \$7}'")" || return 1
+  local required_mb=$(( CCGM_MIN_MEM_MB_PER_AGENT * CCGM_AGENTS_PER_VM ))
+  [[ "${free_mb}" -ge "${required_mb}" ]]
+}
+
+# check_agent_users <ip> - returns 0 if agent-0 through agent-N-1 all exist
+check_agent_users() {
+  local ip="$1"
+  local script=""
+  for (( u=0; u<CCGM_AGENTS_PER_VM; u++ )); do
+    script+="id agent-${u} >/dev/null 2>&1 || exit 1; "
+  done
+  _remote "${ip}" "bash -c '${script}exit 0'" >/dev/null 2>&1
+}
+
+# check_iptables <ip> - returns 0 if iptables has at least one non-default chain rule
+check_iptables() {
+  local ip="$1"
+  local rule_count
+  rule_count="$(_remote "${ip}" "iptables -L -n | grep -c '^[A-Z]' || true")" 2>/dev/null || return 1
+  [[ "${rule_count}" -gt 3 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Run health checks on each VM
+# ---------------------------------------------------------------------------
+
+declare -a HEALTHY_NAMES=()
+declare -a DEGRADED_NAMES=()
+declare -a UNREACHABLE_NAMES=()
+
+echo ""
+echo "${_COLOR_BOLD}==== CCGM Agent VM Health Check ====${_COLOR_RESET}"
+echo ""
+
+for name in "${TARGET_NAMES[@]}"; do
+  ip="$(vm_ip "${name}" 2>/dev/null || true)"
+  if [[ -z "${ip}" ]]; then
+    log_warn "${name}: could not resolve IP (VM may not exist)."
+    UNREACHABLE_NAMES+=("${name}")
+    printf "  %-32s  %s\n" "${name}" "${_COLOR_RED}UNREACHABLE${_COLOR_RESET} (no IP)"
+    continue
+  fi
+
+  # SSH reachability is a hard requirement
+  if ! check_ssh "${ip}" 2>/dev/null; then
+    UNREACHABLE_NAMES+=("${name}")
+    printf "  %-32s  %s\n" "${name}" "${_COLOR_RED}UNREACHABLE${_COLOR_RESET} (SSH timeout)"
+    continue
+  fi
+
+  declare -a failures=()
+
+  check_claude "${ip}"   || failures+=("claude-not-found")
+  check_disk "${ip}"     || failures+=("low-disk (<${CCGM_MIN_DISK_GB}GB)")
+  check_memory "${ip}"   || failures+=("low-memory (<$(( CCGM_MIN_MEM_MB_PER_AGENT * CCGM_AGENTS_PER_VM ))MB free)")
+  check_agent_users "${ip}" || failures+=("missing-agent-users")
+  check_iptables "${ip}" || failures+=("iptables-inactive")
+
+  if [[ ${#failures[@]} -eq 0 ]]; then
+    HEALTHY_NAMES+=("${name}")
+    printf "  %-32s  %s\n" "${name}" "${_COLOR_GREEN}HEALTHY${_COLOR_RESET}"
+  else
+    DEGRADED_NAMES+=("${name}")
+    printf "  %-32s  %s  [%s]\n" \
+      "${name}" \
+      "${_COLOR_YELLOW}DEGRADED${_COLOR_RESET}" \
+      "${failures[*]}"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "${_COLOR_BOLD}Summary:${_COLOR_RESET}"
+echo "  Healthy:     ${#HEALTHY_NAMES[@]}"
+echo "  Degraded:    ${#DEGRADED_NAMES[@]}"
+echo "  Unreachable: ${#UNREACHABLE_NAMES[@]}"
+echo "  Total:       ${#TARGET_NAMES[@]}"
+echo ""
+
+if [[ ${#DEGRADED_NAMES[@]} -gt 0 ]] || [[ ${#UNREACHABLE_NAMES[@]} -gt 0 ]]; then
+  exit 1
+fi

--- a/modules/cloud-dispatch/lib/vm-ssh.sh
+++ b/modules/cloud-dispatch/lib/vm-ssh.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# vm-ssh.sh - SSH into a CCGM agent VM.
+#
+# Usage:
+#   vm-ssh.sh <vm-name> [command [args...]]
+#
+# If a command is provided, it is executed non-interactively and the script
+# exits with its return code. If no command is given, an interactive shell
+# session is opened.
+#
+# ControlMaster sockets are reused when available (see SSH config in common.sh).
+#
+# Environment:
+#   HCLOUD_TOKEN  Hetzner Cloud API token (required to resolve the VM IP)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <vm-name> [command [args...]]" >&2
+  exit 1
+fi
+
+VM_NAME="$1"
+shift
+REMOTE_CMD=("$@")
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+
+require_cmd hcloud
+require_cmd ssh
+require_cmd python3
+
+if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+  log_error "HCLOUD_TOKEN is not set. Export it before running this script."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve IP
+# ---------------------------------------------------------------------------
+
+log_info "Resolving IP for ${VM_NAME}..."
+VM_IP="$(vm_ip "${VM_NAME}")"
+
+if [[ -z "${VM_IP}" ]]; then
+  log_error "Could not resolve IP for VM '${VM_NAME}'. Is it running?"
+  exit 1
+fi
+
+log_info "${VM_NAME} -> ${VM_IP}"
+
+# ---------------------------------------------------------------------------
+# Build SSH options array
+# ---------------------------------------------------------------------------
+
+# Using read -ra to split the opts string into an array
+# shellcheck disable=SC2206
+read -ra SSH_OPTS <<< "$(ssh_opts)"
+
+# ---------------------------------------------------------------------------
+# Connect
+# ---------------------------------------------------------------------------
+
+if [[ ${#REMOTE_CMD[@]} -gt 0 ]]; then
+  # Non-interactive: run command and exit
+  exec ssh "${SSH_OPTS[@]}" "root@${VM_IP}" "${REMOTE_CMD[@]}"
+else
+  # Interactive session: allocate a TTY
+  exec ssh -t "${SSH_OPTS[@]}" "root@${VM_IP}"
+fi

--- a/modules/cloud-dispatch/lib/vm-status.sh
+++ b/modules/cloud-dispatch/lib/vm-status.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# vm-status.sh - List all running CCGM agent VMs with status details.
+#
+# Usage:
+#   vm-status.sh
+#
+# Output:
+#   Formatted table: NAME | IP | LOCATION | STATUS | UPTIME | TYPE
+#
+# Environment:
+#   HCLOUD_TOKEN  Hetzner Cloud API token (required)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+
+require_cmd hcloud
+require_cmd python3
+
+if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+  log_error "HCLOUD_TOKEN is not set. Export it before running this script."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Fetch and format VM list
+# ---------------------------------------------------------------------------
+
+log_info "Fetching VM list..."
+
+python3 - <<'PYEOF'
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+result = subprocess.run(
+    ["hcloud", "server", "list", "--output", "json"],
+    capture_output=True,
+    text=True,
+)
+if result.returncode != 0:
+    print(f"ERROR: hcloud server list failed: {result.stderr}", file=sys.stderr)
+    sys.exit(1)
+
+servers = json.loads(result.stdout)
+
+# Filter to ccgm-agent-* VMs only
+servers = [s for s in servers if s.get("name", "").startswith("ccgm-agent-")]
+
+if not servers:
+    print("No ccgm-agent-* VMs found.")
+    sys.exit(0)
+
+# Sort by name for stable output
+servers.sort(key=lambda s: s["name"])
+
+# Column widths
+col_name = max(len(s["name"]) for s in servers) + 2
+col_ip   = 16
+col_loc  = 8
+col_stat = 10
+col_up   = 16
+col_type = 8
+
+header = (
+    f"{'NAME':<{col_name}}  {'IP':<{col_ip}}  {'LOC':<{col_loc}}"
+    f"  {'STATUS':<{col_stat}}  {'UPTIME':<{col_up}}  {'TYPE':<{col_type}}"
+)
+sep = "-" * len(header)
+
+print(header)
+print(sep)
+
+now = datetime.now(timezone.utc)
+for s in servers:
+    name   = s.get("name", "")
+    ip     = s.get("public_net", {}).get("ipv4", {}).get("ip", "")
+    loc    = s.get("datacenter", {}).get("location", {}).get("name", "")
+    status = s.get("status", "")
+    stype  = s.get("server_type", {}).get("name", "")
+
+    created_str = s.get("created", "")
+    if created_str:
+        try:
+            created = datetime.fromisoformat(created_str.replace("Z", "+00:00"))
+            delta   = now - created
+            total   = int(delta.total_seconds())
+            hours, rem = divmod(total, 3600)
+            mins        = rem // 60
+            uptime  = f"{hours}h {mins}m"
+        except ValueError:
+            uptime = "unknown"
+    else:
+        uptime = "unknown"
+
+    print(
+        f"{name:<{col_name}}  {ip:<{col_ip}}  {loc:<{col_loc}}"
+        f"  {status:<{col_stat}}  {uptime:<{col_up}}  {stype:<{col_type}}"
+    )
+
+print()
+print(f"Total: {len(servers)} VM(s)")
+PYEOF


### PR DESCRIPTION
Closes #215

## Summary

- Adds `modules/cloud-dispatch/lib/` with 6 bash scripts for Hetzner VM lifecycle management
- `common.sh` - shared config, SSH helpers, logging utilities, cleanup trap registration
- `vm-create.sh` - create N VMs from golden snapshot, round-robin across fsn1/nbg1/hel1, wait for SSH
- `vm-destroy.sh` - destroy VMs by name or `--all`, cleans known_hosts and ControlMaster sockets
- `vm-status.sh` - formatted table of all ccgm-agent-* VMs with IP, location, status, uptime, type
- `vm-ssh.sh` - SSH into a VM by name (interactive session or non-interactive command execution)
- `vm-health.sh` - per-VM health checks: SSH, claude version, disk, memory, agent users, iptables

## Test plan

- [ ] shellcheck -x passes (verified locally: clean pass)
- [ ] vm-create.sh creates 3 VMs spread across fsn1/nbg1/hel1 and waits for SSH
- [ ] vm-status.sh shows expected table output
- [ ] vm-health.sh reports HEALTHY / DEGRADED / UNREACHABLE correctly
- [ ] vm-ssh.sh opens interactive session and executes remote commands
- [ ] vm-destroy.sh --all with --force removes all VMs and cleans known_hosts