### PR TITLE
#240: cloud-agent preset includes all CCGM modules

### DIFF
--- a/presets/cloud-agent.json
+++ b/presets/cloud-agent.json
@@ -1,12 +1,1 @@
-[
-  "autonomy",
-  "git-workflow",
-  "code-quality",
-  "systematic-debugging",
-  "verification",
-  "common-mistakes",
-  "self-improving",
-  "subagent-patterns",
-  "test-driven-development",
-  "settings"
-]
+["global-claude-md", "autonomy", "identity", "git-workflow", "hooks", "settings", "commands-core", "session-logging", "multi-agent", "github-protocols", "xplan", "code-quality", "browser-automation", "commands-extra", "commands-utility", "common-mistakes", "copycat", "debugging", "documentation", "supabase", "cloudflare", "systematic-debugging", "test-driven-development", "verification", "frontend-design", "mcp-development", "shadcn", "tailwind", "self-improving", "subagent-patterns", "brand-naming", "remote-server", "editorial-critique", "design-review", "ideate", "research", "test-vision", "atdd", "agent-manager", "cloud-dispatch"]


### PR DESCRIPTION
Follow-up to #241. The cloud-agent preset was limited to 10 modules but there's no reason to strip it down. Cloud agents benefit from the full ruleset - irrelevant rules are harmlessly ignored.

Also adds `cloud-dispatch` module itself so agents on VMs have access to dispatch commands.

Closes #240