### PR TITLE
#221: add E2E test and comprehensive documentation

### DIFF
--- a/modules/cloud-dispatch/README.md
+++ b/modules/cloud-dispatch/README.md
@@ -2,33 +2,43 @@
 
 Delegate Claude Code agent work to Hetzner Cloud VMs. Boot ephemeral agents from a pre-baked golden image in 30-90 seconds, dispatch GitHub issues across them in parallel, and collect PRs when done.
 
-## What This Module Does
+Up to 12 agents (3 VMs x 4 agents each) can run simultaneously, each working an independent GitHub issue from its own isolated user account.
 
-- **Golden image**: Packer template that bakes a Hetzner snapshot with the full toolchain pre-installed
-- **VM lifecycle**: Create, start, stop, and destroy VMs on demand
-- **Secret injection**: Ephemeral GitHub and Anthropic credentials injected at session time via tmpfs
-- **Workspace provisioning**: Clone repos and assign issues to agent slots across VMs
-- **Agent dispatch**: Launch Claude Code agents via SSH with isolated user accounts
-- **/dispatch command**: One-command interface to orchestrate the full pipeline
+## Overview
+
+The dispatch pipeline runs entirely from your local machine via SSH:
+
+1. **Create** cx22 VMs from a pre-baked Hetzner snapshot (30-90 seconds boot)
+2. **Inject** credentials at session time via tmpfs (never in git or cloud-init)
+3. **Provision** a git clone per agent slot with an issue assignment
+4. **Launch** Claude Code via SSH into a named tmux session
+5. **Monitor** via `/dispatch-status` or `agent-status.sh --all`
+6. **Collect** PR URLs and commit hashes when work is done
+7. **Destroy** VMs to stop billing
 
 ## Prerequisites
 
 | Tool | Install | Purpose |
 |------|---------|---------|
 | `hcloud` | `brew install hcloud` | Hetzner Cloud CLI |
-| `terraform` | `brew install terraform` | (optional) Infrastructure as code |
+| `terraform` | `brew install terraform` | Infrastructure provisioning (optional) |
 | `packer` | `brew install packer` | Build golden images |
 | `gh` | `brew install gh` | GitHub CLI |
+| `jq` | `brew install jq` | JSON parsing |
 
 You also need:
+
 - A [Hetzner Cloud](https://console.hetzner.cloud) account with an API token
-- An [Anthropic API key](https://console.anthropic.com) for agents
-- A GitHub fine-grained PAT with `contents:write` and `pull_requests:write`
+- An [Anthropic API key](https://console.anthropic.com) for agents, or an active Claude Max subscription
+- A GitHub fine-grained PAT with `contents:write` and `pull_requests:write` scoped to the target repo
+- `ssh-agent` running with `SSH_AUTH_SOCK` set
 
 Set your Hetzner token:
+
 ```bash
 export HCLOUD_TOKEN=your-token-here
-# Or: hcloud context create my-project
+# Or use named contexts:
+hcloud context create my-project
 ```
 
 ## Quick Start
@@ -41,127 +51,288 @@ packer init agent-image.pkr.hcl
 HCLOUD_TOKEN=$HCLOUD_TOKEN packer build agent-image.pkr.hcl
 ```
 
-Build takes 5-10 minutes. Creates a snapshot named `ccgm-agent-1.0.0` in your Hetzner project.
+Build takes 5-10 minutes. Creates a Hetzner snapshot labeled `purpose=ccgm-agent`.
 
-### 2. Dispatch Issues
+### 2. (Optional) Apply Terraform Infrastructure
+
+```bash
+cd modules/cloud-dispatch/terraform
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your SSH public key and firewall settings
+terraform init
+terraform apply
+```
+
+This creates the named SSH key and firewall rules in Hetzner that the VM scripts expect.
+
+### 3. Dispatch Issues
 
 In Claude Code, run:
+
 ```
 /dispatch owner/repo --issues 42,43,44
 ```
 
-This will:
-1. Spin up 3 VMs (or reuse existing ones)
-2. Inject your credentials securely
-3. Clone the repo and assign one issue per agent
-4. Launch 3-12 parallel Claude Code agents
-5. Report back which agent got which issue
+Or run the pipeline directly:
 
-### 3. Monitor Progress
+```bash
+# Create VMs
+bash lib/vm-create.sh 1
+
+# Initialize session credentials
+bash lib/secrets-init.sh
+
+# Inject GitHub token into all agents
+GITHUB_TOKEN=$(gh auth token)
+bash lib/secrets-inject-all.sh --github-token "$GITHUB_TOKEN"
+
+# Clone repo and assign issues
+bash lib/workspace-setup-all.sh "https://github.com/owner/repo.git" --issues "42,43"
+
+# Launch agents
+bash lib/agent-launch-all.sh --max-turns 200
+```
+
+### 4. Monitor Progress
 
 ```
 /dispatch-status
 ```
 
-### 4. Collect and Clean Up
+Or directly:
+
+```bash
+bash lib/agent-status.sh --all
+```
+
+### 5. Collect Results and Clean Up
 
 ```
 /dispatch-stop
 ```
 
+Or directly:
+
+```bash
+bash lib/workspace-collect.sh --all
+bash lib/agent-stop.sh --all
+bash lib/secrets-cleanup.sh
+bash lib/vm-destroy.sh --all --force
+```
+
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| `/dispatch` | Dispatch GitHub issues to cloud agents |
-| `/dispatch-status` | Check agent status and collect PR URLs |
-| `/dispatch-stop` | Stop agents, optionally destroy VMs |
-| `/vm-manage` | Low-level VM management (create/destroy/status/ssh) |
+### /dispatch
+
+Orchestrates the full pipeline: creates VMs if needed, injects credentials, provisions workspaces, and launches agents.
+
+```
+/dispatch owner/repo --issues 42,43,44
+/dispatch owner/repo --issues 42,43,44 --vm-count 2 --max-turns 100
+```
+
+Arguments extracted from the message:
+
+- `REPO` - GitHub repo in `owner/repo` format
+- `ISSUES` - Comma-separated issue numbers
+- `VM_COUNT` - Number of VMs to create (default: 3, or ceil(issues/4), whichever is smaller)
+- `MAX_TURNS` - Max turns per agent (default: 200)
+
+### /dispatch-status
+
+Checks the status of all running agents and reports PR URLs, last log line, and elapsed time.
+
+```
+/dispatch-status
+```
+
+### /dispatch-stop
+
+Stops all running agents and optionally destroys VMs.
+
+```
+/dispatch-stop
+/dispatch-stop --destroy    # also destroys VMs after stopping
+```
+
+### /vm-manage
+
+Low-level VM management. Accepts sub-commands:
+
+| Sub-command | Description |
+|-------------|-------------|
+| `create [N]` | Create N VMs from golden image (default: 3) |
+| `destroy [--all \| name]` | Destroy one or all VMs |
+| `status` | List all VMs with state and IP |
+| `health` | Run health checks on all VMs |
+| `ssh <name>` | Open SSH session into a named VM |
 
 ## Architecture
 
+### System Overview
+
 ```
-Orchestrator (local Claude Code)
+MacBook (orchestrator)
   |
   +-- /dispatch owner/repo --issues 42,43,44
         |
-        +-- vm-create.sh          # 3x cx22 VMs boot from golden snapshot
-        +-- secrets-inject-all.sh # GitHub PAT + Anthropic key -> /run/secrets/agent-N/
+        +-- vm-create.sh          # Boot cx22 VMs from golden snapshot
+        +-- secrets-init.sh       # Generate session SSH keypair
+        +-- secrets-inject-all.sh # GitHub PAT -> /run/secrets/agent-N/ on each VM
         +-- workspace-setup-all.sh# git clone + issue assignment per agent slot
         +-- agent-launch-all.sh   # SSH -> tmux -> claude --dangerously-skip-permissions
               |
-              +-- VM 1: agent-0 (issue 42), agent-1 (issue 43)
-              +-- VM 2: agent-2 (issue 44), agent-3 (idle)
-              +-- VM 3: idle
+              +-- VM 1 (fsn1): agent-0 (issue 42), agent-1 (issue 43)
+              +-- VM 2 (nbg1): agent-2 (issue 44), agent-3 (idle)
+              +-- VM 3 (hel1): idle
 ```
 
-Each VM runs Ubuntu 22.04 LTS with 4 isolated agent user accounts (`agent-0` through `agent-3`). Agents run inside tmux sessions for persistence across SSH disconnects.
+VMs are spread round-robin across three Hetzner datacenters (fsn1, nbg1, hel1) for availability.
+
+### VM Layout
+
+Each VM runs Ubuntu 22.04 LTS with 4 isolated agent user accounts:
+
+```
+/
++-- home/
+|   +-- agent-0/         # agent user 0
+|   |   +-- workspace/   # git clone lives here
+|   |   +-- assignment.json  # issue metadata
+|   |   +-- status       # AGENT_RUNNING / AGENT_STOPPED / AGENT_TIMEOUT
+|   |   +-- run.log      # stdout from claude process
+|   +-- agent-1/  ...
+|   +-- agent-2/  ...
+|   +-- agent-3/  ...
++-- opt/
+|   +-- ccgm/
+|       +-- auto-shutdown.sh  # cron: idle shutdown after 15m, forced after 8h
++-- run/
+|   +-- secrets/         # tmpfs - credentials live here only at runtime
+|       +-- agent-0/
+|       |   +-- github_token
+|       |   +-- claude_auth
+|       +-- agent-1/ ...
++-- var/
+    +-- lib/ccgm/        # auto-shutdown state (last-active, vm-start timestamps)
+    +-- log/ccgm-shutdown.log
+```
+
+### Security Model
+
+- **Credentials not in git or cloud-init**: GitHub PAT and Anthropic key are injected at session time via SSH, written only to `tmpfs` at `/run/secrets/agent-N/`
+- **Ephemeral session keys**: `secrets-init.sh` generates a per-session ed25519 keypair, loads it into ssh-agent, and registers the public key with Hetzner. `secrets-cleanup.sh` revokes it.
+- **Agent isolation**: Each agent runs as a dedicated Linux user with no sudo access, `chmod 700` home directory, and `HISTFILE=/dev/null`
+- **Network egress allowlist**: iptables rules allow only `github.com` (TCP 443+22), `api.anthropic.com` (TCP 443), and `registry.npmjs.org` (TCP 443)
+- **Hetzner metadata API blocked**: The metadata endpoint (169.254.169.254) is blocked for non-root processes
+- **Fine-grained PAT scoping**: Scope the GitHub token to the specific repo being worked on
+
+### Network
+
+The Terraform config creates a Hetzner firewall (`ccgm-dispatch-firewall`) that:
+
+- Allows inbound SSH (port 22) from any source
+- Blocks all other inbound traffic
+
+On each VM, iptables rules (set by the golden image security hardening script) control egress:
+
+- Allowlisted outbound: `github.com`, `api.anthropic.com`, `registry.npmjs.org`
+- Everything else blocked for non-root users
 
 ### VM Sizing
 
-| VM Type | vCPU | RAM | Price/hr | Agents |
-|---------|------|-----|----------|--------|
-| cx22 | 2 | 4 GB | ~$0.005 | 2-4 |
+| VM Type | vCPU | RAM | Price/hr | Recommended agents |
+|---------|------|-----|----------|--------------------|
+| cx22 | 2 | 4 GB | ~$0.005 | 1-2 |
 | cx32 | 4 | 8 GB | ~$0.010 | 4 |
-| cx42 | 8 | 16 GB | ~$0.020 | 4-8 |
+| ccx63 | 48 | 192 GB | ~$0.80 | 4 (memory-rich) |
 
-Default: cx22. Override in `lib/common.sh`.
+Default is `ccx63` (set in `lib/common.sh` as `CCGM_SERVER_TYPE`). Override with:
+
+```bash
+CCGM_SERVER_TYPE=cx22 bash lib/vm-create.sh 3
+```
 
 ### Cost Reference
 
-| Session | VMs | Duration | Estimated Cost |
-|---------|-----|----------|----------------|
-| Small (3 issues) | 1 VM | 2 hr | ~$0.01 |
-| Medium (12 issues) | 3 VMs | 4 hr | ~$0.06 |
-| Large (24 issues) | 6 VMs | 4 hr | ~$0.12 |
+Cost depends on VM type, session length, and whether you're using a Claude API key or Max subscription. VM costs only (Claude API/Max subscription is separate):
 
-VMs are billed per hour. Destroy them when done to stop charges.
+| VM type | VMs | Hours/day | VM cost/month estimate |
+|---------|-----|-----------|------------------------|
+| cx22 | 3 | 8 | ~$4 |
+| cx32 | 3 | 8 | ~$7 |
+| ccx63 | 3 | 8 | ~$580 |
 
-## Security Model
+VMs are billed per second on Hetzner. Destroy them when done to stop charges. The auto-shutdown cron job on each VM shuts it down after 15 minutes of inactivity or 8 hours of wall-clock time (whichever comes first).
 
-- **No secrets in git or cloud-init**: GitHub PAT and Anthropic key are injected at session time via SSH, written only to `tmpfs` at `/run/secrets/agent-N/`
-- **Ephemeral SSH keys**: A session keypair is generated locally, pushed to VMs, and revoked by `secrets-cleanup.sh`
-- **Agent isolation**: Each agent runs as a dedicated Linux user with no sudo access, `chmod 700` home dir, and `HISTFILE=/dev/null`
-- **Network egress allowlist**: iptables rules allow only github.com (TCP 443+22), api.anthropic.com (TCP 443), and registry.npmjs.org (TCP 443)
-- **Metadata API blocked**: The Hetzner metadata endpoint (169.254.169.254) is blocked for non-root processes
-- **Fine-grained PAT**: Scope the GitHub token to the specific repo being worked on
+## Script Reference
 
-## Lib Scripts
+### VM Lifecycle
 
-| Script | Description |
-|--------|-------------|
-| `lib/common.sh` | Shared config, SSH helpers, logging |
-| `lib/vm-create.sh` | Boot N VMs from golden snapshot |
-| `lib/vm-destroy.sh` | Destroy VMs (--all or by name) |
-| `lib/vm-status.sh` | List VMs with state and IP |
-| `lib/vm-health.sh` | SSH reachability + agent user checks |
-| `lib/vm-ssh.sh` | Interactive SSH into a named VM |
-| `lib/secrets-init.sh` | Generate session SSH keypair |
-| `lib/secrets-inject.sh` | Inject credentials to one VM |
-| `lib/secrets-inject-all.sh` | Inject credentials to all VMs |
-| `lib/secrets-cleanup.sh` | Revoke session keys, clear tmpfs |
-| `lib/secrets-rotate.sh` | Rotate credentials without destroying VMs |
-| `lib/workspace-setup.sh` | Clone repo + assign issue on one VM |
-| `lib/workspace-setup-all.sh` | Set up workspaces across all VMs |
-| `lib/workspace-assign.sh` | Assign a specific issue to an agent slot |
-| `lib/workspace-collect.sh` | Pull PR URLs and results from VMs |
-| `lib/workspace-cleanup.sh` | Remove workspace dirs from VMs |
+| Script | Usage | Description |
+|--------|-------|-------------|
+| `lib/vm-create.sh` | `vm-create.sh [count] [--type TYPE]` | Boot N VMs from golden snapshot |
+| `lib/vm-destroy.sh` | `vm-destroy.sh --all [--force]` | Destroy VMs; prompts unless `--force` |
+| `lib/vm-status.sh` | `vm-status.sh` | List all ccgm-agent-* VMs with IP and state |
+| `lib/vm-health.sh` | `vm-health.sh --all` | SSH reachability + agent user + disk + memory |
+| `lib/vm-ssh.sh` | `vm-ssh.sh <name>` | Interactive SSH into a named VM |
 
-## Packer Golden Image
+### Secret Management
 
-### What's Baked In
+| Script | Usage | Description |
+|--------|-------|-------------|
+| `lib/secrets-init.sh` | `secrets-init.sh` | Generate session keypair, register with Hetzner |
+| `lib/secrets-inject.sh` | `secrets-inject.sh <ip> <agent-index> --github-token TOKEN` | Inject credentials to one agent slot |
+| `lib/secrets-inject-all.sh` | `secrets-inject-all.sh --github-token TOKEN` | Inject to all agents on all VMs |
+| `lib/secrets-cleanup.sh` | `secrets-cleanup.sh` | Revoke session key from Hetzner, clear tmpfs |
+| `lib/secrets-rotate.sh` | `secrets-rotate.sh --github-token TOKEN` | Rotate credentials without destroying VMs |
 
-| Component | Version |
-|-----------|---------|
-| OS | Ubuntu 22.04 LTS |
-| Node.js | 22 LTS (via NodeSource) |
-| pnpm | latest stable |
-| Claude Code CLI | pinned in `agent-image.pkr.hcl` |
-| Playwright + Chromium | pinned |
-| git, tmux, jq, curl | system packages |
-| Python 3 | system package |
+### Workspace Management
 
-### Build with Custom Versions
+| Script | Usage | Description |
+|--------|-------|-------------|
+| `lib/workspace-setup.sh` | `workspace-setup.sh <ip> <agent-index> <repo-url>` | Clone repo on one agent slot |
+| `lib/workspace-setup-all.sh` | `workspace-setup-all.sh <repo-url> --issues "42,43"` | Clone and assign across all VMs |
+| `lib/workspace-assign.sh` | `workspace-assign.sh <ip> <agent-index> <issue-num> <title>` | Write assignment.json to one slot |
+| `lib/workspace-collect.sh` | `workspace-collect.sh --all [--json]` | Pull PR URLs and git state from all agents |
+| `lib/workspace-cleanup.sh` | `workspace-cleanup.sh --all` | Remove workspace dirs from VMs |
+
+### Agent Management
+
+| Script | Usage | Description |
+|--------|-------|-------------|
+| `lib/agent-launch.sh` | `agent-launch.sh <ip> <agent-index> [--max-turns N]` | Launch one agent via SSH + tmux |
+| `lib/agent-launch-all.sh` | `agent-launch-all.sh [--max-turns N] [--jitter N] [--dry-run]` | Launch all assigned agents with jitter |
+| `lib/agent-status.sh` | `agent-status.sh --all` | Report status, issue, last log, PR URL per agent |
+| `lib/agent-stop.sh` | `agent-stop.sh --all` | Kill tmux sessions and write AGENT_STOPPED |
+| `lib/agent-collect.sh` | `agent-collect.sh --all [--json]` | Collect agent results (status, PR, log tail) |
+
+### VM Auto-Shutdown
+
+| Script | Location | Description |
+|--------|----------|-------------|
+| `lib/auto-shutdown.sh` | Installed on VM at `/opt/ccgm/auto-shutdown.sh` | Cron-based shutdown: idle after 15m, forced after 8h |
+
+Configure via environment variables on the VM (`/etc/ccgm/env`):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MAX_HOURS` | `8` | Wall-clock hours before forced shutdown |
+| `IDLE_MINUTES` | `15` | Minutes of no active tmux sessions before idle shutdown |
+
+## Golden Image
+
+### Building
+
+```bash
+cd modules/cloud-dispatch/packer
+packer init agent-image.pkr.hcl
+HCLOUD_TOKEN=$HCLOUD_TOKEN packer build agent-image.pkr.hcl
+```
+
+Build takes 5-10 minutes. Creates a Hetzner snapshot with label `purpose=ccgm-agent`. The `vm-create.sh` script selects the most recently created snapshot with this label.
+
+### Building with Custom Versions
 
 ```bash
 HCLOUD_TOKEN=$HCLOUD_TOKEN packer build \
@@ -171,29 +342,146 @@ HCLOUD_TOKEN=$HCLOUD_TOKEN packer build \
   packer/agent-image.pkr.hcl
 ```
 
+### When to Rebuild
+
+Rebuild the golden image when:
+
+- A new major version of Claude Code is released
+- Node.js LTS version changes
+- Security patches are needed (or allow unattended-upgrades to handle them)
+- Every 4-8 weeks as general maintenance
+
+### What Is Baked In
+
+| Component | Notes |
+|-----------|-------|
+| OS | Ubuntu 22.04 LTS |
+| Node.js | 22 LTS (via NodeSource) |
+| pnpm | Latest stable |
+| Claude Code CLI | Pinned version in `agent-image.pkr.hcl` |
+| Playwright + Chromium | Pinned version |
+| git, tmux, jq, curl, python3 | System packages |
+| Agent users | `agent-0` through `agent-3` created |
+| `/opt/ccgm/auto-shutdown.sh` | Installed and registered in cron |
+| iptables egress rules | Applied via security-hardening.sh |
+
 ### Packer Files
 
 | File | Description |
 |------|-------------|
 | `packer/agent-image.pkr.hcl` | Main Packer template |
 | `packer/scripts/install-tools.sh` | Node.js, pnpm, Claude Code, Playwright |
-| `packer/scripts/setup.sh` | Agent users, /opt/ccgm, SSH config |
-| `packer/scripts/security-hardening.sh` | iptables, sshd, unattended-upgrades |
+| `packer/scripts/setup.sh` | Agent users, `/opt/ccgm`, SSH config |
+| `packer/scripts/security-hardening.sh` | iptables, sshd hardening, unattended-upgrades |
 | `packer/scripts/validate.sh` | Post-build verification |
+
+## Terraform Infrastructure
+
+The Terraform config in `terraform/` creates Hetzner resources that the scripts depend on:
+
+- **SSH key** (`ccgm-dispatch-key`) - a placeholder used when creating VMs. The actual session key is generated by `secrets-init.sh`.
+- **Firewall** (`ccgm-dispatch-firewall`) - inbound SSH only, all other inbound blocked
+
+These resources are optional if you create them manually in the Hetzner dashboard, but Terraform makes it reproducible.
+
+```bash
+cd modules/cloud-dispatch/terraform
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars
+terraform init && terraform apply
+```
+
+## Jitter
+
+The `--jitter` option in `agent-launch-all.sh` (default: 90 seconds) staggers agent starts to avoid simultaneous Claude API requests hitting the rate limiter. With 4 agents and a 90s max jitter, total launch time is up to 4.5 minutes.
+
+Increase jitter if you see rate limit errors. Set to 0 to disable (not recommended with more than 2 agents).
+
+## E2E Testing
+
+A manual end-to-end test script is provided at `tests/e2e-dispatch.sh`. It validates the full pipeline against real Hetzner infrastructure.
+
+```bash
+# Preview without executing (no cost)
+bash tests/e2e-dispatch.sh --dry-run
+
+# Full run (~$2-3 cost, auto-cleans up)
+bash tests/e2e-dispatch.sh
+
+# Leave VMs running after test (for manual inspection)
+bash tests/e2e-dispatch.sh --skip-cleanup
+```
+
+Prerequisites: `HCLOUD_TOKEN` set, golden image built, `gh` authenticated, `ssh-agent` running.
 
 ## Troubleshooting
 
-**"hcloud not authenticated"**
+### "hcloud not authenticated"
+
 Set `HCLOUD_TOKEN` in your environment or run `hcloud context create`.
 
-**"No snapshot found matching ccgm-agent-*"**
-Build the golden image first: `packer build packer/agent-image.pkr.hcl`.
+### "No snapshot found matching label purpose=ccgm-agent"
 
-**VM boots but health check fails**
-SSH may not be ready yet. Wait 60 seconds and retry `/vm-manage health`. If it persists, check the VM console in the Hetzner dashboard.
+Build the golden image first:
 
-**Agent exits immediately**
-Check that secrets were injected: `bash lib/vm-ssh.sh VM_NAME "ls /run/secrets/agent-0/"`. If empty, rerun `secrets-inject-all.sh`.
+```bash
+cd packer && packer build agent-image.pkr.hcl
+```
 
-**Rate limit errors across agents**
-The `--jitter` flag in `agent-launch-all.sh` staggers agent starts. Increase the jitter value (default 75 seconds) if hitting API rate limits.
+### VM boots but health check fails
+
+SSH may not be ready yet. Wait 60 seconds and retry `/vm-manage health`. Check whether the VM console in the Hetzner dashboard shows a boot error.
+
+### Agent exits immediately after launch
+
+Check that secrets were injected:
+
+```bash
+bash lib/vm-ssh.sh VM_NAME "ls /run/secrets/agent-0/"
+```
+
+If the directory is empty, rerun `secrets-inject-all.sh`.
+
+### "SSH_AUTH_SOCK is not set"
+
+`secrets-init.sh` requires a running `ssh-agent`. Start one:
+
+```bash
+eval "$(ssh-agent -s)"
+```
+
+Then rerun `secrets-init.sh`.
+
+### Rate limit errors across agents
+
+Increase the `--jitter` value when launching:
+
+```bash
+bash lib/agent-launch-all.sh --jitter 120
+```
+
+The default is 90 seconds. At 120 seconds, 4 agents take up to 6 minutes to start.
+
+### "No running ccgm-agent-* VMs found"
+
+Run `vm-status.sh` to see VM states. VMs may have auto-shutdown. Create new ones with `vm-create.sh`.
+
+### Secrets-cleanup fails to find session file
+
+If `/tmp/ccgm-session.json` was removed (e.g., VM reboot), manually delete the session key from Hetzner:
+
+```bash
+hcloud ssh-key list
+hcloud ssh-key delete ccgm-session-TIMESTAMP
+```
+
+## Manual Installation
+
+If you are not using the CCGM installer, copy these files manually:
+
+1. Copy `modules/cloud-dispatch/` to a location of your choice
+2. Copy `modules/cloud-dispatch/commands/*.md` to `~/.claude/commands/`
+3. Copy `modules/cloud-dispatch/rules/cloud-dispatch.md` to `~/.claude/rules/`
+4. Ensure all scripts in `lib/` are executable: `chmod +x lib/*.sh`
+5. Set `HCLOUD_TOKEN` in your environment
+6. Build the golden image (see Quick Start)

--- a/modules/cloud-dispatch/tests/e2e-dispatch.sh
+++ b/modules/cloud-dispatch/tests/e2e-dispatch.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# E2E test for the cloud-dispatch module.
+#
+# This test validates the full dispatch pipeline end-to-end against real
+# Hetzner Cloud infrastructure.
+#
+# COST WARNING: This test creates REAL VMs and costs REAL money (~$2-3 for a
+# full run). Always run with --dry-run first to preview what will happen.
+#
+# Prerequisites:
+#   - HCLOUD_TOKEN set to a valid Hetzner Cloud API token
+#   - hcloud CLI installed (brew install hcloud)
+#   - gh CLI installed and authenticated (brew install gh)
+#   - jq installed (brew install jq)
+#   - ssh-agent running with SSH_AUTH_SOCK set
+#   - Golden image built (cd packer && packer build agent-image.pkr.hcl)
+#
+# Usage:
+#   bash tests/e2e-dispatch.sh              # Full run with cleanup
+#   bash tests/e2e-dispatch.sh --dry-run    # Preview steps without executing
+#   bash tests/e2e-dispatch.sh --skip-cleanup  # Leave VMs running after test
+#
+# Environment variables:
+#   E2E_TEST_REPO   GitHub repo to use (default: lucasmccomb/ccgm)
+#   E2E_VM_COUNT    Number of VMs to create (default: 1)
+#   E2E_MAX_TURNS   Max agent turns before stopping (default: 10)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/lib/common.sh"
+
+TEST_REPO="${E2E_TEST_REPO:-lucasmccomb/ccgm}"
+VM_COUNT="${E2E_VM_COUNT:-1}"
+MAX_TURNS="${E2E_MAX_TURNS:-10}"
+
+DRY_RUN=false
+SKIP_CLEANUP=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)      DRY_RUN=true;      shift ;;
+    --skip-cleanup) SKIP_CLEANUP=true; shift ;;
+    --repo)         TEST_REPO="$2";    shift 2 ;;
+    --vm-count)     VM_COUNT="$2";     shift 2 ;;
+    --max-turns)    MAX_TURNS="$2";    shift 2 ;;
+    --help|-h)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -30
+      exit 0
+      ;;
+    *)
+      log_error "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Cleanup tracking
+# ---------------------------------------------------------------------------
+
+TEST_ISSUE=""
+
+cleanup_test_resources() {
+  if [[ "${SKIP_CLEANUP}" == "true" ]]; then
+    log_warn "Skipping cleanup (--skip-cleanup). Remember to run vm-destroy.sh --all --force manually!"
+    return 0
+  fi
+
+  log_info "Cleaning up test resources..."
+
+  bash "${SCRIPT_DIR}/lib/agent-stop.sh" --all 2>/dev/null || true
+  bash "${SCRIPT_DIR}/lib/secrets-cleanup.sh" 2>/dev/null || true
+  bash "${SCRIPT_DIR}/lib/vm-destroy.sh" --all --force 2>/dev/null || true
+
+  if [[ -n "${TEST_ISSUE}" ]]; then
+    gh issue close "${TEST_ISSUE}" \
+      --repo "${TEST_REPO}" \
+      --comment "E2E test complete - closing automatically" \
+      2>/dev/null || true
+    log_info "Closed test issue #${TEST_ISSUE}"
+  fi
+
+  log_success "Cleanup complete"
+}
+
+register_cleanup cleanup_test_resources
+
+# ---------------------------------------------------------------------------
+# Test header
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "${_COLOR_BOLD}=== Cloud Dispatch E2E Test ===${_COLOR_RESET}"
+echo ""
+log_info "Repo:       ${TEST_REPO}"
+log_info "VM count:   ${VM_COUNT}"
+log_info "Max turns:  ${MAX_TURNS}"
+log_info "Dry run:    ${DRY_RUN}"
+echo ""
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  log_warn "DRY RUN MODE: steps will be printed but not executed"
+  echo ""
+fi
+
+# ---------------------------------------------------------------------------
+# Helper: run or print a command depending on --dry-run
+# ---------------------------------------------------------------------------
+
+run_step() {
+  local description="$1"
+  shift
+  log_info "${description}"
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "  [dry-run] would run: $*"
+    return 0
+  fi
+  "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: Validate prerequisites
+# ---------------------------------------------------------------------------
+
+log_info "Step 1: Checking prerequisites..."
+
+require_cmd hcloud
+require_cmd gh
+require_cmd jq
+require_cmd ssh
+require_cmd ssh-add
+
+if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+  log_error "HCLOUD_TOKEN is not set. Export it before running this test."
+  exit 1
+fi
+
+if [[ -z "${SSH_AUTH_SOCK:-}" ]]; then
+  log_error "SSH_AUTH_SOCK is not set. Start ssh-agent and retry."
+  exit 1
+fi
+
+if ! hcloud server-type list >/dev/null 2>&1; then
+  log_error "hcloud CLI cannot reach the Hetzner API. Check HCLOUD_TOKEN."
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  log_error "gh CLI is not authenticated. Run: gh auth login"
+  exit 1
+fi
+
+log_success "Step 1: Prerequisites OK"
+
+# ---------------------------------------------------------------------------
+# Step 2: Check for golden image
+# ---------------------------------------------------------------------------
+
+log_info "Step 2: Checking for golden image snapshot..."
+
+if [[ "${DRY_RUN}" == "false" ]]; then
+  IMAGE_ID="$(latest_image_id 2>/dev/null || true)"
+  if [[ -z "${IMAGE_ID}" ]]; then
+    log_error "No golden image found (label selector: ${CCGM_IMAGE_LABEL})."
+    log_error "Build one first:"
+    log_error "  cd ${SCRIPT_DIR}/packer && packer build agent-image.pkr.hcl"
+    exit 1
+  fi
+  log_success "Step 2: Golden image found: ${IMAGE_ID}"
+else
+  log_info "  [dry-run] would check for snapshot with label ${CCGM_IMAGE_LABEL}"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: Create test VM(s)
+# ---------------------------------------------------------------------------
+
+run_step "Step 3: Creating ${VM_COUNT} test VM(s)..." \
+  bash "${SCRIPT_DIR}/lib/vm-create.sh" "${VM_COUNT}"
+
+# ---------------------------------------------------------------------------
+# Step 4: Health check VM(s)
+# ---------------------------------------------------------------------------
+
+run_step "Step 4: Health checking VM(s)..." \
+  bash "${SCRIPT_DIR}/lib/vm-health.sh" --all
+
+# ---------------------------------------------------------------------------
+# Step 5: Initialize session secrets
+# ---------------------------------------------------------------------------
+
+run_step "Step 5: Initializing session secrets..." \
+  bash "${SCRIPT_DIR}/lib/secrets-init.sh"
+
+# ---------------------------------------------------------------------------
+# Step 6: Inject secrets
+# ---------------------------------------------------------------------------
+
+if [[ "${DRY_RUN}" == "false" ]]; then
+  log_info "Step 6: Injecting secrets into agents..."
+  GITHUB_TOKEN="$(gh auth token)"
+  bash "${SCRIPT_DIR}/lib/secrets-inject-all.sh" --github-token "${GITHUB_TOKEN}"
+  log_success "Step 6: Secrets injected"
+else
+  log_info "  [dry-run] would run: secrets-inject-all.sh --github-token <token>"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 7: Create test issue and set up workspaces
+# ---------------------------------------------------------------------------
+
+if [[ "${DRY_RUN}" == "false" ]]; then
+  log_info "Step 7: Creating test GitHub issue..."
+  TEST_ISSUE="$(gh issue create \
+    --repo "${TEST_REPO}" \
+    --title "E2E test: cloud-dispatch validation (safe to close)" \
+    --body "Automated E2E test issue created by tests/e2e-dispatch.sh. Safe to close." \
+    2>&1 | grep -oE '[0-9]+$')"
+
+  if [[ -z "${TEST_ISSUE}" ]]; then
+    log_error "Failed to create test issue on ${TEST_REPO}"
+    exit 1
+  fi
+  log_info "Created test issue #${TEST_ISSUE} on ${TEST_REPO}"
+
+  log_info "Step 7: Setting up workspace for issue #${TEST_ISSUE}..."
+  bash "${SCRIPT_DIR}/lib/workspace-setup-all.sh" \
+    "https://github.com/${TEST_REPO}.git" \
+    --issues "${TEST_ISSUE}"
+  log_success "Step 7: Workspace set up"
+else
+  log_info "  [dry-run] would create test issue on ${TEST_REPO}"
+  log_info "  [dry-run] would run: workspace-setup-all.sh https://github.com/${TEST_REPO}.git --issues <number>"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 8: Launch agent(s)
+# ---------------------------------------------------------------------------
+
+run_step "Step 8: Launching test agent(s) (max-turns=${MAX_TURNS})..." \
+  bash "${SCRIPT_DIR}/lib/agent-launch-all.sh" \
+    --max-turns "${MAX_TURNS}" \
+    --jitter 0
+
+# ---------------------------------------------------------------------------
+# Step 9: Wait and check status
+# ---------------------------------------------------------------------------
+
+if [[ "${DRY_RUN}" == "false" ]]; then
+  log_info "Step 9: Waiting 30s then checking agent status..."
+  sleep 30
+  bash "${SCRIPT_DIR}/lib/agent-status.sh" --all
+  log_success "Step 9: Status check complete"
+else
+  log_info "  [dry-run] would wait 30s then run: agent-status.sh --all"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 10: Collect results
+# ---------------------------------------------------------------------------
+
+run_step "Step 10: Collecting results from agents..." \
+  bash "${SCRIPT_DIR}/lib/workspace-collect.sh" --all
+
+# ---------------------------------------------------------------------------
+# Test complete
+# ---------------------------------------------------------------------------
+
+echo ""
+log_success "=== E2E Test Complete ==="
+echo ""
+
+if [[ "${SKIP_CLEANUP}" == "true" ]]; then
+  log_warn "VMs are still running. Destroy them when done:"
+  log_warn "  bash ${SCRIPT_DIR}/lib/vm-destroy.sh --all --force"
+fi


### PR DESCRIPTION
Closes #221

## Summary

- Adds `modules/cloud-dispatch/tests/e2e-dispatch.sh`: a manual end-to-end test script that validates the full dispatch pipeline (VM create, health check, secrets init/inject, workspace setup, agent launch, status check, collect, cleanup) against real Hetzner infrastructure
- Updates `modules/cloud-dispatch/README.md`: expands the existing docs with full architecture diagrams, VM layout, security model details, per-script reference tables, Terraform section, jitter explanation, and troubleshooting guide

## Test plan

- [ ] Shellcheck passes on `tests/e2e-dispatch.sh` (verified locally: no errors)
- [ ] `--dry-run` flag prints all steps without executing
- [ ] `--skip-cleanup` flag skips VM destruction
- [ ] README sections match actual scripts in `lib/` (cross-checked all script names and flags)
- [ ] No personal data or hardcoded tokens in either file