### PR TITLE
#219: add /dispatch command and CCGM module packaging

### DIFF
--- a/modules/cloud-dispatch/README.md
+++ b/modules/cloud-dispatch/README.md
@@ -1,31 +1,155 @@
 # cloud-dispatch
 
-Hetzner Cloud VM orchestration for ephemeral Claude Code agent execution. Agents boot from a pre-baked golden image in 30-90 seconds rather than spending 5-8 minutes installing tools via cloud-init.
+Delegate Claude Code agent work to Hetzner Cloud VMs. Boot ephemeral agents from a pre-baked golden image in 30-90 seconds, dispatch GitHub issues across them in parallel, and collect PRs when done.
 
 ## What This Module Does
 
-Provides the infrastructure layer for running Claude Code agents on disposable cloud VMs:
-
 - **Golden image**: Packer template that bakes a Hetzner snapshot with the full toolchain pre-installed
-- **VM lifecycle**: Create, start, stop, and destroy VMs on demand (future epics)
-- **Agent dispatch**: SSH into a VM and invoke a Claude Code agent with injected credentials (future epics)
+- **VM lifecycle**: Create, start, stop, and destroy VMs on demand
+- **Secret injection**: Ephemeral GitHub and Anthropic credentials injected at session time via tmpfs
+- **Workspace provisioning**: Clone repos and assign issues to agent slots across VMs
+- **Agent dispatch**: Launch Claude Code agents via SSH with isolated user accounts
+- **/dispatch command**: One-command interface to orchestrate the full pipeline
+
+## Prerequisites
+
+| Tool | Install | Purpose |
+|------|---------|---------|
+| `hcloud` | `brew install hcloud` | Hetzner Cloud CLI |
+| `terraform` | `brew install terraform` | (optional) Infrastructure as code |
+| `packer` | `brew install packer` | Build golden images |
+| `gh` | `brew install gh` | GitHub CLI |
+
+You also need:
+- A [Hetzner Cloud](https://console.hetzner.cloud) account with an API token
+- An [Anthropic API key](https://console.anthropic.com) for agents
+- A GitHub fine-grained PAT with `contents:write` and `pull_requests:write`
+
+Set your Hetzner token:
+```bash
+export HCLOUD_TOKEN=your-token-here
+# Or: hcloud context create my-project
+```
+
+## Quick Start
+
+### 1. Build the Golden Image (one-time setup)
+
+```bash
+cd modules/cloud-dispatch/packer
+packer init agent-image.pkr.hcl
+HCLOUD_TOKEN=$HCLOUD_TOKEN packer build agent-image.pkr.hcl
+```
+
+Build takes 5-10 minutes. Creates a snapshot named `ccgm-agent-1.0.0` in your Hetzner project.
+
+### 2. Dispatch Issues
+
+In Claude Code, run:
+```
+/dispatch owner/repo --issues 42,43,44
+```
+
+This will:
+1. Spin up 3 VMs (or reuse existing ones)
+2. Inject your credentials securely
+3. Clone the repo and assign one issue per agent
+4. Launch 3-12 parallel Claude Code agents
+5. Report back which agent got which issue
+
+### 3. Monitor Progress
+
+```
+/dispatch-status
+```
+
+### 4. Collect and Clean Up
+
+```
+/dispatch-stop
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/dispatch` | Dispatch GitHub issues to cloud agents |
+| `/dispatch-status` | Check agent status and collect PR URLs |
+| `/dispatch-stop` | Stop agents, optionally destroy VMs |
+| `/vm-manage` | Low-level VM management (create/destroy/status/ssh) |
 
 ## Architecture
 
 ```
-Orchestrator (local or CI)
+Orchestrator (local Claude Code)
   |
-  +-- hcloud create-server --snapshot ccgm-agent-{version}
-  |     (boots in 30-90s, all tools already installed)
-  |
-  +-- SSH as root -> inject agent credentials into /run/secrets/agent-N/
-  |
-  +-- SSH as agent-N -> run claude --dangerously-skip-permissions ...
+  +-- /dispatch owner/repo --issues 42,43,44
+        |
+        +-- vm-create.sh          # 3x cx22 VMs boot from golden snapshot
+        +-- secrets-inject-all.sh # GitHub PAT + Anthropic key -> /run/secrets/agent-N/
+        +-- workspace-setup-all.sh# git clone + issue assignment per agent slot
+        +-- agent-launch-all.sh   # SSH -> tmux -> claude --dangerously-skip-permissions
+              |
+              +-- VM 1: agent-0 (issue 42), agent-1 (issue 43)
+              +-- VM 2: agent-2 (issue 44), agent-3 (idle)
+              +-- VM 3: idle
 ```
+
+Each VM runs Ubuntu 22.04 LTS with 4 isolated agent user accounts (`agent-0` through `agent-3`). Agents run inside tmux sessions for persistence across SSH disconnects.
+
+### VM Sizing
+
+| VM Type | vCPU | RAM | Price/hr | Agents |
+|---------|------|-----|----------|--------|
+| cx22 | 2 | 4 GB | ~$0.005 | 2-4 |
+| cx32 | 4 | 8 GB | ~$0.010 | 4 |
+| cx42 | 8 | 16 GB | ~$0.020 | 4-8 |
+
+Default: cx22. Override in `lib/common.sh`.
+
+### Cost Reference
+
+| Session | VMs | Duration | Estimated Cost |
+|---------|-----|----------|----------------|
+| Small (3 issues) | 1 VM | 2 hr | ~$0.01 |
+| Medium (12 issues) | 3 VMs | 4 hr | ~$0.06 |
+| Large (24 issues) | 6 VMs | 4 hr | ~$0.12 |
+
+VMs are billed per hour. Destroy them when done to stop charges.
+
+## Security Model
+
+- **No secrets in git or cloud-init**: GitHub PAT and Anthropic key are injected at session time via SSH, written only to `tmpfs` at `/run/secrets/agent-N/`
+- **Ephemeral SSH keys**: A session keypair is generated locally, pushed to VMs, and revoked by `secrets-cleanup.sh`
+- **Agent isolation**: Each agent runs as a dedicated Linux user with no sudo access, `chmod 700` home dir, and `HISTFILE=/dev/null`
+- **Network egress allowlist**: iptables rules allow only github.com (TCP 443+22), api.anthropic.com (TCP 443), and registry.npmjs.org (TCP 443)
+- **Metadata API blocked**: The Hetzner metadata endpoint (169.254.169.254) is blocked for non-root processes
+- **Fine-grained PAT**: Scope the GitHub token to the specific repo being worked on
+
+## Lib Scripts
+
+| Script | Description |
+|--------|-------------|
+| `lib/common.sh` | Shared config, SSH helpers, logging |
+| `lib/vm-create.sh` | Boot N VMs from golden snapshot |
+| `lib/vm-destroy.sh` | Destroy VMs (--all or by name) |
+| `lib/vm-status.sh` | List VMs with state and IP |
+| `lib/vm-health.sh` | SSH reachability + agent user checks |
+| `lib/vm-ssh.sh` | Interactive SSH into a named VM |
+| `lib/secrets-init.sh` | Generate session SSH keypair |
+| `lib/secrets-inject.sh` | Inject credentials to one VM |
+| `lib/secrets-inject-all.sh` | Inject credentials to all VMs |
+| `lib/secrets-cleanup.sh` | Revoke session keys, clear tmpfs |
+| `lib/secrets-rotate.sh` | Rotate credentials without destroying VMs |
+| `lib/workspace-setup.sh` | Clone repo + assign issue on one VM |
+| `lib/workspace-setup-all.sh` | Set up workspaces across all VMs |
+| `lib/workspace-assign.sh` | Assign a specific issue to an agent slot |
+| `lib/workspace-collect.sh` | Pull PR URLs and results from VMs |
+| `lib/workspace-cleanup.sh` | Remove workspace dirs from VMs |
 
 ## Packer Golden Image
 
-The snapshot contains:
+### What's Baked In
 
 | Component | Version |
 |-----------|---------|
@@ -37,53 +161,17 @@ The snapshot contains:
 | git, tmux, jq, curl | system packages |
 | Python 3 | system package |
 
-Security configuration baked into the image:
-
-- Agent users `agent-0` through `agent-3` with `chmod 700` home dirs and no sudo
-- `HISTFILE=/dev/null` for all agent users
-- iptables egress allowlist: github.com (TCP 443+22), api.anthropic.com (TCP 443), registry.npmjs.org (TCP 443)
-- 169.254.169.254 metadata API blocked for non-root users
-- SSH password authentication disabled (key-only)
-- Unattended security updates enabled
-
-## Building the Image
-
-### Prerequisites
-
-- [Packer](https://developer.hashicorp.com/packer/install) >= 1.9.0
-- `hcloud` Packer plugin (installed automatically by `packer init`)
-- A Hetzner Cloud API token with read/write permissions
-
-### Build
+### Build with Custom Versions
 
 ```bash
-cd modules/cloud-dispatch/packer
-
-# Initialize plugins
-packer init agent-image.pkr.hcl
-
-# Validate the template
-packer validate agent-image.pkr.hcl
-
-# Build the snapshot
-HCLOUD_TOKEN=<your-token> packer build agent-image.pkr.hcl
-```
-
-The build takes 5-10 minutes. On success, a snapshot named `ccgm-agent-1.0.0` appears in your Hetzner Cloud project.
-
-### Pinning Tool Versions
-
-Override the defaults by setting variables:
-
-```bash
-HCLOUD_TOKEN=<token> packer build \
+HCLOUD_TOKEN=$HCLOUD_TOKEN packer build \
   -var "image_version=1.1.0" \
   -var "node_version=22" \
   -var "claude_code_version=1.5.0" \
-  agent-image.pkr.hcl
+  packer/agent-image.pkr.hcl
 ```
 
-## Files
+### Packer Files
 
 | File | Description |
 |------|-------------|
@@ -93,9 +181,19 @@ HCLOUD_TOKEN=<token> packer build \
 | `packer/scripts/security-hardening.sh` | iptables, sshd, unattended-upgrades |
 | `packer/scripts/validate.sh` | Post-build verification |
 
-## Security Notes
+## Troubleshooting
 
-- `HCLOUD_TOKEN` is consumed from the environment at build time and never written to disk
-- The Hetzner metadata API (169.254.169.254) is blocked for all non-root processes
-- Agent users have no sudo access and no persistent shell history
-- Credentials (GitHub tokens, Anthropic keys) are injected at VM boot via tmpfs at `/run/secrets/agent-N/`, not baked into the image
+**"hcloud not authenticated"**
+Set `HCLOUD_TOKEN` in your environment or run `hcloud context create`.
+
+**"No snapshot found matching ccgm-agent-*"**
+Build the golden image first: `packer build packer/agent-image.pkr.hcl`.
+
+**VM boots but health check fails**
+SSH may not be ready yet. Wait 60 seconds and retry `/vm-manage health`. If it persists, check the VM console in the Hetzner dashboard.
+
+**Agent exits immediately**
+Check that secrets were injected: `bash lib/vm-ssh.sh VM_NAME "ls /run/secrets/agent-0/"`. If empty, rerun `secrets-inject-all.sh`.
+
+**Rate limit errors across agents**
+The `--jitter` flag in `agent-launch-all.sh` staggers agent starts. Increase the jitter value (default 75 seconds) if hitting API rate limits.

--- a/modules/cloud-dispatch/commands/dispatch-status.md
+++ b/modules/cloud-dispatch/commands/dispatch-status.md
@@ -1,0 +1,35 @@
+---
+description: Check the status of dispatched agents across all cloud VMs
+allowed-tools: Bash
+---
+
+# /dispatch-status - Check agent status
+
+Check the status of dispatched agents across all cloud VMs.
+
+## Execution
+
+### Step 1: Check Agent Status
+
+```bash
+bash modules/cloud-dispatch/lib/agent-status.sh --all
+```
+
+### Step 2: Collect Results
+
+Pull PR URLs and completed work from all VMs:
+
+```bash
+bash modules/cloud-dispatch/lib/workspace-collect.sh --all
+```
+
+### Step 3: Present Summary
+
+Format and present the results showing each agent's:
+- VM name and agent slot (e.g. ccgm-agent-1 / agent-0)
+- Assigned issue number
+- Status: running / completed / failed / idle
+- PR URL (if a PR was opened)
+- Last git commit message (if available)
+
+If all agents have completed, remind the user they can run `/dispatch-stop` to clean up.

--- a/modules/cloud-dispatch/commands/dispatch-stop.md
+++ b/modules/cloud-dispatch/commands/dispatch-stop.md
@@ -1,0 +1,47 @@
+---
+description: Stop all dispatched agents and optionally destroy cloud VMs
+allowed-tools: Bash
+---
+
+# /dispatch-stop - Stop dispatched agents
+
+Stop all running agents and optionally destroy VMs.
+
+## Execution
+
+### Step 1: Stop Agents
+
+```bash
+bash modules/cloud-dispatch/lib/agent-stop.sh --all
+```
+
+### Step 2: Collect Results
+
+Pull any final results, PRs, or uncommitted work before cleanup:
+
+```bash
+bash modules/cloud-dispatch/lib/workspace-collect.sh --all
+```
+
+### Step 3: Ask About Cleanup
+
+Ask the user:
+
+"Agents stopped. What do you want to do with the VMs?
+1. Keep running (reuse for another dispatch later - saves ~2 min boot time)
+2. Destroy VMs (clean shutdown, stops billing)"
+
+If the user chooses destroy:
+
+```bash
+# Revoke session SSH keys and clear secrets from tmpfs
+bash modules/cloud-dispatch/lib/secrets-cleanup.sh
+
+# Destroy all dispatch VMs
+bash modules/cloud-dispatch/lib/vm-destroy.sh --all --force
+```
+
+Confirm destruction with a final status:
+```bash
+bash modules/cloud-dispatch/lib/vm-status.sh
+```

--- a/modules/cloud-dispatch/commands/dispatch.md
+++ b/modules/cloud-dispatch/commands/dispatch.md
@@ -1,0 +1,100 @@
+---
+description: Delegate work to cloud VMs - dispatch GitHub issues to autonomous Claude Code agents running on Hetzner Cloud
+allowed-tools: Bash
+---
+
+# /dispatch - Delegate work to cloud VMs
+
+Dispatch GitHub issues to autonomous Claude Code agents running on Hetzner Cloud VMs.
+
+## Usage
+
+The user will provide:
+- Which repo to work on
+- Which issues to dispatch (by number)
+- Optionally: number of VMs, max turns, time limit
+
+## Execution Steps
+
+Follow these steps in order. Use the Bash tool to run the shell scripts.
+
+### Step 1: Parse Arguments
+
+Extract from the user's message:
+- `REPO`: GitHub repo (owner/repo format, or just repo name to resolve from ~/code/)
+- `ISSUES`: Comma-separated issue numbers
+- `VM_COUNT`: Number of VMs (default: 3, or issues / 4 rounded up, whichever is smaller)
+- `MAX_TURNS`: Max turns per agent (default: 200)
+- `MAX_HOURS`: Max hours before auto-shutdown (default: 4)
+
+### Step 2: Validate Prerequisites
+
+```bash
+# Check required tools
+command -v hcloud >/dev/null 2>&1 || { echo "ERROR: hcloud CLI not installed. Run: brew install hcloud"; exit 1; }
+command -v gh >/dev/null 2>&1 || { echo "ERROR: gh CLI not installed. Run: brew install gh"; exit 1; }
+
+# Check Hetzner auth
+hcloud server-type list >/dev/null 2>&1 || { echo "ERROR: hcloud not authenticated. Set HCLOUD_TOKEN env var or run: hcloud context create"; exit 1; }
+
+# Check GitHub auth
+gh auth status >/dev/null 2>&1 || { echo "ERROR: gh not authenticated. Run: gh auth login"; exit 1; }
+```
+
+### Step 3: Check VM Status
+
+```bash
+source modules/cloud-dispatch/lib/common.sh
+bash modules/cloud-dispatch/lib/vm-status.sh
+```
+
+If no VMs are running, create them:
+```bash
+bash modules/cloud-dispatch/lib/vm-create.sh $VM_COUNT
+```
+
+If VMs exist, health-check them:
+```bash
+bash modules/cloud-dispatch/lib/vm-health.sh --all
+```
+
+### Step 4: Initialize Session Secrets
+
+```bash
+bash modules/cloud-dispatch/lib/secrets-init.sh
+```
+
+Ask the user for their GitHub token if not already configured:
+
+"I need a GitHub fine-grained PAT with `contents:write` and `pull_requests:write` scoped to the target repo. Provide it now, or press Enter to use the token from `gh auth token`."
+
+If the user provides a token, set `GITHUB_TOKEN` to that value. Otherwise:
+```bash
+GITHUB_TOKEN=$(gh auth token)
+```
+
+Then inject secrets to all VMs:
+```bash
+bash modules/cloud-dispatch/lib/secrets-inject-all.sh --github-token "$GITHUB_TOKEN"
+```
+
+### Step 5: Set Up Workspaces
+
+```bash
+bash modules/cloud-dispatch/lib/workspace-setup-all.sh "https://github.com/$REPO.git" --issues "$ISSUES"
+```
+
+### Step 6: Launch Agents
+
+```bash
+bash modules/cloud-dispatch/lib/agent-launch-all.sh --max-turns $MAX_TURNS --jitter 75
+```
+
+### Step 7: Report
+
+Print a summary of what was dispatched:
+- Number of agents launched
+- Which issues were assigned to which VM/agent
+- How to check status: "Run /dispatch-status to check progress"
+- How to stop: "Run /dispatch-stop to terminate all agents"
+- Estimated cost: roughly $0.015/hour per cx22 VM (3 VMs = $0.045/hour)

--- a/modules/cloud-dispatch/commands/vm-manage.md
+++ b/modules/cloud-dispatch/commands/vm-manage.md
@@ -1,0 +1,43 @@
+---
+description: Manage Hetzner Cloud VMs for agent dispatch - create, destroy, status, health checks, and SSH access
+allowed-tools: Bash
+---
+
+# /vm-manage - Manage cloud VMs
+
+Manage Hetzner Cloud VMs for agent dispatch.
+
+## Usage
+
+The user will specify an action:
+- `create [N]` - Create N VMs (default 3)
+- `destroy [--all | name]` - Destroy one or all VMs
+- `status` - List all VMs and their current state
+- `health` - Run health checks on all VMs
+- `ssh <name>` - Open an SSH session into a VM
+
+## Execution
+
+Parse the action from the user's message and run the corresponding script:
+
+```bash
+# For create:
+bash modules/cloud-dispatch/lib/vm-create.sh $N
+
+# For destroy (all):
+bash modules/cloud-dispatch/lib/vm-destroy.sh --all
+
+# For destroy (specific VM):
+bash modules/cloud-dispatch/lib/vm-destroy.sh $VM_NAME
+
+# For status:
+bash modules/cloud-dispatch/lib/vm-status.sh
+
+# For health:
+bash modules/cloud-dispatch/lib/vm-health.sh --all
+
+# For ssh:
+bash modules/cloud-dispatch/lib/vm-ssh.sh $VM_NAME
+```
+
+After running each command, display the output clearly. For `status`, format it as a table showing VM name, IP, state, and uptime.

--- a/modules/cloud-dispatch/module.json
+++ b/modules/cloud-dispatch/module.json
@@ -1,11 +1,39 @@
 {
   "name": "cloud-dispatch",
   "displayName": "Cloud Dispatch",
-  "description": "Hetzner Cloud VM orchestration for ephemeral Claude Code agent execution: golden image pipeline, VM lifecycle management, and agent dispatch.",
+  "description": "Delegate Claude Code agent work to Hetzner Cloud VMs. Provides golden image pipeline, VM lifecycle management, secret injection, workspace provisioning, and /dispatch command for one-command multi-agent dispatch.",
   "category": "workflow",
   "scope": ["global"],
   "dependencies": [],
-  "files": {},
-  "tags": ["cloud", "hetzner", "packer", "agents", "infrastructure"],
-  "configPrompts": []
+  "files": {
+    "commands/dispatch.md": { "target": "commands/dispatch.md", "type": "command", "template": false },
+    "commands/dispatch-status.md": { "target": "commands/dispatch-status.md", "type": "command", "template": false },
+    "commands/dispatch-stop.md": { "target": "commands/dispatch-stop.md", "type": "command", "template": false },
+    "commands/vm-manage.md": { "target": "commands/vm-manage.md", "type": "command", "template": false },
+    "rules/cloud-dispatch.md": { "target": "rules/cloud-dispatch.md", "type": "rule", "template": false },
+    "lib/common.sh": { "target": "lib/cloud-dispatch/common.sh", "type": "lib", "template": false },
+    "lib/vm-create.sh": { "target": "lib/cloud-dispatch/vm-create.sh", "type": "lib", "template": false },
+    "lib/vm-destroy.sh": { "target": "lib/cloud-dispatch/vm-destroy.sh", "type": "lib", "template": false },
+    "lib/vm-health.sh": { "target": "lib/cloud-dispatch/vm-health.sh", "type": "lib", "template": false },
+    "lib/vm-ssh.sh": { "target": "lib/cloud-dispatch/vm-ssh.sh", "type": "lib", "template": false },
+    "lib/vm-status.sh": { "target": "lib/cloud-dispatch/vm-status.sh", "type": "lib", "template": false },
+    "lib/secrets-cleanup.sh": { "target": "lib/cloud-dispatch/secrets-cleanup.sh", "type": "lib", "template": false },
+    "lib/secrets-init.sh": { "target": "lib/cloud-dispatch/secrets-init.sh", "type": "lib", "template": false },
+    "lib/secrets-inject-all.sh": { "target": "lib/cloud-dispatch/secrets-inject-all.sh", "type": "lib", "template": false },
+    "lib/secrets-inject.sh": { "target": "lib/cloud-dispatch/secrets-inject.sh", "type": "lib", "template": false },
+    "lib/secrets-rotate.sh": { "target": "lib/cloud-dispatch/secrets-rotate.sh", "type": "lib", "template": false },
+    "lib/workspace-assign.sh": { "target": "lib/cloud-dispatch/workspace-assign.sh", "type": "lib", "template": false },
+    "lib/workspace-cleanup.sh": { "target": "lib/cloud-dispatch/workspace-cleanup.sh", "type": "lib", "template": false },
+    "lib/workspace-collect.sh": { "target": "lib/cloud-dispatch/workspace-collect.sh", "type": "lib", "template": false },
+    "lib/workspace-setup-all.sh": { "target": "lib/cloud-dispatch/workspace-setup-all.sh", "type": "lib", "template": false },
+    "lib/workspace-setup.sh": { "target": "lib/cloud-dispatch/workspace-setup.sh", "type": "lib", "template": false }
+  },
+  "tags": ["cloud", "hetzner", "packer", "agents", "infrastructure", "dispatch"],
+  "configPrompts": [
+    {
+      "key": "hcloudSetup",
+      "prompt": "Set HCLOUD_TOKEN in your shell environment (e.g. export HCLOUD_TOKEN=... in ~/.zshrc). See https://console.hetzner.cloud -> Security -> API Tokens.",
+      "default": ""
+    }
+  ]
 }

--- a/modules/cloud-dispatch/rules/cloud-dispatch.md
+++ b/modules/cloud-dispatch/rules/cloud-dispatch.md
@@ -1,0 +1,28 @@
+# Cloud Dispatch Rules
+
+Rules that apply when working with cloud-dispatched agents.
+
+## VM Agent Behavior
+
+When running as an agent on a cloud VM:
+- Always create a feature branch before making changes
+- Commit frequently (every significant change) for git-based recovery
+- Create a PR when work is complete
+- Never push directly to main
+- Use --max-turns to prevent runaway execution
+
+## Dispatch Workflow
+
+When dispatching work to cloud VMs:
+- Verify VMs are healthy before dispatching
+- Use jittered starts to avoid rate limit thundering herd
+- Monitor agent status periodically
+- Collect results and clean up VMs when done
+- Track costs and stay within budget
+
+## Security
+
+- Never embed secrets in cloud-init or commit them to git
+- Use fine-grained GitHub PATs scoped to the target repo
+- Session SSH keys are ephemeral - generated per session, revoked on cleanup
+- Agent isolation: each agent runs as a separate Linux user with no sudo access


### PR DESCRIPTION
Closes #219

## Summary

- Adds four slash commands: `/dispatch`, `/dispatch-status`, `/dispatch-stop`, `/vm-manage`
- Adds `rules/cloud-dispatch.md` with behavioral rules for cloud-dispatched agents
- Updates `module.json` to declare all commands, rules, and lib scripts as installable module files
- Rewrites `README.md` with full documentation: prerequisites, quick start, command reference, architecture, VM/cost table, security model, lib script index, and troubleshooting

## Changes

**New files:**
- `commands/dispatch.md` - Main dispatch command: validates prereqs, creates/health-checks VMs, injects secrets, sets up workspaces, launches agents, reports results
- `commands/dispatch-status.md` - Check agent status and collect PR URLs
- `commands/dispatch-stop.md` - Stop agents with optional VM destruction
- `commands/vm-manage.md` - Low-level VM management (create/destroy/status/health/ssh)
- `rules/cloud-dispatch.md` - Rules for VM agent behavior, dispatch workflow, and security

**Updated files:**
- `module.json` - Complete file manifest covering all 21 lib scripts + 4 commands + 1 rule
- `README.md` - Full documentation replacing the placeholder content

## Test plan

- [ ] Read `commands/dispatch.md` and verify all referenced lib scripts exist in `lib/`
- [ ] Validate `module.json` - all file keys match actual paths on disk
- [ ] Run `bash tests/test-modules.sh` to confirm module schema is valid
- [ ] Run `bash tests/test-no-personal-data.sh` to confirm no personal data leaked