### PR TITLE
#259: Remove Anthropic API from deepresearch CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ For a quick install with a preset:
 
 The `/deepresearch` command is a more powerful research pipeline that lives in its own repo: **[lem-deepresearch](https://github.com/lucasmccomb/lem-deepresearch)**. It replaces `/research`'s parallel subagent approach with a local-first pipeline that produces higher-quality, source-backed research documents.
 
-**How it works:** Ollama (qwen2.5:72b) generates search queries and extracts facts, SearXNG (self-hosted Docker) runs parallel web searches across Google/Bing/DuckDuckGo, and a single Anthropic API call (Sonnet) synthesizes everything into a structured research.md.
+**How it works:** Ollama (qwen2.5:72b) generates search queries and extracts facts, SearXNG (self-hosted Docker) runs parallel web searches across Google/Bing/DuckDuckGo, and Claude Code synthesizes everything into a structured research.md. The pipeline is fully local - no external API keys required beyond what Claude Code already uses.
 
 **Why it's separate:** It requires local infrastructure (Docker, Ollama with a ~40GB model, a Python venv) that not every CCGM user will want. But if you use `/xplan`, you'll want this - xplan delegates its research phase to `/deepresearch`.
 

--- a/modules/research/README.md
+++ b/modules/research/README.md
@@ -25,7 +25,7 @@ Spawns up to 7 parallel research agents that each investigate the topic from a d
 
 ## /deepresearch - Local Pipeline Upgrade
 
-For higher-quality, faster, and cheaper research, install **[lem-deepresearch](https://github.com/lucasmccomb/lem-deepresearch)**. It replaces parallel subagents with a local pipeline: Ollama for query generation and fact extraction, SearXNG for web search, and a single Anthropic API call for synthesis.
+For higher-quality, faster, and cheaper research, install **[lem-deepresearch](https://github.com/lucasmccomb/lem-deepresearch)**. It replaces parallel subagents with a fully local pipeline: Ollama for query generation and fact extraction, SearXNG for web search. Claude Code performs the final synthesis using its own model. No external API keys required.
 
 `/deepresearch` requires Docker, Ollama (~40GB model), and a Python venv. See the [lem-deepresearch README](https://github.com/lucasmccomb/lem-deepresearch) for setup.
 

--- a/modules/xplan/README.md
+++ b/modules/xplan/README.md
@@ -44,7 +44,7 @@ Companion commands:
 
 xplan's research phase (Phase 1) spawns an agent that runs `/deepresearch` to produce a comprehensive research.md. Without it, xplan cannot complete its research step.
 
-`/deepresearch` uses a local pipeline - Ollama (qwen2.5:72b) for query generation and fact extraction, SearXNG (self-hosted Docker) for web search, and a single Anthropic API call (Sonnet) for synthesis. It requires Docker, Ollama (~40GB model), and a Python venv, which the installer handles.
+`/deepresearch` uses a fully local pipeline - Ollama (qwen2.5:72b) for query generation and fact extraction, SearXNG (self-hosted Docker) for web search - then Claude Code synthesizes the results. No external API keys required. It requires Docker, Ollama (~40GB model), and a Python venv, which the installer handles.
 
 ```bash
 git clone https://github.com/lucasmccomb/lem-deepresearch.git


### PR DESCRIPTION
## Summary
- Removes the Anthropic API (Sonnet) dependency from `deepresearch-cli.py` in the lem-deepresearch repo
- CLI now outputs structured JSON (facts + sources) to stdout after the local pipeline completes
- Claude Code performs synthesis using its own model instead of a separate API call
- Eliminates `anthropic` Python dependency and API key requirement from the script
- Updates CCGM documentation (README, research module, xplan module) to reflect the change

## Changes in this repo (CCGM)
- `README.md` - updated deepresearch description to remove Anthropic API mention
- `modules/research/README.md` - updated /deepresearch description
- `modules/xplan/README.md` - updated /deepresearch dependency description

## Changes in lem-deepresearch repo (applied separately)
- `bin/deepresearch-cli.py` - removed `anthropic` import, `get_api_key()`, `synthesize_with_sonnet()`, `SYNTHESIS_SYSTEM` prompt, `--synthesis-model` arg; CLI now outputs JSON to stdout
- `deepresearch.md` - added Phase 2.5 (Claude Code synthesis), updated pipeline description from 4 steps to 3, removed Anthropic prerequisites
- `install.sh` - removed `anthropic` from pip install, removed API key verification step
- `README.md` - removed all Anthropic API references, updated architecture description

Closes #259