### PR TITLE
#273: add agents/ directory convention to module schema

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ modules/{name}/
 │   └── {name}.md
 ├── commands/            # Command files (.md) - available as /command-name
 │   └── {command}.md
+├── agents/              # Reusable subagent prompts (.md) - invoked by commands/skills
+│   └── {agent}.md
 ├── hooks/               # Hook scripts (.py) - triggered by Claude Code events
 │   └── {hook}.py
 ├── settings.base.json   # Settings template (merged into settings.json)
@@ -67,7 +69,12 @@ Create the files referenced in `module.json`. Place them in subdirectories that 
 
 - `rules/*.md` for rule files
 - `commands/*.md` for slash commands
+- `agents/*.md` for reusable subagent prompts
 - `hooks/*.py` for event hooks
+
+### When to use `agents/`
+
+Use `agents/` for reusable subagent definitions that are invoked by multiple commands or skills (for example, a `code-reviewer` or `adversarial-reviewer` prompt that several review pipelines share). Keep one-off prompts inline in the command or skill that uses them — promote to `agents/` only when the second caller appears.
 
 ### 4. Write a README.md
 
@@ -133,7 +140,7 @@ Each entry in the `files` object maps a source path (relative to the module dire
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `target` | string | yes | Destination path relative to the install root (`~/.claude/` or `.claude/`). |
-| `type` | string | yes | File type: `rule`, `command`, `hook`, `config`, or `doc`. |
+| `type` | string | yes | File type: `rule`, `command`, `agent`, `hook`, `config`, or `doc`. |
 | `template` | boolean | yes | Whether the file contains `__PLACEHOLDER__` template variables to expand. |
 | `merge` | boolean | no | For `config` type only. If `true`, the file is merged into the target rather than replacing it. Used for settings partials. |
 
@@ -143,6 +150,7 @@ Each entry in the `files` object maps a source path (relative to the module dire
 |------|-----------|-------------|
 | `rule` | `.md` | Markdown rules loaded by Claude Code at session start. Shapes behavior and decision-making. |
 | `command` | `.md` | Markdown files that become slash commands in Claude Code. File name becomes the command name. |
+| `agent` | `.md` | Reusable subagent prompts invoked by commands or skills via the Task tool. Installed to `~/.claude/agents/`. Use for prompts shared across two or more callers; keep one-off prompts inline. |
 | `hook` | `.py` | Python scripts triggered by Claude Code events (PreToolUse, UserPromptSubmit, etc.). |
 | `config` | `.json` | JSON configuration files (settings, partials). May be merged into existing files. |
 | `doc` | `.md` | Documentation files installed alongside rules. Referenced by rules but not auto-loaded. |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ CCGM places files into `~/.claude/` (global) or `.claude/` (project-level):
 |-----------|------|-------------------|
 | `rules/*.md` | Behavior rules | Loaded automatically at session start |
 | `commands/*.md` | Slash commands | Available as `/commit`, `/pr`, etc. |
+| `agents/*.md` | Subagent prompts | Reusable prompts invoked by commands and skills via the Task tool |
 | `hooks/*.py` | Workflow hooks | Triggered on Claude Code events |
 | `settings.json` | Permissions | Controls tool access and auto-approval |
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -10,6 +10,7 @@ A module installs one or more of these file types:
 |-----------|----------|-------------------|
 | **Rules** (`rules/*.md`) | `~/.claude/rules/` | Loaded automatically at session start. Guides Claude's behavior. |
 | **Commands** (`commands/*.md`) | `~/.claude/commands/` | Available as `/command-name` slash commands. |
+| **Agents** (`agents/*.md`) | `~/.claude/agents/` | Reusable subagent prompts invoked by commands or skills via the Task tool. Use for prompts shared by multiple callers; keep one-off prompts inline. |
 | **Hooks** (`hooks/*.py`) | `~/.claude/hooks/` | Triggered by Claude Code events (tool calls, session start, etc.). |
 | **Settings** (`settings.*.json`) | `~/.claude/settings.json` | Deep-merged into the permissions configuration. |
 | **Docs** (`*.md` reference files) | `~/.claude/` | Reference documentation accessible to Claude. |


### PR DESCRIPTION
Closes #273

## Summary

Adds `agent` as a recognized `type` in the module.json file-descriptor schema, establishing `modules/*/agents/` as the convention for reusable subagent prompts with install target `~/.claude/agents/`. This is Phase 0 groundwork that unblocks follow-up issues #268, #276, #277, #278, #286, which will add the first concrete agent files (review orchestrator, compound-knowledge, document-review, session-history, agent-native).

## Why no installer code change

The CCGM installer routes file copy/link by the `target` path in each file descriptor, not by `type`. Setting `"target": "agents/foo.md"` already lands the file at `~/.claude/agents/foo.md` and `mkdir -p "$(dirname "$target")"` (start.sh:848) handles the new parent directory on demand. The `type` field is metadata used by docs and future tooling, so no changes to `lib/modules.sh`, `start.sh`, or `uninstall.sh` are required.

## Changes

- `CONTRIBUTING.md`: add `agents/` to module directory structure, add "When to use `agents/`" subsection with the rule-of-thumb, add `agent` to the `type` field enum and the File Types table.
- `docs/modules.md`: add Agents row to the file-type table.
- `README.md`: add `agents/*.md` row to the directory table.

## Audit note

No existing modules have inline agent definitions that are trivially migratable — the first agent files will land with #276 (compound-knowledge) and #268 (two-stage review templates). Per scope, not expanding to migrate anything here.

## Test plan

- [x] `bash tests/test-modules.sh` — 702 passed, 0 failed.
- [x] `bash tests/test-no-personal-data.sh` — only pre-existing cloud-dispatch failures (unrelated to this change).
- [x] Diff reviewed for unintended changes.