### PR TITLE
#217: add workspace provisioner scripts

### DIFF
--- a/modules/cloud-dispatch/lib/workspace-assign.sh
+++ b/modules/cloud-dispatch/lib/workspace-assign.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# workspace-assign.sh — Assign a GitHub issue to an agent on a VM.
+#
+# Usage:
+#   workspace-assign.sh <vm-ip> <agent-index> <issue-number> <issue-title> \
+#     [--repo OWNER/REPO] [--max-turns N]
+#
+# Arguments:
+#   vm-ip          Public IP of the Hetzner Cloud VM
+#   agent-index    0-3, selects agent-N user on the VM
+#   issue-number   GitHub issue number to assign
+#   issue-title    Issue title (used to build the branch slug)
+#   --repo         GitHub repo in owner/repo format (required)
+#   --max-turns    Maximum agent turns before stopping (default: 200)
+#
+# Side effects:
+#   - Writes /home/agent-N/assignment.json on the VM
+#   - Creates a feature branch in /home/agent-N/workspace/<repo>
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+if [[ $# -lt 4 ]]; then
+  echo "Usage: $0 <vm-ip> <agent-index> <issue-number> <issue-title> [--repo OWNER/REPO] [--max-turns N]" >&2
+  exit 1
+fi
+
+VM_IP="$1"
+AGENT_INDEX="$2"
+ISSUE_NUMBER="$3"
+ISSUE_TITLE="$4"
+shift 4
+
+REPO=""
+MAX_TURNS=200
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --max-turns)
+      MAX_TURNS="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${REPO}" ]]; then
+  echo "Error: --repo OWNER/REPO is required" >&2
+  exit 1
+fi
+
+if ! [[ "$AGENT_INDEX" =~ ^[0-3]$ ]]; then
+  echo "Error: agent-index must be 0, 1, 2, or 3 (got: $AGENT_INDEX)" >&2
+  exit 1
+fi
+
+if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "Error: issue-number must be a positive integer (got: $ISSUE_NUMBER)" >&2
+  exit 1
+fi
+
+if ! [[ "$MAX_TURNS" =~ ^[0-9]+$ ]]; then
+  echo "Error: --max-turns must be a positive integer (got: $MAX_TURNS)" >&2
+  exit 1
+fi
+
+AGENT_USER="agent-${AGENT_INDEX}"
+AGENT_HOME="/home/${AGENT_USER}"
+REPO_NAME=$(basename "${REPO}")
+CLONE_DIR="${AGENT_HOME}/workspace/${REPO_NAME}"
+SSH_KEY="${SSH_KEY_PATH:-${HOME}/.ssh/id_ed25519}"
+
+# Build branch slug: lowercase, replace spaces/non-alphanumeric with hyphens,
+# trim leading/trailing hyphens, collapse repeated hyphens.
+SLUG=$(echo "${ISSUE_TITLE}" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed 's/[^a-z0-9]/-/g' \
+  | sed 's/-\{2,\}/-/g' \
+  | sed 's/^-//;s/-$//')
+BRANCH_NAME="${ISSUE_NUMBER}-${SLUG}"
+
+# ISO 8601 timestamp (UTC)
+ASSIGNED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# ---------------------------------------------------------------------------
+# Helper: run a command on the VM as root
+# ---------------------------------------------------------------------------
+ssh_root() {
+  ssh -i "${SSH_KEY}" \
+      -o StrictHostKeyChecking=accept-new \
+      -o BatchMode=yes \
+      "root@${VM_IP}" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run a command on the VM as agent-N (via root su)
+# ---------------------------------------------------------------------------
+ssh_agent() {
+  local cmd="$1"
+  ssh_root "su - ${AGENT_USER} -c $(printf '%q' "$cmd")"
+}
+
+echo "==> Assigning issue #${ISSUE_NUMBER} to ${AGENT_USER} on ${VM_IP}"
+
+# ---------------------------------------------------------------------------
+# Step 1: Verify the workspace clone exists before assigning
+# ---------------------------------------------------------------------------
+if ! ssh_root "test -d '${CLONE_DIR}/.git'"; then
+  echo "Error: workspace not found at ${CLONE_DIR}. Run workspace-setup.sh first." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Write assignment.json
+# ---------------------------------------------------------------------------
+echo "--> Writing assignment.json"
+ASSIGNMENT_FILE="${AGENT_HOME}/assignment.json"
+
+ASSIGNMENT_JSON=$(cat <<JSON
+{
+  "issue_number": ${ISSUE_NUMBER},
+  "issue_title": "${ISSUE_TITLE}",
+  "repo": "${REPO}",
+  "branch": "${BRANCH_NAME}",
+  "max_turns": ${MAX_TURNS},
+  "assigned_at": "${ASSIGNED_AT}"
+}
+JSON
+)
+
+ssh_root "printf '%s\n' '${ASSIGNMENT_JSON}' > '${ASSIGNMENT_FILE}' && chown '${AGENT_USER}:${AGENT_USER}' '${ASSIGNMENT_FILE}'"
+
+# ---------------------------------------------------------------------------
+# Step 3: Create the feature branch
+# ---------------------------------------------------------------------------
+echo "--> Creating branch ${BRANCH_NAME} from origin/main"
+ssh_agent "git -C '${CLONE_DIR}' fetch origin"
+ssh_agent "git -C '${CLONE_DIR}' checkout -b '${BRANCH_NAME}' origin/main"
+
+# ---------------------------------------------------------------------------
+# Step 4: Verify
+# ---------------------------------------------------------------------------
+echo "--> Verifying branch"
+CURRENT_BRANCH=$(ssh_agent "git -C '${CLONE_DIR}' rev-parse --abbrev-ref HEAD")
+if [[ "${CURRENT_BRANCH}" != "${BRANCH_NAME}" ]]; then
+  echo "Error: expected branch ${BRANCH_NAME}, got ${CURRENT_BRANCH}" >&2
+  exit 1
+fi
+
+echo "==> Assignment complete"
+echo "    Agent:  ${AGENT_USER}@${VM_IP}"
+echo "    Issue:  #${ISSUE_NUMBER} - ${ISSUE_TITLE}"
+echo "    Branch: ${BRANCH_NAME}"
+echo "    Repo:   ${REPO}"

--- a/modules/cloud-dispatch/lib/workspace-cleanup.sh
+++ b/modules/cloud-dispatch/lib/workspace-cleanup.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# workspace-cleanup.sh — Remove workspace artifacts from one or all agent users on a VM.
+#
+# Usage:
+#   workspace-cleanup.sh <vm-ip> <agent-index>
+#   workspace-cleanup.sh <vm-ip> --all
+#
+# Arguments:
+#   vm-ip         Public IP of the Hetzner Cloud VM
+#   agent-index   0-3, selects agent-N user to clean up
+#   --all         Clean up all 4 agent users on the VM
+#
+# What is removed (per agent):
+#   - /home/agent-N/workspace/    (repo clone)
+#   - /home/agent-N/assignment.json
+#   - /home/agent-N/run.log
+#
+# What is preserved:
+#   - /home/agent-N/              (home directory)
+#   - /home/agent-N/.gitconfig    (identity config, reused on next assignment)
+#   - /home/agent-N/.claude/      (CCGM settings, reused on next assignment)
+#   - /home/agent-N/.ssh/         (SSH config)
+#   - /home/agent-N/.bashrc
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <vm-ip> <agent-index>" >&2
+  echo "       $0 <vm-ip> --all" >&2
+  exit 1
+fi
+
+VM_IP="$1"
+AGENT_ARG="$2"
+SSH_KEY="${SSH_KEY_PATH:-${HOME}/.ssh/id_ed25519}"
+AGENTS_PER_VM=4
+
+# Build list of agent indexes to clean
+declare -a AGENT_INDEXES
+if [[ "${AGENT_ARG}" == "--all" ]]; then
+  for i in $(seq 0 $(( AGENTS_PER_VM - 1 ))); do
+    AGENT_INDEXES+=("$i")
+  done
+else
+  if ! [[ "${AGENT_ARG}" =~ ^[0-3]$ ]]; then
+    echo "Error: agent-index must be 0, 1, 2, or 3 (got: ${AGENT_ARG})" >&2
+    exit 1
+  fi
+  AGENT_INDEXES=("${AGENT_ARG}")
+fi
+
+# ---------------------------------------------------------------------------
+# Helper: run a command on the VM as root
+# ---------------------------------------------------------------------------
+ssh_root() {
+  ssh -i "${SSH_KEY}" \
+      -o StrictHostKeyChecking=accept-new \
+      -o BatchMode=yes \
+      -o ConnectTimeout=10 \
+      "root@${VM_IP}" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Clean one agent
+# ---------------------------------------------------------------------------
+cleanup_one() {
+  local agent_index="$1"
+  local agent_user="agent-${agent_index}"
+  local agent_home="/home/${agent_user}"
+  local workspace_dir="${agent_home}/workspace"
+  local assignment_file="${agent_home}/assignment.json"
+  local run_log="${agent_home}/run.log"
+
+  echo "==> Cleaning up ${agent_user}@${VM_IP}"
+
+  # Stop any running agent process owned by this user before removing files
+  local pids
+  pids=$(ssh_root "pgrep -u '${agent_user}' -f 'claude' 2>/dev/null || true")
+  if [[ -n "${pids}" ]]; then
+    echo "--> Stopping running agent process(es): ${pids}"
+    ssh_root "pkill -u '${agent_user}' -f 'claude' 2>/dev/null || true"
+    # Give process a moment to terminate
+    sleep 2
+  fi
+
+  # Remove workspace (repo clone)
+  if ssh_root "test -d '${workspace_dir}'"; then
+    echo "--> Removing workspace: ${workspace_dir}"
+    ssh_root "rm -rf '${workspace_dir}'"
+  else
+    echo "--> Workspace not found, skipping: ${workspace_dir}"
+  fi
+
+  # Remove assignment.json
+  if ssh_root "test -f '${assignment_file}'"; then
+    echo "--> Removing assignment file: ${assignment_file}"
+    ssh_root "rm -f '${assignment_file}'"
+  else
+    echo "--> Assignment file not found, skipping"
+  fi
+
+  # Remove run log
+  if ssh_root "test -f '${run_log}'"; then
+    echo "--> Removing run log: ${run_log}"
+    ssh_root "rm -f '${run_log}'"
+  else
+    echo "--> Run log not found, skipping"
+  fi
+
+  echo "--> ${agent_user} cleaned up"
+}
+
+# ---------------------------------------------------------------------------
+# Execute cleanup
+# ---------------------------------------------------------------------------
+for agent_index in "${AGENT_INDEXES[@]}"; do
+  cleanup_one "${agent_index}"
+done
+
+echo ""
+echo "==> Cleanup complete on ${VM_IP} (agents: ${AGENT_INDEXES[*]})"

--- a/modules/cloud-dispatch/lib/workspace-collect.sh
+++ b/modules/cloud-dispatch/lib/workspace-collect.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# workspace-collect.sh — Collect results from agent workspaces.
+#
+# Usage:
+#   workspace-collect.sh --all
+#   workspace-collect.sh <vm-ip> <agent-index>
+#
+# Options:
+#   --all         Collect from all running ccgm-agent-* VMs (all 4 agents each)
+#   --json        Emit machine-readable JSON instead of formatted text
+#   --log-lines N Number of log tail lines to include (default: 50)
+#
+# Requires:
+#   - hcloud CLI (when --all is used)
+#   - SSH key in ~/.ssh/id_ed25519 or $SSH_KEY_PATH
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 --all [--json] [--log-lines N]" >&2
+  echo "       $0 <vm-ip> <agent-index> [--json] [--log-lines N]" >&2
+  exit 1
+fi
+
+COLLECT_ALL=false
+VM_IP=""
+AGENT_INDEX=""
+JSON_OUTPUT=false
+LOG_LINES=50
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      COLLECT_ALL=true
+      shift
+      ;;
+    --json)
+      JSON_OUTPUT=true
+      shift
+      ;;
+    --log-lines)
+      LOG_LINES="$2"
+      shift 2
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -z "${VM_IP}" ]]; then
+        VM_IP="$1"
+      elif [[ -z "${AGENT_INDEX}" ]]; then
+        AGENT_INDEX="$1"
+      else
+        echo "Unexpected argument: $1" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ "${COLLECT_ALL}" == "false" ]]; then
+  if [[ -z "${VM_IP}" || -z "${AGENT_INDEX}" ]]; then
+    echo "Error: provide --all or both <vm-ip> and <agent-index>" >&2
+    exit 1
+  fi
+  if ! [[ "${AGENT_INDEX}" =~ ^[0-3]$ ]]; then
+    echo "Error: agent-index must be 0, 1, 2, or 3 (got: ${AGENT_INDEX})" >&2
+    exit 1
+  fi
+fi
+
+SSH_KEY="${SSH_KEY_PATH:-${HOME}/.ssh/id_ed25519}"
+AGENTS_PER_VM=4
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+ssh_root() {
+  local ip="$1"; shift
+  ssh -i "${SSH_KEY}" \
+      -o StrictHostKeyChecking=accept-new \
+      -o BatchMode=yes \
+      -o ConnectTimeout=10 \
+      "root@${ip}" "$@" 2>/dev/null
+}
+
+# Collect data for one agent and emit a result block
+collect_one() {
+  local vm_ip="$1"
+  local agent_index="$2"
+  local agent_user="agent-${agent_index}"
+  local agent_home="/home/${agent_user}"
+  local assignment_file="${agent_home}/assignment.json"
+  local run_log="${agent_home}/run.log"
+
+  # --- assignment ---
+  local issue_number="" issue_title="" repo="" branch="" assigned_at=""
+  if ssh_root "${vm_ip}" "test -f '${assignment_file}'" 2>/dev/null; then
+    local assignment
+    assignment=$(ssh_root "${vm_ip}" "cat '${assignment_file}'" 2>/dev/null || echo "{}")
+    issue_number=$(echo "${assignment}" | grep -o '"issue_number":[^,}]*' | sed 's/"issue_number"://' | tr -d ' "')
+    issue_title=$(echo "${assignment}" | grep -o '"issue_title":"[^"]*"' | sed 's/"issue_title":"//;s/"$//')
+    repo=$(echo "${assignment}" | grep -o '"repo":"[^"]*"' | sed 's/"repo":"//;s/"$//')
+    branch=$(echo "${assignment}" | grep -o '"branch":"[^"]*"' | sed 's/"branch":"//;s/"$//')
+    assigned_at=$(echo "${assignment}" | grep -o '"assigned_at":"[^"]*"' | sed 's/"assigned_at":"//;s/"$//')
+  fi
+
+  # --- git state ---
+  local current_branch="" last_commit_sha="" last_commit_msg=""
+  local workspace_dir="${agent_home}/workspace"
+
+  if [[ -n "${repo}" ]]; then
+    local repo_name
+    repo_name=$(basename "${repo}")
+    local clone_dir="${workspace_dir}/${repo_name}"
+    if ssh_root "${vm_ip}" "test -d '${clone_dir}/.git'" 2>/dev/null; then
+      current_branch=$(ssh_root "${vm_ip}" \
+        "su - ${agent_user} -c 'git -C ${clone_dir} rev-parse --abbrev-ref HEAD'" 2>/dev/null || echo "unknown")
+      last_commit_sha=$(ssh_root "${vm_ip}" \
+        "su - ${agent_user} -c 'git -C ${clone_dir} rev-parse --short HEAD'" 2>/dev/null || echo "unknown")
+      last_commit_msg=$(ssh_root "${vm_ip}" \
+        "su - ${agent_user} -c 'git -C ${clone_dir} log -1 --pretty=%s'" 2>/dev/null || echo "")
+    fi
+  fi
+
+  # --- PR detection ---
+  local pr_url=""
+  if [[ -n "${branch}" && -n "${repo}" ]]; then
+    # Check gh CLI on the VM, or fall back to grepping the run log
+    pr_url=$(ssh_root "${vm_ip}" \
+      "su - ${agent_user} -c 'gh pr list --repo ${repo} --head ${branch} --json url --jq .[0].url 2>/dev/null'" \
+      2>/dev/null || true)
+    if [[ -z "${pr_url}" && -f "${run_log}" ]]; then
+      pr_url=$(ssh_root "${vm_ip}" "grep -oE 'https://github.com/[^ ]*/pull/[0-9]+' '${run_log}' | tail -1" 2>/dev/null || true)
+    fi
+  fi
+
+  # --- agent process status ---
+  local agent_pid="" agent_status="unknown"
+  agent_pid=$(ssh_root "${vm_ip}" \
+    "pgrep -u ${agent_user} -f 'claude' | head -1" 2>/dev/null || true)
+  if [[ -n "${agent_pid}" ]]; then
+    agent_status="running"
+  elif [[ -f "${run_log}" ]]; then
+    # Check last exit code if logged
+    local last_exit
+    last_exit=$(ssh_root "${vm_ip}" "tail -1 '${run_log}'" 2>/dev/null || true)
+    if echo "${last_exit}" | grep -qi "exit.*0\|completed\|success"; then
+      agent_status="completed"
+    elif echo "${last_exit}" | grep -qi "exit\|error\|fail"; then
+      agent_status="failed"
+    else
+      agent_status="idle"
+    fi
+  fi
+
+  # --- run log tail ---
+  local log_tail=""
+  if ssh_root "${vm_ip}" "test -f '${run_log}'" 2>/dev/null; then
+    log_tail=$(ssh_root "${vm_ip}" "tail -n ${LOG_LINES} '${run_log}'" 2>/dev/null || true)
+  fi
+
+  # --- VM name (best effort) ---
+  local vm_name=""
+  if command -v hcloud &>/dev/null; then
+    vm_name=$(hcloud server list --output columns=name,ipv4 2>/dev/null \
+      | awk -v ip="${vm_ip}" '$2==ip {print $1}' || true)
+  fi
+  [[ -z "${vm_name}" ]] && vm_name="${vm_ip}"
+
+  # ---------------------------------------------------------------------------
+  # Output
+  # ---------------------------------------------------------------------------
+  if [[ "${JSON_OUTPUT}" == "true" ]]; then
+    # Escape strings for JSON (basic escaping)
+    json_escape() { printf '%s' "$1" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" 2>/dev/null || printf '"%s"' "$1"; }
+    printf '{\n'
+    printf '  "vm": %s,\n'            "$(json_escape "${vm_name}")"
+    printf '  "agent": %s,\n'         "$(json_escape "${agent_user}")"
+    printf '  "issue_number": %s,\n'  "${issue_number:-null}"
+    printf '  "issue_title": %s,\n'   "$(json_escape "${issue_title}")"
+    printf '  "repo": %s,\n'          "$(json_escape "${repo}")"
+    printf '  "branch": %s,\n'        "$(json_escape "${branch}")"
+    printf '  "current_branch": %s,\n' "$(json_escape "${current_branch}")"
+    printf '  "last_commit": %s,\n'   "$(json_escape "${last_commit_sha} ${last_commit_msg}")"
+    printf '  "pr_url": %s,\n'        "$(json_escape "${pr_url}")"
+    printf '  "status": %s,\n'        "$(json_escape "${agent_status}")"
+    printf '  "assigned_at": %s\n'    "$(json_escape "${assigned_at}")"
+    printf '}\n'
+  else
+    echo "---"
+    printf "Agent:       %s / %s\n" "${vm_name}" "${agent_user}"
+    if [[ -n "${issue_number}" ]]; then
+      printf "Issue:       #%s - %s\n" "${issue_number}" "${issue_title}"
+      printf "Repo:        %s\n" "${repo}"
+    else
+      printf "Issue:       (no assignment)\n"
+    fi
+    printf "Branch:      %s\n" "${branch:-${current_branch:-(none)}}"
+    printf "Status:      %s\n" "${agent_status}"
+    if [[ -n "${pr_url}" ]]; then
+      printf "PR:          %s\n" "${pr_url}"
+    fi
+    if [[ -n "${last_commit_sha}" && "${last_commit_sha}" != "unknown" ]]; then
+      printf "Last commit: %s \"%s\"\n" "${last_commit_sha}" "${last_commit_msg}"
+    fi
+    if [[ -n "${assigned_at}" ]]; then
+      printf "Assigned:    %s\n" "${assigned_at}"
+    fi
+    if [[ -n "${log_tail}" ]]; then
+      echo ""
+      echo "Log (last ${LOG_LINES} lines):"
+      while IFS= read -r log_line; do printf '  %s\n' "${log_line}"; done <<< "${log_tail}"
+    fi
+    echo ""
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Single agent
+# ---------------------------------------------------------------------------
+if [[ "${COLLECT_ALL}" == "false" ]]; then
+  collect_one "${VM_IP}" "${AGENT_INDEX}"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# All agents across all running VMs
+# ---------------------------------------------------------------------------
+if ! command -v hcloud &>/dev/null; then
+  echo "Error: hcloud CLI is required for --all mode" >&2
+  exit 1
+fi
+
+mapfile -t VM_NAMES < <(hcloud server list --output columns=name,status | awk '$2=="running" && /ccgm-agent/ {print $1}' | sort)
+
+if [[ ${#VM_NAMES[@]} -eq 0 ]]; then
+  echo "No running ccgm-agent-* VMs found." >&2
+  exit 0
+fi
+
+if [[ "${JSON_OUTPUT}" == "true" ]]; then
+  echo "["
+  first=true
+fi
+
+for vm_name in "${VM_NAMES[@]}"; do
+  vm_ip=$(hcloud server describe "${vm_name}" --output format='{{.PublicNet.IPv4.IP}}')
+  for agent_index in $(seq 0 $(( AGENTS_PER_VM - 1 ))); do
+    if [[ "${JSON_OUTPUT}" == "true" && "${first}" != "true" ]]; then
+      echo ","
+    fi
+    collect_one "${vm_ip}" "${agent_index}"
+    first=false
+  done
+done
+
+if [[ "${JSON_OUTPUT}" == "true" ]]; then
+  echo "]"
+fi

--- a/modules/cloud-dispatch/lib/workspace-setup-all.sh
+++ b/modules/cloud-dispatch/lib/workspace-setup-all.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# workspace-setup-all.sh — Provision workspaces across all running agent VMs.
+#
+# Usage:
+#   workspace-setup-all.sh <repo-url> --issues "42,43,44,45,46,47,48,49"
+#
+# Arguments:
+#   repo-url     HTTPS URL of the target repo (e.g. https://github.com/owner/repo)
+#   --issues     Comma-separated list of issue numbers to distribute
+#   --titles     Optional: JSON file mapping issue numbers to titles
+#                If omitted, titles are fetched from GitHub via gh CLI
+#   --repo       GitHub repo in owner/repo format (derived from repo-url if omitted)
+#   --max-turns  Maximum agent turns per assignment (default: 200)
+#   --branch     Optional base branch for all workspaces (default: main)
+#   --dry-run    Print the assignment plan without executing it
+#
+# Requires:
+#   - Hetzner Cloud CLI (hcloud) installed and authenticated
+#   - workspace-setup.sh and workspace-assign.sh in the same directory as this script
+#   - SSH key in ~/.ssh/id_ed25519 or $SSH_KEY_PATH
+#   - gh CLI authenticated (for fetching issue titles when --titles not provided)
+#
+# NOTE: If common.sh from Epic 3 is available in the same lib/ directory, source it
+#       for shared SSH helpers. This script defines its own helpers as a fallback
+#       since Epic 3 may not be merged when this runs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source common.sh if available (Epic 3 dependency — may not be merged yet)
+if [[ -f "${SCRIPT_DIR}/common.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "${SCRIPT_DIR}/common.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <repo-url> --issues \"42,43,44\" [--titles FILE] [--repo OWNER/REPO] [--max-turns N] [--branch BRANCH] [--dry-run]" >&2
+  exit 1
+fi
+
+REPO_URL="$1"
+shift
+
+ISSUES_CSV=""
+TITLES_FILE=""
+REPO_OVERRIDE=""
+MAX_TURNS=200
+BRANCH=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issues)
+      ISSUES_CSV="$2"
+      shift 2
+      ;;
+    --titles)
+      TITLES_FILE="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO_OVERRIDE="$2"
+      shift 2
+      ;;
+    --max-turns)
+      MAX_TURNS="$2"
+      shift 2
+      ;;
+    --branch)
+      BRANCH="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${ISSUES_CSV}" ]]; then
+  echo "Error: --issues is required" >&2
+  exit 1
+fi
+
+# Derive repo in owner/repo format from URL
+if [[ -n "${REPO_OVERRIDE}" ]]; then
+  REPO="${REPO_OVERRIDE}"
+else
+  # Strip https://github.com/ prefix and .git suffix
+  REPO=$(echo "${REPO_URL}" | sed 's|https://github.com/||;s|\.git$||')
+fi
+
+# SSH_KEY is passed via SSH_KEY_PATH env to child scripts (workspace-setup.sh, workspace-assign.sh)
+export SSH_KEY_PATH="${SSH_KEY_PATH:-${HOME}/.ssh/id_ed25519}"
+
+# ---------------------------------------------------------------------------
+# Parse issue list
+# ---------------------------------------------------------------------------
+IFS=',' read -ra ISSUE_LIST <<< "${ISSUES_CSV}"
+ISSUE_COUNT="${#ISSUE_LIST[@]}"
+
+# ---------------------------------------------------------------------------
+# Fetch issue titles
+# ---------------------------------------------------------------------------
+declare -A ISSUE_TITLES
+
+if [[ -n "${TITLES_FILE}" ]]; then
+  # Load from JSON file: {"42": "feat: habit streaks", "43": "fix: login bug"}
+  if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required when --titles is specified" >&2
+    exit 1
+  fi
+  while IFS= read -r line; do
+    num=$(echo "${line}" | jq -r '.key')
+    title=$(echo "${line}" | jq -r '.value')
+    ISSUE_TITLES["${num}"]="${title}"
+  done < <(jq -r 'to_entries[] | {key, value} | @json' "${TITLES_FILE}")
+else
+  echo "==> Fetching issue titles from GitHub"
+  if ! command -v gh &>/dev/null; then
+    echo "Error: gh CLI is required to fetch issue titles. Install it or use --titles to provide them." >&2
+    exit 1
+  fi
+  for issue_num in "${ISSUE_LIST[@]}"; do
+    issue_num=$(echo "${issue_num}" | tr -d '[:space:]')
+    title=$(gh issue view "${issue_num}" --repo "${REPO}" --json title --jq '.title' 2>/dev/null || echo "issue-${issue_num}")
+    ISSUE_TITLES["${issue_num}"]="${title}"
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Discover running agent VMs via hcloud CLI
+# ---------------------------------------------------------------------------
+echo "==> Discovering running agent VMs"
+if ! command -v hcloud &>/dev/null; then
+  echo "Error: hcloud CLI is required. Install it from https://github.com/hetznercloud/cli" >&2
+  exit 1
+fi
+
+# VMs created by the ccgm terraform config are named ccgm-agent-{location}-{n}
+# List all running servers with the ccgm-agent prefix, sorted by name.
+mapfile -t VM_NAMES < <(hcloud server list --output columns=name,status | awk '$2=="running" && /ccgm-agent/ {print $1}' | sort)
+
+if [[ ${#VM_NAMES[@]} -eq 0 ]]; then
+  echo "Error: no running ccgm-agent-* VMs found. Create them with Terraform first." >&2
+  exit 1
+fi
+
+echo "Found ${#VM_NAMES[@]} VM(s): ${VM_NAMES[*]}"
+
+# ---------------------------------------------------------------------------
+# Build assignment plan: distribute issues round-robin across agent slots
+#
+# Slot order: VM0-agent0, VM0-agent1, VM0-agent2, VM0-agent3,
+#             VM1-agent0, VM1-agent1, ...
+# ---------------------------------------------------------------------------
+declare -a PLAN_VM_IPS
+declare -a PLAN_AGENT_INDEXES
+declare -a PLAN_ISSUE_NUMBERS
+AGENTS_PER_VM=4
+
+slot=0
+for issue_num in "${ISSUE_LIST[@]}"; do
+  issue_num=$(echo "${issue_num}" | tr -d '[:space:]')
+  vm_index=$(( slot / AGENTS_PER_VM ))
+  agent_index=$(( slot % AGENTS_PER_VM ))
+
+  if [[ ${vm_index} -ge ${#VM_NAMES[@]} ]]; then
+    echo "Warning: more issues (${ISSUE_COUNT}) than agent slots ($(( ${#VM_NAMES[@]} * AGENTS_PER_VM ))). Stopping at slot ${slot}." >&2
+    break
+  fi
+
+  VM_NAME="${VM_NAMES[$vm_index]}"
+  VM_IP=$(hcloud server describe "${VM_NAME}" --output format='{{.PublicNet.IPv4.IP}}')
+
+  PLAN_VM_IPS+=("${VM_IP}")
+  PLAN_AGENT_INDEXES+=("${agent_index}")
+  PLAN_ISSUE_NUMBERS+=("${issue_num}")
+
+  slot=$(( slot + 1 ))
+done
+
+# ---------------------------------------------------------------------------
+# Print assignment plan
+# ---------------------------------------------------------------------------
+echo ""
+echo "Assignment plan:"
+echo "  Repo:      ${REPO}"
+echo "  Issues:    ${ISSUE_COUNT}"
+echo "  VMs:       ${#VM_NAMES[@]}"
+echo ""
+printf "  %-6s  %-8s  %-20s  %s\n" "Issue" "Agent" "VM" "Branch"
+printf "  %-6s  %-8s  %-20s  %s\n" "------" "--------" "--------------------" "------"
+for i in "${!PLAN_ISSUE_NUMBERS[@]}"; do
+  num="${PLAN_ISSUE_NUMBERS[$i]}"
+  title="${ISSUE_TITLES[$num]:-issue-${num}}"
+  slug=$(echo "${title}" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed 's/[^a-z0-9]/-/g' \
+    | sed 's/-\{2,\}/-/g' \
+    | sed 's/^-//;s/-$//')
+  branch="${num}-${slug}"
+  printf "  %-6s  %-8s  %-20s  %s\n" "#${num}" "agent-${PLAN_AGENT_INDEXES[$i]}" "${PLAN_VM_IPS[$i]}" "${branch}"
+done
+echo ""
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo "(--dry-run: no changes made)"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Execute: setup workspace then assign issue for each slot
+# ---------------------------------------------------------------------------
+SETUP_SCRIPT="${SCRIPT_DIR}/workspace-setup.sh"
+ASSIGN_SCRIPT="${SCRIPT_DIR}/workspace-assign.sh"
+
+for script in "${SETUP_SCRIPT}" "${ASSIGN_SCRIPT}"; do
+  if [[ ! -x "${script}" ]]; then
+    echo "Error: ${script} not found or not executable" >&2
+    exit 1
+  fi
+done
+
+SUCCESS=0
+FAILED=0
+
+for i in "${!PLAN_ISSUE_NUMBERS[@]}"; do
+  vm_ip="${PLAN_VM_IPS[$i]}"
+  agent_index="${PLAN_AGENT_INDEXES[$i]}"
+  issue_num="${PLAN_ISSUE_NUMBERS[$i]}"
+  title="${ISSUE_TITLES[$issue_num]:-issue-${issue_num}}"
+
+  echo "==> [${i}] Setting up ${vm_ip} agent-${agent_index} for issue #${issue_num}"
+
+  setup_args=("${vm_ip}" "${agent_index}" "${REPO_URL}")
+  if [[ -n "${BRANCH}" ]]; then
+    setup_args+=(--branch "${BRANCH}")
+  fi
+
+  if "${SETUP_SCRIPT}" "${setup_args[@]}"; then
+    if "${ASSIGN_SCRIPT}" "${vm_ip}" "${agent_index}" "${issue_num}" "${title}" \
+        --repo "${REPO}" --max-turns "${MAX_TURNS}"; then
+      SUCCESS=$(( SUCCESS + 1 ))
+    else
+      echo "Error: workspace-assign.sh failed for issue #${issue_num} on ${vm_ip} agent-${agent_index}" >&2
+      FAILED=$(( FAILED + 1 ))
+    fi
+  else
+    echo "Error: workspace-setup.sh failed for ${vm_ip} agent-${agent_index}" >&2
+    FAILED=$(( FAILED + 1 ))
+  fi
+done
+
+echo ""
+echo "==> Setup complete: ${SUCCESS} succeeded, ${FAILED} failed"
+[[ ${FAILED} -eq 0 ]]

--- a/modules/cloud-dispatch/lib/workspace-setup.sh
+++ b/modules/cloud-dispatch/lib/workspace-setup.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# workspace-setup.sh — Set up an agent workspace on a Hetzner Cloud VM.
+#
+# Usage:
+#   workspace-setup.sh <vm-ip> <agent-index> <repo-url> [--branch BRANCH]
+#
+# Arguments:
+#   vm-ip         Public IP of the Hetzner Cloud VM
+#   agent-index   0-3, selects agent-N user on the VM
+#   repo-url      HTTPS URL of the target repo (e.g. https://github.com/owner/repo)
+#   --branch      Optional branch to check out after clone (default: main)
+#
+# Requires:
+#   - SSH access to the VM as root (key in ~/.ssh/id_ed25519 or SSH_KEY_PATH)
+#   - /run/secrets/agent-N/github_token populated on the VM before this runs
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <vm-ip> <agent-index> <repo-url> [--branch BRANCH]" >&2
+  exit 1
+fi
+
+VM_IP="$1"
+AGENT_INDEX="$2"
+REPO_URL="$3"
+shift 3
+
+BRANCH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch)
+      BRANCH="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate agent index
+if ! [[ "$AGENT_INDEX" =~ ^[0-3]$ ]]; then
+  echo "Error: agent-index must be 0, 1, 2, or 3 (got: $AGENT_INDEX)" >&2
+  exit 1
+fi
+
+AGENT_USER="agent-${AGENT_INDEX}"
+AGENT_HOME="/home/${AGENT_USER}"
+WORKSPACE_DIR="${AGENT_HOME}/workspace"
+SECRETS_DIR="/run/secrets/${AGENT_USER}"
+SSH_KEY="${SSH_KEY_PATH:-${HOME}/.ssh/id_ed25519}"
+
+# Extract repo name from URL (strip .git suffix if present)
+REPO_NAME=$(basename "${REPO_URL}" .git)
+
+# ---------------------------------------------------------------------------
+# Helper: run a command on the VM as root
+# ---------------------------------------------------------------------------
+ssh_root() {
+  ssh -i "${SSH_KEY}" \
+      -o StrictHostKeyChecking=accept-new \
+      -o BatchMode=yes \
+      "root@${VM_IP}" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run a command on the VM as agent-N (via root su)
+# ---------------------------------------------------------------------------
+ssh_agent() {
+  local cmd="$1"
+  ssh_root "su - ${AGENT_USER} -c $(printf '%q' "$cmd")"
+}
+
+echo "==> Setting up workspace for ${AGENT_USER} on ${VM_IP}"
+
+# ---------------------------------------------------------------------------
+# Step 1: Create workspace directory
+# ---------------------------------------------------------------------------
+echo "--> Creating workspace directory"
+ssh_root "mkdir -p '${WORKSPACE_DIR}' && chown '${AGENT_USER}:${AGENT_USER}' '${WORKSPACE_DIR}'"
+
+# ---------------------------------------------------------------------------
+# Step 2: Clone the repo using the agent's GitHub token
+# ---------------------------------------------------------------------------
+echo "--> Cloning ${REPO_URL}"
+CLONE_DIR="${WORKSPACE_DIR}/${REPO_NAME}"
+
+# Build a token-authenticated URL from the plain HTTPS URL.
+# The token is read on the VM from /run/secrets/agent-N/github_token — it
+# never appears in the SSH command itself or in local shell variables.
+CLONE_SCRIPT=$(cat <<'SCRIPT'
+set -euo pipefail
+AGENT_USER="__AGENT_USER__"
+REPO_URL="__REPO_URL__"
+CLONE_DIR="__CLONE_DIR__"
+SECRETS_DIR="__SECRETS_DIR__"
+
+TOKEN_FILE="${SECRETS_DIR}/github_token"
+if [[ ! -f "${TOKEN_FILE}" ]]; then
+  echo "Error: token file not found at ${TOKEN_FILE}" >&2
+  exit 1
+fi
+GIT_TOKEN=$(cat "${TOKEN_FILE}")
+
+# Inject token into HTTPS URL: https://<token>@github.com/owner/repo
+AUTH_URL="${REPO_URL/https:\/\//https://${GIT_TOKEN}@}"
+
+if [[ -d "${CLONE_DIR}/.git" ]]; then
+  echo "Repo already cloned at ${CLONE_DIR}, skipping"
+else
+  git clone "${AUTH_URL}" "${CLONE_DIR}"
+fi
+SCRIPT
+)
+
+CLONE_SCRIPT="${CLONE_SCRIPT//__AGENT_USER__/$AGENT_USER}"
+CLONE_SCRIPT="${CLONE_SCRIPT//__REPO_URL__/$REPO_URL}"
+CLONE_SCRIPT="${CLONE_SCRIPT//__CLONE_DIR__/$CLONE_DIR}"
+CLONE_SCRIPT="${CLONE_SCRIPT//__SECRETS_DIR__/$SECRETS_DIR}"
+
+ssh_root "su - ${AGENT_USER} -c 'bash -s'" <<< "${CLONE_SCRIPT}"
+
+# ---------------------------------------------------------------------------
+# Step 3: Configure git identity for the agent
+# ---------------------------------------------------------------------------
+echo "--> Configuring git identity"
+ssh_agent "git -C '${CLONE_DIR}' config user.name 'CCGM Agent ${AGENT_INDEX}'"
+ssh_agent "git -C '${CLONE_DIR}' config user.email 'ccgm-agent-${AGENT_INDEX}@dispatch.local'"
+
+# ---------------------------------------------------------------------------
+# Step 4: Checkout branch (if specified)
+# ---------------------------------------------------------------------------
+if [[ -n "${BRANCH}" ]]; then
+  echo "--> Checking out branch: ${BRANCH}"
+  ssh_agent "git -C '${CLONE_DIR}' checkout '${BRANCH}'"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5: Set up CCGM config (Claude Code settings for headless mode)
+# ---------------------------------------------------------------------------
+echo "--> Writing Claude Code settings"
+CLAUDE_DIR="${AGENT_HOME}/.claude"
+ssh_root "mkdir -p '${CLAUDE_DIR}' && chown '${AGENT_USER}:${AGENT_USER}' '${CLAUDE_DIR}'"
+
+# Write settings.json enabling dangerously-skip-permissions for headless runs.
+# See: https://docs.anthropic.com/en/docs/claude-code/settings
+SETTINGS_JSON='{
+  "permissions": {
+    "allow": ["Bash", "Read", "Write", "Edit", "Glob", "Grep"],
+    "deny": []
+  },
+  "dangerouslySkipPermissions": true
+}'
+
+ssh_root "printf '%s\n' '${SETTINGS_JSON}' > '${CLAUDE_DIR}/settings.json' && chown '${AGENT_USER}:${AGENT_USER}' '${CLAUDE_DIR}/settings.json'"
+
+# Symlink global CCGM rules from /opt/ccgm if the directory exists on the VM
+RULES_SYMLINK="${CLAUDE_DIR}/rules"
+ssh_root "
+if [[ -d /opt/ccgm/rules && ! -e '${RULES_SYMLINK}' ]]; then
+  ln -s /opt/ccgm/rules '${RULES_SYMLINK}'
+  chown -h '${AGENT_USER}:${AGENT_USER}' '${RULES_SYMLINK}'
+  echo 'Symlinked /opt/ccgm/rules -> ${RULES_SYMLINK}'
+else
+  echo 'Skipping rules symlink (/opt/ccgm/rules not found or link already exists)'
+fi
+"
+
+# ---------------------------------------------------------------------------
+# Step 6: Verify
+# ---------------------------------------------------------------------------
+echo "--> Verifying workspace"
+ssh_agent "git -C '${CLONE_DIR}' status"
+ssh_agent "git -C '${CLONE_DIR}' config user.email"
+
+echo "==> Workspace setup complete: ${AGENT_USER}@${VM_IP} -> ${CLONE_DIR}"


### PR DESCRIPTION
Closes #217

## Summary

- Adds `modules/cloud-dispatch/lib/` with 5 bash scripts for provisioning and managing agent workspaces on Hetzner Cloud VMs
- Each script uses `set -euo pipefail` and passes shellcheck with no errors

## Scripts

| Script | Purpose |
|--------|---------|
| `workspace-setup.sh` | Clone repo, configure git identity, write Claude Code settings on a single agent user |
| `workspace-assign.sh` | Write `assignment.json` and create feature branch for a specific issue |
| `workspace-setup-all.sh` | Discover running ccgm-agent-* VMs, distribute issues round-robin, call setup+assign for each slot |
| `workspace-collect.sh` | SSH into agents and report branch, last commit, PR URL, status, and log tail |
| `workspace-cleanup.sh` | Remove workspace dir, assignment.json, and run.log from one or all agents (preserves home dir for reuse) |

## Design notes

- GitHub tokens are read from `/run/secrets/agent-N/github_token` on the VM; never passed through the orchestrator shell
- `workspace-setup-all.sh` exports `SSH_KEY_PATH` so child scripts inherit the SSH key path
- `workspace-setup-all.sh` sources `common.sh` if present (Epic 3 dependency) with a local fallback note; no hard dependency
- `--dry-run` flag on `workspace-setup-all.sh` prints the full assignment plan without executing
- `workspace-collect.sh` supports `--json` output for programmatic consumption