### PR TITLE
#220: add cost control, recovery, and budget tracking

### DIFF
--- a/modules/cloud-dispatch/lib/budget-track.sh
+++ b/modules/cloud-dispatch/lib/budget-track.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+# budget-track.sh — Track VM costs for CCGM cloud-dispatch sessions.
+#
+# Usage:
+#   budget-track.sh start
+#   budget-track.sh stop
+#   budget-track.sh status
+#   budget-track.sh report
+#
+# Subcommands:
+#   start   Record session start time and active VM details to BUDGET_FILE.
+#   stop    Finalize session cost and append to MONTHLY_FILE.
+#   status  Print current session runtime and running cost estimate.
+#   report  Print full cost report for the current month.
+#
+# State files:
+#   /tmp/ccgm-budget.json         Current session data
+#   /tmp/ccgm-budget-monthly.json Monthly session log (append-only array)
+#
+# Hourly rates (USD, approximate EUR->USD at 1.08):
+#   CCX63: $0.58/hr  (48 vCPU, 192 GB)
+#   CCX43: $0.28/hr  (16 vCPU,  64 GB)
+#   CCX33: $0.20/hr  ( 8 vCPU,  32 GB)
+#
+# Requires: jq, hcloud (for start subcommand)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+BUDGET_FILE="${CCGM_BUDGET_FILE:-/tmp/ccgm-budget.json}"
+MONTHLY_FILE="${CCGM_MONTHLY_FILE:-/tmp/ccgm-budget-monthly.json}"
+MONTHLY_BUDGET_USD="${CCGM_MONTHLY_BUDGET:-2000}"
+CLAUDE_MAX_USD="${CCGM_CLAUDE_MAX_USD:-200}"
+
+# Hourly rates by server type (USD)
+declare -A HOURLY_RATES=(
+  [ccx63]="0.58"
+  [ccx43]="0.28"
+  [ccx33]="0.20"
+)
+DEFAULT_RATE="0.58"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+  echo "Usage: $0 <start|stop|status|report>" >&2
+  exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+SUBCOMMAND="$1"
+shift
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+require_cmd jq
+
+# hourly_rate <server-type> — print the USD/hr rate for a given server type
+hourly_rate() {
+  local stype
+  stype=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+  echo "${HOURLY_RATES[$stype]:-${DEFAULT_RATE}}"
+}
+
+# now_iso — current UTC time in ISO 8601 format
+now_iso() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# now_epoch — current time as Unix epoch seconds
+now_epoch() {
+  date +%s
+}
+
+# iso_to_epoch <iso-string> — convert ISO 8601 UTC string to epoch seconds
+iso_to_epoch() {
+  python3 -c "
+from datetime import datetime, timezone
+s = '$1'.replace('Z', '+00:00')
+try:
+    dt = datetime.fromisoformat(s)
+    print(int(dt.timestamp()))
+except Exception:
+    print(0)
+"
+}
+
+# elapsed_human <start_epoch> — return human-readable elapsed time
+elapsed_human() {
+  local start="$1"
+  local now
+  now=$(now_epoch)
+  local total=$(( now - start ))
+  local h=$(( total / 3600 ))
+  local m=$(( (total % 3600) / 60 ))
+  if [[ ${h} -gt 0 ]]; then
+    echo "${h}h ${m}m"
+  else
+    echo "${m}m"
+  fi
+}
+
+# session_id — generate a session ID from current timestamp
+session_id() {
+  date -u +"%Y%m%d-%H%M%S"
+}
+
+# current_month — YYYY-MM
+current_month() {
+  date -u +"%Y-%m"
+}
+
+# month_label — "Month YYYY" format for display
+month_label() {
+  date -u +"%B %Y"
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: start
+# ---------------------------------------------------------------------------
+cmd_start() {
+  require_cmd hcloud
+
+  if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+    log_error "HCLOUD_TOKEN is not set. Cannot list VMs."
+    exit 1
+  fi
+
+  log_info "Scanning for running ccgm-agent-* VMs..."
+
+  # Collect VM details via hcloud
+  local vm_json
+  vm_json=$(hcloud server list --output json 2>/dev/null \
+    | python3 -c "
+import json, sys
+servers = json.load(sys.stdin)
+result = []
+for s in servers:
+    name = s.get('name', '')
+    if not name.startswith('ccgm-agent'):
+        continue
+    if s.get('status', '') != 'running':
+        continue
+    stype = ''
+    st = s.get('server_type', {})
+    if st:
+        stype = st.get('name', '')
+    created = s.get('created', '')
+    result.append({'name': name, 'type': stype, 'started_at': created})
+print(json.dumps(result))
+" 2>/dev/null || echo "[]")
+
+  local sid
+  sid=$(session_id)
+  local ts
+  ts=$(now_iso)
+
+  # Build per-VM entries with hourly rates using jq
+  local rate_map_json
+  rate_map_json=$(jq -n \
+    --argjson ccx63 "${HOURLY_RATES[ccx63]:-${DEFAULT_RATE}}" \
+    --argjson ccx43 "${HOURLY_RATES[ccx43]:-${DEFAULT_RATE}}" \
+    --argjson ccx33 "${HOURLY_RATES[ccx33]:-${DEFAULT_RATE}}" \
+    '{ccx63: $ccx63, ccx43: $ccx43, ccx33: $ccx33}')
+
+  local default_rate="${DEFAULT_RATE}"
+  local vms_json
+  vms_json=$(echo "${vm_json}" | jq \
+    --argjson rates "${rate_map_json}" \
+    --argjson default_rate "${default_rate}" \
+    --arg fallback_ts "${ts}" \
+    '[.[] | {
+       name: .name,
+       type: (.type | ascii_downcase),
+       hourly_rate: ($rates[(.type | ascii_downcase)] // $default_rate),
+       started_at: (if .started_at == "" or .started_at == null then $fallback_ts else .started_at end)
+     }]' 2>/dev/null || echo "[]")
+
+  jq -n \
+    --arg sid "${sid}" \
+    --arg ts "${ts}" \
+    --argjson vms "${vms_json}" \
+    '{
+      session_id: $sid,
+      started_at: $ts,
+      vms: $vms,
+      vm_hours_total: 0,
+      estimated_cost_usd: 0
+    }' > "${BUDGET_FILE}"
+
+  local vm_count
+  vm_count=$(jq '.vms | length' "${BUDGET_FILE}")
+  log_success "Session ${sid} started. Tracking ${vm_count} VM(s)."
+  echo "  Budget file: ${BUDGET_FILE}"
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: stop
+# ---------------------------------------------------------------------------
+cmd_stop() {
+  if [[ ! -f "${BUDGET_FILE}" ]]; then
+    log_error "No active session found at ${BUDGET_FILE}. Run 'start' first."
+    exit 1
+  fi
+
+  local now_ts
+  now_ts=$(now_iso)
+
+  # Calculate total VM-hours and cost
+  local total_hours total_cost
+  total_hours=$(jq --arg now "${now_ts}" '
+    [.vms[] |
+      (($now | gsub("Z$";"") | strptime("%Y-%m-%dT%H:%M:%S") | mktime) -
+       (.started_at | gsub("Z$";"") | strptime("%Y-%m-%dT%H:%M:%S") | mktime)) / 3600
+    ] | add // 0
+  ' "${BUDGET_FILE}" 2>/dev/null || echo "0")
+
+  total_cost=$(jq --arg now "${now_ts}" '
+    [.vms[] |
+      ((($now | gsub("Z$";"") | strptime("%Y-%m-%dT%H:%M:%S") | mktime) -
+        (.started_at | gsub("Z$";"") | strptime("%Y-%m-%dT%H:%M:%S") | mktime)) / 3600) * .hourly_rate
+    ] | add // 0
+  ' "${BUDGET_FILE}" 2>/dev/null || echo "0")
+
+  # Update session file with final values
+  local session_data
+  session_data=$(jq \
+    --arg stopped "${now_ts}" \
+    --argjson hours "${total_hours}" \
+    --argjson cost "${total_cost}" \
+    '. + {stopped_at: $stopped, vm_hours_total: $hours, estimated_cost_usd: $cost}' \
+    "${BUDGET_FILE}")
+
+  # Append to monthly log
+  local month
+  month=$(current_month)
+
+  if [[ ! -f "${MONTHLY_FILE}" ]]; then
+    echo '{"sessions": []}' > "${MONTHLY_FILE}"
+  fi
+
+  jq --argjson entry "${session_data}" --arg month "${month}" \
+    '.sessions += [$entry] | .last_updated = now | .month = $month' \
+    "${MONTHLY_FILE}" > "${MONTHLY_FILE}.tmp" && mv "${MONTHLY_FILE}.tmp" "${MONTHLY_FILE}"
+
+  # Print session summary
+  local sid
+  sid=$(jq -r '.session_id' "${BUDGET_FILE}")
+  printf "\nSession %s complete.\n" "${sid}"
+  printf "  VM-hours:  %.2f\n" "${total_hours}"
+  printf "  Cost:      \$%.2f\n" "${total_cost}"
+  printf "  Saved to:  %s\n\n" "${MONTHLY_FILE}"
+
+  # Clean up session file
+  rm -f "${BUDGET_FILE}"
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: status
+# ---------------------------------------------------------------------------
+cmd_status() {
+  if [[ ! -f "${BUDGET_FILE}" ]]; then
+    log_warn "No active session. Run 'start' to begin tracking."
+    exit 0
+  fi
+
+  local started_at
+  started_at=$(jq -r '.started_at' "${BUDGET_FILE}")
+  local start_ep
+  start_ep=$(iso_to_epoch "${started_at}")
+  local elapsed
+  elapsed=$(elapsed_human "${start_ep}")
+
+  local vm_count
+  vm_count=$(jq '.vms | length' "${BUDGET_FILE}")
+
+  # Running cost: sum of (elapsed_hours * hourly_rate) per VM
+  local now_ts
+  now_ts=$(now_iso)
+  local running_cost
+  running_cost=$(jq --arg now "${now_ts}" '
+    [.vms[] |
+      ((($now | gsub("Z$";"") | strptime("%Y-%m-%dT%H:%M:%S") | mktime) -
+        (.started_at | gsub("Z$";"") | strptime("%Y-%m-%dT%H:%M:%S") | mktime)) / 3600) * .hourly_rate
+    ] | add // 0
+  ' "${BUDGET_FILE}" 2>/dev/null || echo "0")
+
+  local hourly_rate_total
+  hourly_rate_total=$(jq '[.vms[].hourly_rate] | add // 0' "${BUDGET_FILE}")
+
+  # Monthly stats
+  local monthly_total="0"
+  if [[ -f "${MONTHLY_FILE}" ]]; then
+    monthly_total=$(jq '[.sessions[].estimated_cost_usd // 0] | add // 0' "${MONTHLY_FILE}" 2>/dev/null || echo "0")
+  fi
+
+  # Session-hours so far (for monthly projection)
+  local month_seconds_elapsed
+  month_seconds_elapsed=$(python3 -c "
+from datetime import datetime, timezone
+now = datetime.now(timezone.utc)
+import calendar
+days_in_month = calendar.monthrange(now.year, now.month)[1]
+day = now.day + now.hour/24.0
+print(int(day / days_in_month * 86400 * days_in_month))
+" 2>/dev/null || echo "1")
+
+  local month_seconds_total
+  month_seconds_total=$(python3 -c "
+from datetime import datetime, timezone
+import calendar
+now = datetime.now(timezone.utc)
+days_in_month = calendar.monthrange(now.year, now.month)[1]
+print(days_in_month * 86400)
+" 2>/dev/null || echo "2592000")
+
+  local grand_total
+  grand_total=$(python3 -c "print(round(${monthly_total} + ${running_cost}, 2))" 2>/dev/null || echo "${monthly_total}")
+
+  local projected
+  projected=$(python3 -c "
+elapsed = ${month_seconds_elapsed}
+total = ${month_seconds_total}
+spent = ${grand_total}
+if elapsed > 0:
+    print(round(spent / elapsed * total, 2))
+else:
+    print(0)
+" 2>/dev/null || echo "0")
+
+  printf "Session: %s | VMs: %s | Rate: \$%.2f/hr | Session cost: \$%.2f\n" \
+    "${elapsed}" "${vm_count}" "${hourly_rate_total}" "${running_cost}"
+  printf "Monthly total: \$%.2f (est. \$%.2f/mo at current pace)\n" \
+    "${grand_total}" "${projected}"
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: report
+# ---------------------------------------------------------------------------
+cmd_report() {
+  local month_label
+  month_label=$(month_label)
+
+  echo "=== CCGM Cloud Dispatch - Cost Report ==="
+  echo "Month: ${month_label}"
+
+  if [[ ! -f "${MONTHLY_FILE}" ]]; then
+    echo "No session data found for this month."
+    exit 0
+  fi
+
+  # Session stats
+  local session_count total_vm_hours total_vm_cost issues_completed
+  session_count=$(jq '.sessions | length' "${MONTHLY_FILE}")
+  total_vm_hours=$(jq '[.sessions[].vm_hours_total // 0] | add // 0' "${MONTHLY_FILE}")
+  total_vm_cost=$(jq '[.sessions[].estimated_cost_usd // 0] | add // 0' "${MONTHLY_FILE}")
+
+  # Count issues (vms * agents * sessions as a proxy - sum vm counts per session)
+  issues_completed=$(jq '[.sessions[] | (.vms | length)] | add // 0' "${MONTHLY_FILE}")
+
+  local total_cost
+  total_cost=$(python3 -c "print(round(${total_vm_cost} + ${CLAUDE_MAX_USD}, 2))" 2>/dev/null || echo "${total_vm_cost}")
+
+  local budget_remaining
+  budget_remaining=$(python3 -c "print(round(${MONTHLY_BUDGET_USD} - ${total_cost}, 2))" 2>/dev/null || echo "0")
+
+  # Projection
+  local month_seconds_total
+  month_seconds_total=$(python3 -c "
+from datetime import datetime, timezone
+import calendar
+now = datetime.now(timezone.utc)
+days_in_month = calendar.monthrange(now.year, now.month)[1]
+print(days_in_month * 86400)
+" 2>/dev/null || echo "2592000")
+
+  local month_seconds_elapsed
+  month_seconds_elapsed=$(python3 -c "
+from datetime import datetime, timezone
+import calendar
+now = datetime.now(timezone.utc)
+days_in_month = calendar.monthrange(now.year, now.month)[1]
+elapsed = (now.day - 1) * 86400 + now.hour * 3600 + now.minute * 60 + now.second
+print(max(1, elapsed))
+" 2>/dev/null || echo "86400")
+
+  local projected
+  projected=$(python3 -c "
+elapsed = ${month_seconds_elapsed}
+total = ${month_seconds_total}
+spent = ${total_cost}
+print(round(spent / elapsed * total, 2))
+" 2>/dev/null || echo "0")
+
+  printf "Sessions:               %s\n" "${session_count}"
+  printf "Total VM-hours:         %.1f\n" "${total_vm_hours}"
+  printf "Total VM cost:          \$%.2f\n" "${total_vm_cost}"
+  printf "Claude Max subscription:\$%.2f\n" "${CLAUDE_MAX_USD}"
+  printf "Estimated total:        \$%.2f\n" "${total_cost}"
+  printf "Budget remaining:       \$%.2f (of \$%s)\n" "${budget_remaining}" "${MONTHLY_BUDGET_USD}"
+  printf "Projected month-end:    \$%.2f\n" "${projected}"
+
+  # Cost per issue (if any completed)
+  if [[ "${issues_completed}" -gt 0 && $(python3 -c "print(1 if ${total_cost} > 0 else 0)") == "1" ]]; then
+    local cost_per_issue
+    cost_per_issue=$(python3 -c "print(round(${total_vm_cost} / ${issues_completed}, 2))" 2>/dev/null || echo "N/A")
+    printf "Cost per issue (VM):    \$%s\n" "${cost_per_issue}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+case "${SUBCOMMAND}" in
+  start)  cmd_start  ;;
+  stop)   cmd_stop   ;;
+  status) cmd_status ;;
+  report) cmd_report ;;
+  *)
+    log_error "Unknown subcommand: ${SUBCOMMAND}"
+    usage
+    ;;
+esac

--- a/modules/cloud-dispatch/lib/cost-report.sh
+++ b/modules/cloud-dispatch/lib/cost-report.sh
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+# cost-report.sh — Generate cost reports for CCGM cloud-dispatch sessions.
+#
+# Usage:
+#   cost-report.sh session [--json]
+#   cost-report.sh monthly [--json]
+#
+# Subcommands:
+#   session   Report for the current or last completed session.
+#   monthly   Report for the current calendar month.
+#
+# Flags:
+#   --json    Output machine-readable JSON instead of formatted text.
+#
+# Reads from:
+#   /tmp/ccgm-budget.json         Current or last session data
+#   /tmp/ccgm-budget-monthly.json Monthly session log
+#
+# Requires: jq
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+BUDGET_FILE="${CCGM_BUDGET_FILE:-/tmp/ccgm-budget.json}"
+MONTHLY_FILE="${CCGM_MONTHLY_FILE:-/tmp/ccgm-budget-monthly.json}"
+MONTHLY_BUDGET_USD="${CCGM_MONTHLY_BUDGET:-2000}"
+CLAUDE_MAX_USD="${CCGM_CLAUDE_MAX_USD:-200}"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+  echo "Usage: $0 <session|monthly> [--json]" >&2
+  exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+SUBCOMMAND="$1"
+shift
+
+JSON_OUTPUT=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json)
+      JSON_OUTPUT=true
+      shift
+      ;;
+    *)
+      log_error "Unknown argument: $1"
+      usage
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+require_cmd jq
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# month_label — "Month YYYY" format for display
+month_label() {
+  date -u +"%B %Y"
+}
+
+# current_month — YYYY-MM
+current_month() {
+  date -u +"%Y-%m"
+}
+
+# safe_jq <filter> <file> <default> — run jq filter and return default on failure
+safe_jq() {
+  local filter="$1"
+  local file="$2"
+  local default="${3:-0}"
+  jq -r "${filter}" "${file}" 2>/dev/null || echo "${default}"
+}
+
+# py_calc <expr> — evaluate a Python arithmetic expression and print result
+py_calc() {
+  python3 -c "print(round(${1}, 2))" 2>/dev/null || echo "0"
+}
+
+# duration_label <hours_float> — convert decimal hours to human-readable string
+duration_label() {
+  python3 -c "
+h = float('${1}')
+hours = int(h)
+mins = int((h - hours) * 60)
+if hours > 0:
+    print(f'{hours}h {mins}m')
+else:
+    print(f'{mins}m')
+" 2>/dev/null || echo "${1}h"
+}
+
+# ---------------------------------------------------------------------------
+# Compute session-level stats from a session JSON object
+# Returns a JSON object with derived fields
+# ---------------------------------------------------------------------------
+session_stats() {
+  local session_json="$1"
+
+  # Extract base fields
+  local sid started_at stopped_at vm_count vm_hours_total cost
+  sid=$(echo "${session_json}"           | jq -r '.session_id // "unknown"')
+  started_at=$(echo "${session_json}"    | jq -r '.started_at // ""')
+  stopped_at=$(echo "${session_json}"    | jq -r '.stopped_at // ""')
+  vm_count=$(echo "${session_json}"      | jq '.vms | length')
+  vm_hours_total=$(echo "${session_json}" | jq '.vm_hours_total // 0')
+  cost=$(echo "${session_json}"          | jq '.estimated_cost_usd // 0')
+
+  # Compute wall-clock duration
+  local duration_hours="0"
+  if [[ -n "${started_at}" && -n "${stopped_at}" ]]; then
+    duration_hours=$(python3 -c "
+from datetime import datetime, timezone
+def parse(s):
+    return datetime.fromisoformat(s.replace('Z', '+00:00'))
+try:
+    s = parse('${started_at}')
+    e = parse('${stopped_at}')
+    print(round((e - s).total_seconds() / 3600, 3))
+except Exception:
+    print(0)
+" 2>/dev/null || echo "0")
+  fi
+
+  # VM breakdown
+  local vm_breakdown
+  vm_breakdown=$(echo "${session_json}" | jq -c '[.vms[] | {name: .name, type: .type, hourly_rate: .hourly_rate}]')
+
+  jq -n \
+    --arg sid "${sid}" \
+    --arg started_at "${started_at}" \
+    --arg stopped_at "${stopped_at}" \
+    --argjson vm_count "${vm_count}" \
+    --argjson vm_hours "${vm_hours_total}" \
+    --argjson cost "${cost}" \
+    --argjson duration "${duration_hours}" \
+    --argjson vms "${vm_breakdown}" \
+    '{
+      session_id: $sid,
+      started_at: $started_at,
+      stopped_at: $stopped_at,
+      vm_count: $vm_count,
+      vm_hours_total: $vm_hours,
+      estimated_cost_usd: $cost,
+      duration_hours: $duration,
+      vms: $vms
+    }'
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: session
+# ---------------------------------------------------------------------------
+cmd_session() {
+  local session_json
+
+  if [[ -f "${BUDGET_FILE}" ]]; then
+    # Active session
+    session_json=$(cat "${BUDGET_FILE}")
+    local is_active=true
+
+    # For active sessions, compute running cost from current time
+    local now_ts
+    now_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    local running_cost
+    running_cost=$(echo "${session_json}" | jq --arg now "${now_ts}" '
+      [.vms[] |
+        ((($now | gsub("Z$";"") | strptime("%Y-%m-%dT%H:%M:%S") | mktime) -
+          (.started_at | gsub("Z$";"") | strptime("%Y-%m-%dT%H:%M:%S") | mktime)) / 3600) * .hourly_rate
+      ] | add // 0
+    ' 2>/dev/null || echo "0")
+
+    session_json=$(echo "${session_json}" | jq --argjson cost "${running_cost}" '.estimated_cost_usd = $cost')
+  elif [[ -f "${MONTHLY_FILE}" ]]; then
+    # Use last completed session
+    session_json=$(jq '.sessions[-1]' "${MONTHLY_FILE}" 2>/dev/null || echo "null")
+    if [[ "${session_json}" == "null" ]]; then
+      log_warn "No session data found."
+      exit 0
+    fi
+    local is_active=false
+  else
+    log_warn "No session data found. Run 'budget-track.sh start' to begin tracking."
+    exit 0
+  fi
+
+  local stats
+  stats=$(session_stats "${session_json}")
+
+  if [[ "${JSON_OUTPUT}" == "true" ]]; then
+    echo "${stats}"
+    return
+  fi
+
+  # Human-readable output
+  local sid vm_count vm_hours cost duration
+  sid=$(echo "${stats}"      | jq -r '.session_id')
+  vm_count=$(echo "${stats}" | jq '.vm_count')
+  vm_hours=$(echo "${stats}" | jq '.vm_hours_total')
+  cost=$(echo "${stats}"     | jq '.estimated_cost_usd')
+  duration=$(echo "${stats}" | jq '.duration_hours')
+
+  local duration_str
+  duration_str=$(duration_label "${duration}")
+
+  echo "=== CCGM Cloud Dispatch - Session Report ==="
+  printf "Session ID:    %s\n" "${sid}"
+
+  if [[ "${is_active}" == "true" ]]; then
+    printf "Status:        ACTIVE (running)\n"
+  else
+    printf "Status:        Completed\n"
+  fi
+
+  printf "Duration:      %s\n" "${duration_str}"
+  printf "VMs active:    %s\n" "${vm_count}"
+  printf "VM-hours:      %.2f\n" "${vm_hours}"
+  printf "Session cost:  \$%.2f\n" "${cost}"
+
+  # VM breakdown
+  local vm_entries
+  vm_entries=$(echo "${stats}" | jq -r '.vms[] | "  \(.name) (\(.type)): \$\(.hourly_rate)/hr"')
+  if [[ -n "${vm_entries}" ]]; then
+    echo ""
+    echo "VM Breakdown:"
+    echo "${vm_entries}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: monthly
+# ---------------------------------------------------------------------------
+cmd_monthly() {
+  if [[ ! -f "${MONTHLY_FILE}" ]]; then
+    log_warn "No monthly data found at ${MONTHLY_FILE}."
+    exit 0
+  fi
+
+  # Aggregate session stats
+  local session_count avg_duration_hours total_vm_hours total_vm_cost
+  session_count=$(jq '.sessions | length' "${MONTHLY_FILE}")
+  total_vm_hours=$(jq '[.sessions[].vm_hours_total // 0] | add // 0' "${MONTHLY_FILE}")
+  total_vm_cost=$(jq '[.sessions[].estimated_cost_usd // 0] | add // 0' "${MONTHLY_FILE}")
+
+  if [[ "${session_count}" -gt 0 ]]; then
+    avg_duration_hours=$(python3 -c "print(round(${total_vm_hours} / ${session_count}, 2))" 2>/dev/null || echo "0")
+  else
+    avg_duration_hours="0"
+  fi
+
+  # Count total issues dispatched (sum of VM counts across sessions as proxy)
+  local issues_dispatched
+  issues_dispatched=$(jq '[.sessions[] | (.vms | length)] | add // 0' "${MONTHLY_FILE}")
+
+  # Total cost including Claude subscription
+  local total_cost
+  total_cost=$(py_calc "${total_vm_cost} + ${CLAUDE_MAX_USD}")
+
+  # Budget utilization
+  local budget_remaining budget_pct_used
+  budget_remaining=$(py_calc "${MONTHLY_BUDGET_USD} - ${total_cost}")
+  budget_pct_used=$(python3 -c "print(round(${total_cost} / ${MONTHLY_BUDGET_USD} * 100, 1))" 2>/dev/null || echo "0")
+
+  # Cost per issue
+  local cost_per_issue="N/A"
+  if [[ "${issues_dispatched}" -gt 0 ]]; then
+    cost_per_issue=$(python3 -c "print(f'\${round(${total_vm_cost} / ${issues_dispatched}, 2)}')" 2>/dev/null || echo "N/A")
+  fi
+
+  # Month-end projection based on days elapsed
+  local month_days_total month_days_elapsed projected_cost
+  month_days_total=$(python3 -c "
+from datetime import datetime, timezone
+import calendar
+now = datetime.now(timezone.utc)
+print(calendar.monthrange(now.year, now.month)[1])
+" 2>/dev/null || echo "30")
+
+  month_days_elapsed=$(python3 -c "
+from datetime import datetime, timezone
+now = datetime.now(timezone.utc)
+print(max(1, now.day))
+" 2>/dev/null || echo "1")
+
+  projected_cost=$(python3 -c "
+print(round(${total_cost} / ${month_days_elapsed} * ${month_days_total}, 2))
+" 2>/dev/null || echo "0")
+
+  # Per-session type breakdown (by server type)
+  local type_breakdown
+  type_breakdown=$(jq -r '
+    [.sessions[].vms[]] |
+    group_by(.type) |
+    map({type: .[0].type, count: length, rate: .[0].hourly_rate}) |
+    .[] |
+    "  \(.type): \(.count) VM-slot(s) @ $\(.rate)/hr"
+  ' "${MONTHLY_FILE}" 2>/dev/null || true)
+
+  if [[ "${JSON_OUTPUT}" == "true" ]]; then
+    jq -n \
+      --arg month "$(current_month)" \
+      --argjson sessions "${session_count}" \
+      --argjson issues "${issues_dispatched}" \
+      --argjson vm_hours "${total_vm_hours}" \
+      --argjson vm_cost "${total_vm_cost}" \
+      --argjson claude_cost "${CLAUDE_MAX_USD}" \
+      --argjson total "${total_cost}" \
+      --argjson remaining "${budget_remaining}" \
+      --argjson budget "${MONTHLY_BUDGET_USD}" \
+      --argjson projected "${projected_cost}" \
+      --argjson pct "${budget_pct_used}" \
+      '{
+        month: $month,
+        session_count: $sessions,
+        issues_dispatched: $issues,
+        vm_hours_total: $vm_hours,
+        vm_cost_usd: $vm_cost,
+        claude_subscription_usd: $claude_cost,
+        total_cost_usd: $total,
+        budget_usd: $budget,
+        budget_remaining_usd: $remaining,
+        budget_pct_used: $pct,
+        projected_month_end_usd: $projected
+      }'
+    return
+  fi
+
+  # Human-readable output
+  local month_lbl
+  month_lbl=$(month_label)
+
+  echo "=== CCGM Cloud Dispatch - Cost Report ==="
+  printf "Month:                  %s\n" "${month_lbl}"
+  printf "Sessions:               %s\n" "${session_count}"
+  printf "Issues dispatched:      %s\n" "${issues_dispatched}"
+  printf "Total VM-hours:         %.1f\n" "${total_vm_hours}"
+
+  if [[ "${session_count}" -gt 0 ]]; then
+    local avg_str
+    avg_str=$(duration_label "${avg_duration_hours}")
+    printf "Avg session duration:   %s\n" "${avg_str}"
+  fi
+
+  echo ""
+  printf "Total VM cost:          \$%.2f\n" "${total_vm_cost}"
+  printf "Claude Max subscription:\$%.2f\n" "${CLAUDE_MAX_USD}"
+  printf "Estimated total:        \$%.2f\n" "${total_cost}"
+  echo ""
+  printf "Budget:                 \$%s\n" "${MONTHLY_BUDGET_USD}"
+  printf "Budget used:            %.1f%%\n" "${budget_pct_used}"
+  printf "Budget remaining:       \$%.2f\n" "${budget_remaining}"
+  printf "Projected month-end:    \$%.2f\n" "${projected_cost}"
+
+  if [[ "${cost_per_issue}" != "N/A" ]]; then
+    echo ""
+    printf "Cost per issue (VM):    %s\n" "${cost_per_issue}"
+  fi
+
+  if [[ -n "${type_breakdown}" ]]; then
+    echo ""
+    echo "VM Type Usage:"
+    echo "${type_breakdown}"
+  fi
+
+  # Budget warning
+  if python3 -c "exit(0 if ${budget_pct_used} >= 80 else 1)" 2>/dev/null; then
+    echo ""
+    log_warn "Budget utilization is ${budget_pct_used}%. Consider reviewing dispatch frequency."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+case "${SUBCOMMAND}" in
+  session) cmd_session ;;
+  monthly) cmd_monthly ;;
+  *)
+    log_error "Unknown subcommand: ${SUBCOMMAND}"
+    usage
+    ;;
+esac

--- a/modules/cloud-dispatch/lib/recovery.sh
+++ b/modules/cloud-dispatch/lib/recovery.sh
@@ -1,0 +1,432 @@
+#!/usr/bin/env bash
+# recovery.sh — Failure recovery for CCGM cloud-dispatch agents.
+#
+# Usage:
+#   recovery.sh check
+#   recovery.sh retry <vm-ip> <agent-index>
+#   recovery.sh retry-all
+#
+# Subcommands:
+#   check              Scan all agents for failures and classify them.
+#   retry <ip> <idx>   Re-dispatch a specific failed agent.
+#   retry-all          Retry all agents currently classified as failed.
+#
+# Failure classifications:
+#   rate-limited  Agent hit Claude API rate limits
+#   crashed       Agent process died unexpectedly (tmux gone, no status file)
+#   timeout       Auto-shutdown killed the agent (AGENT_TIMEOUT status)
+#   error         Agent completed but with errors (AGENT_ERROR status)
+#   success       Agent completed successfully (AGENT_DONE status, PR created)
+#   running       Agent is still running
+#   unknown       Cannot determine state
+#
+# Requires: hcloud, jq, SSH key at ~/.ssh/ccgm-dispatch-session
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+RETRY_LOG="${CCGM_RETRY_LOG:-/tmp/ccgm-recovery.json}"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+  echo "Usage: $0 check" >&2
+  echo "       $0 retry <vm-ip> <agent-index>" >&2
+  echo "       $0 retry-all" >&2
+  exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+SUBCOMMAND="$1"
+shift
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+require_cmd jq
+
+# ---------------------------------------------------------------------------
+# SSH helpers
+# ---------------------------------------------------------------------------
+ssh_root_quiet() {
+  local ip="$1"; shift
+  # shellcheck disable=SC2206
+  read -ra _opts <<< "$(ssh_opts)"
+  # SC2029: expansion is intentional - building command on client side
+  # shellcheck disable=SC2029
+  ssh "${_opts[@]}" "root@${ip}" "$@" 2>/dev/null
+}
+
+ssh_agent_quiet() {
+  local ip="$1"
+  local agent_user="$2"
+  local cmd="$3"
+  # SC2029: expansion is intentional
+  # shellcheck disable=SC2029
+  ssh_root_quiet "${ip}" "su - ${agent_user} -c $(printf '%q' "${cmd}")" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# classify_agent <vm-ip> <vm-name> <agent-index>
+# Prints a JSON object describing the agent's failure state.
+# ---------------------------------------------------------------------------
+classify_agent() {
+  local ip="$1"
+  local vm_name="$2"
+  local idx="$3"
+  local agent_user="agent-${idx}"
+  local agent_home="/home/${agent_user}"
+  local assignment_file="${agent_home}/assignment.json"
+  local status_file="${agent_home}/status"
+  local run_log="${agent_home}/run.log"
+
+  # --- assignment ---
+  local issue_number="" issue_title="" repo="" branch=""
+  if ssh_root_quiet "${ip}" "test -f '${assignment_file}'" 2>/dev/null; then
+    local raw
+    raw=$(ssh_root_quiet "${ip}" "cat '${assignment_file}'" || echo "{}")
+    issue_number=$(echo "${raw}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('issue_number',''))" 2>/dev/null || true)
+    issue_title=$(echo "${raw}"  | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('issue_title',''))"  2>/dev/null || true)
+    repo=$(echo "${raw}"         | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('repo',''))"         2>/dev/null || true)
+    branch=$(echo "${raw}"       | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('branch',''))"       2>/dev/null || true)
+  fi
+
+  if [[ -z "${issue_number}" ]]; then
+    # No assignment - skip this agent slot
+    echo "null"
+    return
+  fi
+
+  # --- tmux session state ---
+  local tmux_running=false
+  if ssh_root_quiet "${ip}" "su - ${agent_user} -c 'tmux has-session -t ${agent_user} 2>/dev/null'" 2>/dev/null; then
+    tmux_running=true
+  fi
+
+  # --- status file ---
+  local status_content=""
+  if ssh_root_quiet "${ip}" "test -f '${status_file}'" 2>/dev/null; then
+    status_content=$(ssh_root_quiet "${ip}" "cat '${status_file}'" 2>/dev/null | tr -d '[:space:]' || true)
+  fi
+
+  # --- log analysis for rate limits ---
+  local rate_limited=false
+  if ssh_root_quiet "${ip}" "test -f '${run_log}'" 2>/dev/null; then
+    if ssh_root_quiet "${ip}" "grep -qiE 'rate.?limit|429|too many requests|overloaded' '${run_log}'" 2>/dev/null; then
+      rate_limited=true
+    fi
+  fi
+
+  # --- PR existence check ---
+  local has_pr=false
+  if [[ -n "${branch}" && -n "${repo}" ]]; then
+    local pr_url
+    pr_url=$(ssh_agent_quiet "${ip}" "${agent_user}" \
+      "gh pr list --repo ${repo} --head ${branch} --json url --jq '.[0].url' 2>/dev/null" || true)
+    [[ -n "${pr_url}" ]] && has_pr=true
+  fi
+
+  # --- git commits check ---
+  local has_commits=false
+  if [[ -n "${repo}" ]]; then
+    local repo_name
+    repo_name=$(basename "${repo}")
+    local clone_dir="${agent_home}/workspace/${repo_name}"
+    if ssh_root_quiet "${ip}" "test -d '${clone_dir}/.git'" 2>/dev/null; then
+      local commit_count
+      commit_count=$(ssh_agent_quiet "${ip}" "${agent_user}" \
+        "git -C '${clone_dir}' rev-list --count HEAD ^origin/main 2>/dev/null" || echo "0")
+      [[ "${commit_count:-0}" -gt 0 ]] && has_commits=true
+    fi
+  fi
+
+  # --- classify ---
+  local classification
+  if [[ "${tmux_running}" == "true" ]]; then
+    classification="running"
+  elif [[ "${status_content}" == "AGENT_DONE" && "${has_pr}" == "true" ]]; then
+    classification="success"
+  elif [[ "${status_content}" == "AGENT_TIMEOUT" ]]; then
+    classification="timeout"
+  elif [[ "${rate_limited}" == "true" ]]; then
+    classification="rate-limited"
+  elif [[ "${status_content}" == "AGENT_ERROR" ]]; then
+    classification="error"
+  elif [[ "${tmux_running}" == "false" && -z "${status_content}" ]]; then
+    classification="crashed"
+  else
+    classification="unknown"
+  fi
+
+  # Output JSON
+  jq -n \
+    --arg vm "${vm_name}" \
+    --arg ip "${ip}" \
+    --arg agent "${agent_user}" \
+    --argjson idx "${idx}" \
+    --arg issue "${issue_number}" \
+    --arg title "${issue_title}" \
+    --arg repo "${repo}" \
+    --arg branch "${branch}" \
+    --arg status "${status_content}" \
+    --arg class "${classification}" \
+    --argjson has_pr "${has_pr}" \
+    --argjson has_commits "${has_commits}" \
+    '{
+      vm: $vm,
+      ip: $ip,
+      agent: $agent,
+      agent_index: $idx,
+      issue_number: $issue,
+      issue_title: $title,
+      repo: $repo,
+      branch: $branch,
+      status: $status,
+      classification: $class,
+      has_pr: $has_pr,
+      has_commits: $has_commits
+    }'
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: check
+# ---------------------------------------------------------------------------
+cmd_check() {
+  require_cmd hcloud
+
+  if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+    log_error "HCLOUD_TOKEN is not set."
+    exit 1
+  fi
+
+  mapfile -t VM_NAMES < <(hcloud server list --output columns=name,status \
+    | awk '$2=="running" && /ccgm-agent/ {print $1}' \
+    | sort)
+
+  if [[ ${#VM_NAMES[@]} -eq 0 ]]; then
+    log_warn "No running ccgm-agent-* VMs found."
+    exit 0
+  fi
+
+  local results=()
+  local total=0
+  local running=0
+  local success=0
+  local failed=0
+
+  for vm_name in "${VM_NAMES[@]}"; do
+    local ip
+    ip=$(hcloud server describe "${vm_name}" --output format='{{.PublicNet.IPv4.IP}}')
+    for idx in $(seq 0 $(( CCGM_AGENTS_PER_VM - 1 ))); do
+      log_info "Checking ${vm_name} agent-${idx}..."
+      local result
+      result=$(classify_agent "${ip}" "${vm_name}" "${idx}")
+      if [[ "${result}" == "null" ]]; then
+        continue
+      fi
+      results+=("${result}")
+      total=$(( total + 1 ))
+
+      local class
+      class=$(echo "${result}" | jq -r '.classification')
+      case "${class}" in
+        running) running=$(( running + 1 )) ;;
+        success) success=$(( success + 1 )) ;;
+        *)       failed=$(( failed + 1 ))  ;;
+      esac
+    done
+  done
+
+  # Save results to retry log
+  printf '[%s]' "$(IFS=','; echo "${results[*]}")" \
+    | jq '.' > "${RETRY_LOG}" 2>/dev/null || true
+
+  # Print summary
+  echo ""
+  echo "=== Agent Recovery Check ==="
+  printf "Total agents: %s | Running: %s | Success: %s | Failed: %s\n\n" \
+    "${total}" "${running}" "${success}" "${failed}"
+
+  # Print per-agent status
+  for result in "${results[@]}"; do
+    local vm agent issue class has_pr has_commits
+    vm=$(echo "${result}"          | jq -r '.vm')
+    agent=$(echo "${result}"       | jq -r '.agent')
+    issue=$(echo "${result}"       | jq -r '.issue_number')
+    class=$(echo "${result}"       | jq -r '.classification')
+    has_pr=$(echo "${result}"      | jq -r '.has_pr')
+    has_commits=$(echo "${result}" | jq -r '.has_commits')
+
+    local status_icon
+    case "${class}" in
+      success)      status_icon="${_COLOR_GREEN}[OK]${_COLOR_RESET}   " ;;
+      running)      status_icon="${_COLOR_CYAN}[RUN]${_COLOR_RESET}  " ;;
+      rate-limited) status_icon="${_COLOR_YELLOW}[RATE]${_COLOR_RESET} " ;;
+      crashed)      status_icon="${_COLOR_RED}[CRASH]${_COLOR_RESET}" ;;
+      timeout)      status_icon="${_COLOR_YELLOW}[TIME]${_COLOR_RESET} " ;;
+      error)        status_icon="${_COLOR_RED}[ERR]${_COLOR_RESET}  " ;;
+      *)            status_icon="[???]  " ;;
+    esac
+
+    printf "%s %-24s %-8s #%-6s %s" \
+      "${status_icon}" "${vm}" "${agent}" "${issue}" "${class}"
+    [[ "${has_commits}" == "true" ]] && printf " [has-commits]"
+    [[ "${has_pr}" == "true" ]] && printf " [pr-created]"
+    echo ""
+  done
+
+  echo ""
+  if [[ ${failed} -gt 0 ]]; then
+    echo "Run '$0 retry-all' to re-dispatch all failed agents."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# retry_one <vm-ip> <agent-index>
+# Re-dispatch a single failed agent, resuming from last commit if possible.
+# ---------------------------------------------------------------------------
+retry_one() {
+  local ip="$1"
+  local idx="$2"
+  local agent_user="agent-${idx}"
+  local agent_home="/home/${agent_user}"
+  local assignment_file="${agent_home}/assignment.json"
+
+  log_info "Preparing retry for ${agent_user}@${ip}"
+
+  # Read assignment
+  if ! ssh_root_quiet "${ip}" "test -f '${assignment_file}'" 2>/dev/null; then
+    log_error "No assignment.json for ${agent_user}@${ip}. Cannot retry."
+    return 1
+  fi
+
+  local raw
+  raw=$(ssh_root_quiet "${ip}" "cat '${assignment_file}'" || echo "{}")
+  local issue_number repo branch
+  issue_number=$(echo "${raw}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('issue_number',''))" 2>/dev/null || true)
+  repo=$(echo "${raw}"         | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('repo',''))"         2>/dev/null || true)
+  branch=$(echo "${raw}"       | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('branch',''))"       2>/dev/null || true)
+
+  if [[ -z "${issue_number}" || -z "${repo}" || -z "${branch}" ]]; then
+    log_error "Incomplete assignment.json for ${agent_user}@${ip}."
+    return 1
+  fi
+
+  local repo_name
+  repo_name=$(basename "${repo}")
+  local clone_dir="${agent_home}/workspace/${repo_name}"
+
+  # Check if the branch has commits beyond origin/main
+  local has_commits=false
+  local commit_count
+  commit_count=$(ssh_agent_quiet "${ip}" "${agent_user}" \
+    "git -C '${clone_dir}' rev-list --count HEAD ^origin/main 2>/dev/null" || echo "0")
+  [[ "${commit_count:-0}" -gt 0 ]] && has_commits=true
+
+  # Choose prompt based on commit state
+  local prompt
+  if [[ "${has_commits}" == "true" ]]; then
+    log_info "Branch has commits - resuming from checkpoint."
+    prompt="You are resuming work on issue #${issue_number}. \
+Check the current state of the branch '${branch}' and continue from where the previous agent left off. \
+Review any existing commits, assess what remains to be done, and complete the implementation. \
+Create a PR when complete that closes #${issue_number}."
+  else
+    log_info "No commits found - starting fresh."
+    # Reset branch to origin/main
+    ssh_agent_quiet "${ip}" "${agent_user}" \
+      "git -C '${clone_dir}' checkout -B '${branch}' origin/main 2>/dev/null" || true
+    prompt="You are an autonomous Claude Code agent. Work on GitHub issue #${issue_number}. \
+Create a branch named ${branch}, implement the changes with tests, and create a PR that closes #${issue_number}. \
+Follow the repo's CLAUDE.md instructions. Commit with message format: #${issue_number}: description."
+  fi
+
+  # Clear previous status and log (append retry marker)
+  ssh_root_quiet "${ip}" "rm -f '${agent_home}/status'" || true
+  ssh_root_quiet "${ip}" \
+    "echo '--- RETRY $(date -u +"%Y-%m-%dT%H:%M:%SZ") ---' >> '${agent_home}/run.log'" || true
+
+  # Re-launch via agent-launch.sh
+  "${SCRIPT_DIR}/agent-launch.sh" "${ip}" "${idx}" --prompt "${prompt}"
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: retry <vm-ip> <agent-index>
+# ---------------------------------------------------------------------------
+cmd_retry() {
+  if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 retry <vm-ip> <agent-index>" >&2
+    exit 1
+  fi
+  local ip="$1"
+  local idx="$2"
+
+  if ! [[ "${idx}" =~ ^[0-3]$ ]]; then
+    log_error "agent-index must be 0, 1, 2, or 3 (got: ${idx})"
+    exit 1
+  fi
+
+  retry_one "${ip}" "${idx}"
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: retry-all
+# ---------------------------------------------------------------------------
+cmd_retry_all() {
+  if [[ ! -f "${RETRY_LOG}" ]]; then
+    log_warn "No recovery data found at ${RETRY_LOG}. Run 'check' first."
+    exit 0
+  fi
+
+  local retry_count=0
+  local skip_count=0
+
+  # Read failed agents from the check results
+  while IFS= read -r entry; do
+    local class ip idx
+    class=$(echo "${entry}" | jq -r '.classification')
+    ip=$(echo "${entry}"    | jq -r '.ip')
+    idx=$(echo "${entry}"   | jq -r '.agent_index')
+
+    case "${class}" in
+      success|running)
+        skip_count=$(( skip_count + 1 ))
+        log_info "Skipping agent-${idx}@${ip} (${class})"
+        ;;
+      *)
+        log_info "Retrying agent-${idx}@${ip} (${class})"
+        if retry_one "${ip}" "${idx}"; then
+          retry_count=$(( retry_count + 1 ))
+        else
+          log_warn "Retry failed for agent-${idx}@${ip}"
+        fi
+        ;;
+    esac
+  done < <(jq -c '.[]' "${RETRY_LOG}" 2>/dev/null || true)
+
+  echo ""
+  log_success "Retry complete: ${retry_count} agent(s) re-dispatched, ${skip_count} skipped."
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+case "${SUBCOMMAND}" in
+  check)      cmd_check                ;;
+  retry)      cmd_retry "$@"           ;;
+  retry-all)  cmd_retry_all            ;;
+  *)
+    log_error "Unknown subcommand: ${SUBCOMMAND}"
+    usage
+    ;;
+esac


### PR DESCRIPTION
Closes #220

## Summary

- `budget-track.sh` - Track VM costs per session (start/stop/status/report). Records session data to `/tmp/ccgm-budget.json` and appends to `/tmp/ccgm-budget-monthly.json`. Supports configurable rates per server type (CCX63: $0.58/hr, CCX43: $0.28/hr, CCX33: $0.20/hr).
- `recovery.sh` - Failure recovery for agents (check/retry/retry-all). Classifies agents as rate-limited, crashed, timeout, error, or success. Resume-aware retry reads git history to determine whether to resume from last commit or start fresh.
- `cost-report.sh` - Cost reporting (session/monthly/--json). Includes VM cost breakdown, Claude Max subscription, budget utilization, cost-per-issue, and month-end projection.

## Details

All scripts follow existing patterns: `set -euo pipefail`, source `common.sh`, use `jq` for JSON, `python3` for date math, and pass `shellcheck -x`.

Budget tracking uses `/tmp` for state files. Hourly rates are configurable via `CCGM_*` environment variables. Monthly budget defaults to $2,000 with $200 Claude Max subscription included in totals.

Recovery classifies failures by inspecting tmux session state, the `~/status` file, and run.log patterns (rate limit keywords, AGENT_TIMEOUT, AGENT_ERROR). Retry uses `agent-launch.sh` with a resume-aware prompt when git commits exist on the branch.