### PR TITLE
#218: add agent launcher scripts

### DIFF
--- a/modules/cloud-dispatch/lib/agent-collect.sh
+++ b/modules/cloud-dispatch/lib/agent-collect.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# agent-collect.sh — Collect run results from one or all Claude Code agents.
+#
+# Usage:
+#   agent-collect.sh --all [--json] [--log-lines N]
+#   agent-collect.sh <vm-ip> <agent-index> [--json] [--log-lines N]
+#
+# Output:
+#   Formatted summary table (or JSON with --json) containing:
+#     - Agent status (from ~/status)
+#     - PR URL (from run.log or gh CLI)
+#     - Branch name and last commit
+#     - Exit status
+#     - Last N lines of run.log (default: 20)
+#
+# Requires:
+#   - hcloud CLI (when --all is used)
+#   - SSH key in ~/.ssh/ccgm-dispatch-session or $SSH_KEY_PATH
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 --all [--json] [--log-lines N]" >&2
+  echo "       $0 <vm-ip> <agent-index> [--json] [--log-lines N]" >&2
+  exit 1
+fi
+
+COLLECT_ALL=false
+VM_IP=""
+AGENT_INDEX=""
+JSON_OUTPUT=false
+LOG_LINES=20
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      COLLECT_ALL=true
+      shift
+      ;;
+    --json)
+      JSON_OUTPUT=true
+      shift
+      ;;
+    --log-lines)
+      LOG_LINES="$2"
+      shift 2
+      ;;
+    -*)
+      log_error "Unknown option: $1"
+      exit 1
+      ;;
+    *)
+      if [[ -z "${VM_IP}" ]]; then
+        VM_IP="$1"
+      elif [[ -z "${AGENT_INDEX}" ]]; then
+        AGENT_INDEX="$1"
+      else
+        log_error "Unexpected argument: $1"
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ "${COLLECT_ALL}" == "false" ]]; then
+  if [[ -z "${VM_IP}" || -z "${AGENT_INDEX}" ]]; then
+    log_error "Provide --all or both <vm-ip> and <agent-index>"
+    exit 1
+  fi
+  if ! [[ "${AGENT_INDEX}" =~ ^[0-3]$ ]]; then
+    log_error "agent-index must be 0, 1, 2, or 3 (got: ${AGENT_INDEX})"
+    exit 1
+  fi
+fi
+
+if ! [[ "${LOG_LINES}" =~ ^[0-9]+$ ]]; then
+  log_error "--log-lines must be a positive integer (got: ${LOG_LINES})"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+if [[ "${COLLECT_ALL}" == "true" ]]; then
+  require_cmd hcloud
+  if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+    log_error "HCLOUD_TOKEN is not set."
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+ssh_root_quiet() {
+  local ip="$1"; shift
+  # shellcheck disable=SC2206
+  read -ra _opts <<< "$(ssh_opts)"
+  # SC2029: expansion on client side is intentional
+  # shellcheck disable=SC2029
+  ssh "${_opts[@]}" "root@${ip}" "$@" 2>/dev/null
+}
+
+json_escape() {
+  printf '%s' "$1" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" 2>/dev/null \
+    || printf '"%s"' "$1"
+}
+
+collect_one() {
+  local ip="$1"
+  local vm_name="$2"
+  local idx="$3"
+  local agent_user="agent-${idx}"
+  local agent_home="/home/${agent_user}"
+  local assignment_file="${agent_home}/assignment.json"
+  local status_file="${agent_home}/status"
+  local run_log="${agent_home}/run.log"
+
+  # --- assignment ---
+  local issue_number="" issue_title="" repo="" branch=""
+  if ssh_root_quiet "${ip}" "test -f '${assignment_file}'"; then
+    local raw_assignment
+    raw_assignment=$(ssh_root_quiet "${ip}" "cat '${assignment_file}'" || echo "{}")
+    issue_number=$(echo "${raw_assignment}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('issue_number',''))" 2>/dev/null || true)
+    issue_title=$(echo "${raw_assignment}"  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('issue_title',''))"  2>/dev/null || true)
+    repo=$(echo "${raw_assignment}"         | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('repo',''))"         2>/dev/null || true)
+    branch=$(echo "${raw_assignment}"       | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('branch',''))"       2>/dev/null || true)
+  fi
+
+  # --- status file ---
+  local agent_status="unknown"
+  if ssh_root_quiet "${ip}" "test -f '${status_file}'"; then
+    agent_status=$(ssh_root_quiet "${ip}" "cat '${status_file}'" 2>/dev/null | tr -d '[:space:]' || echo "unknown")
+  fi
+
+  # --- git state ---
+  local current_branch="" last_commit=""
+  if [[ -n "${repo}" ]]; then
+    local repo_name
+    repo_name=$(basename "${repo}")
+    local clone_dir="${agent_home}/workspace/${repo_name}"
+    if ssh_root_quiet "${ip}" "test -d '${clone_dir}/.git'"; then
+      current_branch=$(ssh_root_quiet "${ip}" \
+        "su - ${agent_user} -c 'git -C ${clone_dir} rev-parse --abbrev-ref HEAD'" \
+        2>/dev/null || echo "")
+      local sha msg
+      sha=$(ssh_root_quiet "${ip}" \
+        "su - ${agent_user} -c 'git -C ${clone_dir} rev-parse --short HEAD'" \
+        2>/dev/null || echo "")
+      msg=$(ssh_root_quiet "${ip}" \
+        "su - ${agent_user} -c 'git -C ${clone_dir} log -1 --pretty=%s'" \
+        2>/dev/null || echo "")
+      [[ -n "${sha}" ]] && last_commit="${sha} ${msg}"
+    fi
+  fi
+
+  # --- PR URL ---
+  local pr_url=""
+  if [[ -n "${branch}" && -n "${repo}" ]]; then
+    pr_url=$(ssh_root_quiet "${ip}" \
+      "su - ${agent_user} -c 'gh pr list --repo ${repo} --head ${branch} --json url --jq .[0].url 2>/dev/null'" \
+      2>/dev/null || true)
+  fi
+  if [[ -z "${pr_url}" ]]; then
+    pr_url=$(ssh_root_quiet "${ip}" \
+      "grep -oE 'https://github.com/[^/]+/[^/]+/pull/[0-9]+' '${run_log}' 2>/dev/null | tail -1" \
+      2>/dev/null || true)
+  fi
+
+  # --- log tail ---
+  local log_tail=""
+  if ssh_root_quiet "${ip}" "test -f '${run_log}'"; then
+    log_tail=$(ssh_root_quiet "${ip}" "tail -n ${LOG_LINES} '${run_log}'" 2>/dev/null || true)
+  fi
+
+  # ---------------------------------------------------------------------------
+  # Output
+  # ---------------------------------------------------------------------------
+  if [[ "${JSON_OUTPUT}" == "true" ]]; then
+    printf '{\n'
+    printf '  "vm": %s,\n'            "$(json_escape "${vm_name}")"
+    printf '  "agent": %s,\n'         "$(json_escape "${agent_user}")"
+    printf '  "issue_number": %s,\n'  "${issue_number:-null}"
+    printf '  "issue_title": %s,\n'   "$(json_escape "${issue_title}")"
+    printf '  "repo": %s,\n'          "$(json_escape "${repo}")"
+    printf '  "branch": %s,\n'        "$(json_escape "${branch}")"
+    printf '  "current_branch": %s,\n' "$(json_escape "${current_branch}")"
+    printf '  "last_commit": %s,\n'   "$(json_escape "${last_commit}")"
+    printf '  "pr_url": %s,\n'        "$(json_escape "${pr_url}")"
+    printf '  "status": %s,\n'        "$(json_escape "${agent_status}")"
+    printf '  "log_tail": %s\n'       "$(json_escape "${log_tail}")"
+    printf '}'
+  else
+    echo "--- ${vm_name} / ${agent_user} ---"
+    printf "Status:       %s\n" "${agent_status}"
+    if [[ -n "${issue_number}" ]]; then
+      printf "Issue:        #%s - %s\n" "${issue_number}" "${issue_title}"
+    else
+      printf "Issue:        (no assignment)\n"
+    fi
+    printf "Repo:         %s\n" "${repo:-(none)}"
+    printf "Branch:       %s\n" "${branch:-${current_branch:-(none)}}"
+    if [[ -n "${last_commit}" ]]; then
+      printf "Last commit:  %s\n" "${last_commit}"
+    fi
+    if [[ -n "${pr_url}" ]]; then
+      printf "PR:           %s\n" "${pr_url}"
+    fi
+    if [[ -n "${log_tail}" ]]; then
+      echo ""
+      echo "Log (last ${LOG_LINES} lines):"
+      while IFS= read -r line; do
+        printf '  %s\n' "${line}"
+      done <<< "${log_tail}"
+    fi
+    echo ""
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Single agent
+# ---------------------------------------------------------------------------
+if [[ "${COLLECT_ALL}" == "false" ]]; then
+  VM_NAME="${VM_IP}"
+  if command -v hcloud &>/dev/null && [[ -n "${HCLOUD_TOKEN:-}" ]]; then
+    VM_NAME=$(hcloud server list --output columns=name,ipv4 2>/dev/null \
+      | awk -v ip="${VM_IP}" '$2==ip {print $1}' || echo "${VM_IP}")
+  fi
+  collect_one "${VM_IP}" "${VM_NAME}" "${AGENT_INDEX}"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# All agents across all running VMs
+# ---------------------------------------------------------------------------
+mapfile -t VM_NAMES < <(hcloud server list --output columns=name,status \
+  | awk '$2=="running" && /ccgm-agent/ {print $1}' \
+  | sort)
+
+if [[ ${#VM_NAMES[@]} -eq 0 ]]; then
+  log_warn "No running ccgm-agent-* VMs found."
+  exit 0
+fi
+
+if [[ "${JSON_OUTPUT}" == "true" ]]; then
+  echo "["
+  first_entry=true
+fi
+
+for vm_name in "${VM_NAMES[@]}"; do
+  ip=$(hcloud server describe "${vm_name}" --output format='{{.PublicNet.IPv4.IP}}')
+  for idx in $(seq 0 $(( CCGM_AGENTS_PER_VM - 1 ))); do
+    if [[ "${JSON_OUTPUT}" == "true" && "${first_entry}" != "true" ]]; then
+      echo ","
+    fi
+    collect_one "${ip}" "${vm_name}" "${idx}"
+    first_entry=false
+  done
+done
+
+if [[ "${JSON_OUTPUT}" == "true" ]]; then
+  echo ""
+  echo "]"
+fi

--- a/modules/cloud-dispatch/lib/agent-launch-all.sh
+++ b/modules/cloud-dispatch/lib/agent-launch-all.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# agent-launch-all.sh — Launch all assigned agents across all running VMs with jitter.
+#
+# Usage:
+#   agent-launch-all.sh [--jitter SECONDS] [--max-turns N] [--prompt PROMPT] [--dry-run]
+#
+# Options:
+#   --jitter N    Random sleep max between agent launches in seconds (default: 90).
+#                 Actual sleep is a random value between 60 and JITTER (min 60).
+#                 Set to 0 to disable jitter.
+#   --max-turns N Maximum turns per agent (default: 200)
+#   --prompt P    Claude prompt override (passed to agent-launch.sh)
+#   --dry-run     Print what would be launched without executing
+#
+# Jitter is critical: it staggers Claude API calls so all agents don't hit the
+# rate limiter simultaneously.
+#
+# Requires:
+#   - hcloud CLI installed and authenticated (HCLOUD_TOKEN set)
+#   - agent-launch.sh in the same directory as this script
+#   - SSH key in ~/.ssh/ccgm-dispatch-session or $SSH_KEY_PATH
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+MAX_TURNS=200
+JITTER=90
+CUSTOM_PROMPT=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --jitter)
+      JITTER="$2"
+      shift 2
+      ;;
+    --max-turns)
+      MAX_TURNS="$2"
+      shift 2
+      ;;
+    --prompt)
+      CUSTOM_PROMPT="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    *)
+      log_error "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "${MAX_TURNS}" =~ ^[0-9]+$ ]]; then
+  log_error "--max-turns must be a positive integer (got: ${MAX_TURNS})"
+  exit 1
+fi
+
+if ! [[ "${JITTER}" =~ ^[0-9]+$ ]]; then
+  log_error "--jitter must be a non-negative integer (got: ${JITTER})"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+require_cmd hcloud
+require_cmd python3
+
+if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+  log_error "HCLOUD_TOKEN is not set. Export it before running this script."
+  exit 1
+fi
+
+LAUNCH_SCRIPT="${SCRIPT_DIR}/agent-launch.sh"
+if [[ ! -x "${LAUNCH_SCRIPT}" ]]; then
+  log_error "agent-launch.sh not found or not executable at ${LAUNCH_SCRIPT}"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Discover running agent VMs
+# ---------------------------------------------------------------------------
+log_info "Discovering running ccgm-agent-* VMs..."
+
+mapfile -t VM_NAMES < <(hcloud server list --output columns=name,status \
+  | awk '$2=="running" && /ccgm-agent/ {print $1}' \
+  | sort)
+
+if [[ ${#VM_NAMES[@]} -eq 0 ]]; then
+  log_error "No running ccgm-agent-* VMs found."
+  exit 1
+fi
+
+log_info "Found ${#VM_NAMES[@]} VM(s): ${VM_NAMES[*]}"
+
+# ---------------------------------------------------------------------------
+# Build launch list: only slots that have an assignment.json
+# ---------------------------------------------------------------------------
+ssh_root() {
+  local ip="$1"; shift
+  # shellcheck disable=SC2206
+  read -ra _opts <<< "$(ssh_opts)"
+  # SC2029: expansion on client side is intentional
+  # shellcheck disable=SC2029
+  ssh "${_opts[@]}" "root@${ip}" "$@" 2>/dev/null
+}
+
+declare -a LAUNCH_VM_IPS
+declare -a LAUNCH_VM_NAMES
+declare -a LAUNCH_AGENT_INDEXES
+
+log_info "Checking agent assignments..."
+
+for vm_name in "${VM_NAMES[@]}"; do
+  vm_ip=$(hcloud server describe "${vm_name}" --output format='{{.PublicNet.IPv4.IP}}')
+  for agent_index in $(seq 0 $(( CCGM_AGENTS_PER_VM - 1 ))); do
+    agent_user="agent-${agent_index}"
+    assignment_file="/home/${agent_user}/assignment.json"
+    if ssh_root "${vm_ip}" "test -f '${assignment_file}'"; then
+      LAUNCH_VM_IPS+=("${vm_ip}")
+      LAUNCH_VM_NAMES+=("${vm_name}")
+      LAUNCH_AGENT_INDEXES+=("${agent_index}")
+      log_info "  ${vm_name} / ${agent_user} - has assignment"
+    else
+      log_warn "  ${vm_name} / ${agent_user} - no assignment, skipping"
+    fi
+  done
+done
+
+TOTAL="${#LAUNCH_VM_IPS[@]}"
+
+if [[ "${TOTAL}" -eq 0 ]]; then
+  log_warn "No agents have assignments. Run workspace-assign.sh (or workspace-setup-all.sh) first."
+  exit 0
+fi
+
+log_info "Agents to launch: ${TOTAL}"
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo ""
+  echo "Dry run - agents that would be launched:"
+  for i in "${!LAUNCH_VM_IPS[@]}"; do
+    printf "  %s / agent-%s\n" "${LAUNCH_VM_NAMES[$i]}" "${LAUNCH_AGENT_INDEXES[$i]}"
+  done
+  echo ""
+  echo "(--dry-run: no changes made)"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Launch agents with jitter between each
+# ---------------------------------------------------------------------------
+LAUNCHED=0
+FAILED=0
+START_TIME=$(date +%s)
+
+for i in "${!LAUNCH_VM_IPS[@]}"; do
+  vm_ip="${LAUNCH_VM_IPS[$i]}"
+  vm_name="${LAUNCH_VM_NAMES[$i]}"
+  agent_index="${LAUNCH_AGENT_INDEXES[$i]}"
+  agent_user="agent-${agent_index}"
+
+  log_info "[$(( i + 1 ))/${TOTAL}] Launching ${vm_name} / ${agent_user}"
+
+  launch_args=("${vm_ip}" "${agent_index}" --max-turns "${MAX_TURNS}")
+  if [[ -n "${CUSTOM_PROMPT}" ]]; then
+    launch_args+=(--prompt "${CUSTOM_PROMPT}")
+  fi
+
+  if "${LAUNCH_SCRIPT}" "${launch_args[@]}"; then
+    LAUNCHED=$(( LAUNCHED + 1 ))
+  else
+    log_error "Launch failed for ${vm_name} / ${agent_user}"
+    FAILED=$(( FAILED + 1 ))
+  fi
+
+  # Jitter: sleep a random amount between 60s and JITTER (skip after last agent)
+  if [[ "${JITTER}" -gt 0 && $(( i + 1 )) -lt "${TOTAL}" ]]; then
+    if [[ "${JITTER}" -gt 60 ]]; then
+      sleep_secs=$(( 60 + RANDOM % (JITTER - 60 + 1) ))
+    else
+      sleep_secs="${JITTER}"
+    fi
+    log_info "Jitter: sleeping ${sleep_secs}s before next launch..."
+    sleep "${sleep_secs}"
+  fi
+done
+
+END_TIME=$(date +%s)
+ELAPSED=$(( END_TIME - START_TIME ))
+
+echo ""
+log_info "Launch complete"
+echo "  Total agents launched: ${LAUNCHED}"
+if [[ "${FAILED}" -gt 0 ]]; then
+  echo "  Failed:                ${FAILED}"
+fi
+echo "  Total elapsed:         ${ELAPSED}s"
+
+[[ "${FAILED}" -eq 0 ]]

--- a/modules/cloud-dispatch/lib/agent-launch.sh
+++ b/modules/cloud-dispatch/lib/agent-launch.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# agent-launch.sh — Launch a single Claude Code agent in a tmux session on a VM.
+#
+# Usage:
+#   agent-launch.sh <vm-ip> <agent-index> [--max-turns N] [--prompt PROMPT]
+#
+# Arguments:
+#   vm-ip          Public IP of the Hetzner Cloud VM
+#   agent-index    0-3, selects agent-N user on the VM
+#   --max-turns    Maximum turns before Claude stops (default: 200)
+#   --prompt       Override default Claude prompt
+#
+# The agent's assignment is read from /home/agent-N/assignment.json on the VM.
+# The tmux session is named agent-N and output is appended to ~/run.log.
+# On completion, ~/status is set to AGENT_DONE (or AGENT_ERROR on failure).
+#
+# Requires:
+#   - SSH key in ~/.ssh/ccgm-dispatch-session or $SSH_KEY_PATH
+#   - assignment.json already written (run workspace-assign.sh first)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <vm-ip> <agent-index> [--max-turns N] [--prompt PROMPT]" >&2
+  exit 1
+fi
+
+VM_IP="$1"
+AGENT_INDEX="$2"
+shift 2
+
+MAX_TURNS=200
+CUSTOM_PROMPT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --max-turns)
+      MAX_TURNS="$2"
+      shift 2
+      ;;
+    --prompt)
+      CUSTOM_PROMPT="$2"
+      shift 2
+      ;;
+    *)
+      log_error "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "${AGENT_INDEX}" =~ ^[0-3]$ ]]; then
+  log_error "agent-index must be 0, 1, 2, or 3 (got: ${AGENT_INDEX})"
+  exit 1
+fi
+
+if ! [[ "${MAX_TURNS}" =~ ^[0-9]+$ ]]; then
+  log_error "--max-turns must be a positive integer (got: ${MAX_TURNS})"
+  exit 1
+fi
+
+AGENT_USER="agent-${AGENT_INDEX}"
+AGENT_HOME="/home/${AGENT_USER}"
+ASSIGNMENT_FILE="${AGENT_HOME}/assignment.json"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+ssh_root() {
+  # shellcheck disable=SC2206
+  read -ra _opts <<< "$(ssh_opts)"
+  # SC2029: expansion on client side is intentional (remote command args are built locally)
+  # shellcheck disable=SC2029
+  ssh "${_opts[@]}" "root@${VM_IP}" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: Verify assignment.json exists
+# ---------------------------------------------------------------------------
+log_info "Checking assignment for ${AGENT_USER} on ${VM_IP}"
+
+if ! ssh_root "test -f '${ASSIGNMENT_FILE}'" 2>/dev/null; then
+  log_error "No assignment.json found at ${ASSIGNMENT_FILE}. Run workspace-assign.sh first."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Read assignment fields
+# ---------------------------------------------------------------------------
+ASSIGNMENT=$(ssh_root "cat '${ASSIGNMENT_FILE}'" 2>/dev/null)
+
+ISSUE_NUMBER=$(echo "${ASSIGNMENT}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('issue_number',''))" 2>/dev/null || true)
+ISSUE_TITLE=$(echo "${ASSIGNMENT}"  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('issue_title',''))"  2>/dev/null || true)
+REPO=$(echo "${ASSIGNMENT}"         | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('repo',''))"         2>/dev/null || true)
+BRANCH=$(echo "${ASSIGNMENT}"       | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('branch',''))"       2>/dev/null || true)
+
+if [[ -z "${ISSUE_NUMBER}" || -z "${REPO}" ]]; then
+  log_error "assignment.json is missing required fields (issue_number, repo)."
+  exit 1
+fi
+
+REPO_NAME=$(basename "${REPO}")
+WORKSPACE_DIR="${AGENT_HOME}/workspace/${REPO_NAME}"
+
+# ---------------------------------------------------------------------------
+# Step 3: Build the Claude prompt
+# ---------------------------------------------------------------------------
+if [[ -n "${CUSTOM_PROMPT}" ]]; then
+  PROMPT="${CUSTOM_PROMPT}"
+else
+  PROMPT="You are an autonomous Claude Code agent. Work on GitHub issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}. \
+Create a branch named ${BRANCH}, implement the changes with tests, and create a PR that closes #${ISSUE_NUMBER}. \
+Follow the repo's CLAUDE.md instructions. Commit with message format: #${ISSUE_NUMBER}: description."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Kill any existing session with the same name
+# ---------------------------------------------------------------------------
+log_info "Launching tmux session '${AGENT_USER}' on ${VM_IP}"
+
+# Silently kill a stale session if present
+ssh_root "su - ${AGENT_USER} -c 'tmux kill-session -t ${AGENT_USER} 2>/dev/null || true'" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Step 5: Build the inner shell command
+#
+# The command runs as agent-N inside tmux. It:
+#   1. Sources the injected secrets env file
+#   2. cd's into the workspace clone
+#   3. Runs claude in print mode
+#   4. Writes AGENT_DONE (or AGENT_ERROR) to ~/status
+# ---------------------------------------------------------------------------
+
+# Single-quote the prompt for safe embedding in the outer double-quoted string.
+# We use printf %q which escapes for bash, then wrap in single quotes for the
+# su -c argument.
+ESCAPED_PROMPT=$(printf '%s' "${PROMPT}" | sed "s/'/'\\\\''/g")
+
+INNER_CMD="source /run/secrets/${AGENT_USER}/env 2>/dev/null || true; \
+cd '${WORKSPACE_DIR}'; \
+claude -p '${ESCAPED_PROMPT}' --dangerously-skip-permissions --max-turns ${MAX_TURNS} \
+  >> ~/run.log 2>&1 \
+  && echo AGENT_DONE > ~/status \
+  || echo AGENT_ERROR > ~/status"
+
+# Wrap inner command for su -c (needs single outer quotes)
+SU_CMD="tmux new-session -d -s ${AGENT_USER} 'bash -lc $(printf '%q' "${INNER_CMD}")'"
+
+ssh_root "su - ${AGENT_USER} -c $(printf '%q' "${SU_CMD}")"
+
+# ---------------------------------------------------------------------------
+# Step 6: Verify the session was created
+# ---------------------------------------------------------------------------
+if ssh_root "su - ${AGENT_USER} -c 'tmux has-session -t ${AGENT_USER} 2>/dev/null'" 2>/dev/null; then
+  log_success "Session '${AGENT_USER}' is running on ${VM_IP}"
+  echo "    Agent:  ${AGENT_USER}@${VM_IP}"
+  echo "    Issue:  #${ISSUE_NUMBER} - ${ISSUE_TITLE}"
+  echo "    Branch: ${BRANCH}"
+  echo "    Repo:   ${REPO}"
+else
+  log_error "tmux session '${AGENT_USER}' did not start on ${VM_IP}"
+  exit 1
+fi

--- a/modules/cloud-dispatch/lib/agent-status.sh
+++ b/modules/cloud-dispatch/lib/agent-status.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# agent-status.sh — Report the status of one or all Claude Code agents.
+#
+# Usage:
+#   agent-status.sh --all
+#   agent-status.sh <vm-ip> <agent-index>
+#
+# Output per agent:
+#   VM: ccgm-agent-fsn1-0 | Agent: agent-0 | Status: running | Issue: #42
+#   Last log: "Creating PR for branch 42-habit-streaks..."
+#   Duration: 23m
+#
+# Requires:
+#   - hcloud CLI (when --all is used)
+#   - SSH key in ~/.ssh/ccgm-dispatch-session or $SSH_KEY_PATH
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 --all" >&2
+  echo "       $0 <vm-ip> <agent-index>" >&2
+  exit 1
+fi
+
+STATUS_ALL=false
+VM_IP=""
+AGENT_INDEX=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      STATUS_ALL=true
+      shift
+      ;;
+    -*)
+      log_error "Unknown option: $1"
+      exit 1
+      ;;
+    *)
+      if [[ -z "${VM_IP}" ]]; then
+        VM_IP="$1"
+      elif [[ -z "${AGENT_INDEX}" ]]; then
+        AGENT_INDEX="$1"
+      else
+        log_error "Unexpected argument: $1"
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ "${STATUS_ALL}" == "false" ]]; then
+  if [[ -z "${VM_IP}" || -z "${AGENT_INDEX}" ]]; then
+    log_error "Provide --all or both <vm-ip> and <agent-index>"
+    exit 1
+  fi
+  if ! [[ "${AGENT_INDEX}" =~ ^[0-3]$ ]]; then
+    log_error "agent-index must be 0, 1, 2, or 3 (got: ${AGENT_INDEX})"
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+if [[ "${STATUS_ALL}" == "true" ]]; then
+  require_cmd hcloud
+  if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+    log_error "HCLOUD_TOKEN is not set."
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+ssh_root_quiet() {
+  local ip="$1"; shift
+  # shellcheck disable=SC2206
+  read -ra _opts <<< "$(ssh_opts)"
+  # SC2029: expansion on client side is intentional
+  # shellcheck disable=SC2029
+  ssh "${_opts[@]}" "root@${ip}" "$@" 2>/dev/null
+}
+
+# status_one <vm-ip> <vm-name> <agent-index>
+status_one() {
+  local ip="$1"
+  local name="$2"
+  local idx="$3"
+  local agent_user="agent-${idx}"
+  local agent_home="/home/${agent_user}"
+  local assignment_file="${agent_home}/assignment.json"
+  local status_file="${agent_home}/status"
+  local run_log="${agent_home}/run.log"
+
+  # --- assignment ---
+  local issue_number="" issue_title="" assigned_at=""
+  if ssh_root_quiet "${ip}" "test -f '${assignment_file}'"; then
+    local raw_assignment
+    raw_assignment=$(ssh_root_quiet "${ip}" "cat '${assignment_file}'" || echo "{}")
+    issue_number=$(echo "${raw_assignment}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('issue_number',''))" 2>/dev/null || true)
+    issue_title=$(echo "${raw_assignment}"  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('issue_title',''))"  2>/dev/null || true)
+    assigned_at=$(echo "${raw_assignment}"  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('assigned_at',''))"  2>/dev/null || true)
+  fi
+
+  # --- tmux / status ---
+  local agent_state="no-session"
+  if ssh_root_quiet "${ip}" "su - ${agent_user} -c 'tmux has-session -t ${agent_user} 2>/dev/null'"; then
+    agent_state="running"
+  elif ssh_root_quiet "${ip}" "test -f '${status_file}'"; then
+    agent_state=$(ssh_root_quiet "${ip}" "cat '${status_file}'" 2>/dev/null | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]' || echo "unknown")
+  fi
+
+  # --- last log line ---
+  local last_log_line=""
+  if ssh_root_quiet "${ip}" "test -f '${run_log}'"; then
+    last_log_line=$(ssh_root_quiet "${ip}" "tail -1 '${run_log}'" 2>/dev/null | tr -d '\r' || true)
+  fi
+
+  # --- PR URL ---
+  local pr_url=""
+  if ssh_root_quiet "${ip}" "test -f '${run_log}'"; then
+    pr_url=$(ssh_root_quiet "${ip}" "grep -oE 'https://github.com/[^/]+/[^/]+/pull/[0-9]+' '${run_log}' | tail -1" 2>/dev/null || true)
+  fi
+
+  # --- duration ---
+  local duration=""
+  if [[ -n "${assigned_at}" ]]; then
+    duration=$(python3 - "${assigned_at}" <<'PYEOF'
+import sys
+from datetime import datetime, timezone
+try:
+    assigned = datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+    now = datetime.now(timezone.utc)
+    total = int((now - assigned).total_seconds())
+    h, rem = divmod(total, 3600)
+    m = rem // 60
+    if h > 0:
+        print(f"{h}h {m}m")
+    else:
+        print(f"{m}m")
+except Exception:
+    print("")
+PYEOF
+    )
+  fi
+
+  # --- output ---
+  printf "VM: %-24s | Agent: %-8s | Status: %-14s | Issue: %s\n" \
+    "${name}" "${agent_user}" "${agent_state}" "${issue_number:-(none)}"
+
+  if [[ -n "${issue_title}" ]]; then
+    printf "  Title:    %s\n" "${issue_title}"
+  fi
+  if [[ -n "${last_log_line}" ]]; then
+    printf "  Last log: %s\n" "${last_log_line}"
+  fi
+  if [[ -n "${pr_url}" ]]; then
+    printf "  PR:       %s\n" "${pr_url}"
+  fi
+  if [[ -n "${duration}" ]]; then
+    printf "  Duration: %s\n" "${duration}"
+  fi
+  echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Single agent
+# ---------------------------------------------------------------------------
+if [[ "${STATUS_ALL}" == "false" ]]; then
+  # Resolve VM name from IP (best effort)
+  VM_NAME="${VM_IP}"
+  if command -v hcloud &>/dev/null && [[ -n "${HCLOUD_TOKEN:-}" ]]; then
+    VM_NAME=$(hcloud server list --output columns=name,ipv4 2>/dev/null \
+      | awk -v ip="${VM_IP}" '$2==ip {print $1}' || echo "${VM_IP}")
+  fi
+  status_one "${VM_IP}" "${VM_NAME}" "${AGENT_INDEX}"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# All agents across all running VMs
+# ---------------------------------------------------------------------------
+mapfile -t VM_NAMES < <(hcloud server list --output columns=name,status \
+  | awk '$2=="running" && /ccgm-agent/ {print $1}' \
+  | sort)
+
+if [[ ${#VM_NAMES[@]} -eq 0 ]]; then
+  log_warn "No running ccgm-agent-* VMs found."
+  exit 0
+fi
+
+for vm_name in "${VM_NAMES[@]}"; do
+  ip=$(hcloud server describe "${vm_name}" --output format='{{.PublicNet.IPv4.IP}}')
+  for idx in $(seq 0 $(( CCGM_AGENTS_PER_VM - 1 ))); do
+    status_one "${ip}" "${vm_name}" "${idx}"
+  done
+done

--- a/modules/cloud-dispatch/lib/agent-stop.sh
+++ b/modules/cloud-dispatch/lib/agent-stop.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# agent-stop.sh — Stop one or all running Claude Code agent tmux sessions.
+#
+# Usage:
+#   agent-stop.sh --all
+#   agent-stop.sh <vm-ip> <agent-index>
+#
+# For each target agent:
+#   1. Kills the tmux session named agent-N on the VM
+#   2. Writes AGENT_STOPPED to ~/status
+#
+# Requires:
+#   - hcloud CLI (when --all is used)
+#   - SSH key in ~/.ssh/ccgm-dispatch-session or $SSH_KEY_PATH
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 --all" >&2
+  echo "       $0 <vm-ip> <agent-index>" >&2
+  exit 1
+fi
+
+STOP_ALL=false
+VM_IP=""
+AGENT_INDEX=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      STOP_ALL=true
+      shift
+      ;;
+    -*)
+      log_error "Unknown option: $1"
+      exit 1
+      ;;
+    *)
+      if [[ -z "${VM_IP}" ]]; then
+        VM_IP="$1"
+      elif [[ -z "${AGENT_INDEX}" ]]; then
+        AGENT_INDEX="$1"
+      else
+        log_error "Unexpected argument: $1"
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ "${STOP_ALL}" == "false" ]]; then
+  if [[ -z "${VM_IP}" || -z "${AGENT_INDEX}" ]]; then
+    log_error "Provide --all or both <vm-ip> and <agent-index>"
+    exit 1
+  fi
+  if ! [[ "${AGENT_INDEX}" =~ ^[0-3]$ ]]; then
+    log_error "agent-index must be 0, 1, 2, or 3 (got: ${AGENT_INDEX})"
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+if [[ "${STOP_ALL}" == "true" ]]; then
+  require_cmd hcloud
+  if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+    log_error "HCLOUD_TOKEN is not set."
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+ssh_root_quiet() {
+  local ip="$1"; shift
+  # shellcheck disable=SC2206
+  read -ra _opts <<< "$(ssh_opts)"
+  # SC2029: expansion on client side is intentional
+  # shellcheck disable=SC2029
+  ssh "${_opts[@]}" "root@${ip}" "$@" 2>/dev/null
+}
+
+stop_one() {
+  local ip="$1"
+  local idx="$2"
+  local agent_user="agent-${idx}"
+  local agent_home="/home/${agent_user}"
+  local status_file="${agent_home}/status"
+
+  log_info "Stopping ${agent_user} on ${ip}"
+
+  # Kill the tmux session (ignore errors if not running)
+  ssh_root_quiet "${ip}" "su - ${agent_user} -c 'tmux kill-session -t ${agent_user} 2>/dev/null || true'"
+
+  # Write stopped status
+  ssh_root_quiet "${ip}" "echo AGENT_STOPPED > '${status_file}' && chown '${agent_user}:${agent_user}' '${status_file}'"
+
+  log_success "Stopped ${agent_user} on ${ip}"
+}
+
+# ---------------------------------------------------------------------------
+# Single agent
+# ---------------------------------------------------------------------------
+if [[ "${STOP_ALL}" == "false" ]]; then
+  stop_one "${VM_IP}" "${AGENT_INDEX}"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# All agents across all running VMs
+# ---------------------------------------------------------------------------
+mapfile -t VM_NAMES < <(hcloud server list --output columns=name,status \
+  | awk '$2=="running" && /ccgm-agent/ {print $1}' \
+  | sort)
+
+if [[ ${#VM_NAMES[@]} -eq 0 ]]; then
+  log_warn "No running ccgm-agent-* VMs found."
+  exit 0
+fi
+
+STOPPED=0
+
+for vm_name in "${VM_NAMES[@]}"; do
+  ip=$(hcloud server describe "${vm_name}" --output format='{{.PublicNet.IPv4.IP}}')
+  for idx in $(seq 0 $(( CCGM_AGENTS_PER_VM - 1 ))); do
+    stop_one "${ip}" "${idx}"
+    STOPPED=$(( STOPPED + 1 ))
+  done
+done
+
+log_info "Stopped ${STOPPED} agent session(s)."

--- a/modules/cloud-dispatch/lib/auto-shutdown.sh
+++ b/modules/cloud-dispatch/lib/auto-shutdown.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# auto-shutdown.sh — Auto-shutdown script that runs ON the VM (not the orchestrator).
+#
+# Installed as a cron job on the VM (every 5 minutes):
+#   */5 * * * * /opt/ccgm/auto-shutdown.sh >> /var/log/ccgm-shutdown.log 2>&1
+#
+# Behavior:
+#   1. If any agent tmux sessions are still active, record the time and exit.
+#   2. If no sessions have been active for 15+ minutes, initiate shutdown.
+#   3. If MAX_HOURS wall-clock time has been exceeded, kill all agents and shut down.
+#
+# Environment variables (read from /etc/ccgm/env if present):
+#   MAX_HOURS    Maximum wall-clock hours before forced shutdown (default: 8)
+#   IDLE_MINUTES Minutes of no active sessions before idle shutdown (default: 15)
+#
+# State files (on the VM):
+#   /var/lib/ccgm/last-active   Timestamp of last observed active session (epoch seconds)
+#   /var/lib/ccgm/vm-start      Timestamp of VM start / script first run (epoch seconds)
+#   /var/log/ccgm-shutdown.log  Shutdown reason and timing (written by this script)
+#
+# Install in the golden image or via workspace-setup.sh:
+#   install -m 0755 auto-shutdown.sh /opt/ccgm/auto-shutdown.sh
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+MAX_HOURS="${MAX_HOURS:-8}"
+IDLE_MINUTES="${IDLE_MINUTES:-15}"
+
+STATE_DIR="/var/lib/ccgm"
+LAST_ACTIVE_FILE="${STATE_DIR}/last-active"
+VM_START_FILE="${STATE_DIR}/vm-start"
+SHUTDOWN_LOG="/var/log/ccgm-shutdown.log"
+ENV_FILE="/etc/ccgm/env"
+
+# ---------------------------------------------------------------------------
+# Logging (to shutdown log only - stdout is redirected there by cron)
+# ---------------------------------------------------------------------------
+log() {
+  echo "$(date '+%Y-%m-%dT%H:%M:%S') [auto-shutdown] $*"
+}
+
+# ---------------------------------------------------------------------------
+# Load optional env overrides
+# ---------------------------------------------------------------------------
+if [[ -f "${ENV_FILE}" ]]; then
+  # shellcheck source=/dev/null
+  source "${ENV_FILE}"
+fi
+
+# ---------------------------------------------------------------------------
+# Ensure state directory exists
+# ---------------------------------------------------------------------------
+mkdir -p "${STATE_DIR}"
+
+NOW=$(date +%s)
+
+# ---------------------------------------------------------------------------
+# Record VM start time on first run
+# ---------------------------------------------------------------------------
+if [[ ! -f "${VM_START_FILE}" ]]; then
+  echo "${NOW}" > "${VM_START_FILE}"
+  log "VM start time recorded: ${NOW}"
+fi
+
+VM_START=$(cat "${VM_START_FILE}")
+WALL_CLOCK_SECS=$(( NOW - VM_START ))
+WALL_CLOCK_HOURS=$(( WALL_CLOCK_SECS / 3600 ))
+
+# ---------------------------------------------------------------------------
+# Check wall-clock cap first (hard limit)
+# ---------------------------------------------------------------------------
+MAX_SECS=$(( MAX_HOURS * 3600 ))
+if [[ "${WALL_CLOCK_SECS}" -ge "${MAX_SECS}" ]]; then
+  log "SHUTDOWN: wall-clock limit reached (${WALL_CLOCK_HOURS}h >= ${MAX_HOURS}h limit)"
+  log "Killing all agent tmux sessions..."
+
+  # Kill all agent-N tmux sessions
+  for i in 0 1 2 3; do
+    agent_user="agent-${i}"
+    if id "${agent_user}" &>/dev/null; then
+      su - "${agent_user}" -c "tmux kill-server 2>/dev/null || true" 2>/dev/null || true
+      echo "AGENT_TIMEOUT" > "/home/${agent_user}/status" || true
+      chown "${agent_user}:${agent_user}" "/home/${agent_user}/status" 2>/dev/null || true
+    fi
+  done
+
+  log "SHUTDOWN: initiating poweroff (reason: max-hours)"
+  echo "shutdown" > "${SHUTDOWN_LOG}.reason"
+  /sbin/poweroff
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Check for active tmux sessions across all agent users
+# ---------------------------------------------------------------------------
+ACTIVE_SESSIONS=0
+for i in 0 1 2 3; do
+  agent_user="agent-${i}"
+  if id "${agent_user}" &>/dev/null; then
+    if su - "${agent_user}" -c "tmux has-session 2>/dev/null"; then
+      ACTIVE_SESSIONS=$(( ACTIVE_SESSIONS + 1 ))
+    fi
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Update last-active or check idle timeout
+# ---------------------------------------------------------------------------
+if [[ "${ACTIVE_SESSIONS}" -gt 0 ]]; then
+  echo "${NOW}" > "${LAST_ACTIVE_FILE}"
+  log "Active sessions: ${ACTIVE_SESSIONS} (wall-clock: ${WALL_CLOCK_HOURS}h, max: ${MAX_HOURS}h)"
+  exit 0
+fi
+
+# No active sessions - check idle duration
+if [[ -f "${LAST_ACTIVE_FILE}" ]]; then
+  LAST_ACTIVE=$(cat "${LAST_ACTIVE_FILE}")
+else
+  # Never been active - use VM start as baseline
+  LAST_ACTIVE="${VM_START}"
+  echo "${LAST_ACTIVE}" > "${LAST_ACTIVE_FILE}"
+fi
+
+IDLE_SECS=$(( NOW - LAST_ACTIVE ))
+IDLE_MINS=$(( IDLE_SECS / 60 ))
+IDLE_THRESHOLD_SECS=$(( IDLE_MINUTES * 60 ))
+
+log "No active sessions. Idle for ${IDLE_MINS}m (threshold: ${IDLE_MINUTES}m, wall-clock: ${WALL_CLOCK_HOURS}h)"
+
+if [[ "${IDLE_SECS}" -ge "${IDLE_THRESHOLD_SECS}" ]]; then
+  log "SHUTDOWN: idle threshold reached (${IDLE_MINS}m >= ${IDLE_MINUTES}m)"
+  log "SHUTDOWN: initiating poweroff (reason: idle-timeout)"
+  echo "idle-timeout" > "${SHUTDOWN_LOG}.reason"
+  /sbin/poweroff
+  exit 0
+fi
+
+log "Idle timer running: ${IDLE_MINS}m / ${IDLE_MINUTES}m until shutdown"


### PR DESCRIPTION
Closes #218

## Summary

- `agent-launch.sh`: SSH to a VM, read assignment.json, build Claude prompt, launch in a named tmux session, verify session started
- `agent-launch-all.sh`: Discover all running ccgm-agent-* VMs, check each slot for an assignment, launch with configurable jitter (default random 60-90s between launches) to avoid rate-limit collisions
- `agent-status.sh`: Report tmux session state, status file, last log line, PR URL, and duration for one or all agents
- `agent-stop.sh`: Kill tmux session and write AGENT_STOPPED status for one or all agents
- `agent-collect.sh`: Collect status, PR URL, branch/commit info, and log tail; formatted text or --json output
- `auto-shutdown.sh`: Runs ON the VM via cron every 5 minutes; shuts down after idle threshold (default 15m) or wall-clock cap (default 8h)

## Test plan

- [ ] shellcheck passes: `shellcheck -x --source-path=modules/cloud-dispatch/lib modules/cloud-dispatch/lib/agent-*.sh modules/cloud-dispatch/lib/auto-shutdown.sh`
- [ ] `agent-launch.sh` exits non-zero when no assignment.json is present
- [ ] `agent-launch.sh` exits non-zero when agent-index is out of range
- [ ] `agent-launch-all.sh --dry-run` prints plan without connecting to VMs
- [ ] `agent-stop.sh --all` exits cleanly when no VMs are running
- [ ] `agent-collect.sh --json` emits valid JSON array
- [ ] `auto-shutdown.sh` writes to /var/log/ccgm-shutdown.log and calls poweroff when idle threshold exceeded