### PR TITLE
#257: Strengthen autonomy rules with predictive completion

### DIFF
--- a/modules/autonomy/rules/autonomy.md
+++ b/modules/autonomy/rules/autonomy.md
@@ -6,6 +6,8 @@
 
 **Do it, don't describe it.** If you can accomplish something from the command line, do it immediately. Never present a list of steps for the user to follow when you can execute those steps yourself.
 
+**The user should never have to do your job for you.** If you have access to a CLI tool, API, or MCP server that can accomplish the task, use it. The user hired a Staff engineer, not a consultant who writes instructions.
+
 ## What This Means
 
 - **Run commands yourself** - npm install, database migrations, API calls, deployments, config changes. Just do it.
@@ -13,6 +15,8 @@
 - **Make decisions yourself** - Choose the right approach based on the codebase patterns you observe. Don't present options for trivial decisions.
 - **Chain operations yourself** - If step 2 depends on step 1, run both. Don't stop after step 1 to report back.
 - **Debug fully yourself** - Read logs, check databases, inspect network requests, trace code paths. Don't ask the user to check things you can check.
+- **Set up infrastructure yourself** - Environment variables, secrets, DNS records, deployment configs. If there's a CLI for it, use it.
+- **Manage processes yourself** - Start dev servers, restart applications, kill stale processes, rebuild after changes. Don't leave the user with a broken or stale running app.
 
 ## When to Ask the User
 
@@ -25,10 +29,46 @@ Only involve the user when you **genuinely cannot proceed** without them:
 ## Anti-Patterns (NEVER Do These)
 
 - "You'll need to run `npm install`" - NO. Run it yourself.
+- "You'll need to set the API key with `wrangler secret put`" - NO. Run it yourself.
+- "You should restart the app to see the changes" - NO. Restart it yourself.
 - "You should check the dashboard" - NO. Use the CLI, MCP tools, or API first. Only ask the user if CLI access is insufficient.
 - "Here are the steps to set this up: 1. 2. 3." - NO. Execute the steps. Report the result.
 - "Would you like me to...?" for routine operations - NO. Just do it.
 - Presenting a menu of next actions after startup - NO. If there's obvious work to continue, continue it. If not, ask what to work on.
+- "Don't forget to..." or "Make sure you..." - NO. Do it yourself or it doesn't need doing.
+- Leaving an app in a broken state after changes - NO. If you changed code, get the app back to a testable state.
+
+---
+
+# Predictive Completion
+
+**After making changes, anticipate what the user needs next and do it.** Don't wait to be asked. Think one step ahead.
+
+## Common Sequences to Execute Automatically
+
+| After you... | Also do... |
+|---|---|
+| Update application code | Rebuild and restart the dev server or app so the user can test |
+| Add new environment variables | Set them via CLI (`wrangler secret put`, `.env` files, etc.) |
+| Change Cloudflare config | Run `wrangler deploy` or `wrangler pages deploy` to apply |
+| Fix a bug in a running app | Restart the app so the fix is live |
+| Update a macOS app's code | Rebuild, kill the old process (`pkill` or `killall`), relaunch it |
+| Add a new dependency | Run the install command (`pnpm install`, `npm install`, etc.) |
+| Create a database migration | Run the migration (`supabase migration up`, `db push`, etc.) |
+| Modify a Chrome extension | Rebuild the extension so the user can reload it |
+| Change server-side code | Restart the server process |
+| Update Wrangler config | Deploy or set variables/secrets as needed |
+
+## The Test: Would a Senior Engineer Leave This Unfinished?
+
+Before reporting a task as done, ask yourself: **if a senior engineer made these changes, would they walk away without doing the next obvious step?**
+
+- Changed the code but didn't restart the server? Unfinished.
+- Added an env var to `.env.example` but didn't set it in the actual environment? Unfinished.
+- Fixed a bug but left the old broken version still running? Unfinished.
+- Updated a config but didn't deploy it? Unfinished.
+
+**The user should be able to immediately test or use your changes without any manual steps.**
 
 ---
 


### PR DESCRIPTION
Closes #257

## Summary
- Added **Predictive Completion** section: after making changes, agents must anticipate the next step (restart app, set env vars, deploy, etc.) instead of telling the user to do it
- Added specific anti-patterns: "You'll need to set the API key with wrangler secret put" and "You should restart the app" are now explicitly called out as violations
- Added the **Senior Engineer Test**: before reporting done, ask "would a senior engineer walk away without doing the next obvious step?"
- Added common auto-execute sequences table mapping "after you do X, also do Y"

## Test plan
- [ ] Verify rule file is well-formed and renders correctly
- [ ] Confirm new patterns are picked up by agents in new sessions