### PR TITLE
#294: add careful/freeze/guard PreToolUse safety hooks

### DIFF
--- a/modules/commands-extra/README.md
+++ b/modules/commands-extra/README.md
@@ -1,15 +1,18 @@
 # commands-extra
 
-Additional slash commands for codebase audits, visual verification, guided walkthroughs, and rule promotion.
+Additional slash commands for codebase audits, visual verification, guided walkthroughs, rule promotion, and safety-hook state management.
 
 ## What It Does
 
-This module installs four slash command files:
+This module installs seven slash command files:
 
 - **/audit** - Run a comprehensive codebase audit across 8 categories (security, dependencies, code quality, architecture, TypeScript/React, testing, documentation, performance) with auto-fix capabilities
 - **/pwv** - Playwright Visual Verification for testing UI in a headless browser with screenshots, viewport checks, and theme verification
 - **/walkthrough** - Enter step-by-step guide mode where Claude presents one step at a time and waits for confirmation before proceeding
 - **/promote-rule** - Review repo-level CLAUDE.md files and suggest rules that should be promoted to the global configuration
+- **/freeze** - Scope-lock Edit/Write to a directory by writing `~/.claude/freeze-dir.txt`. Reads by `check-freeze.py` (see the `hooks` module)
+- **/unfreeze** - Clear the freeze scope by deleting `~/.claude/freeze-dir.txt`
+- **/guard** - Compose careful + freeze for focused, safe sessions. Activates the freeze state file and confirms both safety hooks are installed
 
 ## Manual Installation
 
@@ -21,12 +24,18 @@ cp commands/audit.md ~/.claude/commands/audit.md
 cp commands/pwv.md ~/.claude/commands/pwv.md
 cp commands/walkthrough.md ~/.claude/commands/walkthrough.md
 cp commands/promote-rule.md ~/.claude/commands/promote-rule.md
+cp commands/freeze.md ~/.claude/commands/freeze.md
+cp commands/unfreeze.md ~/.claude/commands/unfreeze.md
+cp commands/guard.md ~/.claude/commands/guard.md
 
 # Project-level
 cp commands/audit.md .claude/commands/audit.md
 cp commands/pwv.md .claude/commands/pwv.md
 cp commands/walkthrough.md .claude/commands/walkthrough.md
 cp commands/promote-rule.md .claude/commands/promote-rule.md
+cp commands/freeze.md .claude/commands/freeze.md
+cp commands/unfreeze.md .claude/commands/unfreeze.md
+cp commands/guard.md .claude/commands/guard.md
 ```
 
 ## Files
@@ -37,3 +46,6 @@ cp commands/promote-rule.md .claude/commands/promote-rule.md
 | `commands/pwv.md` | Playwright visual verification command |
 | `commands/walkthrough.md` | Step-by-step guided walkthrough command |
 | `commands/promote-rule.md` | Rule promotion from repo to global config |
+| `commands/freeze.md` | Activate the freeze scope (writes `~/.claude/freeze-dir.txt`) |
+| `commands/unfreeze.md` | Clear the freeze scope (deletes `~/.claude/freeze-dir.txt`) |
+| `commands/guard.md` | Compose careful + freeze for focused, safe sessions |

--- a/modules/commands-extra/commands/freeze.md
+++ b/modules/commands-extra/commands/freeze.md
@@ -1,0 +1,47 @@
+---
+description: Scope-lock Edit/Write to a directory until /unfreeze
+---
+
+# /freeze - Scope-Lock Writes to a Directory
+
+Activate the `check-freeze.py` PreToolUse hook by writing a directory path to
+`~/.claude/freeze-dir.txt`. While a freeze is active, Edit and Write operations
+outside that directory are blocked with a `deny` permission decision.
+
+Use freeze during debugging or focused investigation to prevent scope creep.
+
+## Usage
+
+```
+/freeze                      # Freeze to the current working directory
+/freeze <absolute-or-relative-path>
+```
+
+## Workflow
+
+1. Resolve the argument to an absolute path:
+   - No argument: use the current working directory.
+   - Relative path: resolve against the current working directory.
+   - Absolute path: use as-is.
+2. Verify the path exists and is a directory. If not, report the error and stop.
+3. Write the resolved absolute path to `~/.claude/freeze-dir.txt` (overwriting
+   any previous freeze).
+4. Confirm to the user: `Frozen to: <path>`. Remind them that `/unfreeze`
+   clears the scope.
+
+## Example
+
+```
+/freeze modules/hooks
+# -> Frozen to: /home/user/code/ccgm/modules/hooks
+# Subsequent Edit/Write calls outside modules/hooks are denied.
+```
+
+## Notes
+
+- The freeze state is a single file at `~/.claude/freeze-dir.txt`. Only one
+  directory can be frozen at a time; `/freeze` overwrites the previous value.
+- Paths with symlinks and `..` are resolved before the containment check, so
+  trivial escapes are caught.
+- Bash commands are NOT scope-locked - only Edit and Write. Pair with
+  `/guard` if you also want destructive-command warnings.

--- a/modules/commands-extra/commands/guard.md
+++ b/modules/commands-extra/commands/guard.md
@@ -1,0 +1,47 @@
+---
+description: Compose careful + freeze for focused, safe sessions
+---
+
+# /guard - Compose Careful + Freeze
+
+`guard` combines the two safety hooks shipped by the `hooks` module:
+
+- **check-careful.py** (PreToolUse:Bash) - prompts on destructive commands
+  (`rm -rf`, SQL DROP/TRUNCATE, force push, hard reset, etc.).
+- **check-freeze.py** (PreToolUse:Edit|Write) - denies writes outside the
+  frozen directory.
+
+`/guard` activates both for a named scope. Use it during investigation or
+refactors where you want to stay inside one module and avoid destructive
+surprises.
+
+## Usage
+
+```
+/guard                       # Guard the current working directory
+/guard <absolute-or-relative-path>
+```
+
+## Workflow
+
+1. Resolve the argument to an absolute path (same rules as `/freeze`).
+2. Activate freeze by writing the path to `~/.claude/freeze-dir.txt`.
+3. Confirm both hooks are installed (`~/.claude/hooks/check-careful.py` and
+   `~/.claude/hooks/check-freeze.py` exist). If either is missing, warn the
+   user and point to the `hooks` module README.
+4. Report: `Guarded: <path>. Edit/Write scoped; destructive Bash commands will prompt.`
+5. Remind the user that `/unfreeze` clears the freeze half. The careful hook
+   stays active (it has no state file to clear; it runs on every Bash call).
+
+## When Other Commands Auto-Guard
+
+Slash commands that encourage focused scope (for example `/investigate` when
+adopted) should call `/guard <target-dir>` at the start of the session so the
+user does not have to remember.
+
+## Notes
+
+- `check-careful.py` has no enable/disable state - it inspects every Bash
+  command. The only way to quiet it is to not call destructive commands.
+- `check-freeze.py` is gated by the state file, so `/unfreeze` fully clears
+  the scope lock.

--- a/modules/commands-extra/commands/unfreeze.md
+++ b/modules/commands-extra/commands/unfreeze.md
@@ -1,0 +1,27 @@
+---
+description: Clear the active freeze scope
+---
+
+# /unfreeze - Clear the Freeze Scope
+
+Deactivate the `check-freeze.py` PreToolUse hook by deleting
+`~/.claude/freeze-dir.txt`. After `/unfreeze`, Edit and Write operations are
+no longer scope-locked.
+
+## Usage
+
+```
+/unfreeze
+```
+
+## Workflow
+
+1. Check whether `~/.claude/freeze-dir.txt` exists.
+2. If it exists, delete it and confirm: `Unfrozen (was: <previous-path>)`.
+3. If it does not exist, report: `No freeze active`.
+
+## Notes
+
+- This does not disable the `check-freeze.py` hook itself - it only clears the
+  state file the hook reads. The hook is a no-op when no freeze is set.
+- Use `/freeze <dir>` to re-activate scope locking.

--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -1,7 +1,7 @@
 {
   "name": "commands-extra",
   "displayName": "Extra Commands",
-  "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global).",
+  "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global), /freeze + /unfreeze + /guard (safety-hook state management).",
   "category": "commands",
   "scope": ["global"],
   "dependencies": [],
@@ -10,8 +10,11 @@
     "commands/pwv.md": { "target": "commands/pwv.md", "type": "command", "template": false },
     "commands/walkthrough.md": { "target": "commands/walkthrough.md", "type": "command", "template": false },
     "commands/promote-rule.md": { "target": "commands/promote-rule.md", "type": "command", "template": false },
+    "commands/freeze.md": { "target": "commands/freeze.md", "type": "command", "template": false },
+    "commands/unfreeze.md": { "target": "commands/unfreeze.md", "type": "command", "template": false },
+    "commands/guard.md": { "target": "commands/guard.md", "type": "command", "template": false },
     "skills/audit/SKILL.md": { "target": "skills/audit/SKILL.md", "type": "skill", "template": false }
   },
-  "tags": ["commands", "audit", "verification", "walkthrough"],
+  "tags": ["commands", "audit", "verification", "walkthrough", "safety"],
   "configPrompts": []
 }

--- a/modules/hooks/README.md
+++ b/modules/hooks/README.md
@@ -4,7 +4,7 @@ Python hooks that enforce git workflow rules: issue-first workflow, commit messa
 
 ## What It Does
 
-This module installs nine Python hooks, two Python libraries, and a settings partial:
+This module installs eleven Python hooks, two Python libraries, and a settings partial:
 
 | Hook | Event | Purpose |
 |------|-------|---------|
@@ -17,6 +17,8 @@ This module installs nine Python hooks, two Python libraries, and a settings par
 | `agent-tracking-pre.py` | PreToolUse (Bash) | Warns when claiming an issue already claimed by another agent |
 | `agent-tracking-post.py` | PostToolUse (Bash) | Records issue claims and status transitions in tracking CSV |
 | `check-migration-timestamps.py` | PreToolUse | Validates Supabase migration file timestamps for duplicates before commit |
+| `check-careful.py` | PreToolUse (Bash) | Prompts before destructive Bash commands (rm -rf, SQL DROP/TRUNCATE, force push, hard reset, kubectl delete, docker prune). Build-artifact directories (node_modules, dist, .next, build, __pycache__, .cache, .turbo, coverage) are whitelisted for `rm -rf` |
+| `check-freeze.py` | PreToolUse (Edit/Write) | Denies Edit/Write outside the frozen directory when `~/.claude/freeze-dir.txt` is set. Pair with `/freeze`, `/unfreeze`, `/guard` from `commands-extra` |
 
 The `settings.partial.json` wires these hooks into your `~/.claude/settings.json`.
 
@@ -81,6 +83,8 @@ The default protected branches are: main, master, production, prod, staging, sta
 | `hooks/agent-tracking-pre.py` | Pre-execution issue claim warning |
 | `hooks/agent-tracking-post.py` | Post-execution tracking CSV updates |
 | `hooks/check-migration-timestamps.py` | Supabase migration timestamp validation |
+| `hooks/check-careful.py` | Destructive-command warning (careful safety hook) |
+| `hooks/check-freeze.py` | Scope-lock Edit/Write to `~/.claude/freeze-dir.txt` (freeze safety hook) |
 | `lib/agent_tracking.py` | Python library for tracking CSV operations |
 | `lib/agent_sessions.py` | Python library for live session detection |
 | `settings.partial.json` | Hook wiring configuration to merge into settings.json |

--- a/modules/hooks/hooks/check-careful.py
+++ b/modules/hooks/hooks/check-careful.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook that pauses on destructive Bash commands.
+
+Inspects Bash commands and returns permissionDecision:"ask" with a warning for
+destructive patterns that commonly cause data loss or history destruction:
+  - rm -rf (with smart whitelist for build artifacts)
+  - SQL DROP / TRUNCATE
+  - git push --force (and --force-with-lease)
+  - git reset --hard (history destroying)
+  - git checkout . (dirty discard)
+  - kubectl delete
+  - docker rm -f / docker system prune
+
+Build-artifact directories are whitelisted so `rm -rf node_modules` does not
+trigger a prompt. Whitelist: node_modules, dist, .next, build, __pycache__,
+.cache, .turbo, coverage.
+
+Ported to Python from gstack `careful/bin/check-careful.sh` to match CCGM's
+hook style (JSON stdin/stdout, consistent with auto-approve-bash.py).
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+# Build-artifact directory names that are safe to `rm -rf` without asking.
+# If every path on an rm -rf line matches one of these (exactly or as a
+# trailing component), we let it pass without warning.
+BUILD_ARTIFACT_WHITELIST = {
+    "node_modules",
+    "dist",
+    ".next",
+    "build",
+    "__pycache__",
+    ".cache",
+    ".turbo",
+    "coverage",
+}
+
+
+def _is_whitelisted_rm_rf(command: str) -> bool:
+    """
+    Return True if every target of `rm -rf` in `command` is a build artifact.
+
+    Walks tokens after `rm` (in any order of flags) and verifies each
+    non-flag argument is a recognised build-artifact directory name.
+    Conservative: any unknown target disables the whitelist.
+    """
+    # Extract the argument list after `rm`. We only check the first rm
+    # occurrence; chained commands are handled separately by the caller.
+    m = re.search(r"\brm\s+([^\|&;]+)", command)
+    if not m:
+        return False
+
+    tokens = m.group(1).strip().split()
+    targets: list[str] = []
+    for tok in tokens:
+        if tok.startswith("-"):
+            # Flag (e.g. -rf, -r, -f, --force, -R)
+            continue
+        targets.append(tok)
+
+    if not targets:
+        return False
+
+    for target in targets:
+        # Strip trailing slash, quotes
+        t = target.strip().strip("'\"").rstrip("/")
+        # Extract the last path component (e.g. "apps/web/dist" -> "dist")
+        last = t.rsplit("/", 1)[-1]
+        if last not in BUILD_ARTIFACT_WHITELIST:
+            return False
+
+    return True
+
+
+def check_careful(command: str) -> tuple[bool, str]:
+    """
+    Determine whether the command is destructive and should prompt the user.
+
+    Returns (is_destructive, warning_reason).
+    """
+    # Normalize whitespace for easier matching
+    cmd = command
+
+    # rm -rf  (any order of -r/-R/-f/--recursive/--force)
+    # Matches: rm -rf, rm -fr, rm -r -f, rm --recursive --force, rm -Rf
+    rm_rf_patterns = [
+        r"\brm\s+[^\|&;]*-[rRf]*r[rRf]*f",  # -rf, -fr, -Rf, -fR (r and f together)
+        r"\brm\s+[^\|&;]*-[rRf]*f[rRf]*r",  # -fr ordering
+        r"\brm\s+[^\|&;]*--recursive[^\|&;]*--force",
+        r"\brm\s+[^\|&;]*--force[^\|&;]*--recursive",
+        r"\brm\s+[^\|&;]*-r\b[^\|&;]*-f\b",
+        r"\brm\s+[^\|&;]*-f\b[^\|&;]*-r\b",
+    ]
+    for pattern in rm_rf_patterns:
+        if re.search(pattern, cmd):
+            if _is_whitelisted_rm_rf(cmd):
+                return (False, "")
+            return (True, "Destructive: `rm -rf` deletes recursively. Confirm targets are correct.")
+
+    # SQL DROP statements (DROP TABLE, DROP DATABASE, DROP SCHEMA, etc.)
+    if re.search(r"\bDROP\s+(TABLE|DATABASE|SCHEMA|INDEX|VIEW|FUNCTION|TRIGGER|ROLE|USER)\b", cmd, re.IGNORECASE):
+        return (True, "Destructive SQL: DROP removes objects permanently. Confirm target and environment.")
+
+    # SQL TRUNCATE
+    if re.search(r"\bTRUNCATE\s+(TABLE\s+)?\w+", cmd, re.IGNORECASE):
+        return (True, "Destructive SQL: TRUNCATE empties a table. Confirm target and environment.")
+
+    # git push --force (any form except --force-with-lease to a remote ref).
+    # Block --force, --force-with-lease, -f. The safer --force-with-lease still
+    # rewrites remote history, so we still prompt.
+    if re.search(r"\bgit\s+push\s+[^\|&;]*(--force\b|--force-with-lease\b|-f\b)", cmd):
+        return (True, "History-rewriting: `git push --force` overwrites remote commits. Confirm the branch is yours.")
+
+    # git reset --hard (any target). Even `origin/main` can discard uncommitted work.
+    if re.search(r"\bgit\s+(-C\s+\S+\s+)?reset\s+--hard\b", cmd):
+        return (True, "History-destroying: `git reset --hard` discards local changes and commits. Confirm no work is lost.")
+
+    # git checkout . (discard working tree changes)
+    if re.search(r"\bgit\s+checkout\s+\.(\s|$)", cmd):
+        return (True, "Destructive: `git checkout .` discards all uncommitted changes. Confirm before proceeding.")
+
+    # git restore . / git restore --staged .
+    if re.search(r"\bgit\s+restore\s+(--staged\s+)?\.(\s|$)", cmd):
+        return (True, "Destructive: `git restore .` discards uncommitted changes. Confirm before proceeding.")
+
+    # git clean -f (removes untracked files)
+    if re.search(r"\bgit\s+clean\s+[^\|&;]*-[fdx]*f", cmd):
+        return (True, "Destructive: `git clean -f` removes untracked files. Confirm before proceeding.")
+
+    # kubectl delete
+    if re.search(r"\bkubectl\s+delete\b", cmd):
+        return (True, "Destructive: `kubectl delete` removes cluster resources. Confirm target and namespace.")
+
+    # docker rm -f / docker rmi -f
+    if re.search(r"\bdocker\s+rmi?\s+[^\|&;]*-f", cmd):
+        return (True, "Destructive: `docker rm/rmi -f` force-removes containers/images. Confirm before proceeding.")
+
+    # docker system prune / docker volume prune
+    if re.search(r"\bdocker\s+(system|volume|image|container|network)\s+prune\b", cmd):
+        return (True, "Destructive: `docker ... prune` removes unused resources. Confirm before proceeding.")
+
+    return (False, "")
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    tool_input = input_data.get("tool_input", {})
+
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = tool_input.get("command", "")
+    if not command:
+        sys.exit(0)
+
+    is_destructive, reason = check_careful(command)
+    if not is_destructive:
+        sys.exit(0)
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "ask",
+            "permissionDecisionReason": reason,
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/hooks/hooks/check-freeze.py
+++ b/modules/hooks/hooks/check-freeze.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook that scope-locks Edit/Write to a frozen directory.
+
+When a freeze is active (state file `~/.claude/freeze-dir.txt` exists and
+contains a directory path), Edit and Write operations outside that directory
+are denied. Use `/freeze <dir>` to set the scope and `/unfreeze` to clear it.
+
+Paths are normalised (symlinks resolved, `..` collapsed) before the
+containment check so trivial escape attempts (`../foo`, symlinked parent) are
+caught POSIX-portably.
+
+Ported to Python from gstack `freeze/bin/check-freeze.sh` to match CCGM's
+hook style (JSON stdin/stdout, consistent with auto-approve-file-ops.py).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+FREEZE_FILE = Path.home() / ".claude" / "freeze-dir.txt"
+
+
+def read_freeze_dir() -> str | None:
+    """Return the current freeze directory (absolute, resolved) or None."""
+    if not FREEZE_FILE.exists():
+        return None
+    try:
+        raw = FREEZE_FILE.read_text().strip()
+    except OSError:
+        return None
+    if not raw:
+        return None
+    # Expand ~ and environment variables, then resolve.
+    expanded = os.path.expandvars(os.path.expanduser(raw))
+    try:
+        return str(Path(expanded).resolve())
+    except OSError:
+        return None
+
+
+def resolve_path(path: str) -> str | None:
+    """
+    Resolve `path` to an absolute canonical form.
+
+    Uses Path.resolve(strict=False) so new files (Write) that do not yet
+    exist on disk still get their parent hierarchy resolved and `..` collapsed.
+    """
+    if not path:
+        return None
+    expanded = os.path.expandvars(os.path.expanduser(path))
+    try:
+        return str(Path(expanded).resolve())
+    except OSError:
+        return None
+
+
+def is_within(target: str, parent: str) -> bool:
+    """Return True if `target` is the same path as or nested under `parent`."""
+    # Ensure trailing slash semantics so "/a/b" does not match "/a/bcd".
+    parent_norm = parent.rstrip(os.sep)
+    target_norm = target.rstrip(os.sep)
+    if target_norm == parent_norm:
+        return True
+    return target_norm.startswith(parent_norm + os.sep)
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name not in ("Edit", "Write"):
+        sys.exit(0)
+
+    freeze_dir = read_freeze_dir()
+    if not freeze_dir:
+        # No freeze active. Fall through to default permission handling.
+        sys.exit(0)
+
+    tool_input = input_data.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+    resolved = resolve_path(file_path)
+    if resolved is None:
+        # Could not resolve; fall through rather than block on malformed input.
+        sys.exit(0)
+
+    if is_within(resolved, freeze_dir):
+        # In scope - let other hooks / default system decide.
+        sys.exit(0)
+
+    reason = (
+        f"Freeze active: writes are scoped to {freeze_dir}. "
+        f"{resolved} is outside the frozen directory. "
+        f"Run `/unfreeze` to clear the scope, or stay within the frozen path."
+    )
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/hooks/module.json
+++ b/modules/hooks/module.json
@@ -66,6 +66,16 @@
       "type": "hook",
       "template": false
     },
+    "hooks/check-careful.py": {
+      "target": "hooks/check-careful.py",
+      "type": "hook",
+      "template": false
+    },
+    "hooks/check-freeze.py": {
+      "target": "hooks/check-freeze.py",
+      "type": "hook",
+      "template": false
+    },
     "settings.partial.json": {
       "target": "settings.json",
       "type": "config",

--- a/modules/hooks/settings.partial.json
+++ b/modules/hooks/settings.partial.json
@@ -56,6 +56,11 @@
             "type": "command",
             "command": "python3 $HOME/.claude/hooks/check-migration-timestamps.py",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/check-careful.py",
+            "timeout": 5000
           }
         ]
       },
@@ -76,6 +81,11 @@
             "type": "command",
             "command": "$HOME/.claude/hooks/auto-approve-file-ops.py",
             "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/check-freeze.py",
+            "timeout": 5000
           }
         ]
       },
@@ -85,6 +95,11 @@
           {
             "type": "command",
             "command": "$HOME/.claude/hooks/auto-approve-file-ops.py",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/check-freeze.py",
             "timeout": 5000
           }
         ]


### PR DESCRIPTION
Closes #294

Three composable safety hooks ported from gstack (copycat analysis item 8). Extends the existing `hooks` and `commands-extra` modules - no new module.

## Hooks

**`modules/hooks/hooks/check-careful.py`** (PreToolUse:Bash)
Prompts with `permissionDecision:"ask"` on destructive patterns:
- recursive rm (whitelist for build artifacts: `node_modules`, `dist`, `.next`, `build`, `__pycache__`, `.cache`, `.turbo`, `coverage`)
- SQL DROP (TABLE/DATABASE/SCHEMA/INDEX/VIEW/FUNCTION/TRIGGER/ROLE/USER) and TRUNCATE
- force push (`--force`, `--force-with-lease`, `-f`)
- hard-reset (git reset with the --hard flag, any target)
- dirty-discard (git checkout dot, git restore dot, git clean -f)
- kubectl delete
- docker rm -f, docker rmi -f, docker prune variants

**`modules/hooks/hooks/check-freeze.py`** (PreToolUse:Edit|Write)
Reads `~/.claude/freeze-dir.txt`. When set, denies Edit/Write outside that directory. Resolves symlinks and parent refs before the containment check using `Path.resolve()` so trivial escapes are caught. No-op when the state file is absent.

## Commands

- `/freeze [dir]` - write resolved absolute path to `~/.claude/freeze-dir.txt`
- `/unfreeze` - delete the state file
- `/guard [dir]` - compose: activate freeze and confirm both hooks are installed

All three live in `commands-extra/commands/`.

## Wiring

`modules/hooks/settings.partial.json` adds:
- `check-careful.py` to the PreToolUse:Bash hook chain
- `check-freeze.py` to PreToolUse:Edit and PreToolUse:Write

## Module placement

Used the existing `hooks` module and `commands-extra` module as the issue specifies. No new module.

## Verification

- `bash tests/test-modules.sh` - 707 passed, 0 failed (up from 639)
- `bash tests/test-no-personal-data.sh` - only the pre-existing cloud-dispatch failures remain; new files are clean
- Smoke-tested both hooks with sample PreToolUse JSON:
  - careful: asks on recursive rm, DROP TABLE, force push; allows `rm -rf node_modules`, allows `ls -la`
  - freeze: allows inside scope, denies outside scope, denies parent-ref escape, ignores non-Edit/Write tools