### PR TITLE
#240: install CCGM in golden image and agent workspaces

### DIFF
--- a/modules/cloud-dispatch/lib/ccgm-headless-install.sh
+++ b/modules/cloud-dispatch/lib/ccgm-headless-install.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# ccgm-headless-install.sh — Non-interactive CCGM installer for cloud agent users.
+#
+# Installs a CCGM preset into a target user's ~/.claude/ directory by copying
+# rule and command files from the CCGM repo. No interactive prompts, no template
+# expansion (cloud agents don't need user-specific config).
+#
+# Usage:
+#   ccgm-headless-install.sh <ccgm-repo-path> <preset-name> <target-user-home>
+#
+# Example:
+#   ccgm-headless-install.sh /opt/ccgm/repo cloud-agent /home/agent-0
+#
+# This script is designed to run ON the VM (not from the orchestrator).
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <ccgm-repo-path> <preset-name> <target-user-home>" >&2
+  exit 1
+fi
+
+CCGM_REPO="$1"
+PRESET_NAME="$2"
+TARGET_HOME="$3"
+
+CLAUDE_DIR="${TARGET_HOME}/.claude"
+PRESET_FILE="${CCGM_REPO}/presets/${PRESET_NAME}.json"
+
+if [[ ! -f "${PRESET_FILE}" ]]; then
+  echo "Error: preset not found: ${PRESET_FILE}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${CCGM_REPO}/modules" ]]; then
+  echo "Error: CCGM modules directory not found: ${CCGM_REPO}/modules" >&2
+  exit 1
+fi
+
+# Parse preset JSON to get module list
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required but not installed" >&2
+  exit 1
+fi
+
+mapfile -t MODULES < <(jq -r '.[]' "${PRESET_FILE}")
+
+echo "==> Installing CCGM preset '${PRESET_NAME}' to ${CLAUDE_DIR}"
+echo "    Modules: ${MODULES[*]}"
+
+# Create target directories
+mkdir -p "${CLAUDE_DIR}/rules"
+mkdir -p "${CLAUDE_DIR}/commands"
+
+INSTALLED_RULES=0
+INSTALLED_COMMANDS=0
+
+for module in "${MODULES[@]}"; do
+  MODULE_DIR="${CCGM_REPO}/modules/${module}"
+  MANIFEST="${MODULE_DIR}/module.json"
+
+  if [[ ! -f "${MANIFEST}" ]]; then
+    echo "  WARN: module '${module}' not found, skipping"
+    continue
+  fi
+
+  echo "  --> Installing module: ${module}"
+
+  # Extract file mappings from module.json
+  # Each file entry has: source path (key), target path, and type
+  while IFS=$'\t' read -r src target ftype; do
+    SRC_PATH="${MODULE_DIR}/${src}"
+
+    if [[ ! -f "${SRC_PATH}" ]]; then
+      echo "    WARN: source file not found: ${SRC_PATH}"
+      continue
+    fi
+
+    case "${ftype}" in
+      rule)
+        cp "${SRC_PATH}" "${CLAUDE_DIR}/${target}"
+        INSTALLED_RULES=$((INSTALLED_RULES + 1))
+        ;;
+      command)
+        cp "${SRC_PATH}" "${CLAUDE_DIR}/${target}"
+        INSTALLED_COMMANDS=$((INSTALLED_COMMANDS + 1))
+        ;;
+      # Skip lib, hook, settings, and other non-rule/command types
+      # Cloud agents get lib scripts via the cloud-dispatch module's own paths
+      *)
+        ;;
+    esac
+  done < <(jq -r '.files | to_entries[] | [.key, .value.target, .value.type] | @tsv' "${MANIFEST}")
+done
+
+echo "==> CCGM headless install complete"
+echo "    Rules installed: ${INSTALLED_RULES}"
+echo "    Commands installed: ${INSTALLED_COMMANDS}"
+echo "    Target: ${CLAUDE_DIR}"

--- a/modules/cloud-dispatch/lib/workspace-setup.sh
+++ b/modules/cloud-dispatch/lib/workspace-setup.sh
@@ -158,15 +158,18 @@ SETTINGS_JSON='{
 
 ssh_root "printf '%s\n' '${SETTINGS_JSON}' > '${CLAUDE_DIR}/settings.json' && chown '${AGENT_USER}:${AGENT_USER}' '${CLAUDE_DIR}/settings.json'"
 
-# Symlink global CCGM rules from /opt/ccgm if the directory exists on the VM
-RULES_SYMLINK="${CLAUDE_DIR}/rules"
+# Refresh CCGM installation from the repo on the VM.
+# The golden image pre-installs CCGM, but this ensures rules are current
+# if the image is stale. Also re-runs headless install to pick up any new modules.
+HEADLESS_INSTALLER="/opt/ccgm/repo/modules/cloud-dispatch/lib/ccgm-headless-install.sh"
 ssh_root "
-if [[ -d /opt/ccgm/rules && ! -e '${RULES_SYMLINK}' ]]; then
-  ln -s /opt/ccgm/rules '${RULES_SYMLINK}'
-  chown -h '${AGENT_USER}:${AGENT_USER}' '${RULES_SYMLINK}'
-  echo 'Symlinked /opt/ccgm/rules -> ${RULES_SYMLINK}'
+if [[ -x '${HEADLESS_INSTALLER}' ]]; then
+  echo 'Refreshing CCGM cloud-agent preset for ${AGENT_USER}'
+  bash '${HEADLESS_INSTALLER}' /opt/ccgm/repo cloud-agent '${AGENT_HOME}'
+  chown -R '${AGENT_USER}:${AGENT_USER}' '${CLAUDE_DIR}'
 else
-  echo 'Skipping rules symlink (/opt/ccgm/rules not found or link already exists)'
+  echo 'WARN: CCGM headless installer not found at ${HEADLESS_INSTALLER}'
+  echo 'Agents will run without CCGM rules. Rebuild golden image to fix.'
 fi
 "
 

--- a/modules/cloud-dispatch/packer/scripts/setup.sh
+++ b/modules/cloud-dispatch/packer/scripts/setup.sh
@@ -6,9 +6,16 @@ AGENT_COUNT=4
 CCGM_DIR="/opt/ccgm"
 SECRETS_BASE="/run/secrets"
 
-echo "==> Creating /opt/ccgm shared directory"
+echo "==> Cloning CCGM repo to /opt/ccgm/repo"
 mkdir -p "${CCGM_DIR}"
 chmod 755 "${CCGM_DIR}"
+git clone https://github.com/lucasmccomb/ccgm.git "${CCGM_DIR}/repo"
+
+echo "==> Pre-installing CCGM cloud-agent preset for each agent user"
+# The headless installer copies rules and commands from the CCGM repo
+# into each agent's ~/.claude/ directory without interactive prompts.
+HEADLESS_INSTALLER="${CCGM_DIR}/repo/modules/cloud-dispatch/lib/ccgm-headless-install.sh"
+chmod +x "${HEADLESS_INSTALLER}"
 
 echo "==> Creating agent user accounts (agent-0 through agent-$((AGENT_COUNT - 1)))"
 for i in $(seq 0 $((AGENT_COUNT - 1))); do
@@ -66,6 +73,15 @@ Host github.com
 SSHCONFIG
   chmod 600 "${ssh_dir}/config"
   chown -R "${USER}:${USER}" "${ssh_dir}"
+done
+
+echo "==> Installing CCGM cloud-agent preset for each agent user"
+for i in $(seq 0 $((AGENT_COUNT - 1))); do
+  USER="agent-${i}"
+  HOME_DIR="/home/${USER}"
+  bash "${HEADLESS_INSTALLER}" "${CCGM_DIR}/repo" "cloud-agent" "${HOME_DIR}"
+  chown -R "${USER}:${USER}" "${HOME_DIR}/.claude"
+  echo "  installed CCGM for ${USER}"
 done
 
 echo "==> Creating /run/secrets mount points for agent credential injection"

--- a/modules/cloud-dispatch/packer/scripts/validate.sh
+++ b/modules/cloud-dispatch/packer/scripts/validate.sh
@@ -60,8 +60,14 @@ for i in 0 1 2 3; do
   check_user "agent-${i}"
 done
 
-echo "==> Verifying /opt/ccgm directory"
-check_file "/opt/ccgm exists" "/opt/ccgm"
+echo "==> Verifying CCGM installation"
+check_file "/opt/ccgm/repo exists" "/opt/ccgm/repo"
+check_file "/opt/ccgm/repo/modules dir" "/opt/ccgm/repo/modules"
+check_file "/opt/ccgm/repo/presets/cloud-agent.json" "/opt/ccgm/repo/presets/cloud-agent.json"
+for i in 0 1 2 3; do
+  check_file "agent-${i} has .claude/rules" "/home/agent-${i}/.claude/rules"
+  check "agent-${i} has CCGM rules installed" bash -c "ls /home/agent-${i}/.claude/rules/*.md 2>/dev/null | wc -l | grep -qv '^0$'"
+done
 
 echo "==> Verifying iptables rules are active"
 check "iptables OUTPUT rules present" bash -c "iptables -L OUTPUT -n | grep -q 'DROP\|ACCEPT'"

--- a/presets/cloud-agent.json
+++ b/presets/cloud-agent.json
@@ -1,0 +1,12 @@
+[
+  "autonomy",
+  "git-workflow",
+  "code-quality",
+  "systematic-debugging",
+  "verification",
+  "common-mistakes",
+  "self-improving",
+  "subagent-patterns",
+  "test-driven-development",
+  "settings"
+]


### PR DESCRIPTION
Closes #240

## Summary
- Agents were booting with bare Claude Code and no CCGM configuration
- Golden image now clones CCGM repo and installs cloud-agent preset for each agent user
- Workspace setup refreshes CCGM on each dispatch (handles stale images)

## Changes
- **New**: `presets/cloud-agent.json` - 10 modules for headless cloud agents (autonomy, git-workflow, code-quality, systematic-debugging, verification, common-mistakes, self-improving, subagent-patterns, test-driven-development, settings)
- **New**: `modules/cloud-dispatch/lib/ccgm-headless-install.sh` - Non-interactive installer that copies rules/commands from CCGM repo to a target user's ~/.claude/
- **Modified**: `modules/cloud-dispatch/packer/scripts/setup.sh` - Clones CCGM repo to /opt/ccgm/repo/, runs headless install per agent
- **Modified**: `modules/cloud-dispatch/packer/scripts/validate.sh` - Verifies CCGM rules exist for all agent users
- **Modified**: `modules/cloud-dispatch/lib/workspace-setup.sh` - Refreshes CCGM from repo instead of symlinking empty dir

## Test plan
- [ ] shellcheck passes on all modified scripts (verified)
- [ ] Packer build includes CCGM repo clone
- [ ] Agent users have ~/.claude/rules/ populated after image build
- [ ] workspace-setup.sh refreshes CCGM correctly