### PR TITLE
#269: add git-worktrees module for solo-agent isolation

### DIFF
--- a/modules/git-worktrees/README.md
+++ b/modules/git-worktrees/README.md
@@ -1,0 +1,50 @@
+# git-worktrees
+
+Solo-agent worktree-based isolation for feature work. A lighter alternative to the multi-clone architecture when only a single agent is active.
+
+## What This Module Does
+
+Installs rules and commands that instruct Claude to use `git worktree` for parallel branch work in a single clone. Worktrees let you keep multiple branches checked out simultaneously in sibling directories without duplicating the entire repository.
+
+Key capabilities:
+
+- **Solo-agent isolation**: keep a feature branch's working tree separate from `main` without switching branches in place
+- **`/worktree-start`**: create a new worktree with gitignore verification and project-setup auto-detection
+- **`/worktree-finish`**: four-option finishing gate (merge locally / push + PR / keep / discard with typed confirmation)
+
+## When to Use vs Multi-Agent Clones
+
+| Situation | Use |
+|-----------|-----|
+| Single agent, wants to try an idea on a branch without stashing | **Worktree** (`/worktree-start`) |
+| Single agent, wants to compare two branches side by side | **Worktree** |
+| Multiple agents working on the same repo in parallel | **Multi-clone** (see `multi-agent` module) |
+| Need isolated dev server ports per branch | **Multi-clone** (worktrees share `.env`) |
+| Need per-branch `node_modules` only temporarily | **Worktree** (cheap, local-only) |
+
+Worktrees are cheaper than clones (shared `.git`, no re-fetch) but lack the port-registry, tracking-CSV, and cross-agent log coordination that the `multi-agent` module provides. Use clones when coordination matters, worktrees when isolation alone is enough.
+
+## Files
+
+| File | Type | Description |
+|------|------|-------------|
+| `rules/git-worktrees.md` | rule | When to use worktrees, creation/cleanup, pitfalls |
+| `commands/worktree-start.md` | command | `/worktree-start {branch-name}` |
+| `commands/worktree-finish.md` | command | `/worktree-finish` with four-option gate |
+
+## Dependencies
+
+None. The module is self-contained.
+
+## Manual Installation
+
+```bash
+# Rule
+mkdir -p ~/.claude/rules
+cp rules/git-worktrees.md ~/.claude/rules/git-worktrees.md
+
+# Commands
+mkdir -p ~/.claude/commands
+cp commands/worktree-start.md ~/.claude/commands/worktree-start.md
+cp commands/worktree-finish.md ~/.claude/commands/worktree-finish.md
+```

--- a/modules/git-worktrees/commands/worktree-finish.md
+++ b/modules/git-worktrees/commands/worktree-finish.md
@@ -1,0 +1,135 @@
+---
+description: Finish a git worktree feature branch with a four-option gate (merge locally / push+PR / keep / discard)
+allowed-tools: Bash, Read
+---
+
+# /worktree-finish - Finish a Worktree
+
+Ends feature work in a worktree with an explicit four-option gate. Never silently merges, pushes, or discards - the user picks the outcome, and destructive options require typed confirmation.
+
+## Usage
+
+```
+/worktree-finish [worktree-path]
+```
+
+- `worktree-path` (optional): path to the worktree. Defaults to the current directory if it is a worktree, otherwise asks.
+
+## Workflow
+
+### Phase 1: Detect Context
+
+1. If `worktree-path` was passed, use it. Otherwise, run `git rev-parse --show-toplevel` to find the repo root and check `git worktree list` - if the current directory is a worktree, use it.
+
+2. Verify this IS a worktree, not the main checkout:
+
+   ```bash
+   git rev-parse --git-common-dir   # .git of the main repo
+   git rev-parse --git-dir          # .git-worktrees/<name> of this worktree
+   ```
+
+   If they are the same path, this is the main checkout - stop and report: "this is the main checkout, not a worktree; /worktree-finish is only for worktrees."
+
+3. Gather state:
+   - Current branch: `git rev-parse --abbrev-ref HEAD`
+   - Upstream: `git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null`
+   - Uncommitted changes: `git status --porcelain`
+   - Unpushed commits: `git log @{u}..HEAD --oneline 2>/dev/null`
+   - Merge base with `origin/main`: `git merge-base HEAD origin/main`
+   - Commits ahead of main: `git log origin/main..HEAD --oneline`
+
+### Phase 2: Preflight Warnings
+
+Before showing options, surface any state the user should know about:
+
+- Uncommitted changes: list them. Warn that options 1, 2, and 4 below require a clean tree or an intentional WIP commit.
+- Unpushed commits: list count and titles.
+- Branch not based on latest main: if `git merge-base HEAD origin/main` is not the tip of `origin/main`, suggest a rebase before merging or opening a PR.
+
+### Phase 3: Present Four Options
+
+Print this prompt to the user VERBATIM and wait for a numeric reply:
+
+```
+Finishing worktree: <path>
+Branch: <branch>
+Commits ahead of main: <N>
+Uncommitted changes: <yes/no>
+
+Choose an action:
+  1) Merge locally into main (squash, then remove worktree)
+  2) Push branch and open a PR (worktree stays until PR is merged)
+  3) Keep the worktree as is (no action, just exit)
+  4) Discard the worktree and branch (DESTRUCTIVE, requires typed confirmation)
+
+Enter 1, 2, 3, or 4:
+```
+
+Do NOT pick an option on the user's behalf. If the reply is not `1`, `2`, `3`, or `4`, re-prompt.
+
+### Phase 4: Execute the Chosen Option
+
+#### Option 1: Merge Locally
+
+1. Require a clean tree. If `git status --porcelain` is non-empty, stop and ask the user to commit or discard the changes first.
+2. `cd` to the main checkout: `cd $(git rev-parse --git-common-dir)/..`
+3. `git checkout main && git pull --ff-only origin main`
+4. `git merge --squash <branch>`
+5. Show the staged diff. Ask the user to confirm the squash commit message.
+6. `git commit -m "<message>"`
+7. Push: ask first. If confirmed, `git push origin main`.
+8. Remove the worktree: `git worktree remove <path>`
+9. Delete the branch: `git branch -D <branch>` (safe after squash merge).
+
+#### Option 2: Push and Open PR
+
+1. Require a clean tree (same check as option 1).
+2. Check that `origin/main` is current: `git fetch origin`. If behind, offer to rebase first.
+3. Push: `git push -u origin <branch>`
+4. Create PR: `gh pr create` with title and body. Use the repo's PR template if one exists (check `.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and repo root). Do not add AI attribution footers.
+5. Report the PR URL.
+6. Leave the worktree in place - the user will run `/worktree-finish` again after the PR is merged to clean up (or manually `git worktree remove`).
+
+#### Option 3: Keep
+
+No-op. Report:
+
+```
+Keeping worktree: <path>
+Branch: <branch>
+(Run /worktree-finish again when you are ready to merge, push, or discard.)
+```
+
+#### Option 4: Discard (Typed Confirmation Required)
+
+1. Show what will be lost:
+   - Branch and SHA
+   - List of commits that exist only on this branch (`git log origin/main..HEAD --oneline`)
+   - List of uncommitted changes (`git status --porcelain`)
+2. Ask the user to type the EXACT branch name to confirm. Example:
+
+   ```
+   To confirm discard, type the branch name: <branch>
+   ```
+
+3. If the typed reply does not match the branch name exactly, abort and report: "Discard cancelled - typed name did not match."
+4. If it matches:
+   - `git worktree remove --force <path>`
+   - `git branch -D <branch>`
+   - If the branch was pushed, ask separately whether to delete the remote: `git push origin --delete <branch>`. This is a second typed confirmation.
+5. Report: worktree and branch discarded.
+
+### Phase 5: Final Report
+
+Always report:
+
+- Option chosen
+- Actions taken (commits, pushes, removals)
+- Any warnings the user should follow up on (e.g., unpushed commits when keeping, stale remote branches)
+
+## Safety Notes
+
+- Option 4 is the only destructive action and requires typed confirmation. Do not shortcut it.
+- Never force-push to `main` from any option.
+- Never `rm -rf` a worktree - always use `git worktree remove` (with `--force` only for option 4).
+- If any phase fails, stop and report. Do not fall through to a different option silently.

--- a/modules/git-worktrees/commands/worktree-start.md
+++ b/modules/git-worktrees/commands/worktree-start.md
@@ -1,0 +1,127 @@
+---
+description: Create a new git worktree for solo-agent feature work with gitignore verification and project setup
+allowed-tools: Bash, Read, Edit, Write
+---
+
+# /worktree-start - Start a New Worktree
+
+Creates an isolated git worktree in a sibling directory so feature work does not disturb the main checkout. Use this for solo-agent parallel branch work. For multi-agent parallel work, use the `multi-agent` module's clone setup instead.
+
+## Usage
+
+```
+/worktree-start <branch-name> [base-branch]
+```
+
+- `branch-name` (required): the new branch to create in the worktree
+- `base-branch` (optional, default: `origin/main`): branch to fork from
+
+## Workflow
+
+### Phase 1: Pre-Flight Checks
+
+1. **Confirm repo root**: run `git rev-parse --show-toplevel`. If this fails, stop and report: "not inside a git repository."
+
+2. **Fetch latest**: `git fetch origin`. Do this every time - never assume the local `origin/main` ref is current.
+
+3. **Check for existing worktree on this branch**: `git worktree list --porcelain | grep -A2 "branch refs/heads/<branch-name>"`. If one exists, show its path and ask the user whether to reuse it, pick a different name, or remove the existing worktree first.
+
+4. **Check branch uniqueness**: `git branch --list <branch-name>`. If the branch already exists and the user did not pass `[existing-branch]` as the base, ask whether they meant to check out the existing branch in a worktree.
+
+5. **Verify `.worktrees/` is gitignored**: read `.gitignore` and check for a line matching `.worktrees/` or `.worktrees`. If missing, add it:
+
+   ```bash
+   echo ".worktrees/" >> .gitignore
+   git add .gitignore
+   git commit -m "chore: ignore .worktrees directory"
+   ```
+
+   Do this BEFORE creating the worktree. Creating `.worktrees/` without gitignoring it risks committing the entire worktree back into the repo on a careless `git add .`.
+
+### Phase 2: Create the Worktree
+
+Choose the directory:
+
+- Preferred: `<repo-root>/.worktrees/<branch-name>/`
+- Fallback if `.worktrees/` gitignore cannot be added: `~/code/worktrees/<repo-name>-<branch-name>/` (create this directory first, mkdir -p)
+
+Create the worktree:
+
+```bash
+# New branch off base-branch (default: origin/main)
+git worktree add -b <branch-name> .worktrees/<branch-name> <base-branch>
+```
+
+If the branch already exists and the user confirmed reuse:
+
+```bash
+git worktree add .worktrees/<branch-name> <branch-name>
+```
+
+### Phase 3: Project Setup (Auto-Detect)
+
+Inside the new worktree, detect project type and run the appropriate install / build command. Check for these files in order and run the matching command:
+
+| File present | Command |
+|--------------|---------|
+| `pnpm-lock.yaml` | `pnpm install` |
+| `yarn.lock` | `yarn install` |
+| `package-lock.json` | `npm install` |
+| `package.json` (no lockfile) | `npm install` |
+| `Cargo.toml` | `cargo build` |
+| `requirements.txt` | `pip install -r requirements.txt` |
+| `Gemfile` | `bundle install` |
+| `go.mod` | `go mod download` |
+
+Run only the FIRST match. If the project uses a lockfile, respect it. If the install fails, stop and report the error - do not proceed to baseline checks.
+
+### Phase 4: Copy Non-Tracked Local Config
+
+Worktrees do not inherit `.env` or other gitignored local config. Offer to copy them from the main checkout:
+
+```bash
+# Examples - adjust to what exists in the main checkout
+cp ../../.env .env 2>/dev/null || true
+cp ../../.env.local .env.local 2>/dev/null || true
+```
+
+Only copy files that are gitignored. Never copy a file that could be committed back.
+
+### Phase 5: Baseline Test Run
+
+Run the project's test command once to confirm the baseline is green before feature work starts. Auto-detect:
+
+| File present | Test command |
+|--------------|--------------|
+| `package.json` with `"test"` script | `pnpm test` / `npm test` (match the install command) |
+| `Cargo.toml` | `cargo test` |
+| `pytest.ini` / `pyproject.toml` with pytest | `pytest` |
+| `Gemfile` with rspec | `bundle exec rspec` |
+| `go.mod` | `go test ./...` |
+
+If the baseline test run fails:
+- Do NOT start feature work
+- Report the failure to the user
+- Ask whether to proceed anyway (accepting that later failures will be hard to attribute) or investigate
+
+If the project has no test command, skip this phase and note it in the report.
+
+### Phase 6: Report
+
+Report to the user:
+
+- Worktree path: absolute path
+- Branch name
+- Base branch (ref and SHA)
+- Install / build status
+- Baseline test status (pass / fail / skipped)
+- `cd` command to enter the worktree
+
+Do not claim success if any phase failed.
+
+## Safety Notes
+
+- Never run `rm -rf` on a worktree directory directly - use `git worktree remove`
+- Never `mv` a worktree - use `git worktree move`
+- Never create worktrees inside other worktrees - they cannot share a parent
+- A locked worktree (`.git/worktrees/<name>/locked` present) requires `git worktree unlock` before removal

--- a/modules/git-worktrees/module.json
+++ b/modules/git-worktrees/module.json
@@ -1,0 +1,27 @@
+{
+  "name": "git-worktrees",
+  "displayName": "Git Worktrees",
+  "description": "Solo-agent worktree-based isolation for feature work. Lighter alternative to multi-clone setup when only one agent is active.",
+  "category": "workflow",
+  "scope": ["global"],
+  "dependencies": [],
+  "files": {
+    "rules/git-worktrees.md": {
+      "target": "rules/git-worktrees.md",
+      "type": "rule",
+      "template": false
+    },
+    "commands/worktree-start.md": {
+      "target": "commands/worktree-start.md",
+      "type": "command",
+      "template": false
+    },
+    "commands/worktree-finish.md": {
+      "target": "commands/worktree-finish.md",
+      "type": "command",
+      "template": false
+    }
+  },
+  "tags": ["git", "worktree", "isolation", "workflow"],
+  "configPrompts": []
+}

--- a/modules/git-worktrees/rules/git-worktrees.md
+++ b/modules/git-worktrees/rules/git-worktrees.md
@@ -1,0 +1,123 @@
+# Git Worktrees (Solo-Agent Isolation)
+
+Worktrees let a single agent keep multiple branches checked out at once in sibling directories, sharing one `.git` folder. They are the solo-agent equivalent of the multi-clone setup - lighter, no port registry, no cross-agent coordination.
+
+## When to Use a Worktree
+
+Use `git worktree` when:
+
+- You are the only agent working on the repo right now
+- You want to try a change on a new branch without switching or stashing in place
+- You want to compare two branches side by side (run both, diff outputs)
+- You want a clean test baseline that a destructive experiment cannot pollute
+
+## When NOT to Use a Worktree (Use Clones Instead)
+
+Reach for the `multi-agent` module's multi-clone architecture when:
+
+- Multiple agents are running in parallel on the same repo (worktrees share the index and HEAD ref database - two simultaneous writers cause lock contention)
+- You need per-branch dev server ports (worktrees share `.env`; clones have per-clone `.env.clone` with pre-computed `FRONTEND_PORT` / `BACKEND_PORT`)
+- You need per-branch issue tracking via the hook-driven `tracking.csv`
+- The work will span days and you want persistent per-branch session logs
+
+See `multi-agent/rules/multi-agent.md` and `~/.claude/multi-agent-system.md` for the clone-based alternative.
+
+## Directory Selection
+
+Prefer project-local worktree directories over a global one.
+
+- **Project-local (preferred)**: `<repo>/.worktrees/<branch-name>/`
+  - Keeps worktrees next to the repo they belong to
+  - Easier cleanup when the repo is archived
+  - Requires `.worktrees/` to be gitignored
+- **Global fallback**: `~/code/worktrees/<repo>-<branch-name>/`
+  - Use only when the repo refuses to gitignore `.worktrees/` (e.g., enforced `.gitignore` policy)
+  - Never commit files from a global worktree back without re-verifying paths
+
+## Pre-Flight Checks (Before Creating a Worktree)
+
+1. **Verify `.worktrees/` is gitignored** when using project-local. If not, add it to `.gitignore` in the same commit or before creating the worktree. Committing `.worktrees/` is catastrophic - it nests the entire working tree inside the repo.
+2. **Verify the current working tree is clean** or has only tracked changes. Worktrees share the index with the main checkout; dirty state can confuse `git worktree add`.
+3. **Verify the target branch does not already have a worktree**: `git worktree list` shows all existing worktrees.
+4. **Verify the new branch name is unique**: `git branch --list {name}` must be empty unless you are deliberately re-checking out an existing branch.
+
+## Creating a Worktree
+
+```bash
+# New branch off main
+git fetch origin main
+git worktree add -b <branch-name> .worktrees/<branch-name> origin/main
+
+# Existing branch
+git worktree add .worktrees/<branch-name> <existing-branch>
+```
+
+After creation, run project setup inside the worktree. Auto-detect based on files present:
+
+- `package.json` + `pnpm-lock.yaml` -> `pnpm install`
+- `package.json` + `package-lock.json` -> `npm install`
+- `package.json` + `yarn.lock` -> `yarn install`
+- `Cargo.toml` -> `cargo build`
+- `requirements.txt` -> `pip install -r requirements.txt`
+- `Gemfile` -> `bundle install`
+- `go.mod` -> `go mod download`
+
+Then verify a clean test baseline: run the project's test command once, confirm it exits 0, and only then hand off to feature work. A failing baseline makes later test failures ambiguous.
+
+## Cleanup
+
+When the branch is done (merged, abandoned, or paused), remove the worktree:
+
+```bash
+# Preferred - refuses if there are uncommitted changes
+git worktree remove .worktrees/<branch-name>
+
+# Force - use only after reviewing what would be lost
+git worktree remove --force .worktrees/<branch-name>
+```
+
+After removal, prune stale administrative state:
+
+```bash
+git worktree prune
+```
+
+## Pitfalls
+
+### Worktree Lock
+
+`git worktree add` creates `.git/worktrees/<name>/` with a `locked` file if the worktree is marked as permanent. A locked worktree cannot be removed by `git worktree remove` without first running `git worktree unlock .worktrees/<name>`. Do not lock worktrees unless you have a specific reason.
+
+### Moving a Worktree with Uncommitted Changes
+
+`mv .worktrees/foo .worktrees/bar` breaks Git's internal pointers - the `.git/worktrees/foo/` metadata still refers to the old path. Instead:
+
+```bash
+git worktree move .worktrees/foo .worktrees/bar
+```
+
+Never `mv` or `cp -r` a worktree directory manually. Use `git worktree move` or remove + re-add.
+
+### Two Worktrees, Same Branch
+
+Git refuses to check out the same branch in two worktrees simultaneously. This is a feature, not a bug - it prevents divergent commits on the same branch ref. If you see `fatal: 'branch' is already checked out at ...`, either reuse the existing worktree or switch one of them to a different branch.
+
+### Shared Hooks and Config
+
+Worktrees share `.git/hooks/` and `.git/config` with the main checkout. A hook installed in one affects all worktrees. Treat hook changes as global, not per-branch.
+
+### Stale `.env` Files
+
+Worktrees do NOT copy `.env` from the main checkout. Symlink or copy it manually if the worktree needs local secrets. Never commit `.env` from a worktree - it is typically gitignored in the main checkout but a fresh worktree may not inherit that context if the gitignore rule is out of date.
+
+## Integration with Existing Git Rules
+
+Worktree feature work still follows the repo's git-workflow rules:
+
+- Branch from `origin/main` (fetch first)
+- Rebase by default when pulling main into a feature branch
+- No AI attribution in commits or PRs
+- Always sync before history-altering commands
+- Never `git stash` - commit WIP instead
+
+The only thing worktrees change is **where** the working tree lives, not how branches, commits, or PRs are managed.


### PR DESCRIPTION
Closes #269

## Summary

New `modules/git-worktrees/` module. Ports the worktree workflow from obra/superpowers (`skills/using-git-worktrees/` + `skills/finishing-a-development-branch/`) as a CCGM module. This is the solo-agent complement to the existing `multi-agent` module: worktrees share one `.git`, one port allocation, and one tracking CSV, so they are the right tool when a single agent wants isolated branch work without the full multi-clone overhead.

## Contents

- `rules/git-worktrees.md` - when to use worktrees vs clones, directory-selection heuristic (project-local `.worktrees/` preferred, global fallback), pre-flight checks (gitignore `.worktrees/` before creating, verify branch uniqueness), project-setup auto-detection table, cleanup, and pitfalls (locked worktrees, moving with uncommitted changes, two worktrees on the same branch, shared hooks, stale `.env`).
- `commands/worktree-start.md` - six-phase workflow: pre-flight -> create -> auto-detected install/build -> copy local gitignored config -> baseline test run -> report.
- `commands/worktree-finish.md` - four-option gate: (1) merge locally, (2) push + PR, (3) keep, (4) discard with typed branch-name confirmation. Option 4 is the only destructive path and refuses to shortcut the confirmation.
- `module.json` + `README.md` - standard module metadata and manual-install instructions. No dependencies.

## Test Plan

- [x] `bash tests/test-modules.sh` - 759 passed, 0 failed
- [x] `bash tests/test-no-personal-data.sh` - only pre-existing cloud-dispatch findings, none in new files
- [x] No AI attribution in commits or PR body
- [x] `.env.clone` not staged
- [x] No changes to the `multi-agent` module (cross-reference lives in `git-worktrees` rule file itself)