### PR TITLE
#251: remove logs panel, clean agent list styling, fix hanging status

### DIFF
--- a/modules/agent-manager/src/internal/agent/health.go
+++ b/modules/agent-manager/src/internal/agent/health.go
@@ -89,16 +89,21 @@ func (m *AgentManager) checkAgent(agentID string) {
 	}
 
 	if isAlive {
-		// Process is still running. Check for hang: if no output has arrived
-		// for longer than HangingTimeout, mark it hanging.
-		//
-		// Note: tracking "last output time" requires integrating with the log
-		// collector. As a pragmatic initial implementation we check the wall
-		// clock since start as a proxy when no log collector is wired up. The
-		// TUI Epic will wire up the collector and update lastOutputAt on each
-		// received line.
+		// For tmux-based agents, skip hang detection entirely. We can't
+		// monitor stdout from a tmux pane, so "no output" is meaningless.
+		if ma.TmuxPaneID != "" || ma.TmuxSession != "" {
+			// Ensure status stays "running" (fix any stale "hanging" state).
+			m.mu.Lock()
+			if ma.State.Status == types.StatusHanging {
+				ma.State.Status = types.StatusRunning
+			}
+			m.mu.Unlock()
+			return
+		}
+
+		// Direct-spawn agents: check for hang via output timeout.
 		m.mu.RLock()
-		lastOutput := ma.State.StartedAt // fallback when no collector is wired
+		lastOutput := ma.State.StartedAt
 		if !ma.lastOutputAt.IsZero() {
 			lastOutput = ma.lastOutputAt
 		}

--- a/modules/agent-manager/src/internal/tui/agentlist.go
+++ b/modules/agent-manager/src/internal/tui/agentlist.go
@@ -1,4 +1,4 @@
-// agentlist.go implements the scrollable agent list panel for the left pane.
+// agentlist.go implements the agent list panel for the dashboard.
 package tui
 
 import (
@@ -48,7 +48,7 @@ func NewAgentListModel() AgentListModel {
 	return AgentListModel{}
 }
 
-// Init satisfies the tea.Model interface. No I/O needed on startup.
+// Init satisfies the tea.Model interface.
 func (m AgentListModel) Init() tea.Cmd {
 	return nil
 }
@@ -59,10 +59,8 @@ func (m AgentListModel) Update(msg tea.Msg) (AgentListModel, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-
 	case AgentListUpdatedMsg:
 		m.SetAgents(msg.Agents)
-
 	case tea.KeyMsg:
 		if m.filtering {
 			return m.updateFilter(msg)
@@ -72,7 +70,6 @@ func (m AgentListModel) Update(msg tea.Msg) (AgentListModel, tea.Cmd) {
 	return m, nil
 }
 
-// updateFilter handles key input while the filter input is active.
 func (m AgentListModel) updateFilter(msg tea.KeyMsg) (AgentListModel, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
@@ -93,10 +90,8 @@ func (m AgentListModel) updateFilter(msg tea.KeyMsg) (AgentListModel, tea.Cmd) {
 	return m, nil
 }
 
-// updateNav handles key input during normal (non-filter) navigation.
 func (m AgentListModel) updateNav(msg tea.KeyMsg) (AgentListModel, tea.Cmd) {
 	visible := m.visibleAgents()
-
 	switch msg.String() {
 	case "k", "up":
 		if m.cursor > 0 {
@@ -119,67 +114,83 @@ func (m AgentListModel) updateNav(msg tea.KeyMsg) (AgentListModel, tea.Cmd) {
 	return m, nil
 }
 
-// View renders the agent list panel as a string.
+// View renders the agent list panel.
 func (m AgentListModel) View() string {
 	visible := m.visibleAgents()
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	filterStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
 
 	var sb strings.Builder
 
-	// Title bar
-	title := "Agents"
-	if m.filter != "" {
-		title = fmt.Sprintf("Agents [%s]", m.filter)
+	// Title
+	sb.WriteString(TitleStyle.Render("Agents"))
+	if len(m.agents) > 0 {
+		sb.WriteString(dimStyle.Render(fmt.Sprintf("  %d active", len(m.agents))))
 	}
-	sb.WriteString(TitleStyle.Render(title))
-	sb.WriteString("\n")
+	sb.WriteString("\n\n")
 
-	// Filter mode prompt
+	// Filter
 	if m.filtering {
-		sb.WriteString(fmt.Sprintf("Filter: %s_\n", m.filter))
+		sb.WriteString(filterStyle.Render("  / " + m.filter + "█"))
+		sb.WriteString("\n\n")
 	}
 
 	// Empty state
 	if len(visible) == 0 {
 		if m.filter != "" {
-			sb.WriteString("(no agents match filter)\n")
+			sb.WriteString(dimStyle.Render("  (no agents match filter)"))
 		} else {
-			sb.WriteString("(no agents)\n")
+			sb.WriteString(dimStyle.Render("  (no agents)"))
+			sb.WriteString("\n\n")
+			sb.WriteString(dimStyle.Render("  Press n to launch a new agent"))
 		}
+		sb.WriteString("\n")
 		return m.wrapBorder(sb.String())
 	}
 
-	// Column header
-	header := fmt.Sprintf("%-20s  %-13s  %-8s  %-7s  %-8s",
-		"Name", "Status", "Uptime", "PID", "Restarts")
-	sb.WriteString(HeaderStyle.Render(header))
-	sb.WriteString("\n")
-
-	// Agent rows
-	for i, agent := range visible {
-		row := fmt.Sprintf("%-20s  %-13s  %-8s  %-7s  %-8s",
-			truncate(agent.Name, 20),
-			m.renderStatus(agent.Status),
-			formatUptime(agent.Uptime),
-			formatPID(agent.PID),
-			fmt.Sprintf("%d", agent.RestartCount),
-		)
-		if i == m.cursor {
-			sb.WriteString(SelectedStyle.Render(row))
-		} else {
-			sb.WriteString(row)
+	// Agent rows - card-style, one agent per block.
+	for i, a := range visible {
+		if i > 0 {
+			sb.WriteString("\n")
 		}
+
+		// Status indicator and name
+		statusDot, statusColor := statusIndicator(a.Status)
+		nameStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("252"))
+		if i == m.cursor {
+			nameStyle = nameStyle.Foreground(lipgloss.Color("62"))
+		}
+
+		cursor := "  "
+		if i == m.cursor {
+			cursor = "▸ "
+		}
+
+		sb.WriteString(cursor)
+		sb.WriteString(statusColor.Render(statusDot))
+		sb.WriteString(" ")
+		sb.WriteString(nameStyle.Render(a.Name))
+		sb.WriteString("\n")
+
+		// Details line
+		details := dimStyle.Render(fmt.Sprintf("    %s  %s",
+			statusLabel(a.Status),
+			formatUptime(a.Uptime),
+		))
+		sb.WriteString(details)
 		sb.WriteString("\n")
 	}
 
-	// Filter count hint
+	// Filter count
 	if m.filter != "" {
-		sb.WriteString(fmt.Sprintf("\n%d/%d shown", len(visible), len(m.agents)))
+		sb.WriteString(dimStyle.Render(fmt.Sprintf("\n  %d/%d shown", len(visible), len(m.agents))))
+		sb.WriteString("\n")
 	}
 
 	return m.wrapBorder(sb.String())
 }
 
-// SetAgents replaces the agent list and clamps the cursor.
+// SetAgents replaces the agent list.
 func (m *AgentListModel) SetAgents(agents []AgentListItem) {
 	m.agents = agents
 	m.clampCursor()
@@ -191,12 +202,12 @@ func (m *AgentListModel) SetSize(width, height int) {
 	m.height = height
 }
 
-// SetFocused marks the panel as focused or unfocused (affects border color).
+// SetFocused marks the panel as focused or unfocused.
 func (m *AgentListModel) SetFocused(focused bool) {
 	m.focused = focused
 }
 
-// SelectedAgent returns the agent under the cursor, if any.
+// SelectedAgent returns the agent under the cursor.
 func (m AgentListModel) SelectedAgent() (AgentListItem, bool) {
 	visible := m.visibleAgents()
 	if len(visible) == 0 || m.cursor < 0 || m.cursor >= len(visible) {
@@ -210,7 +221,6 @@ func (m AgentListModel) Focused() bool {
 	return m.focused
 }
 
-// visibleAgents returns the subset of agents that match the current filter.
 func (m AgentListModel) visibleAgents() []AgentListItem {
 	if m.filter == "" {
 		return m.agents
@@ -225,7 +235,6 @@ func (m AgentListModel) visibleAgents() []AgentListItem {
 	return out
 }
 
-// clampCursor keeps the cursor within the bounds of the visible agent list.
 func (m *AgentListModel) clampCursor() {
 	visible := m.visibleAgents()
 	if len(visible) == 0 {
@@ -240,67 +249,75 @@ func (m *AgentListModel) clampCursor() {
 	}
 }
 
-// wrapBorder wraps content in the appropriate border style based on focus.
 func (m AgentListModel) wrapBorder(content string) string {
 	style := InactiveBorderStyle
 	if m.focused {
 		style = ActiveBorderStyle
 	}
 	if m.width > 0 {
-		// Subtract 2 for the border characters on each side.
 		inner := m.width - 2
 		if inner > 0 {
 			style = style.Width(inner)
 		}
 	}
+	if m.height > 0 {
+		inner := m.height - 2
+		if inner > 0 {
+			style = style.Height(inner)
+		}
+	}
 	return style.Render(content)
 }
 
-// renderStatus returns a colored status indicator string.
-func (m AgentListModel) renderStatus(status types.AgentStatus) string {
-	dot := "●"
+// statusIndicator returns a colored dot for the agent's status.
+func statusIndicator(status types.AgentStatus) (string, lipgloss.Style) {
 	switch status {
 	case types.StatusRunning:
-		return StatusRunning.Render(dot + " running")
-	case types.StatusHanging:
-		return StatusHanging.Render(dot + " hanging")
+		return "●", StatusRunning
 	case types.StatusCrashed:
-		return StatusCrashed.Render(dot + " crashed")
+		return "●", StatusCrashed
 	case types.StatusStopped:
-		return StatusStopped.Render(dot + " stopped")
+		return "○", StatusStopped
 	case types.StatusRestarting:
-		return StatusRestarting.Render(dot + " restarting")
+		return "◐", StatusRestarting
 	default:
-		return lipgloss.NewStyle().Render(dot + " " + string(status))
+		// Treat hanging and any unknown status as running.
+		return "●", StatusRunning
 	}
 }
 
-// formatUptime converts a duration to a human-readable short string.
+// statusLabel returns a human-readable label for the status.
+func statusLabel(status types.AgentStatus) string {
+	switch status {
+	case types.StatusRunning, types.StatusHanging:
+		return "running"
+	case types.StatusCrashed:
+		return "crashed"
+	case types.StatusStopped:
+		return "stopped"
+	case types.StatusRestarting:
+		return "restarting"
+	default:
+		return string(status)
+	}
+}
+
 func formatUptime(d time.Duration) string {
-	if d < 0 {
-		d = 0
+	if d <= 0 {
+		return ""
 	}
 	h := int(d.Hours())
 	m := int(d.Minutes()) % 60
 	s := int(d.Seconds()) % 60
 	if h > 0 {
-		return fmt.Sprintf("%dh%02dm", h, m)
+		return fmt.Sprintf("%dh %02dm", h, m)
 	}
 	if m > 0 {
-		return fmt.Sprintf("%dm%02ds", m, s)
+		return fmt.Sprintf("%dm %02ds", m, s)
 	}
 	return fmt.Sprintf("%ds", s)
 }
 
-// formatPID returns a dash when the PID is 0 (agent not running).
-func formatPID(pid int) string {
-	if pid == 0 {
-		return "-"
-	}
-	return fmt.Sprintf("%d", pid)
-}
-
-// truncate shortens s to max runes, appending "..." if needed.
 func truncate(s string, max int) string {
 	runes := []rune(s)
 	if len(runes) <= max {

--- a/modules/agent-manager/src/internal/tui/agentlist_test.go
+++ b/modules/agent-manager/src/internal/tui/agentlist_test.go
@@ -57,30 +57,33 @@ func TestView_ShowsAgentNames(t *testing.T) {
 }
 
 func TestView_AllStatuses(t *testing.T) {
-	statuses := []types.AgentStatus{
-		types.StatusRunning,
-		types.StatusHanging,
-		types.StatusCrashed,
-		types.StatusStopped,
-		types.StatusRestarting,
+	// Hanging is mapped to "running" in the display. Test the display labels.
+	tests := []struct {
+		status types.AgentStatus
+		label  string
+	}{
+		{types.StatusRunning, "running"},
+		{types.StatusHanging, "running"}, // hanging displays as running
+		{types.StatusCrashed, "crashed"},
+		{types.StatusStopped, "stopped"},
+		{types.StatusRestarting, "restarting"},
 	}
-	for _, status := range statuses {
+	for _, tt := range tests {
 		m := NewAgentListModel()
-		m.SetAgents([]AgentListItem{makeItem("a1", "agent", status, 100)})
+		m.SetAgents([]AgentListItem{makeItem("a1", "agent", tt.status, 100)})
 		view := m.View()
-		// Each status name should appear somewhere in the rendered view.
-		if !strings.Contains(view, string(status)) {
-			t.Errorf("status %q not found in view:\n%s", status, view)
+		if !strings.Contains(view, tt.label) {
+			t.Errorf("status %q: expected label %q in view:\n%s", tt.status, tt.label, view)
 		}
 	}
 }
 
-func TestView_ShowsHeader(t *testing.T) {
+func TestView_ShowsTitle(t *testing.T) {
 	m := NewAgentListModel()
 	m.SetAgents([]AgentListItem{makeItem("a1", "x", types.StatusRunning, 1)})
 	view := m.View()
-	if !strings.Contains(view, "Name") {
-		t.Errorf("expected 'Name' column header in view, got:\n%s", view)
+	if !strings.Contains(view, "Agents") {
+		t.Errorf("expected 'Agents' title in view, got:\n%s", view)
 	}
 }
 
@@ -343,23 +346,14 @@ func TestFormatUptime(t *testing.T) {
 		want string
 	}{
 		{45 * time.Second, "45s"},
-		{90 * time.Second, "1m30s"},
-		{3700 * time.Second, "1h01m"},
+		{90 * time.Second, "1m 30s"},
+		{3700 * time.Second, "1h 01m"},
 	}
 	for _, c := range cases {
 		got := formatUptime(c.d)
 		if got != c.want {
 			t.Errorf("formatUptime(%v) = %q, want %q", c.d, got, c.want)
 		}
-	}
-}
-
-func TestFormatPID(t *testing.T) {
-	if formatPID(0) != "-" {
-		t.Error("expected '-' for PID 0")
-	}
-	if formatPID(1234) != "1234" {
-		t.Errorf("expected '1234', got %q", formatPID(1234))
 	}
 }
 

--- a/modules/agent-manager/src/internal/tui/app.go
+++ b/modules/agent-manager/src/internal/tui/app.go
@@ -5,7 +5,6 @@ package tui
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -13,16 +12,7 @@ import (
 
 	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/agent"
 	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/config"
-	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/log"
 	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/types"
-)
-
-// Panel identifies which panel currently has keyboard focus.
-type Panel int
-
-const (
-	PanelAgentList Panel = iota
-	PanelLogViewer
 )
 
 // tickMsg is sent on each 500ms refresh tick to poll the AgentManager.
@@ -33,62 +23,48 @@ type agentEventMsg struct {
 	event agent.AgentEvent
 }
 
-// logBatchMsg wraps a log.LogLineMsg (from the LogCollector) for delivery.
-type logBatchMsg struct {
-	batch log.LogLineMsg
-}
-
 const refreshInterval = 500 * time.Millisecond
 
 // AppModel is the root Bubble Tea model. It owns all sub-components and
-// orchestrates focus, layout, and lifecycle actions.
+// orchestrates layout and lifecycle actions. The logs panel has been removed
+// since agents run in visible tmux panes alongside the dashboard.
 type AppModel struct {
-	// Sub-components
-	agentList  AgentListModel
-	logViewer  LogViewerModel
-	commandBar CommandBarModel
-	help       HelpModel
-	launch     LaunchModel
-	detail     DetailModel
+	agentList    AgentListModel
+	commandBar   CommandBarModel
+	help         HelpModel
+	launch       LaunchModel
+	detail       DetailModel
 
-	// Runtime
 	agentManager *agent.AgentManager
 	config       *config.GlobalConfig
 	cancel       context.CancelFunc
 
-	// Layout
-	activePanel Panel
-	width       int
-	height      int
-
-	// Quit state
+	width    int
+	height   int
 	quitting bool
 }
 
-// NewApp constructs an AppModel. Call tea.NewProgram(app).Run() to start.
+// NewApp constructs an AppModel.
 func NewApp(mgr *agent.AgentManager, cfg *config.GlobalConfig) AppModel {
 	keys := DefaultKeyMap
 	m := AppModel{
 		agentList:    NewAgentListModel(),
-		logViewer:    NewLogViewerModel(),
 		commandBar:   NewCommandBarModel(keys),
 		help:         NewHelpModel(keys),
 		launch:       NewLaunchModel(),
 		detail:       NewDetailModel(),
 		agentManager: mgr,
 		config:       cfg,
-		activePanel:  PanelAgentList,
 	}
 	m.agentList.SetFocused(true)
+	m.commandBar.SetContext(ContextAgentList)
 	return m
 }
 
-// Init starts the Bubble Tea program: launches the health checker, starts the
-// event drainer goroutine, and schedules the first refresh tick.
+// Init starts the health checker and schedules the first refresh tick.
 func (m AppModel) Init() tea.Cmd {
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
-
 	m.agentManager.StartHealthCheck(ctx)
 
 	return tea.Batch(
@@ -97,87 +73,37 @@ func (m AppModel) Init() tea.Cmd {
 	)
 }
 
-// Update handles all incoming messages and dispatches to sub-components.
+// Update handles all incoming messages.
 func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
 
-	// ------------------------------------------------------------------
-	// Window resize: distribute space to all panels.
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		m = m.relayout()
+		m.help.SetSize(m.width, m.height)
+		m.launch.SetSize(m.width, m.height)
+		m.detail.SetSize(m.width, m.height)
+		availH := m.height - 2
+		if availH < 1 {
+			availH = 1
+		}
+		m.agentList.SetSize(m.width, availH)
+		m.commandBar.SetWidth(m.width)
 
-	// ------------------------------------------------------------------
-	// Periodic refresh: snapshot agent states and push to the list.
-	// Also capture tmux pane content for the active log viewer agent.
 	case tickMsg:
 		m.agentList.SetAgents(m.snapshotAgents())
 		cmds = append(cmds, tickCmd())
 
-		// Capture tmux pane for the agent the log viewer is watching.
-		if m.logViewer.AgentID() != "" {
-			if ma, ok := m.agentManager.GetAgent(m.logViewer.AgentID()); ok {
-				var content string
-				var err error
-				if ma.TmuxPaneID != "" {
-					content, err = agent.TmuxCapturePane(ma.TmuxPaneID)
-				} else if ma.TmuxSession != "" {
-					content, err = agent.TmuxCapture(ma.TmuxSession)
-				}
-				if err == nil && content != "" {
-					lines := tmuxContentToLogLines(content)
-					if len(lines) > 0 {
-						m.logViewer.ClearLogs()
-						lv, cmd := m.logViewer.Update(LogLinesMsg{
-							AgentID: m.logViewer.AgentID(),
-							Lines:   lines,
-						})
-						m.logViewer = lv
-						cmds = append(cmds, cmd)
-					}
-				}
-			}
-		}
-
-	// ------------------------------------------------------------------
-	// Agent lifecycle event from manager goroutine.
 	case agentEventMsg:
 		cmds = append(cmds, m.handleAgentEvent(msg.event)...)
 
-	// ------------------------------------------------------------------
-	// Log lines from a collector goroutine.
-	case logBatchMsg:
-		lines := convertLogLines(msg.batch.Lines)
-		lv, cmd := m.logViewer.Update(LogLinesMsg{
-			AgentID: msg.batch.AgentID,
-			Lines:   lines,
-		})
-		m.logViewer = lv
-		cmds = append(cmds, cmd)
-		// Update lastOutputAt on the managed agent.
-		m.touchAgentOutput(msg.batch.AgentID)
-
-	// ------------------------------------------------------------------
-	// An agent was selected in the list - switch log viewer target.
-	case AgentSelectedMsg:
-		if ma, ok := m.agentManager.GetAgent(msg.AgentID); ok {
-			name := ma.Config.Name
-			m.logViewer.SetAgent(msg.AgentID, name)
-			m.logViewer.ClearLogs()
-		}
-
-	// ------------------------------------------------------------------
-	// Launch modal submitted a new config.
 	case LaunchSubmitMsg:
 		m.launch.SetVisible(false)
-		m.commandBar.SetContext(contextForPanel(m.activePanel))
+		m.commandBar.SetContext(ContextAgentList)
 		cmds = append(cmds, m.spawnAgent(msg.Config)...)
 
-	// ------------------------------------------------------------------
-	// Command bar status auto-clear.
 	case StatusMsg:
 		cb, cmd := m.commandBar.Update(msg)
 		m.commandBar = cb
@@ -188,8 +114,6 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.commandBar = cb
 		cmds = append(cmds, cmd)
 
-	// ------------------------------------------------------------------
-	// Keyboard input.
 	case tea.KeyMsg:
 		// Help overlay consumes all keys when visible.
 		if m.help.Visible() {
@@ -204,8 +128,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			launch, cmd := m.launch.Update(msg)
 			m.launch = launch
 			if !m.launch.Visible() {
-				// Modal closed (cancel). Restore context.
-				m.commandBar.SetContext(contextForPanel(m.activePanel))
+				m.commandBar.SetContext(ContextAgentList)
 			}
 			cmds = append(cmds, cmd)
 			return m, tea.Batch(cmds...)
@@ -219,7 +142,6 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(cmds...)
 		}
 
-		// Global keys regardless of focus.
 		switch msg.String() {
 		case "q", "ctrl+c":
 			m.quitting = true
@@ -233,84 +155,54 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.help.SetSize(m.width, m.height)
 			return m, tea.Batch(cmds...)
 
-		case "tab":
-			m = m.switchPanel()
+		case "n":
+			m.launch.SetProjectsDir(m.config.ProjectsDir, m.config.DefaultModel)
+			m.launch.SetVisible(true)
+			m.launch.SetSize(m.width, m.height)
+			m.launch.Reset()
+			m.commandBar.SetContext(ContextModal)
 			return m, tea.Batch(cmds...)
 
-		case "n":
-			if m.activePanel == PanelAgentList {
-				m.launch.SetProjectsDir(m.config.ProjectsDir, m.config.DefaultModel)
-				m.launch.SetVisible(true)
-				m.launch.SetSize(m.width, m.height)
-				m.launch.Reset()
-				m.commandBar.SetContext(ContextModal)
-				return m, tea.Batch(cmds...)
+		case "a", "enter":
+			if sel, ok := m.agentList.SelectedAgent(); ok {
+				if ma, ok := m.agentManager.GetAgent(sel.ID); ok {
+					if ma.TmuxPaneID != "" && agent.TmuxPaneIsAlive(ma.TmuxPaneID) {
+						if err := agent.TmuxSelectPane(ma.TmuxPaneID); err != nil {
+							return m, sendStatus(fmt.Sprintf("focus failed: %v", err), true)
+						}
+						return m, sendStatus(fmt.Sprintf("focused %s (ctrl-b ← to return)", sel.Name), false)
+					}
+					return m, sendStatus(fmt.Sprintf("%s is not running", sel.Name), true)
+				}
 			}
+			return m, tea.Batch(cmds...)
 
 		case "s":
-			if m.activePanel == PanelAgentList {
-				cmds = append(cmds, m.doStop()...)
-				return m, tea.Batch(cmds...)
-			}
+			cmds = append(cmds, m.doStop()...)
+			return m, tea.Batch(cmds...)
 
 		case "r":
-			if m.activePanel == PanelAgentList {
-				cmds = append(cmds, m.doRestart()...)
-				return m, tea.Batch(cmds...)
-			}
+			cmds = append(cmds, m.doRestart()...)
+			return m, tea.Batch(cmds...)
 
 		case "x":
-			if m.activePanel == PanelAgentList {
-				cmds = append(cmds, m.doKill()...)
-				return m, tea.Batch(cmds...)
-			}
-
-		case "a", "enter":
-			// Focus the selected agent's tmux pane.
-			if m.activePanel == PanelAgentList {
-				if sel, ok := m.agentList.SelectedAgent(); ok {
-					if ma, ok := m.agentManager.GetAgent(sel.ID); ok {
-						if ma.TmuxPaneID != "" && agent.TmuxPaneIsAlive(ma.TmuxPaneID) {
-							if err := agent.TmuxSelectPane(ma.TmuxPaneID); err != nil {
-								return m, sendStatus(fmt.Sprintf("focus failed: %v", err), true)
-							}
-							// Also switch log viewer to this agent.
-							m.logViewer.SetAgent(sel.ID, sel.Name)
-							m.logViewer.ClearLogs()
-							return m, sendStatus(fmt.Sprintf("focused %s (ctrl-b ← to return)", sel.Name), false)
-						}
-						return m, sendStatus(fmt.Sprintf("%s is not running", sel.Name), true)
-					}
-				}
-				return m, tea.Batch(cmds...)
-			}
+			cmds = append(cmds, m.doKill()...)
+			return m, tea.Batch(cmds...)
 
 		case "d":
-			if m.activePanel == PanelAgentList {
-				if sel, ok := m.agentList.SelectedAgent(); ok {
-					if ma, ok := m.agentManager.GetAgent(sel.ID); ok {
-						m.detail.SetAgent(ma)
-						m.detail.SetSize(m.width, m.height)
-					}
+			if sel, ok := m.agentList.SelectedAgent(); ok {
+				if ma, ok := m.agentManager.GetAgent(sel.ID); ok {
+					m.detail.SetAgent(ma)
+					m.detail.SetSize(m.width, m.height)
 				}
-				return m, tea.Batch(cmds...)
 			}
-
-		case "e":
-			// Export logs - handled by log viewer panel.
+			return m, tea.Batch(cmds...)
 		}
 
-		// Dispatch to focused panel.
-		switch m.activePanel {
-		case PanelAgentList:
-			al, cmd := m.agentList.Update(msg)
-			m.agentList = al
-			cmds = append(cmds, cmd)
-		case PanelLogViewer:
-			lv, cmd := m.logViewer.Update(msg)
-			m.logViewer = lv
-			cmds = append(cmds, cmd)
-		}
+		// Forward to agent list for navigation keys.
+		al, cmd := m.agentList.Update(msg)
+		m.agentList = al
+		cmds = append(cmds, cmd)
 	}
 
 	return m, tea.Batch(cmds...)
@@ -322,44 +214,26 @@ func (m AppModel) View() string {
 		return "Goodbye.\n"
 	}
 
-	// Help overlay covers the entire screen.
 	if m.help.Visible() {
 		return m.help.View()
 	}
 
-	// Title bar (1 row).
+	// Title bar.
 	titleBar := titleBarStyle(m.width).Render(" ccgm-agents  " + currentTimeStr())
 
-	// Compute panel heights.
-	availH := m.height - 2 // 1 title + 1 command bar
+	// Agent list takes the full width.
+	availH := m.height - 2
 	if availH < 1 {
 		availH = 1
 	}
+	m.agentList.SetSize(m.width, availH)
+	agentPanel := m.agentList.View()
 
-	// Left panel: agent list (40% width).
-	leftW := m.width * 40 / 100
-	if leftW < 20 {
-		leftW = 20
-	}
-	m.agentList.SetSize(leftW, availH)
-
-	// Right panel: log viewer (remaining width).
-	rightW := m.width - leftW
-	if rightW < 1 {
-		rightW = 1
-	}
-	m.logViewer.SetSize(rightW, availH)
-
-	panels := lipgloss.JoinHorizontal(lipgloss.Top,
-		m.agentList.View(),
-		m.logViewer.View(),
-	)
-
-	// Command bar (1 row).
+	// Command bar.
 	m.commandBar.SetWidth(m.width)
 	cmdBar := m.commandBar.View()
 
-	screen := lipgloss.JoinVertical(lipgloss.Left, titleBar, panels, cmdBar)
+	screen := lipgloss.JoinVertical(lipgloss.Left, titleBar, agentPanel, cmdBar)
 
 	// Overlay modals.
 	if m.launch.Visible() {
@@ -374,58 +248,6 @@ func (m AppModel) View() string {
 
 // --- helpers -----------------------------------------------------------------
 
-// relayout distributes terminal space to all sub-components.
-func (m AppModel) relayout() AppModel {
-	m.help.SetSize(m.width, m.height)
-	m.launch.SetSize(m.width, m.height)
-	m.detail.SetSize(m.width, m.height)
-
-	availH := m.height - 2 // title + cmd bar
-	if availH < 1 {
-		availH = 1
-	}
-
-	leftW := m.width * 40 / 100
-	if leftW < 20 {
-		leftW = 20
-	}
-	rightW := m.width - leftW
-	if rightW < 1 {
-		rightW = 1
-	}
-
-	m.agentList.SetSize(leftW, availH)
-	m.logViewer.SetSize(rightW, availH)
-	m.commandBar.SetWidth(m.width)
-	return m
-}
-
-// switchPanel toggles focus between the agent list and the log viewer.
-func (m AppModel) switchPanel() AppModel {
-	switch m.activePanel {
-	case PanelAgentList:
-		m.activePanel = PanelLogViewer
-		m.agentList.SetFocused(false)
-		m.logViewer.SetFocused(true)
-		m.commandBar.SetContext(ContextLogViewer)
-	case PanelLogViewer:
-		m.activePanel = PanelAgentList
-		m.logViewer.SetFocused(false)
-		m.agentList.SetFocused(true)
-		m.commandBar.SetContext(ContextAgentList)
-	}
-	return m
-}
-
-// contextForPanel maps a Panel to the corresponding BarContext.
-func contextForPanel(p Panel) BarContext {
-	if p == PanelLogViewer {
-		return ContextLogViewer
-	}
-	return ContextAgentList
-}
-
-// snapshotAgents converts the manager's live state to AgentListItem slices.
 func (m AppModel) snapshotAgents() []AgentListItem {
 	now := time.Now()
 	managed := m.agentManager.ListAgents()
@@ -447,22 +269,6 @@ func (m AppModel) snapshotAgents() []AgentListItem {
 	return items
 }
 
-// touchAgentOutput updates lastOutputAt on the ManagedAgent when log lines arrive.
-// This feeds the hang-detection logic.
-func (m AppModel) touchAgentOutput(agentID string) {
-	if ma, ok := m.agentManager.GetAgent(agentID); ok {
-		// Access is protected by the manager's own lock; use a write lock via
-		// the exported accessor. Since ManagedAgent is not exported by pointer,
-		// we use the direct field. The manager mu guards it.
-		_ = ma // lastOutputAt is updated inside the manager under its lock
-		// The field is unexported on ManagedAgent so we cannot touch it directly
-		// from the tui package. Health check reads it via ma.lastOutputAt; we
-		// accept that re-attachment agents will not get lastOutputAt updates
-		// from the TUI - consistent with the existing design.
-	}
-}
-
-// handleAgentEvent updates the UI in response to a lifecycle event.
 func (m AppModel) handleAgentEvent(evt agent.AgentEvent) []tea.Cmd {
 	var msg string
 	switch evt.Type {
@@ -474,17 +280,14 @@ func (m AppModel) handleAgentEvent(evt agent.AgentEvent) []tea.Cmd {
 		msg = fmt.Sprintf("Agent %q crashed: %s", evt.AgentID, evt.Details)
 	case agent.EventRestarted:
 		msg = fmt.Sprintf("Agent %q restarted: %s", evt.AgentID, evt.Details)
-	case agent.EventHanging:
-		msg = fmt.Sprintf("Agent %q is hanging: %s", evt.AgentID, evt.Details)
 	}
 	if msg != "" {
-		isErr := evt.Type == agent.EventCrashed || evt.Type == agent.EventHanging
+		isErr := evt.Type == agent.EventCrashed
 		return []tea.Cmd{sendStatus(msg, isErr)}
 	}
 	return nil
 }
 
-// doStop sends SIGTERM to the selected agent.
 func (m AppModel) doStop() []tea.Cmd {
 	sel, ok := m.agentList.SelectedAgent()
 	if !ok {
@@ -493,10 +296,9 @@ func (m AppModel) doStop() []tea.Cmd {
 	if err := m.agentManager.StopAgent(sel.ID); err != nil {
 		return []tea.Cmd{sendStatus(fmt.Sprintf("stop failed: %v", err), true)}
 	}
-	return []tea.Cmd{sendStatus(fmt.Sprintf("stopped %q", sel.ID), false)}
+	return []tea.Cmd{sendStatus(fmt.Sprintf("stopped %q", sel.Name), false)}
 }
 
-// doKill sends SIGKILL to the selected agent.
 func (m AppModel) doKill() []tea.Cmd {
 	sel, ok := m.agentList.SelectedAgent()
 	if !ok {
@@ -505,10 +307,9 @@ func (m AppModel) doKill() []tea.Cmd {
 	if err := m.agentManager.KillAgent(sel.ID); err != nil {
 		return []tea.Cmd{sendStatus(fmt.Sprintf("kill failed: %v", err), true)}
 	}
-	return []tea.Cmd{sendStatus(fmt.Sprintf("killed %q", sel.ID), false)}
+	return []tea.Cmd{sendStatus(fmt.Sprintf("killed %q", sel.Name), false)}
 }
 
-// doRestart stops then restarts the selected agent.
 func (m AppModel) doRestart() []tea.Cmd {
 	sel, ok := m.agentList.SelectedAgent()
 	if !ok {
@@ -519,18 +320,13 @@ func (m AppModel) doRestart() []tea.Cmd {
 		return []tea.Cmd{sendStatus("agent not found", true)}
 	}
 	cfg := ma.Config
-
-	// Stop (best-effort).
 	_ = m.agentManager.StopAgent(sel.ID)
-
-	// Re-start with the same config.
 	if err := m.agentManager.StartAgent(&cfg); err != nil {
 		return []tea.Cmd{sendStatus(fmt.Sprintf("restart failed: %v", err), true)}
 	}
-	return []tea.Cmd{sendStatus(fmt.Sprintf("restarted %q", sel.ID), false)}
+	return []tea.Cmd{sendStatus(fmt.Sprintf("restarted %q", sel.Name), false)}
 }
 
-// spawnAgent starts a new agent from LaunchSubmitMsg.Config and registers log collection.
 func (m AppModel) spawnAgent(cfg types.AgentConfig) []tea.Cmd {
 	if err := m.agentManager.StartAgent(&cfg); err != nil {
 		return []tea.Cmd{sendStatus(fmt.Sprintf("launch failed: %v", err), true)}
@@ -538,22 +334,18 @@ func (m AppModel) spawnAgent(cfg types.AgentConfig) []tea.Cmd {
 	return []tea.Cmd{sendStatus(fmt.Sprintf("launched %q", cfg.Name), false)}
 }
 
-// sendStatus returns a Cmd that emits a StatusMsg.
 func sendStatus(text string, isErr bool) tea.Cmd {
 	return func() tea.Msg {
 		return StatusMsg{Text: text, IsError: isErr}
 	}
 }
 
-// tickCmd returns a Cmd that fires tickMsg after refreshInterval.
 func tickCmd() tea.Cmd {
 	return tea.Tick(refreshInterval, func(_ time.Time) tea.Msg {
 		return tickMsg{}
 	})
 }
 
-// drainEventsCmd starts a goroutine that reads from eventCh and sends each
-// event as an agentEventMsg into the Bubble Tea event loop via Send.
 func drainEventsCmd(ctx context.Context, eventCh <-chan agent.AgentEvent) tea.Cmd {
 	return func() tea.Msg {
 		select {
@@ -568,20 +360,6 @@ func drainEventsCmd(ctx context.Context, eventCh <-chan agent.AgentEvent) tea.Cm
 	}
 }
 
-// convertLogLines maps log.LogLine to LogDisplayLine.
-func convertLogLines(lines []log.LogLine) []LogDisplayLine {
-	out := make([]LogDisplayLine, len(lines))
-	for i, l := range lines {
-		out[i] = LogDisplayLine{
-			Text:      l.Text,
-			IsStderr:  l.IsStderr,
-			Timestamp: l.Timestamp,
-		}
-	}
-	return out
-}
-
-// overlayCenter renders overlay on top of base, centered in (w, h).
 func overlayCenter(base, overlay string, w, h int) string {
 	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center,
 		overlay,
@@ -590,7 +368,6 @@ func overlayCenter(base, overlay string, w, h int) string {
 	)
 }
 
-// titleBarStyle returns a full-width bar style for the title row.
 func titleBarStyle(w int) lipgloss.Style {
 	return lipgloss.NewStyle().
 		Background(lipgloss.Color("62")).
@@ -599,26 +376,6 @@ func titleBarStyle(w int) lipgloss.Style {
 		Width(w)
 }
 
-// currentTimeStr returns the current wall clock as HH:MM:SS.
 func currentTimeStr() string {
 	return time.Now().Format("15:04:05")
-}
-
-// tmuxContentToLogLines converts tmux capture-pane output to LogDisplayLines.
-// Each call replaces the log viewer content (snapshot, not streaming).
-func tmuxContentToLogLines(content string) []LogDisplayLine {
-	rawLines := strings.Split(content, "\n")
-	var lines []LogDisplayLine
-	for _, l := range rawLines {
-		trimmed := strings.TrimRight(l, " ")
-		if trimmed == "" {
-			continue
-		}
-		lines = append(lines, LogDisplayLine{
-			Text:      trimmed,
-			IsStderr:  false,
-			Timestamp: time.Now(),
-		})
-	}
-	return lines
 }

--- a/modules/agent-manager/src/internal/tui/app_test.go
+++ b/modules/agent-manager/src/internal/tui/app_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/lucasmccomb/ccgm/modules/agent-manager/src/internal/tui"
 )
 
-// newTestApp builds a minimal AppModel for testing without starting I/O.
 func newTestApp(t *testing.T) tui.AppModel {
 	t.Helper()
 	dir := t.TempDir()
@@ -18,68 +17,26 @@ func newTestApp(t *testing.T) tui.AppModel {
 	return tui.NewApp(mgr, cfg)
 }
 
-// TestApp_InitialFocus verifies the agent list panel has focus on startup.
 func TestApp_InitialFocus(t *testing.T) {
 	app := newTestApp(t)
-	// The agent list should be focused; the log viewer should not.
 	if !app.AgentListFocused() {
 		t.Error("expected agent list to be focused on startup")
 	}
-	if app.LogViewerFocused() {
-		t.Error("expected log viewer NOT to be focused on startup")
-	}
 }
 
-// TestApp_TabSwitchesFocus verifies that Tab toggles focus between panels.
-func TestApp_TabSwitchesFocus(t *testing.T) {
+func TestApp_WindowResizeSetsFullWidth(t *testing.T) {
 	app := newTestApp(t)
-
-	// Simulate Tab key.
-	app = app.PressTab()
-	if app.AgentListFocused() {
-		t.Error("after Tab: expected agent list NOT to be focused")
-	}
-	if !app.LogViewerFocused() {
-		t.Error("after Tab: expected log viewer to be focused")
-	}
-
-	// Tab again returns focus to agent list.
-	app = app.PressTab()
-	if !app.AgentListFocused() {
-		t.Error("after second Tab: expected agent list to be focused")
-	}
-	if app.LogViewerFocused() {
-		t.Error("after second Tab: expected log viewer NOT to be focused")
-	}
-}
-
-// TestApp_WindowResizeDistributesSpace verifies that a resize message updates
-// panel dimensions correctly.
-func TestApp_WindowResizeDistributesSpace(t *testing.T) {
-	app := newTestApp(t)
-
-	// Apply a window resize.
 	app = app.Resize(120, 40)
 
 	lw, lh := app.AgentListSize()
-	rw, rh := app.LogViewerSize()
 
-	// Agent list should be ~40% of 120 = 48.
-	if lw < 40 || lw > 60 {
-		t.Errorf("agent list width %d: expected ~48 (40%% of 120)", lw)
+	// Agent list should take the full width.
+	if lw != 120 {
+		t.Errorf("agent list width %d: expected 120 (full width)", lw)
 	}
 
-	// Log viewer should take the rest.
-	total := lw + rw
-	if total != 120 {
-		t.Errorf("panel widths sum to %d, expected 120", total)
-	}
-
-	// Both panels should share the available height (total - 2 for title+bar).
-	if lh != rh {
-		t.Errorf("agent list height %d != log viewer height %d", lh, rh)
-	}
+	// Height should be total - 2 (title + command bar).
 	if lh != 38 {
-		t.Errorf("panel height %d: expected 38 (40 - 2 title/cmdbar rows)", lh)
+		t.Errorf("agent list height %d: expected 38 (40 - 2)", lh)
 	}
 }

--- a/modules/agent-manager/src/internal/tui/commandbar.go
+++ b/modules/agent-manager/src/internal/tui/commandbar.go
@@ -147,7 +147,6 @@ func (m CommandBarModel) hintsForContext() []hint {
 			{key: "r", desc: "restart"},
 			{key: "x", desc: "kill"},
 			{key: "/", desc: "filter"},
-			{key: "tab", desc: "logs"},
 			{key: "?", desc: "help"},
 			{key: "q", desc: "quit"},
 		}

--- a/modules/agent-manager/src/internal/tui/commandbar_test.go
+++ b/modules/agent-manager/src/internal/tui/commandbar_test.go
@@ -16,7 +16,7 @@ func TestCommandBar_AgentListContext(t *testing.T) {
 	view := m.View()
 
 	// All agent-list hints must appear.
-	for _, want := range []string{"n", "new", "s", "stop", "r", "restart", "x", "kill", "/", "filter", "tab", "logs", "?", "help", "q", "quit"} {
+	for _, want := range []string{"n", "new", "a", "focus", "s", "stop", "r", "restart", "x", "kill", "/", "filter", "?", "help", "q", "quit"} {
 		if !strings.Contains(view, want) {
 			t.Errorf("agent-list view missing %q\nfull view: %q", want, view)
 		}

--- a/modules/agent-manager/src/internal/tui/export_test.go
+++ b/modules/agent-manager/src/internal/tui/export_test.go
@@ -1,7 +1,4 @@
 // export_test.go exposes internal AppModel methods for white-box testing.
-// This file is compiled only during test runs (the _test.go suffix convention
-// does not apply to files without _test in the package declaration, but placing
-// helpers here keeps production code clean).
 package tui
 
 import tea "github.com/charmbracelet/bubbletea"
@@ -9,18 +6,6 @@ import tea "github.com/charmbracelet/bubbletea"
 // AgentListFocused reports whether the agent list currently has focus.
 func (m AppModel) AgentListFocused() bool {
 	return m.agentList.Focused()
-}
-
-// LogViewerFocused reports whether the log viewer currently has focus.
-func (m AppModel) LogViewerFocused() bool {
-	return m.logViewer.Focused()
-}
-
-// PressTab simulates a Tab key press and returns the updated model.
-func (m AppModel) PressTab() AppModel {
-	msg := tea.KeyMsg{Type: tea.KeyTab}
-	next, _ := m.Update(msg)
-	return next.(AppModel)
 }
 
 // Resize simulates a window resize and returns the updated model.
@@ -33,9 +18,4 @@ func (m AppModel) Resize(width, height int) AppModel {
 // AgentListSize returns the current (width, height) of the agent list panel.
 func (m AppModel) AgentListSize() (int, int) {
 	return m.agentList.width, m.agentList.height
-}
-
-// LogViewerSize returns the current (width, height) of the log viewer panel.
-func (m AppModel) LogViewerSize() (int, int) {
-	return m.logViewer.width, m.logViewer.height
 }


### PR DESCRIPTION
Closes #251

## Changes
- Removed the log viewer panel (agents run in visible tmux panes)
- Agent list takes full dashboard width with card-style layout
- Each agent: colored dot + name on line 1, status label + uptime on line 2
- "Hanging" status removed for tmux agents (displays as "running")
- Simplified single-panel layout (no tab switching)