### PR TITLE
#243: discover existing Claude sessions, directory picker launch, readable command bar

### DIFF
--- a/modules/agent-manager/src/.gitignore
+++ b/modules/agent-manager/src/.gitignore
@@ -1,3 +1,3 @@
 # Build output
 dist/
-ccgm-agents
+/ccgm-agents

--- a/modules/agent-manager/src/cmd/ccgm-agents/main.go
+++ b/modules/agent-manager/src/cmd/ccgm-agents/main.go
@@ -56,6 +56,14 @@ func main() {
 		fmt.Fprintf(os.Stderr, "ccgm-agents: reattach warning: %v\n", err)
 	}
 
+	// Discover existing Claude Code processes running on the system.
+	if procs, err := agent.DiscoverClaudeProcesses(); err == nil && len(procs) > 0 {
+		count := mgr.RegisterDiscovered(procs)
+		if count > 0 {
+			fmt.Fprintf(os.Stderr, "ccgm-agents: discovered %d running Claude session(s)\n", count)
+		}
+	}
+
 	// Build and run the TUI.
 	app := tui.NewApp(mgr, cfg)
 	p := tea.NewProgram(app, tea.WithAltScreen())

--- a/modules/agent-manager/src/internal/agent/discover.go
+++ b/modules/agent-manager/src/internal/agent/discover.go
@@ -1,0 +1,165 @@
+// discover.go scans the system for running Claude Code processes and registers
+// them as discovered agents so the TUI can display and manage them.
+package agent
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/types"
+)
+
+// DiscoveredProcess holds info about a running Claude Code process found via ps.
+type DiscoveredProcess struct {
+	PID        int
+	WorkingDir string
+	Command    string
+}
+
+// DiscoverClaudeProcesses finds running Claude Code CLI processes by scanning
+// the process table. Returns only main Claude sessions (filters out plugins,
+// subprocesses, and the agent-manager itself).
+func DiscoverClaudeProcesses() ([]DiscoveredProcess, error) {
+	// Find PIDs of processes whose command starts with "claude ".
+	pgrepOut, err := exec.Command("pgrep", "-f", "^claude ").Output()
+	if err != nil {
+		// pgrep returns exit code 1 when no matches found - that's not an error.
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("discover: pgrep: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(pgrepOut)), "\n")
+	if len(lines) == 0 || (len(lines) == 1 && lines[0] == "") {
+		return nil, nil
+	}
+
+	var discovered []DiscoveredProcess
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		pid, err := strconv.Atoi(line)
+		if err != nil {
+			continue
+		}
+
+		// Get command line for this PID.
+		cmdOut, err := exec.Command("ps", "-o", "command=", "-p", strconv.Itoa(pid)).Output()
+		if err != nil {
+			continue
+		}
+		cmdLine := strings.TrimSpace(string(cmdOut))
+
+		// Skip non-session processes (plugins, bun subprocesses, etc).
+		if !isClaudeSession(cmdLine) {
+			continue
+		}
+
+		// Get working directory via lsof.
+		cwd := getProcessCwd(pid)
+		if cwd == "" {
+			continue
+		}
+
+		discovered = append(discovered, DiscoveredProcess{
+			PID:        pid,
+			WorkingDir: cwd,
+			Command:    cmdLine,
+		})
+	}
+
+	return discovered, nil
+}
+
+// isClaudeSession returns true if the command line looks like a Claude Code
+// interactive session (not a plugin, subprocess, or bun runner).
+func isClaudeSession(cmdLine string) bool {
+	if !strings.HasPrefix(cmdLine, "claude ") && cmdLine != "claude" {
+		return false
+	}
+	// Filter out plugin/bun subprocesses.
+	if strings.Contains(cmdLine, "bun") || strings.Contains(cmdLine, "plugin") {
+		return false
+	}
+	return true
+}
+
+// getProcessCwd returns the current working directory of a process on macOS
+// using lsof. Returns empty string on failure.
+func getProcessCwd(pid int) string {
+	out, err := exec.Command("lsof", "-a", "-d", "cwd", "-p", strconv.Itoa(pid), "-Fn").Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "n/") {
+			return strings.TrimPrefix(line, "n")
+		}
+	}
+	return ""
+}
+
+// RegisterDiscovered adds discovered system processes to the AgentManager as
+// read-only monitored agents. These agents were not spawned by the manager,
+// so they have no stdout/stderr pipes - only PID-based health monitoring.
+func (m *AgentManager) RegisterDiscovered(procs []DiscoveredProcess) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	count := 0
+	for _, proc := range procs {
+		// Derive a name from the working directory.
+		name := filepath.Base(proc.WorkingDir)
+		id := fmt.Sprintf("discovered-%d", proc.PID)
+
+		// Skip if we already track this PID.
+		alreadyTracked := false
+		for _, existing := range m.agents {
+			if existing.State.PID == proc.PID {
+				alreadyTracked = true
+				break
+			}
+		}
+		if alreadyTracked {
+			continue
+		}
+
+		// Verify the process is actually alive before registering.
+		if err := syscall.Kill(proc.PID, 0); err != nil {
+			continue
+		}
+
+		cfg := types.AgentConfig{
+			ID:         id,
+			Name:       name,
+			Command:    "claude",
+			WorkingDir: proc.WorkingDir,
+			RestartPolicy: types.RestartPolicy{
+				Type: "never", // don't restart discovered processes
+			},
+		}
+
+		ma := &ManagedAgent{
+			Config:  cfg,
+			Process: nil, // no process handle - we didn't spawn it
+			State: types.AgentState{
+				Config:    cfg,
+				PID:       proc.PID,
+				Status:    types.StatusRunning,
+				StartedAt: time.Now(), // approximate - we don't know actual start time
+			},
+		}
+
+		m.agents[id] = ma
+		count++
+	}
+	return count
+}

--- a/modules/agent-manager/src/internal/agent/health.go
+++ b/modules/agent-manager/src/internal/agent/health.go
@@ -4,6 +4,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"syscall"
 	"time"
 
 	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/types"
@@ -62,7 +63,7 @@ func (m *AgentManager) checkAgent(agentID string) {
 	ma, ok := m.agents[agentID]
 	m.mu.RUnlock()
 
-	if !ok || ma.Process == nil {
+	if !ok {
 		return
 	}
 
@@ -75,7 +76,15 @@ func (m *AgentManager) checkAgent(agentID string) {
 		return
 	}
 
-	if ma.Process.IsAlive() {
+	// For discovered agents (no Process handle), use kill -0 to check liveness.
+	isAlive := false
+	if ma.Process != nil {
+		isAlive = ma.Process.IsAlive()
+	} else if ma.State.PID > 0 {
+		isAlive = syscall.Kill(ma.State.PID, 0) == nil
+	}
+
+	if isAlive {
 		// Process is still running. Check for hang: if no output has arrived
 		// for longer than HangingTimeout, mark it hanging.
 		//
@@ -116,7 +125,10 @@ func (m *AgentManager) checkAgent(agentID string) {
 		m.mu.Unlock()
 		return
 	}
-	exitCode := ma.Process.ExitCode()
+	exitCode := -1
+	if ma.Process != nil {
+		exitCode = ma.Process.ExitCode()
+	}
 	ma.State.Status = types.StatusCrashed
 	ma.State.ExitCode = exitCode
 	stoppedAt := nowFunc()

--- a/modules/agent-manager/src/internal/config/config.go
+++ b/modules/agent-manager/src/internal/config/config.go
@@ -22,6 +22,8 @@ const (
 // GlobalConfig holds runtime settings for the agent-manager daemon.
 type GlobalConfig struct {
 	DataDir             string        `json:"data_dir"`
+	ProjectsDir         string        `json:"projects_dir"`
+	DefaultModel        string        `json:"default_model"`
 	HealthCheckInterval time.Duration `json:"health_check_interval"`
 	HangingTimeout      time.Duration `json:"hanging_timeout"`
 	LogMaxSize          int64         `json:"log_max_size"`
@@ -37,6 +39,8 @@ func DefaultConfig() *GlobalConfig {
 	}
 	return &GlobalConfig{
 		DataDir:             filepath.Join(home, ".ccgm", "agent-manager"),
+		ProjectsDir:         filepath.Join(home, "code"),
+		DefaultModel:        "opus",
 		HealthCheckInterval: defaultHealthCheckInterval,
 		HangingTimeout:      defaultHangingTimeout,
 		LogMaxSize:          defaultLogMaxSize,

--- a/modules/agent-manager/src/internal/tui/app.go
+++ b/modules/agent-manager/src/internal/tui/app.go
@@ -212,6 +212,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "n":
 			if m.activePanel == PanelAgentList {
+				m.launch.SetProjectsDir(m.config.ProjectsDir, m.config.DefaultModel)
 				m.launch.SetVisible(true)
 				m.launch.SetSize(m.width, m.height)
 				m.launch.Reset()

--- a/modules/agent-manager/src/internal/tui/commandbar.go
+++ b/modules/agent-manager/src/internal/tui/commandbar.go
@@ -157,19 +157,22 @@ func (m CommandBarModel) hintsForContext() []hint {
 func renderHints(hints []hint, width int) string {
 	keyStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("15")).
-		Background(lipgloss.Color("236"))
+		Foreground(lipgloss.Color("0")).
+		Background(lipgloss.Color("62")).
+		PaddingLeft(1).
+		PaddingRight(1)
 
 	descStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("244")).
-		Background(lipgloss.Color("236"))
+		Foreground(lipgloss.Color("252")).
+		Background(lipgloss.Color("236")).
+		PaddingRight(1)
 
 	var parts []string
 	for _, h := range hints {
-		parts = append(parts, keyStyle.Render(h.key)+" "+descStyle.Render(h.desc))
+		parts = append(parts, keyStyle.Render(h.key)+descStyle.Render(h.desc))
 	}
 
-	content := " " + strings.Join(parts, "  ")
+	content := " " + strings.Join(parts, " ")
 	_ = width // width is applied by the outer bg style
 	return content
 }

--- a/modules/agent-manager/src/internal/tui/launch.go
+++ b/modules/agent-manager/src/internal/tui/launch.go
@@ -1,71 +1,42 @@
-// launch.go implements the modal form for launching a new agent.
+// launch.go implements a directory picker modal for launching new agents.
+// Instead of typing fields manually, the user picks a project directory
+// from a configurable base path. Name and model are derived automatically.
 package tui
 
 import (
-	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 
-	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/types"
 )
 
-// LaunchSubmitMsg is emitted when the user confirms the launch form.
+// LaunchSubmitMsg is emitted when the user selects a directory to launch in.
 type LaunchSubmitMsg struct {
 	Config types.AgentConfig
 }
 
-// launchField is an index into LaunchModel.inputs.
-const (
-	fieldName = iota
-	fieldCommand
-	fieldWorkDir
-	fieldModel
-	numFields
-)
-
-// LaunchModel is a Bubble Tea component that renders a centered modal form
-// for creating a new agent configuration.
+// LaunchModel is a Bubble Tea component that renders a directory picker modal.
 type LaunchModel struct {
-	inputs  [numFields]textinput.Model
-	focused int
-	visible bool
-	width   int
-	height  int
-	err     string
+	dirs         []string // directory names (basenames)
+	filtered     []string // filtered subset
+	cursor       int
+	filter       string
+	filtering    bool
+	visible      bool
+	width        int
+	height       int
+	projectsDir  string // base directory to scan
+	defaultModel string // default model (e.g., "opus")
 }
 
-// NewLaunchModel returns a LaunchModel with all inputs initialized.
+// NewLaunchModel returns a LaunchModel. Call SetProjectsDir before showing.
 func NewLaunchModel() LaunchModel {
-	m := LaunchModel{}
-
-	placeholders := [numFields]string{
-		"e.g. my-agent",
-		"claude",
-		"/path/to/workdir",
-		"opus (optional)",
-	}
-	labels := [numFields]string{
-		"Name (required)",
-		"Command (required)",
-		"Working Directory (required)",
-		"Model (optional)",
-	}
-
-	for i := 0; i < numFields; i++ {
-		ti := textinput.New()
-		ti.Placeholder = placeholders[i]
-		ti.CharLimit = 256
-		ti.Width = 50
-		ti.Prompt = fmt.Sprintf("%-28s ", labels[i])
-		m.inputs[i] = ti
-	}
-
-	// Defaults.
-	m.inputs[fieldCommand].SetValue("claude")
-	return m
+	return LaunchModel{}
 }
 
 // Init satisfies tea.Model.
@@ -81,77 +52,141 @@ func (m LaunchModel) Update(msg tea.Msg) (LaunchModel, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if m.filtering {
+			switch msg.String() {
+			case "esc":
+				m.filtering = false
+				m.filter = ""
+				m.applyFilter()
+				return m, nil
+			case "enter":
+				m.filtering = false
+				return m, nil
+			case "backspace":
+				if len(m.filter) > 0 {
+					m.filter = m.filter[:len(m.filter)-1]
+					m.applyFilter()
+				}
+				return m, nil
+			default:
+				if len(msg.String()) == 1 {
+					m.filter += msg.String()
+					m.applyFilter()
+					return m, nil
+				}
+			}
+			return m, nil
+		}
+
 		switch msg.String() {
-		case "esc":
+		case "esc", "q":
 			m.visible = false
-			m.err = ""
 			return m, nil
 
-		case "tab", "down":
-			m.err = ""
-			m.inputs[m.focused].Blur()
-			m.focused = (m.focused + 1) % numFields
-			m.inputs[m.focused].Focus()
-			return m, textinput.Blink
+		case "j", "down":
+			if m.cursor < len(m.filtered)-1 {
+				m.cursor++
+			}
+			return m, nil
 
-		case "shift+tab", "up":
-			m.err = ""
-			m.inputs[m.focused].Blur()
-			m.focused = (m.focused - 1 + numFields) % numFields
-			m.inputs[m.focused].Focus()
-			return m, textinput.Blink
+		case "k", "up":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+			return m, nil
+
+		case "/":
+			m.filtering = true
+			m.filter = ""
+			return m, nil
 
 		case "enter":
-			if m.focused == numFields-1 {
-				// Last field: try to submit.
-				return m.trySubmit()
+			if len(m.filtered) > 0 && m.cursor < len(m.filtered) {
+				return m.submit()
 			}
-			// Advance to next field.
-			m.inputs[m.focused].Blur()
-			m.focused++
-			m.inputs[m.focused].Focus()
-			return m, textinput.Blink
+			return m, nil
 		}
 	}
-
-	// Forward key strokes to the focused input.
-	var cmd tea.Cmd
-	m.inputs[m.focused], cmd = m.inputs[m.focused].Update(msg)
-	return m, cmd
+	return m, nil
 }
 
-// View renders the modal as a centered dialog string. Returns "" when hidden.
+// View renders the directory picker modal.
 func (m LaunchModel) View() string {
 	if !m.visible {
 		return ""
 	}
 
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12"))
-	errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("62"))
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("0")).Background(lipgloss.Color("62"))
+	normalStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	filterStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
 	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
 	boxStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("62")).
-		Padding(1, 3).
-		Background(lipgloss.Color("235"))
+		Padding(1, 2).
+		Background(lipgloss.Color("235")).
+		Width(60)
 
 	var sb strings.Builder
 	sb.WriteString(titleStyle.Render("Launch New Agent"))
+	sb.WriteString("\n")
+	sb.WriteString(dimStyle.Render("Select a project directory"))
 	sb.WriteString("\n\n")
 
-	for i := 0; i < numFields; i++ {
-		sb.WriteString(m.inputs[i].View())
-		sb.WriteString("\n")
+	if m.filtering {
+		sb.WriteString(filterStyle.Render("/ " + m.filter + "█"))
+		sb.WriteString("\n\n")
+	} else if m.filter != "" {
+		sb.WriteString(dimStyle.Render("filter: " + m.filter))
+		sb.WriteString("\n\n")
 	}
 
-	if m.err != "" {
+	if len(m.filtered) == 0 {
+		sb.WriteString(dimStyle.Render("  (no directories found)"))
 		sb.WriteString("\n")
-		sb.WriteString(errorStyle.Render(m.err))
-		sb.WriteString("\n")
+	} else {
+		// Show a scrollable window of directories.
+		maxVisible := 15
+		if m.height > 0 {
+			maxVisible = m.height/2 - 6
+			if maxVisible < 5 {
+				maxVisible = 5
+			}
+		}
+
+		start := 0
+		if m.cursor >= maxVisible {
+			start = m.cursor - maxVisible + 1
+		}
+		end := start + maxVisible
+		if end > len(m.filtered) {
+			end = len(m.filtered)
+		}
+
+		for i := start; i < end; i++ {
+			prefix := "  "
+			style := normalStyle
+			if i == m.cursor {
+				prefix = "▸ "
+				style = selectedStyle
+			}
+			sb.WriteString(prefix + style.Render(m.filtered[i]))
+			sb.WriteString("\n")
+		}
+
+		if len(m.filtered) > maxVisible {
+			sb.WriteString(dimStyle.Render(
+				strings.Repeat(" ", 2) +
+					"(" + strings.Repeat("·", len(m.filtered)-maxVisible) + ")",
+			))
+			sb.WriteString("\n")
+		}
 	}
 
 	sb.WriteString("\n")
-	sb.WriteString(hintStyle.Render("tab/↓↑ navigate   enter confirm   esc cancel"))
+	sb.WriteString(hintStyle.Render("j/k navigate   enter select   / filter   esc cancel"))
 
 	return boxStyle.Render(sb.String())
 }
@@ -159,11 +194,6 @@ func (m LaunchModel) View() string {
 // SetVisible shows or hides the modal.
 func (m *LaunchModel) SetVisible(v bool) {
 	m.visible = v
-	if v {
-		m.inputs[m.focused].Focus()
-	} else {
-		m.inputs[m.focused].Blur()
-	}
 }
 
 // Visible reports whether the modal is currently shown.
@@ -171,78 +201,95 @@ func (m LaunchModel) Visible() bool {
 	return m.visible
 }
 
-// SetSize stores terminal dimensions (used by the parent to center the overlay).
+// SetSize stores terminal dimensions.
 func (m *LaunchModel) SetSize(w, h int) {
 	m.width = w
 	m.height = h
 }
 
-// Reset clears all input fields and positions focus on the Name field.
-func (m *LaunchModel) Reset() {
-	for i := 0; i < numFields; i++ {
-		m.inputs[i].SetValue("")
-		m.inputs[i].Blur()
-	}
-	m.inputs[fieldCommand].SetValue("claude")
-	m.focused = fieldName
-	m.inputs[m.focused].Focus()
-	m.err = ""
+// SetProjectsDir sets the base directory to scan and the default model.
+func (m *LaunchModel) SetProjectsDir(dir, defaultModel string) {
+	m.projectsDir = dir
+	m.defaultModel = defaultModel
 }
 
-// trySubmit validates inputs and returns LaunchSubmitMsg if valid.
-func (m LaunchModel) trySubmit() (LaunchModel, tea.Cmd) {
-	name := strings.TrimSpace(m.inputs[fieldName].Value())
-	command := strings.TrimSpace(m.inputs[fieldCommand].Value())
-	workDir := strings.TrimSpace(m.inputs[fieldWorkDir].Value())
-	modelVal := strings.TrimSpace(m.inputs[fieldModel].Value())
+// Reset scans the projects directory and resets selection state.
+func (m *LaunchModel) Reset() {
+	m.cursor = 0
+	m.filter = ""
+	m.filtering = false
+	m.dirs = scanDirs(m.projectsDir)
+	m.filtered = m.dirs
+}
 
-	if name == "" {
-		m.err = "Name is required"
-		m.focused = fieldName
-		m.inputs[m.focused].Focus()
-		return m, nil
+// applyFilter updates the filtered list based on the current filter string.
+func (m *LaunchModel) applyFilter() {
+	if m.filter == "" {
+		m.filtered = m.dirs
+	} else {
+		lower := strings.ToLower(m.filter)
+		m.filtered = nil
+		for _, d := range m.dirs {
+			if strings.Contains(strings.ToLower(d), lower) {
+				m.filtered = append(m.filtered, d)
+			}
+		}
 	}
-	if command == "" {
-		m.err = "Command is required"
-		m.focused = fieldCommand
-		m.inputs[m.focused].Focus()
-		return m, nil
+	if m.cursor >= len(m.filtered) {
+		m.cursor = len(m.filtered) - 1
 	}
-	if workDir == "" {
-		m.err = "Working Directory is required"
-		m.focused = fieldWorkDir
-		m.inputs[m.focused].Focus()
-		return m, nil
+	if m.cursor < 0 {
+		m.cursor = 0
 	}
+}
 
-	// Generate a stable ID from the name.
-	id := sanitizeID(name)
+// submit creates an AgentConfig from the selected directory.
+func (m LaunchModel) submit() (LaunchModel, tea.Cmd) {
+	dirName := m.filtered[m.cursor]
+	fullPath := filepath.Join(m.projectsDir, dirName)
+	id := sanitizeID(dirName)
 
 	cfg := types.AgentConfig{
 		ID:         id,
-		Name:       name,
-		Command:    command,
-		WorkingDir: workDir,
-		Model:      modelVal,
+		Name:       dirName,
+		Command:    "claude",
+		WorkingDir: fullPath,
+		Model:      m.defaultModel,
 		RestartPolicy: types.RestartPolicy{
 			Type: "never",
 		},
 	}
 
-	if err := cfg.Validate(); err != nil {
-		m.err = err.Error()
-		return m, nil
-	}
-
 	m.visible = false
-	m.err = ""
 	return m, func() tea.Msg {
 		return LaunchSubmitMsg{Config: cfg}
 	}
 }
 
-// sanitizeID converts a display name to a valid agent ID by lowercasing and
-// replacing invalid characters with hyphens.
+// scanDirs reads the immediate subdirectories of dir and returns their names sorted.
+func scanDirs(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var dirs []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		// Skip hidden directories.
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		dirs = append(dirs, name)
+	}
+	sort.Strings(dirs)
+	return dirs
+}
+
+// sanitizeID converts a display name to a valid agent ID.
 func sanitizeID(name string) string {
 	name = strings.ToLower(name)
 	var sb strings.Builder


### PR DESCRIPTION
Closes #243

## Changes

**Process Discovery**
- On startup, scans for running Claude Code processes via `pgrep`/`lsof`
- Registers discovered sessions with their PID and working directory
- Health check handles discovered agents (no Process handle) via `kill -0`

**Launch Modal Redesign**
- Replaced text-input form with a directory picker
- Scans `projects_dir` (configurable, defaults to `~/code`) for subdirectories
- j/k navigation, `/` to filter, Enter to select
- Agent name auto-derived from directory name
- Model defaults to `opus` (configurable via `default_model`)
- No typing required - just pick and go

**Command Bar Readability**
- Keys now have highlighted background (color 62) with dark text
- Descriptions use brighter foreground (color 252)
- Much higher contrast than the previous dim styling

**Config Additions**
- `projects_dir`: base directory for the directory picker (default: `~/code`)
- `default_model`: default model for new agents (default: `opus`)