### PR TITLE
#249: tmux pane-based layout with persistent dashboard

### DIFF
--- a/modules/agent-manager/src/internal/agent/health.go
+++ b/modules/agent-manager/src/internal/agent/health.go
@@ -76,9 +76,11 @@ func (m *AgentManager) checkAgent(agentID string) {
 		return
 	}
 
-	// Check liveness: tmux session first, then direct process, then PID.
+	// Check liveness: tmux pane first, then session, then direct process, then PID.
 	isAlive := false
-	if ma.TmuxSession != "" {
+	if ma.TmuxPaneID != "" {
+		isAlive = TmuxPaneIsAlive(ma.TmuxPaneID)
+	} else if ma.TmuxSession != "" {
 		isAlive = TmuxIsAlive(ma.TmuxSession)
 	} else if ma.Process != nil {
 		isAlive = ma.Process.IsAlive()

--- a/modules/agent-manager/src/internal/agent/manager.go
+++ b/modules/agent-manager/src/internal/agent/manager.go
@@ -129,8 +129,9 @@ type AgentEvent struct {
 type ManagedAgent struct {
 	Config       types.AgentConfig
 	State        types.AgentState
-	TmuxSession  string    // tmux session name (e.g., "ccgm-my-agent")
-	Process      *Process  // legacy: only used by tests with direct spawn
+	TmuxSession  string    // legacy tmux session name
+	TmuxPaneID   string    // tmux pane ID (e.g., "%5") for pane-based layout
+	Process      *Process  // only used by tests with DirectSpawn
 	lastOutputAt time.Time // updated by the log collector when output is received
 }
 
@@ -223,15 +224,15 @@ func (m *AgentManager) StartAgent(agentCfg *types.AgentConfig) error {
 		return nil
 	}
 
-	// Tmux mode (production).
-	sessionName := TmuxSessionName(agentCfg.ID)
-	if _, err := TmuxLaunch(agentCfg); err != nil {
+	// Tmux pane mode (production).
+	paneInfo, err := TmuxLaunchPane(agentCfg)
+	if err != nil {
 		return fmt.Errorf("start agent %q: %w", agentCfg.ID, err)
 	}
 
 	ma := &ManagedAgent{
-		Config:      *agentCfg,
-		TmuxSession: sessionName,
+		Config:     *agentCfg,
+		TmuxPaneID: paneInfo.PaneID,
 		State: types.AgentState{
 			Config:    *agentCfg,
 			Status:    types.StatusRunning,
@@ -243,7 +244,7 @@ func (m *AgentManager) StartAgent(agentCfg *types.AgentConfig) error {
 	m.agents[agentCfg.ID] = ma
 	m.mu.Unlock()
 
-	m.emit(AgentEvent{AgentID: agentCfg.ID, Type: EventStarted, Details: fmt.Sprintf("tmux:%s", sessionName)})
+	m.emit(AgentEvent{AgentID: agentCfg.ID, Type: EventStarted, Details: fmt.Sprintf("pane:%s", paneInfo.PaneID)})
 	return nil
 }
 
@@ -257,8 +258,12 @@ func (m *AgentManager) StopAgent(agentID string) error {
 		return fmt.Errorf("stop agent %q: not found", agentID)
 	}
 
-	// Try tmux kill first, fall back to direct process kill.
-	if ma.TmuxSession != "" {
+	// Try tmux pane kill first, then session, then direct process.
+	if ma.TmuxPaneID != "" {
+		if err := TmuxKillPane(ma.TmuxPaneID); err != nil {
+			return fmt.Errorf("stop agent %q: %w", agentID, err)
+		}
+	} else if ma.TmuxSession != "" {
 		if err := TmuxKill(ma.TmuxSession); err != nil {
 			return fmt.Errorf("stop agent %q: %w", agentID, err)
 		}

--- a/modules/agent-manager/src/internal/agent/tmux.go
+++ b/modules/agent-manager/src/internal/agent/tmux.go
@@ -1,6 +1,6 @@
-// tmux.go provides tmux-based process management for Claude Code agents.
-// Instead of spawning claude as a child process with captured pipes, we launch
-// it in a tmux session so it gets a real TTY and the user can attach to interact.
+// tmux.go provides tmux pane-based process management for Claude Code agents.
+// The agent manager runs in a left pane, and each agent gets its own pane
+// in the same tmux window. Users navigate with standard tmux keybindings.
 package agent
 
 import (
@@ -11,53 +11,121 @@ import (
 	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/types"
 )
 
-// TmuxSession represents a Claude Code agent running in a tmux session.
-type TmuxSession struct {
-	Name       string // tmux session name (same as agent ID)
-	WorkingDir string
+// TmuxSessionName is the tmux session name used by the agent manager.
+const TmuxSessionName = "ccgm-am"
+
+// TmuxPaneInfo holds the tmux pane ID for a launched agent.
+type TmuxPaneInfo struct {
+	PaneID string // e.g., "%5"
 }
 
-// TmuxLaunch creates a new tmux session running claude in the given directory.
-// The session name is derived from the agent config ID.
-func TmuxLaunch(cfg *types.AgentConfig) (*TmuxSession, error) {
-	sessionName := "ccgm-" + cfg.ID
-
-	// Build the claude command with model flag if specified.
+// TmuxLaunchPane creates a new tmux pane running claude in the given directory.
+// The pane is created by splitting the current window horizontally (new pane
+// appears to the right). Returns the pane ID.
+func TmuxLaunchPane(cfg *types.AgentConfig) (*TmuxPaneInfo, error) {
+	// Build the claude command.
 	claudeCmd := "claude"
 	if cfg.Model != "" {
 		claudeCmd = fmt.Sprintf("claude --model %s", cfg.Model)
 	}
 
-	// Create a detached tmux session running claude.
-	// tmux new-session -d -s {name} -c {workdir} "{command}"
-	cmd := exec.Command("tmux", "new-session", "-d",
-		"-s", sessionName,
+	// Split the window horizontally, creating a new pane to the right.
+	// -d: don't switch focus to the new pane (keep focus on the manager)
+	// -c: set the working directory
+	// -P -F '#{pane_id}': print the new pane's ID
+	cmd := exec.Command("tmux", "split-window", "-h",
+		"-d",
 		"-c", cfg.WorkingDir,
+		"-P", "-F", "#{pane_id}",
 		claudeCmd,
 	)
 
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return nil, fmt.Errorf("tmux launch %q: %s: %w", sessionName, strings.TrimSpace(string(out)), err)
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr = string(exitErr.Stderr)
+		}
+		return nil, fmt.Errorf("tmux split-window: %s: %w", strings.TrimSpace(stderr), err)
 	}
 
-	return &TmuxSession{
-		Name:       sessionName,
-		WorkingDir: cfg.WorkingDir,
-	}, nil
+	paneID := strings.TrimSpace(string(out))
+	if paneID == "" {
+		return nil, fmt.Errorf("tmux split-window: empty pane ID")
+	}
+
+	// Rebalance panes so they're evenly distributed.
+	_ = exec.Command("tmux", "select-layout", "main-vertical").Run()
+
+	return &TmuxPaneInfo{PaneID: paneID}, nil
 }
 
-// TmuxIsAlive checks if a tmux session exists and is running.
+// TmuxPaneIsAlive checks if a tmux pane exists.
+func TmuxPaneIsAlive(paneID string) bool {
+	cmd := exec.Command("tmux", "list-panes", "-F", "#{pane_id}")
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) == paneID {
+			return true
+		}
+	}
+	return false
+}
+
+// TmuxKillPane kills a specific tmux pane.
+func TmuxKillPane(paneID string) error {
+	cmd := exec.Command("tmux", "kill-pane", "-t", paneID)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		outStr := strings.TrimSpace(string(out))
+		if strings.Contains(outStr, "no server running") || strings.Contains(outStr, "can't find") {
+			return nil
+		}
+		return fmt.Errorf("tmux kill-pane %q: %s: %w", paneID, outStr, err)
+	}
+	return nil
+}
+
+// TmuxCapturePane captures the visible content of a tmux pane.
+func TmuxCapturePane(paneID string) (string, error) {
+	cmd := exec.Command("tmux", "capture-pane", "-t", paneID, "-p", "-S", "-50")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("tmux capture-pane %q: %w", paneID, err)
+	}
+	return string(out), nil
+}
+
+// TmuxSelectPane focuses a specific pane.
+func TmuxSelectPane(paneID string) error {
+	cmd := exec.Command("tmux", "select-pane", "-t", paneID)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tmux select-pane %q: %s: %w", paneID, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// TmuxIsInsideSession returns true if we're currently running inside tmux.
+func TmuxIsInsideSession() bool {
+	cmd := exec.Command("tmux", "display-message", "-p", "#{session_name}")
+	return cmd.Run() == nil
+}
+
+// Legacy session-based functions (kept for backward compatibility with state files).
+
+// TmuxIsAlive checks if a tmux session exists. Used for legacy re-attachment.
 func TmuxIsAlive(sessionName string) bool {
 	cmd := exec.Command("tmux", "has-session", "-t", sessionName)
 	return cmd.Run() == nil
 }
 
-// TmuxKill kills a tmux session.
+// TmuxKill kills a tmux session. Used for legacy cleanup.
 func TmuxKill(sessionName string) error {
 	cmd := exec.Command("tmux", "kill-session", "-t", sessionName)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		outStr := strings.TrimSpace(string(out))
-		// Session already dead is not an error.
 		if strings.Contains(outStr, "no server running") || strings.Contains(outStr, "session not found") {
 			return nil
 		}
@@ -66,8 +134,7 @@ func TmuxKill(sessionName string) error {
 	return nil
 }
 
-// TmuxCapture captures the visible content of a tmux pane.
-// Returns the current screen content as a string.
+// TmuxCapture captures content from a tmux session's first pane. Legacy.
 func TmuxCapture(sessionName string) (string, error) {
 	cmd := exec.Command("tmux", "capture-pane", "-t", sessionName, "-p", "-S", "-50")
 	out, err := cmd.Output()
@@ -77,13 +144,7 @@ func TmuxCapture(sessionName string) (string, error) {
 	return string(out), nil
 }
 
-// TmuxAttachCmd returns the exec.Cmd to attach to a tmux session.
-// The caller should use tea.ExecProcess to hand off the terminal.
+// TmuxAttachCmd returns the command to attach to a tmux session. Legacy.
 func TmuxAttachCmd(sessionName string) *exec.Cmd {
 	return exec.Command("tmux", "attach-session", "-t", sessionName)
-}
-
-// TmuxSessionName returns the tmux session name for an agent ID.
-func TmuxSessionName(agentID string) string {
-	return "ccgm-" + agentID
 }

--- a/modules/agent-manager/src/internal/tui/app.go
+++ b/modules/agent-manager/src/internal/tui/app.go
@@ -118,10 +118,16 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, tickCmd())
 
 		// Capture tmux pane for the agent the log viewer is watching.
-		// tmux capture gives a snapshot, so we clear and replace each tick.
 		if m.logViewer.AgentID() != "" {
-			if ma, ok := m.agentManager.GetAgent(m.logViewer.AgentID()); ok && ma.TmuxSession != "" {
-				if content, err := agent.TmuxCapture(ma.TmuxSession); err == nil && content != "" {
+			if ma, ok := m.agentManager.GetAgent(m.logViewer.AgentID()); ok {
+				var content string
+				var err error
+				if ma.TmuxPaneID != "" {
+					content, err = agent.TmuxCapturePane(ma.TmuxPaneID)
+				} else if ma.TmuxSession != "" {
+					content, err = agent.TmuxCapture(ma.TmuxSession)
+				}
+				if err == nil && content != "" {
 					lines := tmuxContentToLogLines(content)
 					if len(lines) > 0 {
 						m.logViewer.ClearLogs()
@@ -260,20 +266,20 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "a", "enter":
-			// Attach to the selected agent's tmux session.
+			// Focus the selected agent's tmux pane.
 			if m.activePanel == PanelAgentList {
 				if sel, ok := m.agentList.SelectedAgent(); ok {
-					if ma, ok := m.agentManager.GetAgent(sel.ID); ok && ma.TmuxSession != "" {
-						if agent.TmuxIsAlive(ma.TmuxSession) {
-							attachCmd := agent.TmuxAttachCmd(ma.TmuxSession)
-							return m, tea.ExecProcess(attachCmd, func(err error) tea.Msg {
-								if err != nil {
-									return StatusMsg{Text: fmt.Sprintf("attach failed: %v", err), IsError: true}
-								}
-								return StatusMsg{Text: fmt.Sprintf("detached from %s", sel.Name), IsError: false}
-							})
+					if ma, ok := m.agentManager.GetAgent(sel.ID); ok {
+						if ma.TmuxPaneID != "" && agent.TmuxPaneIsAlive(ma.TmuxPaneID) {
+							if err := agent.TmuxSelectPane(ma.TmuxPaneID); err != nil {
+								return m, sendStatus(fmt.Sprintf("focus failed: %v", err), true)
+							}
+							// Also switch log viewer to this agent.
+							m.logViewer.SetAgent(sel.ID, sel.Name)
+							m.logViewer.ClearLogs()
+							return m, sendStatus(fmt.Sprintf("focused %s (ctrl-b ← to return)", sel.Name), false)
 						}
-						return m, sendStatus(fmt.Sprintf("session %s is not running", ma.TmuxSession), true)
+						return m, sendStatus(fmt.Sprintf("%s is not running", sel.Name), true)
 					}
 				}
 				return m, tea.Batch(cmds...)

--- a/modules/agent-manager/src/internal/tui/commandbar.go
+++ b/modules/agent-manager/src/internal/tui/commandbar.go
@@ -142,7 +142,7 @@ func (m CommandBarModel) hintsForContext() []hint {
 	default: // ContextAgentList
 		return []hint{
 			{key: "n", desc: "new"},
-			{key: "a", desc: "attach"},
+			{key: "a", desc: "focus"},
 			{key: "s", desc: "stop"},
 			{key: "r", desc: "restart"},
 			{key: "x", desc: "kill"},


### PR DESCRIPTION
Closes #249

## Layout
- `am` launches a tmux session (`ccgm-am`) with the agent manager TUI
- Press `n` to launch a new agent - it opens as a tmux pane to the right
- Dashboard stays visible in the left pane
- Multiple agents visible simultaneously as split panes
- Standard tmux navigation: `ctrl-b ←/→` to switch between dashboard and agents

## Keybindings
- `a` / `Enter`: focus the selected agent's pane
- `ctrl-b ←`: return to dashboard
- `ctrl-b →/↓/↑`: navigate between agent panes
- All other keybindings unchanged