### PR TITLE
#216: add secret management and credential injection scripts

### DIFF
--- a/modules/cloud-dispatch/lib/secrets-cleanup.sh
+++ b/modules/cloud-dispatch/lib/secrets-cleanup.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# secrets-cleanup.sh — Revoke session credentials and wipe VM secrets.
+#
+# Reads session metadata from /tmp/ccgm-session.json (written by secrets-init.sh),
+# deletes the Hetzner SSH key, removes it from ssh-agent, and optionally wipes
+# /run/secrets/ on all running VMs.
+#
+# Usage:
+#   secrets-cleanup.sh [--wipe-vms]
+#
+# Options:
+#   --wipe-vms   SSH into each running ccgm-agent-* VM and wipe /run/secrets/
+#
+# Requirements:
+#   - hcloud CLI authenticated
+#   - jq installed
+
+set -euo pipefail
+
+SESSION_FILE="/tmp/ccgm-session.json"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log()  { printf '[secrets-cleanup] %s\n' "$*" >&2; }
+warn() { printf '[secrets-cleanup] WARN: %s\n' "$*" >&2; }
+die()  { printf '[secrets-cleanup] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+WIPE_VMS=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --wipe-vms)
+      WIPE_VMS=true
+      shift
+      ;;
+    --help|-h)
+      grep '^#' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+
+command -v hcloud >/dev/null 2>&1 || die "hcloud CLI not found in PATH"
+command -v jq >/dev/null 2>&1 || die "jq not found in PATH"
+command -v ssh-add >/dev/null 2>&1 || die "ssh-add not found in PATH"
+
+# ---------------------------------------------------------------------------
+# Read session metadata
+# ---------------------------------------------------------------------------
+
+if [[ ! -f "${SESSION_FILE}" ]]; then
+  warn "Session file not found at ${SESSION_FILE} — nothing to clean up"
+  exit 0
+fi
+
+KEY_ID="$(jq -r '.key_id' "${SESSION_FILE}")"
+KEY_NAME="$(jq -r '.key_name' "${SESSION_FILE}")"
+FINGERPRINT="$(jq -r '.fingerprint' "${SESSION_FILE}")"
+
+[[ -n "${KEY_ID}" && "${KEY_ID}" != "null" ]] \
+  || die "Could not read key_id from ${SESSION_FILE}"
+
+log "Session: key_name=${KEY_NAME} key_id=${KEY_ID} fingerprint=${FINGERPRINT}"
+
+# ---------------------------------------------------------------------------
+# Remove key from ssh-agent
+# ---------------------------------------------------------------------------
+
+log "Removing session key from ssh-agent (fingerprint: ${FINGERPRINT})"
+if ssh-add -l 2>/dev/null | grep -q "${FINGERPRINT}"; then
+  ssh-add -d - 2>/dev/null <<< "" || {
+    # ssh-add -d requires the public key or fingerprint; use -D as fallback
+    # only if no other keys are loaded, to avoid revoking unrelated keys.
+    LOADED_COUNT="$(ssh-add -l 2>/dev/null | grep -c . || true)"
+    if [[ "${LOADED_COUNT}" -eq 1 ]]; then
+      log "  Using ssh-add -D (only session key is loaded)"
+      ssh-add -D
+    else
+      warn "  Could not remove specific key; ${LOADED_COUNT} keys loaded — manual cleanup may be needed"
+    fi
+  }
+else
+  log "  Key not found in ssh-agent (may have already been removed)"
+fi
+
+# ---------------------------------------------------------------------------
+# Delete key from Hetzner
+# ---------------------------------------------------------------------------
+
+log "Deleting SSH key from Hetzner Cloud (ID: ${KEY_ID})"
+if hcloud ssh-key describe "${KEY_ID}" &>/dev/null; then
+  hcloud ssh-key delete "${KEY_ID}"
+  log "  Deleted Hetzner SSH key ${KEY_NAME} (${KEY_ID})"
+else
+  log "  Key ID ${KEY_ID} not found in Hetzner — may have been deleted already"
+fi
+
+# ---------------------------------------------------------------------------
+# Optional: wipe /run/secrets/ on all running VMs
+# ---------------------------------------------------------------------------
+
+if [[ "${WIPE_VMS}" == "true" ]]; then
+  log "Discovering running ccgm-agent-* VMs for secret wipe"
+
+  RUNNING_VMS="$(hcloud server list --output json 2>/dev/null \
+    | jq -r '.[] | select(.name | startswith("ccgm-agent")) | select(.status == "running") | "\(.name) \(.public_net.ipv4.ip)"' \
+    || true)"
+
+  if [[ -z "${RUNNING_VMS}" ]]; then
+    log "No running VMs found — nothing to wipe"
+  else
+    SSH_OPTS=(
+      -o BatchMode=yes
+      -o StrictHostKeyChecking=accept-new
+      -o ConnectTimeout=10
+    )
+
+    while IFS=' ' read -r vm_name vm_ip; do
+      [[ -z "${vm_name}" ]] && continue
+      log "Wiping /run/secrets/ on ${vm_name} (${vm_ip})"
+
+      if HISTFILE=/dev/null ssh -n "${SSH_OPTS[@]}" "root@${vm_ip}" \
+          'find /run/secrets -mindepth 2 -type f -exec shred -u {} \; 2>/dev/null; echo "wiped"' 2>/dev/null; then
+        log "  ${vm_name}: wiped"
+      else
+        warn "  ${vm_name}: wipe failed or VM unreachable"
+      fi
+    done <<< "${RUNNING_VMS}"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Remove session metadata file
+# ---------------------------------------------------------------------------
+
+log "Removing session metadata file ${SESSION_FILE}"
+rm -f "${SESSION_FILE}"
+
+log "secrets-cleanup complete"

--- a/modules/cloud-dispatch/lib/secrets-init.sh
+++ b/modules/cloud-dispatch/lib/secrets-init.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# secrets-init.sh — Initialize session SSH credentials for cloud-dispatch.
+#
+# Generates a per-session ed25519 SSH keypair, loads it into macOS ssh-agent,
+# and registers the public key with Hetzner Cloud. Session metadata is written
+# to /tmp/ccgm-session.json for use by secrets-cleanup.sh.
+#
+# Usage: secrets-init.sh
+#
+# Requirements:
+#   - hcloud CLI authenticated (HCLOUD_TOKEN env or hcloud context)
+#   - macOS ssh-agent running (SSH_AUTH_SOCK set)
+#   - jq installed
+
+set -euo pipefail
+
+SESSION_FILE="/tmp/ccgm-session.json"
+TMPKEY="/tmp/ccgm-session-key-$$"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log()  { printf '[secrets-init] %s\n' "$*" >&2; }
+die()  { printf '[secrets-init] ERROR: %s\n' "$*" >&2; exit 1; }
+
+cleanup_tmpkey() {
+  rm -f "${TMPKEY}" "${TMPKEY}.pub" 2>/dev/null || true
+}
+trap cleanup_tmpkey EXIT
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+
+command -v hcloud >/dev/null 2>&1 || die "hcloud CLI not found in PATH"
+command -v ssh-add >/dev/null 2>&1 || die "ssh-add not found in PATH"
+command -v ssh-keygen >/dev/null 2>&1 || die "ssh-keygen not found in PATH"
+command -v jq >/dev/null 2>&1 || die "jq not found in PATH"
+
+[[ -n "${SSH_AUTH_SOCK:-}" ]] || die "SSH_AUTH_SOCK is not set — is ssh-agent running?"
+
+if [[ -f "${SESSION_FILE}" ]]; then
+  log "WARNING: session file already exists at ${SESSION_FILE}"
+  log "Run secrets-cleanup.sh first to revoke the previous session."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Generate session keypair
+# ---------------------------------------------------------------------------
+
+SESSION_TS="$(date +%s)"
+KEY_NAME="ccgm-session-${SESSION_TS}"
+
+log "Generating ed25519 session keypair (${KEY_NAME})"
+# -N "" means no passphrase so the key can be used by automation without prompting.
+ssh-keygen -t ed25519 -f "${TMPKEY}" -N "" -C "${KEY_NAME}" -q
+
+log "Adding private key to ssh-agent"
+ssh-add "${TMPKEY}"
+
+# Public key is safe to keep until Hetzner upload completes; trap removes both.
+PUBKEY_CONTENT="$(cat "${TMPKEY}.pub")"
+
+# ---------------------------------------------------------------------------
+# Register public key with Hetzner
+# ---------------------------------------------------------------------------
+
+log "Uploading public key to Hetzner Cloud as '${KEY_NAME}'"
+HCLOUD_OUTPUT="$(hcloud ssh-key create --name "${KEY_NAME}" --public-key "${PUBKEY_CONTENT}" --output json 2>/dev/null)"
+HCLOUD_KEY_ID="$(printf '%s' "${HCLOUD_OUTPUT}" | jq -r '.ssh_key.id // .id')"
+HCLOUD_FINGERPRINT="$(printf '%s' "${HCLOUD_OUTPUT}" | jq -r '.ssh_key.fingerprint // .fingerprint')"
+
+[[ -n "${HCLOUD_KEY_ID}" && "${HCLOUD_KEY_ID}" != "null" ]] \
+  || die "Failed to parse key ID from hcloud output"
+
+log "Hetzner SSH key registered: ID=${HCLOUD_KEY_ID} fingerprint=${HCLOUD_FINGERPRINT}"
+
+# ---------------------------------------------------------------------------
+# Write session metadata
+# ---------------------------------------------------------------------------
+
+jq -n \
+  --arg key_name "${KEY_NAME}" \
+  --arg key_id "${HCLOUD_KEY_ID}" \
+  --arg fingerprint "${HCLOUD_FINGERPRINT}" \
+  --arg timestamp "${SESSION_TS}" \
+  '{
+    key_name:    $key_name,
+    key_id:      $key_id,
+    fingerprint: $fingerprint,
+    timestamp:   $timestamp
+  }' > "${SESSION_FILE}"
+
+chmod 0600 "${SESSION_FILE}"
+
+log "Session metadata written to ${SESSION_FILE}"
+log "secrets-init complete"
+log ""
+log "  Key name:    ${KEY_NAME}"
+log "  Key ID:      ${HCLOUD_KEY_ID}"
+log "  Fingerprint: ${HCLOUD_FINGERPRINT}"
+log ""
+log "Run secrets-cleanup.sh to revoke this session when done."

--- a/modules/cloud-dispatch/lib/secrets-inject-all.sh
+++ b/modules/cloud-dispatch/lib/secrets-inject-all.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# secrets-inject-all.sh — Inject credentials into all agents across all running VMs.
+#
+# Discovers running ccgm-agent-* Hetzner VMs, then calls secrets-inject.sh for
+# each agent (0-3) on each VM. Reports per-agent success/failure.
+#
+# Usage:
+#   secrets-inject-all.sh --github-token TOKEN [--claude-auth TOKEN]
+#
+# Requirements:
+#   - hcloud CLI authenticated
+#   - SSH key loaded in ssh-agent (run secrets-init.sh first)
+#   - secrets-inject.sh in the same directory
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INJECT_SCRIPT="${SCRIPT_DIR}/secrets-inject.sh"
+AGENT_COUNT=4
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log()  { printf '[secrets-inject-all] %s\n' "$*" >&2; }
+die()  { printf '[secrets-inject-all] ERROR: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: secrets-inject-all.sh --github-token TOKEN [--claude-auth TOKEN]
+
+Options:
+  --github-token TOKEN   GitHub personal access token (required)
+  --claude-auth TOKEN    Claude authentication token (optional)
+USAGE
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+[[ $# -ge 1 ]] || usage
+
+GITHUB_TOKEN=""
+CLAUDE_AUTH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --github-token)
+      GITHUB_TOKEN="$2"
+      shift 2
+      ;;
+    --claude-auth)
+      CLAUDE_AUTH="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "${GITHUB_TOKEN}" ]] || die "--github-token is required"
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+
+command -v hcloud >/dev/null 2>&1 || die "hcloud CLI not found in PATH"
+[[ -x "${INJECT_SCRIPT}" ]] || die "secrets-inject.sh not found or not executable at ${INJECT_SCRIPT}"
+[[ -n "${SSH_AUTH_SOCK:-}" ]] || die "SSH_AUTH_SOCK is not set — is ssh-agent running?"
+
+# ---------------------------------------------------------------------------
+# Discover running VMs
+# ---------------------------------------------------------------------------
+
+log "Discovering running ccgm-agent-* VMs"
+
+# hcloud server list outputs name, status, public IP etc.
+# Filter for VMs named ccgm-agent-* that are in 'running' status.
+RUNNING_VMS="$(hcloud server list --selector 'ccgm-role=agent' --output columns=name,public_net 2>/dev/null \
+  | tail -n +2 \
+  | awk '{print $1, $2}' \
+  || true)"
+
+# Fallback: list by name prefix if no label selector works
+if [[ -z "${RUNNING_VMS}" ]]; then
+  log "Label selector returned no results; falling back to name-prefix discovery"
+  RUNNING_VMS="$(hcloud server list --output json 2>/dev/null \
+    | jq -r '.[] | select(.name | startswith("ccgm-agent")) | select(.status == "running") | "\(.name) \(.public_net.ipv4.ip)"' \
+    || true)"
+fi
+
+if [[ -z "${RUNNING_VMS}" ]]; then
+  log "No running ccgm-agent-* VMs found."
+  exit 0
+fi
+
+VM_COUNT="$(printf '%s\n' "${RUNNING_VMS}" | grep -c . || true)"
+log "Found ${VM_COUNT} VM(s)"
+
+# ---------------------------------------------------------------------------
+# Inject secrets into each VM / agent combination
+# ---------------------------------------------------------------------------
+
+PASS=0
+FAIL=0
+FAIL_DETAILS=()
+
+while IFS=' ' read -r vm_name vm_ip; do
+  [[ -z "${vm_name}" ]] && continue
+  log "Processing VM: ${vm_name} (${vm_ip})"
+
+  for i in $(seq 0 $((AGENT_COUNT - 1))); do
+    INJECT_ARGS=("${vm_ip}" "${i}" "--github-token" "${GITHUB_TOKEN}")
+    [[ -n "${CLAUDE_AUTH}" ]] && INJECT_ARGS+=("--claude-auth" "${CLAUDE_AUTH}")
+
+    if bash "${INJECT_SCRIPT}" "${INJECT_ARGS[@]}" 2>&1; then
+      PASS=$(( PASS + 1 ))
+      log "  agent-${i}: OK"
+    else
+      FAIL=$(( FAIL + 1 ))
+      FAIL_DETAILS+=("${vm_name}/agent-${i}")
+      log "  agent-${i}: FAILED"
+    fi
+  done
+done <<< "${RUNNING_VMS}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+TOTAL=$(( PASS + FAIL ))
+log ""
+log "Injection complete: ${PASS}/${TOTAL} agents succeeded"
+
+if [[ "${FAIL}" -gt 0 ]]; then
+  log "Failed agents:"
+  for detail in "${FAIL_DETAILS[@]}"; do
+    log "  - ${detail}"
+  done
+  exit 1
+fi

--- a/modules/cloud-dispatch/lib/secrets-inject.sh
+++ b/modules/cloud-dispatch/lib/secrets-inject.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# secrets-inject.sh — Inject credentials into a single agent on a VM.
+#
+# Writes secrets to the agent's tmpfs directory (/run/secrets/agent-N/) via SSH.
+# Secrets are written using heredocs over the SSH connection so they never appear
+# in process arguments (ps output). HISTFILE is disabled for all SSH sessions.
+#
+# Usage:
+#   secrets-inject.sh <vm-ip> <agent-index> [--github-token TOKEN] [--claude-auth TOKEN]
+#
+# Example:
+#   secrets-inject.sh 1.2.3.4 0 --github-token ghp_xxx --claude-auth sk-ant-xxx
+#
+# Requirements:
+#   - SSH key for root access already loaded in ssh-agent (run secrets-init.sh first)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log()  { printf '[secrets-inject] %s\n' "$*" >&2; }
+die()  { printf '[secrets-inject] ERROR: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: secrets-inject.sh <vm-ip> <agent-index> [options]
+
+Options:
+  --github-token TOKEN   GitHub personal access token
+  --claude-auth TOKEN    Claude authentication token (API key or subscription token)
+
+At least one of --github-token or --claude-auth must be provided.
+USAGE
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+[[ $# -ge 2 ]] || usage
+
+VM_IP="$1"
+AGENT_INDEX="$2"
+shift 2
+
+GITHUB_TOKEN=""
+CLAUDE_AUTH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --github-token)
+      GITHUB_TOKEN="$2"
+      shift 2
+      ;;
+    --claude-auth)
+      CLAUDE_AUTH="$2"
+      shift 2
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+# Validate inputs
+[[ "${AGENT_INDEX}" =~ ^[0-3]$ ]] || die "agent-index must be 0, 1, 2, or 3 (got: ${AGENT_INDEX})"
+[[ -n "${VM_IP}" ]] || die "vm-ip is required"
+[[ -n "${GITHUB_TOKEN}" || -n "${CLAUDE_AUTH}" ]] \
+  || die "At least one of --github-token or --claude-auth must be provided"
+
+AGENT_USER="agent-${AGENT_INDEX}"
+SECRETS_DIR="/run/secrets/${AGENT_USER}"
+
+# ---------------------------------------------------------------------------
+# SSH helper — HISTFILE disabled for all sessions to prevent secret leakage
+# ---------------------------------------------------------------------------
+
+# Common SSH flags: batch mode, key-only auth, no stdin consumption.
+SSH_OPTS=(
+  -n
+  -o BatchMode=yes
+  -o StrictHostKeyChecking=accept-new
+  -o ConnectTimeout=10
+)
+
+vm_exec() {
+  HISTFILE=/dev/null ssh "${SSH_OPTS[@]}" "root@${VM_IP}" "$@"
+}
+
+# Variant that reads stdin (for piping secrets); -n flag must be omitted.
+SSH_STDIN_OPTS=(
+  -o BatchMode=yes
+  -o StrictHostKeyChecking=accept-new
+  -o ConnectTimeout=10
+)
+
+vm_exec_stdin() {
+  HISTFILE=/dev/null ssh "${SSH_STDIN_OPTS[@]}" "root@${VM_IP}" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Verify connectivity
+# ---------------------------------------------------------------------------
+
+log "Verifying SSH connectivity to ${VM_IP}"
+vm_exec true || die "Cannot SSH to ${VM_IP} — check that secrets-init.sh has been run"
+
+# ---------------------------------------------------------------------------
+# Ensure secrets directory exists with correct permissions
+# ---------------------------------------------------------------------------
+
+log "Ensuring ${SECRETS_DIR} exists with correct permissions"
+
+# Remote script body stored in a variable so it can be passed via stdin.
+# Variables are expanded on the client side before sending — this is intentional
+# for non-secret values like AGENT_USER and SECRETS_DIR.
+SETUP_SCRIPT="$(cat <<SETUP
+set -euo pipefail
+if mountpoint -q /run 2>/dev/null; then
+  FSTYPE=\"\$(findmnt -n -o FSTYPE /run 2>/dev/null || true)\"
+  if [[ \"\${FSTYPE}\" != \"tmpfs\" ]]; then
+    echo \"WARNING: /run is not tmpfs (found: \${FSTYPE})\" >&2
+  fi
+fi
+mkdir -p '${SECRETS_DIR}'
+chmod 0700 '${SECRETS_DIR}'
+chown '${AGENT_USER}:${AGENT_USER}' '${SECRETS_DIR}'
+SETUP
+)"
+
+printf '%s' "${SETUP_SCRIPT}" | vm_exec_stdin bash
+
+# ---------------------------------------------------------------------------
+# Inject secrets via stdin (never in command arguments)
+# ---------------------------------------------------------------------------
+
+inject_secret() {
+  local filename="$1"
+  local content="$2"
+  local filepath="${SECRETS_DIR}/${filename}"
+
+  log "  Writing ${filepath}"
+
+  # The remote script reads the secret from stdin.
+  # The secret is piped in and never appears in command arguments or ps output.
+  # The remote script body is passed as a -c argument so stdin is free for the secret.
+  local remote_script
+  remote_script="$(cat <<RSCRIPT
+set -euo pipefail
+FILEPATH='${filepath}'
+AGENT='${AGENT_USER}'
+SECRET="\$(cat)"
+printf '%s' "\${SECRET}" > "\${FILEPATH}"
+chmod 0600 "\${FILEPATH}"
+chown "\${AGENT}:\${AGENT}" "\${FILEPATH}"
+RSCRIPT
+)"
+
+  printf '%s' "${content}" \
+    | HISTFILE=/dev/null ssh "${SSH_STDIN_OPTS[@]}" "root@${VM_IP}" bash -c "${remote_script}"
+}
+
+if [[ -n "${GITHUB_TOKEN}" ]]; then
+  inject_secret "github_token" "${GITHUB_TOKEN}"
+fi
+
+if [[ -n "${CLAUDE_AUTH}" ]]; then
+  inject_secret "claude_auth" "${CLAUDE_AUTH}"
+fi
+
+# ---------------------------------------------------------------------------
+# Write env file that the agent sources at startup
+# ---------------------------------------------------------------------------
+
+log "  Writing ${SECRETS_DIR}/env"
+
+ENV_SCRIPT="$(cat <<ENVSCRIPT
+set -euo pipefail
+ENV_FILE='${SECRETS_DIR}/env'
+{
+  printf '# Auto-generated by secrets-inject.sh -- do not edit\n'
+  printf '# Source this file to load agent credentials into the current shell.\n'
+  printf '\n'
+ENVSCRIPT
+)"
+
+if [[ -n "${GITHUB_TOKEN}" ]]; then
+  ENV_SCRIPT+="$(cat <<GITHUB
+  printf 'export GITHUB_TOKEN="\$(cat ${SECRETS_DIR}/github_token)"\n'
+GITHUB
+)"
+fi
+
+if [[ -n "${CLAUDE_AUTH}" ]]; then
+  ENV_SCRIPT+="$(cat <<CLAUDE
+  printf 'export ANTHROPIC_API_KEY="\$(cat ${SECRETS_DIR}/claude_auth)"\n'
+  printf '# Uncomment for subscription-mode auth:\n'
+  printf '# export CLAUDE_AUTH_TOKEN="\$(cat ${SECRETS_DIR}/claude_auth)"\n'
+CLAUDE
+)"
+fi
+
+ENV_SCRIPT+="$(cat <<ENVEND
+} > "\${ENV_FILE}"
+chmod 0600 "\${ENV_FILE}"
+chown '${AGENT_USER}:${AGENT_USER}' "\${ENV_FILE}"
+ENVEND
+)"
+
+printf '%s' "${ENV_SCRIPT}" | vm_exec_stdin bash
+
+# ---------------------------------------------------------------------------
+# Verify injection
+# ---------------------------------------------------------------------------
+
+log "Verifying injection for ${AGENT_USER}"
+
+# Build a list of expected secret files to verify
+EXPECTED_FILES=()
+[[ -n "${GITHUB_TOKEN}" ]] && EXPECTED_FILES+=("github_token")
+[[ -n "${CLAUDE_AUTH}" ]]  && EXPECTED_FILES+=("claude_auth")
+EXPECTED_FILES+=("env")
+
+VERIFY_SCRIPT="$(cat <<VERIFYSCRIPT
+set -euo pipefail
+ALL_OK=true
+AGENT_USER='${AGENT_USER}'
+SECRETS_DIR='${SECRETS_DIR}'
+VERIFYSCRIPT
+)"
+
+for f in "${EXPECTED_FILES[@]}"; do
+  VERIFY_SCRIPT+="$(cat <<VFILE
+fp="\${SECRETS_DIR}/${f}"
+if [[ ! -f "\${fp}" ]]; then
+  printf 'FAIL: %s does not exist\n' "\${fp}" >&2
+  ALL_OK=false
+else
+  perms="\$(stat -c '%a' "\${fp}" 2>/dev/null || stat -f '%OLp' "\${fp}" 2>/dev/null)"
+  owner="\$(stat -c '%U' "\${fp}" 2>/dev/null || stat -f '%Su' "\${fp}" 2>/dev/null)"
+  if [[ "\${perms}" != "600" ]]; then
+    printf 'FAIL: %s has permissions %s (expected 600)\n' "\${fp}" "\${perms}" >&2
+    ALL_OK=false
+  fi
+  if [[ "\${owner}" != "\${AGENT_USER}" ]]; then
+    printf 'FAIL: %s owned by %s (expected %s)\n' "\${fp}" "\${owner}" "\${AGENT_USER}" >&2
+    ALL_OK=false
+  fi
+fi
+VFILE
+)"
+done
+
+VERIFY_SCRIPT+='
+if [[ "${ALL_OK}" == "true" ]]; then
+  printf "OK: all secrets verified\n" >&2
+else
+  exit 1
+fi'
+
+printf '%s' "${VERIFY_SCRIPT}" | vm_exec_stdin bash
+
+log "secrets-inject complete for ${AGENT_USER} on ${VM_IP}"

--- a/modules/cloud-dispatch/lib/secrets-rotate.sh
+++ b/modules/cloud-dispatch/lib/secrets-rotate.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# secrets-rotate.sh — Rotate a GitHub PAT for a specific agent on a VM.
+#
+# Re-injects a new GitHub token for a single agent and verifies the token
+# works by testing git remote access from the agent's workspace.
+#
+# Usage:
+#   secrets-rotate.sh <vm-ip> <agent-index> --github-token NEW_TOKEN
+#
+# Example:
+#   secrets-rotate.sh 1.2.3.4 0 --github-token ghp_newtoken
+#
+# Requirements:
+#   - SSH key loaded in ssh-agent (run secrets-init.sh first)
+#   - secrets-inject.sh in the same directory
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INJECT_SCRIPT="${SCRIPT_DIR}/secrets-inject.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log()  { printf '[secrets-rotate] %s\n' "$*" >&2; }
+die()  { printf '[secrets-rotate] ERROR: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: secrets-rotate.sh <vm-ip> <agent-index> --github-token NEW_TOKEN
+
+Arguments:
+  vm-ip          IP address of the VM
+  agent-index    Agent index (0-3)
+
+Options:
+  --github-token TOKEN   New GitHub personal access token (required)
+USAGE
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+[[ $# -ge 3 ]] || usage
+
+VM_IP="$1"
+AGENT_INDEX="$2"
+shift 2
+
+GITHUB_TOKEN=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --github-token)
+      GITHUB_TOKEN="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "${GITHUB_TOKEN}" ]] || die "--github-token is required"
+[[ "${AGENT_INDEX}" =~ ^[0-3]$ ]] || die "agent-index must be 0, 1, 2, or 3 (got: ${AGENT_INDEX})"
+[[ -n "${VM_IP}" ]] || die "vm-ip is required"
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+
+[[ -x "${INJECT_SCRIPT}" ]] || die "secrets-inject.sh not found or not executable at ${INJECT_SCRIPT}"
+[[ -n "${SSH_AUTH_SOCK:-}" ]] || die "SSH_AUTH_SOCK is not set — is ssh-agent running?"
+
+AGENT_USER="agent-${AGENT_INDEX}"
+SECRETS_DIR="/run/secrets/${AGENT_USER}"
+
+# ---------------------------------------------------------------------------
+# Re-inject the new token
+# ---------------------------------------------------------------------------
+
+log "Rotating GitHub token for ${AGENT_USER} on ${VM_IP}"
+bash "${INJECT_SCRIPT}" "${VM_IP}" "${AGENT_INDEX}" --github-token "${GITHUB_TOKEN}"
+
+# ---------------------------------------------------------------------------
+# Verify the new token works
+# ---------------------------------------------------------------------------
+
+log "Verifying new token with git ls-remote"
+
+SSH_OPTS=(
+  -o BatchMode=yes
+  -o StrictHostKeyChecking=accept-new
+  -o ConnectTimeout=10
+)
+
+# Run git ls-remote as the agent user to confirm the new GITHUB_TOKEN works.
+# The token is read from the secrets file so it never appears in the process list.
+VERIFY_RESULT="$(HISTFILE=/dev/null ssh "${SSH_OPTS[@]}" "root@${VM_IP}" \
+  bash -s "${AGENT_USER}" "${SECRETS_DIR}" <<'VERIFY'
+set -euo pipefail
+AGENT_USER="$1"
+SECRETS_DIR="$2"
+
+# Run as the agent user so the test mirrors actual agent conditions
+if [[ ! -f "${SECRETS_DIR}/github_token" ]]; then
+  echo "FAIL: github_token file not found" >&2
+  exit 1
+fi
+
+TOKEN_FILE="${SECRETS_DIR}/github_token"
+
+# Test API access using the token (does not clone, just checks auth)
+HTTP_STATUS="$(curl -s -o /dev/null -w '%{http_code}' \
+  -H "Authorization: token $(cat ${TOKEN_FILE})" \
+  https://api.github.com/user 2>/dev/null || echo "000")"
+
+case "${HTTP_STATUS}" in
+  200)
+    echo "OK: GitHub API responded 200"
+    ;;
+  401)
+    echo "FAIL: token rejected (401)" >&2
+    exit 1
+    ;;
+  403)
+    echo "FAIL: token forbidden (403)" >&2
+    exit 1
+    ;;
+  000)
+    echo "FAIL: no network response (curl error)" >&2
+    exit 1
+    ;;
+  *)
+    echo "WARN: unexpected HTTP status ${HTTP_STATUS}" >&2
+    ;;
+esac
+VERIFY
+)"
+
+log "${VERIFY_RESULT}"
+log "secrets-rotate complete for ${AGENT_USER} on ${VM_IP}"


### PR DESCRIPTION
Closes #216

## Summary

- Adds `modules/cloud-dispatch/lib/` with 5 secret management scripts for cloud VM agents
- Implements the security architecture from the Epic 4 spec: tmpfs-only secrets, no command-line arg exposure, cross-agent isolation, session-scoped SSH keys
- All scripts pass `shellcheck --severity=warning`

## Scripts

| Script | Purpose |
|--------|---------|
| `secrets-init.sh` | Generate per-session ed25519 keypair, load into macOS ssh-agent, register public key with Hetzner |
| `secrets-inject.sh` | Inject GitHub token and/or Claude auth into a single agent's `/run/secrets/agent-N/` on a VM |
| `secrets-inject-all.sh` | Discover all running `ccgm-agent-*` VMs and inject to all 4 agents per VM |
| `secrets-cleanup.sh` | Delete Hetzner SSH key, remove from ssh-agent, optionally wipe `/run/secrets/` on all VMs |
| `secrets-rotate.sh` | Re-inject a new GitHub PAT for a specific agent and verify it works via GitHub API |

## Security Properties

- Private SSH key is never written to persistent disk (tmpfile + `ssh-add` + `rm`)
- Secrets written via stdin pipe to remote `bash -c`, not as command-line arguments (not visible in `ps`)
- `HISTFILE=/dev/null` set on all SSH sessions
- `/run/secrets/agent-N/` created with mode 0700, files with mode 0600, owned by the target agent user
- Verification step after each injection confirms ownership and permissions