### PR TITLE
#267: decompose systematic-debugging into focused sub-rules

### DIFF
--- a/modules/systematic-debugging/README.md
+++ b/modules/systematic-debugging/README.md
@@ -13,14 +13,26 @@ Installs a rules file that enforces structured debugging instead of random fix a
 
 Includes a three-strike rule: after 3 failed fix attempts, stop and question the architecture.
 
+The parent rule is backed by three focused sub-rules that give agents named moves during Phase 1-2:
+
+- **Root Cause Tracing** - trace errors backward up the call chain to the originating trigger, not the surface symptom
+- **Defense-in-Depth Validation** - once the origin is found, add validation at every layer the bad value passed through so the same class of bug is structurally impossible
+- **Condition-Based Waiting** - replace arbitrary `sleep(N)` with `waitFor(condition)` to eliminate timing-based flaky tests
+
 ## Manual Installation
 
 ```bash
 # Global (all projects)
 cp rules/systematic-debugging.md ~/.claude/rules/systematic-debugging.md
+cp rules/root-cause-tracing.md ~/.claude/rules/root-cause-tracing.md
+cp rules/defense-in-depth.md ~/.claude/rules/defense-in-depth.md
+cp rules/condition-based-waiting.md ~/.claude/rules/condition-based-waiting.md
 
 # Project-level
 cp rules/systematic-debugging.md .claude/rules/systematic-debugging.md
+cp rules/root-cause-tracing.md .claude/rules/root-cause-tracing.md
+cp rules/defense-in-depth.md .claude/rules/defense-in-depth.md
+cp rules/condition-based-waiting.md .claude/rules/condition-based-waiting.md
 ```
 
 ## Files
@@ -28,3 +40,7 @@ cp rules/systematic-debugging.md .claude/rules/systematic-debugging.md
 | File | Description |
 |------|-------------|
 | `rules/systematic-debugging.md` | 4-phase debugging methodology with red flags and escalation rules |
+| `rules/debugging.md` | Trigger guide for the `/debug` skill |
+| `rules/root-cause-tracing.md` | Trace errors backward up the call chain to the originating trigger |
+| `rules/defense-in-depth.md` | Layered validation that makes a fixed bug structurally impossible to reintroduce |
+| `rules/condition-based-waiting.md` | Replace arbitrary sleeps with condition polling to kill flaky tests |

--- a/modules/systematic-debugging/module.json
+++ b/modules/systematic-debugging/module.json
@@ -7,7 +7,10 @@
   "dependencies": [],
   "files": {
     "rules/systematic-debugging.md": { "target": "rules/systematic-debugging.md", "type": "rule", "template": false },
-    "rules/debugging.md": { "target": "rules/debugging.md", "type": "rule", "template": false }
+    "rules/debugging.md": { "target": "rules/debugging.md", "type": "rule", "template": false },
+    "rules/root-cause-tracing.md": { "target": "rules/root-cause-tracing.md", "type": "rule", "template": false },
+    "rules/defense-in-depth.md": { "target": "rules/defense-in-depth.md", "type": "rule", "template": false },
+    "rules/condition-based-waiting.md": { "target": "rules/condition-based-waiting.md", "type": "rule", "template": false }
   },
   "tags": ["debugging", "root-cause", "methodology", "troubleshooting"],
   "configPrompts": []

--- a/modules/systematic-debugging/rules/condition-based-waiting.md
+++ b/modules/systematic-debugging/rules/condition-based-waiting.md
@@ -1,0 +1,84 @@
+# Condition-Based Waiting
+
+Most "flaky test" bugs are timing bugs. The test guesses at how long an async operation should take, the guess is right on the developer's machine, and wrong under CI load. The fix is almost never "increase the timeout." The fix is to wait for the actual condition, not a duration.
+
+This is a companion to `systematic-debugging.md`. Use it when the symptom is intermittent failure in async code, parallel tests, or anything that involves `sleep`, `setTimeout`, `time.sleep`, or `await new Promise(r => setTimeout(r, N))`.
+
+## The Core Move
+
+Replace arbitrary sleeps with a polling helper that checks the condition you actually care about, with a bounded timeout that fails loudly when the condition never becomes true.
+
+- `sleep(50)` asserts "50ms is enough" - a fact about the machine, not the system
+- `waitFor(() => ready)` asserts "the system reached the expected state" - a fact about the system
+
+The second is always the intent. The first is a shortcut that produces flakiness.
+
+## When to Replace a Sleep
+
+Any sleep in a test or verification step is a candidate unless it meets **all** of these:
+
+- It waits for a fixed-duration side effect (a debounce interval, a rate-limit window, a tick-based scheduler)
+- The duration is derived from a known, documented interval - not guessed
+- A comment immediately above the sleep explains why a sleep is correct here
+
+If any of those fail, the sleep is a bug waiting to fire. Replace it.
+
+## Quick Patterns
+
+| Waiting for... | Pattern |
+|----------------|---------|
+| An event to fire | `waitFor(() => events.some(e => e.type === "DONE"))` |
+| State to change | `waitFor(() => machine.state === "ready")` |
+| A count to be reached | `waitFor(() => items.length >= 5)` |
+| A file to appear | `waitFor(() => fs.existsSync(path))` |
+| A compound condition | `waitFor(() => obj.ready && obj.value > 10)` |
+
+## A Minimal Polling Helper
+
+```typescript
+async function waitFor<T>(
+  condition: () => T | undefined | null | false,
+  description: string,
+  timeoutMs = 5000,
+): Promise<T> {
+  const start = Date.now();
+  while (true) {
+    const result = condition();
+    if (result) return result;
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Timeout waiting for ${description} after ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+```
+
+Three things make this helper safe:
+- **A bounded timeout.** It cannot hang forever.
+- **A descriptive error.** A failure message names what was being awaited, not just "timeout."
+- **A reasonable poll interval.** 10ms polling is responsive without pegging the CPU.
+
+Most test frameworks ship an equivalent (`waitFor`, `eventually`, `poll_until`). Use the built-in when one exists.
+
+## Common Mistakes
+
+- **Polling every millisecond.** Wastes CPU, sometimes starves the code under test. Poll at ~10ms.
+- **No timeout.** A broken condition becomes an infinite hang in CI. Always bound the wait.
+- **Caching state outside the loop.** The condition must call the getter each iteration to see fresh state.
+- **Increasing the sleep instead of replacing it.** Longer sleeps reduce flakiness statistically but do not fix the race; they make the test slower and still flaky on a bad day.
+- **Waiting on a timer when you can wait on an event.** If the system exposes an event or promise that resolves when the operation completes, subscribe to that instead of polling.
+
+## When an Arbitrary Timeout Is Actually Correct
+
+Occasionally you do need to wait a specific duration - e.g., verifying that a debounced function only emits after 200ms of silence. In that case:
+
+1. First wait on a condition (e.g., the first event fires) to synchronize the start
+2. Then sleep for the known interval
+3. Then assert on the expected outcome
+4. Comment the sleep with the exact reason ("debounce is 200ms; wait 1 full interval to verify no emission")
+
+A commented, condition-anchored sleep is not flaky. An uncommented sleep-and-pray is.
+
+## Why This Belongs in Debugging
+
+Flaky tests waste debugging time twice: once when they fail and once when they pass on rerun and hide a real bug. Treating a flake as a timing bug and fixing it with condition-based waiting eliminates both failure modes. Retrying a flaky test until it passes is the testing equivalent of swallowing an exception.

--- a/modules/systematic-debugging/rules/defense-in-depth.md
+++ b/modules/systematic-debugging/rules/defense-in-depth.md
@@ -1,0 +1,61 @@
+# Defense-in-Depth Validation
+
+Once root-cause-tracing has identified where a bad value originated, a single fix at that point is necessary but not sufficient. A single validation is a check a future refactor can remove. Layered validation makes the bug structurally impossible.
+
+This is a companion to `systematic-debugging.md` and `root-cause-tracing.md`. Use it in Phase 4 (Implementation), after you have found the origin and are deciding where to put the fix.
+
+## The Core Move
+
+One validation is "we fixed this bug." Validation at every layer the bad value passed through is "we made this bug impossible." Each layer catches different cases - entry validation blocks bad input, business-logic validation blocks bad state, environment guards block dangerous context, and instrumentation captures anything the first three missed.
+
+**The goal is not redundancy. It is independence.** Four layers each with one weakness catch more bugs than one layer with four weaknesses.
+
+## The Four Layers
+
+### Layer 1 - Entry Point Validation
+
+Reject obviously invalid input at the API boundary. Empty strings, nulls, wrong types, missing required fields.
+
+- Validate at the public entry point so callers see failures early
+- Throw with a specific message that names the invalid value
+- This layer catches most real-world bugs and prevents bad values from entering the system
+
+### Layer 2 - Business Logic Validation
+
+Within the operation, assert that the data makes sense for the specific action about to occur. Entry-level validation accepts any non-empty string; business-logic validation rejects a string that is syntactically valid but semantically wrong (a path that does not exist, a user without the required role, a state that forbids this transition).
+
+- Use guard clauses at the top of the operation, not deep inside it
+- Fail with context: what operation, what input, what invariant was violated
+- This layer catches what entry validation cannot, because it depends on runtime state
+
+### Layer 3 - Environment Guards
+
+Forbid dangerous operations in the wrong context. Refuse to run destructive code outside a test sandbox. Refuse to write to production tables from a development build. Refuse to call a paid API without the expected feature flag.
+
+- Gate the dangerous operation on an invariant about the environment, not the input
+- Prefer "refuse unless proven safe" over "allow unless proven dangerous"
+- This layer catches bugs that entry and business validation cannot see, because the bad context comes from the wrong machine, wrong process, or wrong mode
+
+### Layer 4 - Debug Instrumentation
+
+Structured logging immediately before the dangerous operation, capturing the value, the caller, the environment, and a stack trace. This layer does not prevent bugs; it makes the *next* bug fast to diagnose.
+
+- Log enough context that a stack trace alone would identify the broken caller
+- Use stderr or an unfiltered channel so the log survives when the operation fails
+- Leave the instrumentation in for some period after the fix ships; remove it only when the code path has been stable
+
+## How to Apply the Pattern
+
+1. Trace the data flow from origin to failure point (see `root-cause-tracing.md`)
+2. List every layer the bad value passed through
+3. Add a layer-appropriate check at each boundary, not only the one closest to the symptom
+4. Test that each layer fires independently by temporarily disabling the others
+
+Four weak layers of independent validation catch more bugs than one strong layer.
+
+## Anti-Patterns
+
+- **Fixing only at the origin.** The fix is correct but fragile; a future code path can re-introduce the bad value without tripping any check.
+- **Fixing only at the symptom.** The origin continues to produce bad values; the same class of bug reappears through different paths.
+- **Duplicating the same validation at every layer.** Each layer should catch a different class of failure. If all four layers check "non-empty string," you have one layer, repeated.
+- **Skipping instrumentation because "the fix is enough."** Future debugging will be slower without it, and the next bug in this area will have no leverage.

--- a/modules/systematic-debugging/rules/root-cause-tracing.md
+++ b/modules/systematic-debugging/rules/root-cause-tracing.md
@@ -1,0 +1,51 @@
+# Root Cause Tracing
+
+A concrete technique for Phase 1 and Phase 2 of the systematic-debugging methodology. When a bug surfaces deep in a call chain, do not fix where the error appears. Trace backward until you find the original trigger, then fix at the source.
+
+This is a companion to `systematic-debugging.md`. That rule tells you to investigate before fixing. This rule tells you *how* to investigate when the symptom is far from the cause.
+
+## The Core Move
+
+Errors surface where broken invariants finally fail a check. The code that raises the exception is rarely the code that produced the bad value. Tracing means following the bad value backward up the call stack to the place it was first introduced.
+
+**Never fix only where the error appears.** Fixing the symptom leaves the originating code free to produce the same bad value again, through a different path.
+
+## When to Use This Technique
+
+- The stack trace is long and the failure happens far from any user input
+- The immediate cause is clear but the reason that cause occurred is not
+- The same symptom keeps reappearing after previous fixes
+- Instrumentation or logs show a bad value, but not where it came from
+- You catch yourself about to wrap the failing operation in a try/catch
+
+## The Tracing Process
+
+1. **Observe the symptom.** Read the full error, including the exact value that caused it (empty string, null, wrong path, unexpected state).
+2. **Find the immediate cause.** What line of code raised the error? What argument or state was wrong at that point?
+3. **Walk one frame up.** What called this code? What value did the caller pass in?
+4. **Repeat.** Keep walking until the bad value stops being passed in and starts being *produced*. That is the origin.
+5. **Fix at the origin.** Correct the place that first produced the bad value, not every place that forwarded it.
+
+If the call chain crosses module boundaries, instrument each boundary with structured logging (value, caller, timestamp) rather than guessing. A captured stack trace at the suspicious operation is usually enough to collapse the search.
+
+## When Manual Tracing Stalls
+
+If you cannot trace manually because the chain is asynchronous, event-driven, or dynamically dispatched:
+
+- Log `new Error().stack` (or the language equivalent) at the suspicious operation so the full call path is captured at runtime
+- Use `console.error` (or stderr) rather than a logger that may be suppressed in the failing context
+- Log the actual value, the environment, and the call path together - one of them is the clue
+- For test-pollution bugs ("something gets created that should not exist"), bisect the test suite: run subsets until the offending test is identified
+
+The goal of instrumentation is to *discover* where the bad value originated, not to confirm a theory you already have.
+
+## Pair With Defense-in-Depth
+
+Finding the origin tells you where to fix. But a single fix at the origin can be bypassed by a new code path, a refactor, or a mock. Once the origin is identified and fixed, add validation at the other layers the value passed through. See `defense-in-depth.md`.
+
+## Anti-Patterns
+
+- **Fixing at the symptom and declaring victory.** The bug returns through a different path.
+- **Adding a try/catch around the failing operation.** Swallowing the error hides the next occurrence and leaves the origin untouched.
+- **Guessing upward without instrumentation.** If the chain is not obvious from reading, add logging before speculating.
+- **Stopping at the first plausible-looking cause.** Keep asking "what called this?" until the bad value has no caller - only then are you at the origin.


### PR DESCRIPTION
Closes #267

## Summary

Adds three peer rule files to `modules/systematic-debugging/rules/` so the module goes beyond the 4-phase methodology and equips agents with named concrete techniques during Phase 1-2.

- `root-cause-tracing.md` — trace errors backward up the call chain to the originating trigger, not the surface symptom
- `defense-in-depth.md` — once the origin is found, add validation at every layer the bad value passed through so the same class of bug is structurally impossible to reintroduce
- `condition-based-waiting.md` — replace arbitrary `sleep(N)` with `waitFor(condition)` polling to kill timing-based flaky tests

Each file is focused (~60-80 lines), stays in CCGM voice, and does not duplicate content already in `systematic-debugging.md` or `debugging.md` - those remain unmodified. The sub-rules are complementary: tracing finds origins, defense-in-depth prevents fixes from being bypassed, and condition-based waiting addresses a recurring flaky-test pattern that otherwise wastes debugging cycles.

## Changes

- New: `modules/systematic-debugging/rules/root-cause-tracing.md`
- New: `modules/systematic-debugging/rules/defense-in-depth.md`
- New: `modules/systematic-debugging/rules/condition-based-waiting.md`
- Updated: `modules/systematic-debugging/module.json` (registers all three rule files)
- Updated: `modules/systematic-debugging/README.md` (documents sub-rules and install instructions)

## Test Plan

- [x] `bash tests/test-modules.sh` → 729 passed, 0 failed
- [x] `bash tests/test-no-personal-data.sh` → only pre-existing cloud-dispatch failures, unrelated to this change
- [x] Parent rules `systematic-debugging.md` and `debugging.md` not modified