### PR TITLE
#253: sort agent list by name

### DIFF
--- a/modules/agent-manager/src/internal/agent/manager.go
+++ b/modules/agent-manager/src/internal/agent/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -299,7 +300,7 @@ func (m *AgentManager) GetAgent(agentID string) (*ManagedAgent, bool) {
 	return ma, ok
 }
 
-// ListAgents returns a snapshot of all registered agents (running or not).
+// ListAgents returns a snapshot of all registered agents sorted by name.
 func (m *AgentManager) ListAgents() []*ManagedAgent {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -307,5 +308,8 @@ func (m *AgentManager) ListAgents() []*ManagedAgent {
 	for _, ma := range m.agents {
 		out = append(out, ma)
 	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Config.Name < out[j].Config.Name
+	})
 	return out
 }


### PR DESCRIPTION
Closes #253. Go map iteration is random, causing agents to swap positions on every refresh tick. Sort by name.