### PR TITLE
#276: add compound-knowledge module (team-shared learnings in docs/solutions/)

### DIFF
--- a/modules/compound-knowledge/README.md
+++ b/modules/compound-knowledge/README.md
@@ -1,0 +1,132 @@
+# Compound Knowledge
+
+Team-shared learnings in `docs/solutions/`. After solving a non-trivial problem, `/compound` writes a structured markdown doc that later `/xplan` and `/review` runs re-inject as grounding context via the `learnings-researcher` agent.
+
+## Team-Shared vs Personal Memory
+
+CCGM ships two reflection stores; they are complementary, not competing.
+
+| | `self-improving` (personal) | `compound-knowledge` (team) |
+|---|---|---|
+| **Location** | `~/.claude/projects/.../memory/MEMORY.md` | `docs/solutions/` in the working repo |
+| **Committed to git** | No | Yes |
+| **Scope** | Cross-repo, per-user | Per-repo, shared |
+| **What to capture** | User preferences, cross-repo gotchas, working style | Repo-specific bugs, patterns, conventions |
+| **Retrieval** | Auto-loaded at session start | Pulled by `learnings-researcher` on demand |
+
+Use personal memory for things like "user prefers single bundled PRs" or "Tailwind v4 drops `cursor: pointer` - remember this across projects." Use team knowledge for things like "Supabase migrations in this repo quote all reserved words by convention" or "the Vite build in `apps/web` requires a CSS import in this specific order."
+
+A learning can plausibly go in either store. When in doubt, ask: "would a teammate who never worked with this agent want to find this?" If yes, write it to `docs/solutions/`. If it is really about your own working style, write it to personal memory.
+
+## What This Module Provides
+
+Files installed globally to `~/.claude/`:
+
+| Source | Target | Purpose |
+|--------|--------|---------|
+| `skills/compound/SKILL.md` | `skills/compound/SKILL.md` | `/compound` - capture a new learning |
+| `skills/compound/references/schema.yaml` | `skills/compound/references/schema.yaml` | YAML schema for doc frontmatter |
+| `skills/compound-refresh/SKILL.md` | `skills/compound-refresh/SKILL.md` | `/compound-refresh` - maintenance pass |
+| `agents/learnings-researcher.md` | `agents/learnings-researcher.md` | Retrieval agent for `/xplan`, `/review` |
+
+## Manual Installation
+
+```bash
+# From the CCGM repo root:
+
+mkdir -p ~/.claude/skills/compound/references
+mkdir -p ~/.claude/skills/compound-refresh
+mkdir -p ~/.claude/agents
+
+cp modules/compound-knowledge/skills/compound/SKILL.md \
+   ~/.claude/skills/compound/SKILL.md
+
+cp modules/compound-knowledge/skills/compound/references/schema.yaml \
+   ~/.claude/skills/compound/references/schema.yaml
+
+cp modules/compound-knowledge/skills/compound-refresh/SKILL.md \
+   ~/.claude/skills/compound-refresh/SKILL.md
+
+cp modules/compound-knowledge/agents/learnings-researcher.md \
+   ~/.claude/agents/learnings-researcher.md
+```
+
+## Per-Repo Bootstrap
+
+`compound-knowledge` writes to the repo being worked on, not to CCGM or to `~/.claude/`. Each consuming repo needs two small things before the loop is fully discoverable:
+
+1. `docs/solutions/README.md` - an index describing categories and how to add a learning. The `/compound` skill offers to write this automatically on first use.
+
+2. A pointer block in the repo's `AGENTS.md` or `CLAUDE.md`. Example:
+
+   ```markdown
+   ## Prior Learnings
+
+   Team-shared learnings live in `docs/solutions/`. Before planning a new
+   feature or debugging an unfamiliar problem, check for relevant priors.
+   The `learnings-researcher` agent surfaces them automatically at the
+   start of /xplan and /review.
+   ```
+
+The `/compound` skill runs a Discoverability Check on every invocation and offers to add this pointer if missing. You do not need to pre-seed either file - the skill self-bootstraps on first use. Pre-seeding is only worth it when onboarding a new repo or running a large `/xplan` before the first compound.
+
+## Usage
+
+### Capture a learning
+
+```
+/compound
+/compound mode:light
+```
+
+Run after shipping a non-trivial fix or confirming a durable pattern. The skill interviews the session, classifies the problem, scores overlap with existing docs, and writes or updates the corresponding file.
+
+Full mode (default) dispatches four parallel research subagents (Context Analyzer, Solution Extractor, Related Docs Finder, Session Historian). Lightweight mode skips the fan-out and writes directly from the current conversation.
+
+### Maintain the store
+
+```
+/compound-refresh
+/compound-refresh mode:autofix
+/compound-refresh mode:report-only
+```
+
+Monthly or after a major refactor. Classifies each existing doc as Keep / Update / Consolidate / Replace / Delete based on file mtime, referenced-code existence, and overlap with newer docs.
+
+### Retrieve priors
+
+The `learnings-researcher` agent is a drop-in, invoked by other skills. It is not wired into `/xplan` or `/review` by this PR - those integrations are tracked separately (see CCGM issues #268 and #277). To use it manually from any skill or command:
+
+```
+Dispatch the learnings-researcher agent with:
+- task_summary: <one paragraph>
+- files_hint: [<paths>]
+- tags_hint: [<tags>]
+```
+
+The agent returns structured blocks listing matching priors with excerpts.
+
+## Dependencies
+
+- `skill-authoring` - compound and compound-refresh follow the skill-authoring discipline (reference files via backticks, imperative voice, one command per Bash call, etc.)
+
+No runtime dependencies beyond the module system.
+
+## Non-Goals
+
+This module does **not**:
+
+- Replace `self-improving`. Personal memory and team knowledge are complementary. `self-improving` stays installed alongside this module.
+- Auto-wire itself into `/xplan` or `/review`. Those integrations ship as follow-up PRs (#268 for two-stage review prompt templates; #277 for the unified review orchestrator).
+- Install `docs/solutions/` in any repo. The skill bootstraps per-repo on first use - CCGM itself does not touch consuming repos.
+
+## Source
+
+Ported from EveryInc/compound-engineering-plugin. The original ships `ce-compound`, `ce-compound-refresh`, and `agents/research/learnings-researcher.md` as part of a larger compound-engineering loop. CCGM adopts the keystone piece - the learnings loop - while leaving the rest of that plugin's surface for separate evaluation.
+
+Adaptations from the source:
+
+- Mode token names match the CCGM skill-authoring convention (`mode:full`, `mode:light`, `mode:autofix`, `mode:report-only`)
+- Frontmatter schema is extracted to `references/schema.yaml` so the skill body does not carry it in every invocation
+- The pass-paths-not-contents subagent dispatch pattern is applied to the four Phase-1 research subagents
+- The `learnings-researcher` agent lives under `agents/` (per the `agents/` directory convention added in CCGM #273) rather than inside a skill directory

--- a/modules/compound-knowledge/agents/learnings-researcher.md
+++ b/modules/compound-knowledge/agents/learnings-researcher.md
@@ -1,0 +1,114 @@
+---
+name: learnings-researcher
+description: >
+  Retrieves relevant prior learnings from docs/solutions/ in the current repo and returns them as structured context for the caller. Invoked at the start of /xplan and /review so planning and review can stand on codified team knowledge. Grep-first - never reads the full directory.
+tools: Glob, Grep, Read
+---
+
+# learnings-researcher
+
+Find prior `docs/solutions/**/*.md` entries that match the current task and return them as grounding context for the caller. The caller is almost always an orchestrator skill (currently `/xplan` and `/review` - future: any planning or debugging flow).
+
+This agent does **not** write, summarize, or opine. It retrieves, scores, and returns. The caller decides what to do with the matches.
+
+## Inputs
+
+The caller passes a JSON-ish block with:
+
+- `task_summary` (required) - one paragraph describing the new work or problem
+- `files_hint` (optional) - list of paths the task will touch or has touched
+- `tags_hint` (optional) - list of tags the caller thinks are relevant
+- `problem_type_filter` (optional) - `bug`, `knowledge`, or absent for both
+- `max_results` (optional, default 5) - cap on returned priors
+
+Example:
+
+```
+task_summary: >
+  Planning a new Supabase migration that adds a user "position" column
+  and indexes. Want to surface any prior learnings on reserved-word
+  quoting or RLS policy gotchas.
+files_hint: [supabase/migrations/]
+tags_hint: [supabase, postgres, migrations]
+problem_type_filter: knowledge
+max_results: 5
+```
+
+## Discovery
+
+1. Use the native file-search tool (e.g., Glob) to enumerate `docs/solutions/**/*.md` in the repo root. Skip `docs/solutions/README.md` and anything under `docs/solutions/.refresh/`.
+
+2. If the directory does not exist, return `no_solutions_directory: true` and stop. Do not error - this is expected for repos that have not yet bootstrapped.
+
+3. Use the native content-search tool (e.g., Grep) to filter by frontmatter. Preferred signals, in order:
+
+   - Exact match on any tag in `tags_hint` against the `tags:` line
+   - Exact match on any path prefix in `files_hint` against the `files:` list
+   - `module:` or `component:` match on strings in `task_summary`
+   - Keyword match in `title` or `root_cause` against salient terms in `task_summary`
+
+4. If a `problem_type_filter` is set, drop docs whose frontmatter `problem_type` does not match.
+
+## Scoring
+
+For each candidate doc, compute a relevance score out of 10:
+
+| Signal | Points |
+|--------|--------|
+| Exact tag match | 3 per tag, max 6 |
+| `files:` path overlaps `files_hint` | 2 |
+| `module:` or `component:` match | 2 |
+| Keyword match in `title` | 1 |
+| Keyword match in `root_cause` | 1 |
+
+Sort candidates descending by score. Keep the top `max_results`. Drop any doc scoring 0.
+
+If fewer than 3 candidates survive and `tags_hint` was set, retry with `tags_hint` removed to widen the net.
+
+## Output
+
+Return structured results, one block per prior:
+
+```
+### Prior: docs/solutions/{category}/{slug}.md  (score: {N})
+- title: {title}
+- date: {date}
+- problem_type: {bug|knowledge}
+- root_cause: {root_cause}
+- why_relevant: {one sentence - which signal matched}
+- excerpt:
+  {the Solution section verbatim, or Problem section if no Solution present}
+```
+
+Keep each block under 40 lines. If a doc's Solution section is longer than that, excerpt the first 40 lines and end with `...see full doc for remainder`.
+
+End the output with a one-line summary:
+
+```
+Returned {N} priors from docs/solutions/ in {repo}.
+```
+
+If nothing matched:
+
+```
+No prior learnings found in docs/solutions/ for this task.
+```
+
+## Guardrails
+
+- Never read a doc whose frontmatter did not match. The whole point is grep-first retrieval - random full-text reads defeat it.
+- Never return the full body of every candidate. The caller's context window is already under pressure from the planning flow.
+- Never edit any file. This agent is strictly read-only.
+- Never cross repos. Scope to `docs/solutions/` in the current working directory's repo root.
+- Never include frontmatter from docs under `docs/solutions/.refresh/` - those are maintenance artifacts, not learnings.
+
+## When to Invoke
+
+The caller decides. Typical invocations:
+
+- At the start of `/xplan` Phase 0 (research) - pass the user's brief as `task_summary`
+- At the start of `/review` after scope-drift audit - pass the diff summary as `task_summary` and the touched files as `files_hint`
+- At the start of `/debug` when the error message or stack trace hints at a known area
+- Manually, when a user asks "what have we learned about X here"
+
+This agent is a drop-in. Callers do not need to pre-process or post-process results - just forward the output blocks as context into their own reasoning.

--- a/modules/compound-knowledge/module.json
+++ b/modules/compound-knowledge/module.json
@@ -1,0 +1,32 @@
+{
+  "name": "compound-knowledge",
+  "displayName": "Compound Knowledge",
+  "description": "Team-shared learnings in docs/solutions/. After solving a non-trivial problem, /compound writes a structured markdown doc with YAML frontmatter that later /xplan and /review runs re-inject as grounding. Counterpart to self-improving's personal MEMORY.md.",
+  "category": "workflow",
+  "scope": ["global"],
+  "dependencies": ["skill-authoring"],
+  "files": {
+    "skills/compound/SKILL.md": {
+      "target": "skills/compound/SKILL.md",
+      "type": "skill",
+      "template": false
+    },
+    "skills/compound/references/schema.yaml": {
+      "target": "skills/compound/references/schema.yaml",
+      "type": "doc",
+      "template": false
+    },
+    "skills/compound-refresh/SKILL.md": {
+      "target": "skills/compound-refresh/SKILL.md",
+      "type": "skill",
+      "template": false
+    },
+    "agents/learnings-researcher.md": {
+      "target": "agents/learnings-researcher.md",
+      "type": "agent",
+      "template": false
+    }
+  },
+  "tags": ["knowledge", "learnings", "compound", "team", "docs-solutions", "review", "planning"],
+  "configPrompts": []
+}

--- a/modules/compound-knowledge/skills/compound-refresh/SKILL.md
+++ b/modules/compound-knowledge/skills/compound-refresh/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: compound-refresh
+description: >
+  Periodic maintenance pass over docs/solutions/. For each doc, classify as Keep / Update / Consolidate / Replace / Delete based on staleness, referenced-code existence, and overlap with newer learnings. Run monthly or after a major refactor. Modes - interactive, autofix, report-only.
+  Triggers: compound refresh, clean up solutions docs, docs/solutions maintenance, solution doc audit.
+disable-model-invocation: true
+---
+
+# /compound-refresh - Maintain docs/solutions/
+
+`/compound` writes new learnings; `/compound-refresh` reviews existing ones. Over time, solution docs go stale:
+
+- The code they reference gets deleted or moved
+- A newer doc supersedes them
+- Multiple adjacent docs should merge into one
+- The underlying problem stopped being a problem
+
+This skill walks `docs/solutions/**/*.md` in the current repo and classifies each doc into one of five outcomes, then applies (or reports) the classification.
+
+## When to Run
+
+Run `/compound-refresh`:
+
+- Monthly, as a standing maintenance chore
+- After a major refactor that moves or deletes files many solution docs reference
+- Before a milestone that will attract new contributors (clean docs help onboarding)
+- When retrieval feels noisy - too many false-positive hits from `learnings-researcher`
+
+Do NOT run during active feature work - the autofix mode will create a large diff that muddies the signal of the feature branch.
+
+## Mode Selection
+
+Parse `$ARGUMENTS` for a mode token:
+
+- `mode:interactive` (default) - Classify, then ask per-doc before applying any change
+- `mode:autofix` - Apply `Keep`, `Update`, and `Delete` automatically; ask for `Consolidate` and `Replace`
+- `mode:report-only` - Strictly read-only; print the classification table and exit
+
+When composed from other skills (e.g., called from a repo-wide `/audit`), prefer `mode:report-only` so the caller decides.
+
+## Phase 1: Inventory
+
+Use the native file-search tool (e.g., Glob) to list every `docs/solutions/**/*.md` in the current repo. Skip `docs/solutions/README.md`.
+
+For each doc, read the frontmatter and the body. Record:
+
+- Path
+- Frontmatter fields (`title`, `date`, `problem_type`, `category`, `tags`, `files`, `related`, `severity`)
+- File mtime (`git log -1 --format=%ct {path}` for the last change time)
+- Body length in lines
+
+Skip any doc with invalid frontmatter - surface it at the end as a validation failure for the user to fix before re-running.
+
+## Phase 2: Staleness Probes
+
+For each doc, run two probes in parallel across docs (one per file at a time per doc):
+
+### Probe A: Referenced Code Still Exists
+
+For each path in frontmatter `files`:
+
+- Use the native file-search tool to check if the path exists
+- If the path is a file that has been moved, `git log --follow -- {path}` finds the new location
+- If the file still exists, grep it for any identifiers or line ranges referenced in the body (function names, class names, error strings)
+
+Record:
+
+- `files_missing`: count of files no longer present
+- `files_moved`: count of files that moved
+- `identifiers_missing`: count of named symbols in the body no longer present in the code
+
+### Probe B: Age vs Severity
+
+Compute age in days from the frontmatter `date`. Combine with `severity`:
+
+| Severity | Stale after |
+|----------|-------------|
+| P0 | 180 days |
+| P1 | 270 days |
+| P2 | 365 days |
+| P3 | 540 days |
+
+Rationale: higher severity issues are more likely to have been patched at the root by follow-up work; lower severity evergreen-knowledge docs age slower.
+
+Record:
+
+- `age_days`
+- `is_aged`: true if `age_days` > threshold for that severity
+
+## Phase 3: Classify
+
+For each doc, output one of five outcomes:
+
+### Keep
+
+Criteria (all must hold):
+
+- `files_missing` == 0
+- `identifiers_missing` == 0
+- No newer doc supersedes it (no other doc with `related: [this-path]` and a later `date`)
+- `is_aged` is false OR the doc is `problem_type: knowledge` and still accurate
+
+Action: none.
+
+### Update
+
+Criteria (any one holds):
+
+- `files_moved` > 0 and `files_missing` == 0 (paths need rewriting but the substance is intact)
+- `is_aged` is true but the substance still applies (re-date, optionally freshen language)
+- Minor drift from a newer related doc but the two cover different angles
+
+Action: rewrite paths, bump `date`, refresh stale wording. Preserve the substance.
+
+### Consolidate
+
+Criteria:
+
+- Two or more docs share a root cause and a fix, or a tag set of 3+ common tags, and their combined content would be clearer as one doc
+
+Action: Merge content, pick the best slug, set the merged doc's `related: []` to the other paths (now deleted), and `git rm` the obsolete files in the same commit.
+
+### Replace
+
+Criteria:
+
+- `files_missing` > 0 AND a newer doc already exists that correctly captures the current state
+- The doc's `solution` is now wrong (contradicted by the current codebase) but the problem described is real and has a better documented fix elsewhere
+
+Action: Delete this doc. If the replacement doc does not reference it, add a `related` entry to the replacement pointing at the deleted slug in case of link collisions.
+
+### Delete
+
+Criteria (any one holds):
+
+- `files_missing` counts the majority of `files` in frontmatter (the doc is about code that no longer exists)
+- The underlying problem has been fixed at the root and the fix is documented in code comments or in a rule file
+- The doc is a duplicate of another with the same `root_cause` and no additional content
+
+Action: `git rm` the file. If other docs reference it in their `related` list, remove those references in the same commit.
+
+## Phase 4: Apply or Report
+
+### Interactive Mode
+
+For each doc classified as anything other than `Keep`:
+
+1. Print the classification, the reasoning in one line, and a summary of the proposed action
+2. Use an AskUserQuestion with options: `Apply | Skip | Show Details`
+3. On `Show Details`, print the full doc and any supersession candidates
+4. On `Apply`, execute the action; on `Skip`, move to the next doc
+
+### Autofix Mode
+
+Apply `Keep`, `Update`, and `Delete` without prompting. For `Consolidate` and `Replace`, batch the pending items at the end and ask once per category.
+
+Write a run artifact at `docs/solutions/.refresh/{YYYYMMDD-HHMM}.md` summarizing:
+
+- Count of each outcome
+- Every path touched, with the outcome
+- Any failures or skipped items
+
+### Report-Only Mode
+
+Print the classification table, one row per doc:
+
+```
+Path                                                     Outcome    Reason
+docs/solutions/build-errors/vite-preflight.md            Keep       -
+docs/solutions/build-errors/old-webpack-quirk.md         Delete     All referenced files missing
+docs/solutions/data-migrations/reserved-words.md         Keep       -
+docs/solutions/testing/flaky-auth.md                     Consolidate  3-tag overlap with flaky-session-expiry
+```
+
+Do NOT write anything, including the run artifact.
+
+## Phase 5: Commit
+
+In `autofix` and `interactive` modes, stage only the touched `docs/solutions/**` files and the run artifact. Commit with:
+
+```
+compound-refresh: {kept} kept, {updated} updated, {consolidated} consolidated, {replaced} replaced, {deleted} deleted
+```
+
+Do not mix refresh changes with code or config changes. If the working tree has unrelated staged changes, prompt the user to commit or stash (commit - see `git-workflow` rules about never stashing) before running.
+
+## Anti-Patterns
+
+- **Aggressive deletion.** When in doubt, classify as `Update` and re-date. A doc that was useful once may be useful again; deletion is destructive.
+- **Consolidating across categories.** Docs with the same tags in different categories usually cover different angles - merging them hides the distinction.
+- **Running in autofix during a feature branch.** The refresh diff buries the feature diff. Do this on its own branch.
+- **Skipping the run artifact.** Without the artifact, the next refresh cannot tell which docs were last reviewed and when.
+
+## Source
+
+Ported from EveryInc/compound-engineering-plugin's `ce-compound-refresh`. Kept: the 5-outcome classification, the age/severity table, the staleness probes. Adapted: mode names now match CCGM skill-authoring conventions (see `modules/skill-authoring/rules/skill-authoring.md`).

--- a/modules/compound-knowledge/skills/compound/SKILL.md
+++ b/modules/compound-knowledge/skills/compound/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: compound
+description: >
+  After solving a non-trivial problem, extract a durable learning to docs/solutions/ in the current repo. Two modes - Full (parallel research subagents, strict schema, overlap check) and Lightweight (single-pass, direct from current conversation). Writes team-shared knowledge that /xplan and /review later re-inject as grounding. Runs a Discoverability Check so every repo's AGENTS.md or CLAUDE.md points at docs/solutions/.
+  Triggers: compound, capture learning, write solution doc, post-mortem, retro, log this lesson, save this finding.
+disable-model-invocation: true
+---
+
+# /compound - Compound Team Knowledge
+
+Capture a learning from the current task into `docs/solutions/{category}/{slug}.md` in the repo being worked on. The file is committed with the rest of the codebase, greppable by teammates and agents, and re-injected as grounding context on future `/xplan` and `/review` runs via the `learnings-researcher` agent.
+
+This is the team-shared counterpart to the personal `~/.claude/projects/.../memory/MEMORY.md` that the `self-improving` module writes. Both exist; neither replaces the other. Use personal memory for cross-repo patterns about your own working style. Use `docs/solutions/` for durable, per-repo facts that a teammate or a fresh agent session would want on hand.
+
+## When to Run
+
+Run `/compound` after:
+
+- Shipping a fix for a non-trivial bug
+- Resolving a tricky three-strike debugging session
+- Confirming a non-obvious pattern, convention, or constraint that future work will need to respect
+- Landing a decision that a future agent might accidentally unmake without knowing the prior context
+
+Do NOT run for:
+
+- Typo fixes, version bumps, or purely mechanical changes
+- Speculative conclusions from a single observation (wait for the second occurrence)
+- Anything already well-covered in the repo's AGENTS.md, CLAUDE.md, or existing `docs/solutions/` files
+
+## Mode Selection
+
+On invocation, parse `$ARGUMENTS` for a mode token:
+
+- `mode:full` (or no mode token) - Full run with parallel research subagents
+- `mode:light` - Lightweight single-pass, direct from current conversation
+
+Full mode is the default. Use light mode when:
+
+- The session already contains all the evidence needed (the bug and fix just shipped in this conversation)
+- No prior `docs/solutions/` docs exist that plausibly overlap
+- Speed matters more than completeness
+
+If the user runs `/compound` with no arguments and the session is short or still has ambient context about the problem, prefer Full mode - the research passes often surface overlaps and related docs the agent has forgotten.
+
+## Phase 1: Research (Full Mode)
+
+Dispatch four subagents in parallel with the pass-paths-not-contents pattern (see `modules/subagent-patterns/rules/subagent-patterns.md`). Each returns a short structured report; the orchestrator merges them.
+
+### Context Analyzer
+
+Objective: Restate the problem in one paragraph and identify what would make this learning retrievable.
+
+Inputs: the current conversation summary, the most recent diff (`git diff origin/main...HEAD`), and any linked issue or PR.
+
+Deliverable:
+
+- `problem`: one paragraph describing what went wrong or what was learned
+- `trigger`: the specific reproduction steps or the conditions under which the pattern applies
+- `surface_area`: which files, modules, or subsystems are implicated
+- `tags_candidate`: 3-8 searchable tags, biased toward tags that already appear in other `docs/solutions/` docs in this repo
+
+### Solution Extractor
+
+Objective: Extract the fix (for bugs) or the durable rule (for knowledge) as something another agent could execute without the current conversation in context.
+
+Inputs: the recent diff, the conversation trail that led to the fix.
+
+Deliverable:
+
+- `solution`: the fix or rule in imperative voice, 3-8 sentences max
+- `why_it_works`: one paragraph on the mechanism, not just "because it passed tests"
+- `prevention`: how to avoid hitting the same issue again (if bug) or when to apply the pattern (if knowledge)
+- `anti_patterns`: common wrong turns to explicitly reject
+
+### Related Docs Finder
+
+Objective: Find existing `docs/solutions/` docs in this repo that plausibly overlap with the new learning.
+
+Inputs: `tags_candidate`, `surface_area`, the one-paragraph problem.
+
+Method: Use the native file-search tool (e.g., Glob) for `docs/solutions/**/*.md`. Use the native content-search tool (e.g., Grep) to search their frontmatter for matching `tags`, `module`, `component`, or `category`. Read the ones that match.
+
+Deliverable:
+
+- `overlap_candidates`: list of existing doc paths that might duplicate or relate to the new learning
+- For each, a two-line justification
+
+### Session Historian
+
+Objective: Surface any prior conversation or agent log on this exact problem so the new doc can cite "we tried X before and it failed because Y".
+
+Inputs: the repo name, the one-paragraph problem, any session-history module outputs if available.
+
+Method: If the `session-history` module is installed, invoke its `session-historian` agent. Otherwise, grep the local agent log repo (`~/code/{log-repo-name}/{repo-name}/`) for entries mentioning the implicated files or error strings.
+
+Deliverable:
+
+- `prior_sessions`: list of prior session IDs or log entries touching this problem, with a one-line summary of what each concluded
+
+## Phase 2: Classification and Scoring
+
+Classify `problem_type`:
+
+- `bug` - The learning is about a specific failure with a reproducible trigger. Example: "Supabase db push fails with circuit breaker after second retry."
+- `knowledge` - The learning is a durable rule, convention, or constraint. Example: "Always quote PostgreSQL reserved words in migrations."
+
+Both types use the same schema (see `references/schema.yaml`); the tag matters for retrieval - `learnings-researcher` can prefer bug docs when investigating a new failure, or knowledge docs when planning new work.
+
+### Overlap Scoring
+
+For each candidate in `overlap_candidates`, score across 5 dimensions. Each dimension is 0, 1, or 2:
+
+| Dimension | 0 | 1 | 2 |
+|-----------|---|---|---|
+| **Problem** | Different problem | Related problem | Same underlying problem |
+| **Root cause** | Different mechanism | Adjacent mechanism | Same root cause |
+| **Solution** | Different fix | Partially overlapping fix | Same fix |
+| **Files** | No shared files | Some shared files | Majority of files overlap |
+| **Prevention** | Different preventive rule | Partially overlapping rule | Same preventive rule |
+
+Total: 0-10. Decision:
+
+- **8-10** - Update the existing doc in place. Do not create a new file.
+- **5-7** - Create a new doc but set `related: [path-to-overlap]` in frontmatter, and add a one-line "See also" to the existing doc pointing at the new one.
+- **0-4** - Create a new independent doc.
+
+### Category Selection
+
+Select the `category` from the standard list in `references/schema.yaml`. If the repo has already established repo-specific categories (look in `docs/solutions/README.md`), prefer those. Only add a new category when no standard category fits - and when you add one, update `docs/solutions/README.md` at the same time.
+
+## Phase 3: Write or Update
+
+### Path and Slug
+
+Derive the slug from the learning title:
+
+```
+slug = kebab-case(title, max 60 chars)
+path = docs/solutions/{category}/{slug}.md
+```
+
+Always use `.md`. Always lowercase, hyphen-separated slug. No date suffix in the filename - the `date` frontmatter field is the canonical source.
+
+If the slug collides with an existing file, append `-2`, `-3`, etc. Do not overwrite silently.
+
+### Frontmatter
+
+Write frontmatter matching `references/schema.yaml`. Required fields: `title`, `date`, `problem_type`, `category`, `root_cause`, `tags`, `severity`. Optional fields: `module`, `component`, `files`, `related`.
+
+### Body Structure
+
+```markdown
+---
+{frontmatter}
+---
+
+# {title}
+
+## Problem
+{one paragraph; include reproduction steps for bugs}
+
+## Root Cause
+{one or two paragraphs; the "why it works" mechanism}
+
+## Solution
+{imperative-voice fix or rule, 3-8 sentences}
+
+## Prevention
+{how to avoid hitting this again, or when to apply this pattern}
+
+## Anti-Patterns
+{wrong turns the next agent might take; enumerate as bullets}
+
+## References
+{commit SHAs, PR links, issue numbers, related solution docs}
+```
+
+Keep each section short. If any section wants to grow past a page, the learning is probably two learnings - split it.
+
+### Update vs Create
+
+If overlap score was 8-10, update the existing doc:
+
+- Merge new evidence into `Problem`, `Root Cause`, and `References`
+- Bump `date` to today
+- Append to `tags` without removing existing tags
+- Do not rewrite the whole doc
+
+Otherwise create a new doc.
+
+## Phase 4: Discoverability Check
+
+After writing, verify the learning is reachable:
+
+1. Check `docs/solutions/README.md` exists. If not, create it with a short index pointing at the category directories. Use the bootstrap template below.
+
+2. Check `AGENTS.md` or `CLAUDE.md` at the repo root for a pointer to `docs/solutions/`. Look for the phrase "docs/solutions" or the string "compound knowledge" or "prior learnings". If not found, offer to add one. Example pointer block:
+
+   ```
+   ## Prior Learnings
+
+   Team-shared learnings live in `docs/solutions/`. Before planning a new
+   feature or debugging an unfamiliar problem, check for a relevant prior
+   with `rg <keyword> docs/solutions/` or let the `learnings-researcher`
+   agent fan out at the start of /xplan or /review.
+   ```
+
+   Ask the user before writing this pointer. If they accept, inject the block into the file's most appropriate section (usually right after the top-level intro).
+
+3. If the repo has a session log file for today (`~/code/{log-repo-name}/{repo}/YYYYMMDD/{agent-id}.md`), append a one-line entry noting the new learning and its path.
+
+## Phase 5: Lightweight Mode
+
+When invoked with `mode:light`, skip Phases 1 and 2 and write directly from the current conversation. Still:
+
+- Apply the same frontmatter schema
+- Select a `category` from the standard list
+- Run the Discoverability Check at the end
+
+Skip:
+
+- The four-subagent fan-out
+- The overlap scoring
+- The related-docs merge
+
+Use lightweight mode when the cost of a full research pass outweighs the value of catching overlaps. A single-repo agent fresh off fixing a 20-line bug usually knows the context well enough that full-mode research returns the same conclusions.
+
+## Output
+
+On completion, print:
+
+```
+Wrote: docs/solutions/{category}/{slug}.md
+Mode: {full|light}
+Problem type: {bug|knowledge}
+Overlap: {none|related: <path>|updated: <path>}
+Discoverability: {ok|pointer-added|pointer-offered}
+```
+
+If the user has an open PR or branch, suggest committing the new doc alongside the fix so the learning ships with the change that inspired it.
+
+## Anti-Patterns
+
+- **Speculative learnings.** One observation is not a pattern. Wait for the second hit, or write the doc and mark severity P3 with a clear "observed once" note.
+- **Copy-paste from the conversation.** Extract the rule; do not paste the dialogue. If the next agent has to re-read a whole conversation to use the doc, the doc failed.
+- **Skipping the overlap check in Full mode.** Duplicated learnings poison retrieval - two docs on the same problem make the agent see "this has been handled before" twice and dilute the signal.
+- **Writing to a generic category.** `tooling` is not a category; `vite-build-config` is. Be specific; teammates grep by category name.
+- **Second-person voice.** The doc is a spec for the next agent to execute. Use imperative voice: "Quote the identifier." Not: "You should quote the identifier."
+- **Skipping Discoverability.** A doc no agent can find is indistinguishable from no doc.
+
+## Bootstrap Template: docs/solutions/README.md
+
+If the repo has no `docs/solutions/README.md`, write one with this shape:
+
+```markdown
+# Solutions
+
+Team-shared learnings for this repo. Each subdirectory groups docs by
+category. Every doc starts with YAML frontmatter matching the schema at
+`modules/compound-knowledge/skills/compound/references/schema.yaml` in CCGM.
+
+## Categories
+
+- `build-errors/` - Build pipeline failures and their fixes
+- `runtime-errors/` - Application-layer errors encountered in dev or prod
+- `performance-issues/` - Profiling finds, slow queries, render bottlenecks
+- `security-issues/` - Vulnerabilities, mis-configurations, secret handling
+- `data-migrations/` - Schema changes, migration gotchas, rollback patterns
+- `testing/` - Test infrastructure patterns and flake fixes
+- `tooling/` - CI, linters, package managers, local dev environment
+- `skill-design/` - Patterns for writing agent skills and commands
+- `architecture/` - Boundaries, coupling, dependency direction choices
+- `api-contracts/` - Public interface decisions and their rationale
+- `deployment/` - Release, deploy, and rollback procedures
+- `dev-environment/` - Local setup, editor config, tooling quirks
+
+Add a new category only when no existing category fits, and update this
+README in the same commit.
+
+## Adding a Learning
+
+Run `/compound` from Claude Code. It writes a frontmatter-tagged doc to
+the right category and updates related prior docs as needed.
+
+## Reading Learnings
+
+At the start of `/xplan` and `/review`, the `learnings-researcher` agent
+greps this directory by frontmatter tags and surfaces relevant priors as
+planning or review context. Teammates without agents can grep directly -
+tags and categories are designed for human browsing first.
+```
+
+## Source
+
+Ported from EveryInc/compound-engineering-plugin's `ce-compound` skill. Adapted to CCGM voice, schema-first frontmatter, and the pass-paths-not-contents subagent pattern. Kept verbatim: the two-mode choice, the 5-dimension overlap scoring, the Discoverability Check.

--- a/modules/compound-knowledge/skills/compound/references/schema.yaml
+++ b/modules/compound-knowledge/skills/compound/references/schema.yaml
@@ -1,0 +1,136 @@
+# Frontmatter schema for docs/solutions/**/*.md
+#
+# Every learning doc under docs/solutions/ starts with a YAML frontmatter
+# block matching this schema. The learnings-researcher agent greps the
+# frontmatter to retrieve relevant priors during /xplan and /review.
+#
+# Fields marked required: true must be present on every doc. Fields marked
+# required: false are optional but should be filled when the information is
+# known.
+
+fields:
+  title:
+    required: true
+    type: string
+    description: >
+      Short human-readable title. One line. Imperative or noun-phrase, not a
+      question. Example: "Quote PostgreSQL reserved words in migrations".
+
+  date:
+    required: true
+    type: string
+    format: YYYY-MM-DD
+    description: Date the learning was recorded.
+
+  problem_type:
+    required: true
+    type: enum
+    values:
+      - bug
+      - knowledge
+    description: >
+      "bug" tracks a fix for a specific failure with a reproducible trigger.
+      "knowledge" tracks a durable insight, convention, or pattern that is
+      not tied to a single failure (e.g., "we always quote reserved words").
+
+  category:
+    required: true
+    type: string
+    description: >
+      Directory category under docs/solutions/. Matches one of the standard
+      categories below, or a repo-specific category added in the repo's
+      docs/solutions/README.md.
+    standard_values:
+      - build-errors
+      - runtime-errors
+      - performance-issues
+      - security-issues
+      - data-migrations
+      - testing
+      - tooling
+      - skill-design
+      - architecture
+      - api-contracts
+      - deployment
+      - dev-environment
+
+  module:
+    required: false
+    type: string
+    description: >
+      Codebase module / package / service the learning applies to. Use the
+      path or package name the repo itself uses. Blank if the learning is
+      cross-cutting.
+
+  root_cause:
+    required: true
+    type: string
+    description: >
+      One-sentence description of why the problem occurred. For "knowledge"
+      docs, the underlying mechanism or constraint that motivates the
+      pattern.
+
+  component:
+    required: false
+    type: string
+    description: >
+      Finer-grained pointer than "module" - a function, file, class, or
+      subsystem. Example: "auth/middleware/refreshToken".
+
+  tags:
+    required: true
+    type: list<string>
+    description: >
+      3-8 searchable tags. Prefer reusing tags that already appear in other
+      docs/solutions/ files in the same repo. Tags drive retrieval by
+      learnings-researcher.
+    examples:
+      - [supabase, migrations, reserved-words]
+      - [vite, env-vars, build-config]
+      - [react-query, cache-invalidation]
+
+  severity:
+    required: true
+    type: enum
+    values:
+      - P0
+      - P1
+      - P2
+      - P3
+    description: >
+      Impact of the original problem. P0 = blocked a ship / production
+      outage. P1 = broke a workflow for hours. P2 = noticeable friction or
+      rework. P3 = nit or nice-to-know.
+
+  files:
+    required: false
+    type: list<string>
+    description: >
+      Paths to files that were changed or that the fix touches. Used by the
+      overlap scorer to detect duplicate learnings.
+
+  related:
+    required: false
+    type: list<string>
+    description: >
+      Paths (relative to docs/solutions/) of related prior learnings. Use
+      when the new doc extends or supersedes an earlier one.
+
+example: |
+  ---
+  title: "Quote PostgreSQL reserved words in migrations"
+  date: 2026-04-15
+  problem_type: knowledge
+  category: data-migrations
+  module: db/migrations
+  root_cause: >
+    PostgreSQL reserves identifiers like "position", "order", "user" - using
+    them unquoted in CREATE TABLE fails with a syntax error at the column
+    definition.
+  component: supabase/migrations
+  tags: [supabase, postgres, migrations, reserved-words]
+  severity: P1
+  files:
+    - supabase/migrations/20260415_add_user_position.sql
+  related: []
+  ---


### PR DESCRIPTION
Closes #276

## What this adds

New module `modules/compound-knowledge/`:

- `skills/compound/SKILL.md` - `/compound` with two modes (`mode:full` default, `mode:light`). Full mode dispatches four parallel subagents (Context Analyzer, Solution Extractor, Related Docs Finder, Session Historian), classifies `problem_type` as bug or knowledge, scores overlap against existing docs across 5 dimensions (problem / root cause / solution / files / prevention), and writes to `docs/solutions/{category}/{slug}.md`. Lightweight mode skips the fan-out and writes direct from the current conversation.
- `skills/compound/references/schema.yaml` - canonical frontmatter schema (required: `title`, `date`, `problem_type`, `category`, `root_cause`, `tags`, `severity`; optional: `module`, `component`, `files`, `related`).
- `skills/compound-refresh/SKILL.md` - `/compound-refresh` with three modes (`interactive`, `autofix`, `report-only`) and 5-outcome classification (Keep / Update / Consolidate / Replace / Delete). Staleness probes check referenced-code existence and age vs severity.
- `agents/learnings-researcher.md` - read-only retrieval agent, grep-first, returns structured blocks. Drop-in for future `/xplan` and `/review` integrations. Uses the `agents/` convention from #273.
- `README.md` - explains the team vs personal distinction and the per-repo bootstrap.

## Personal vs team knowledge

CCGM already has `self-improving` writing to `~/.claude/projects/.../memory/MEMORY.md` - cross-repo, per-user, not committed. `compound-knowledge` is the complement: per-repo, team-shared, committed to git, grep-retrievable. Both stay installed. Use personal memory for user-preference and cross-repo gotchas; use team knowledge for repo-specific bugs, patterns, and conventions. A consuming repo never needs to choose - both can coexist.

## Per-repo bootstrap

`compound-knowledge` writes into the repo being worked on, not into CCGM or `~/.claude/`. Each consuming repo needs `docs/solutions/README.md` and an `AGENTS.md` / `CLAUDE.md` pointer block to make the knowledge discoverable. The `/compound` skill self-bootstraps via a Discoverability Check on every invocation - no pre-seeding required. (If you want to pre-seed `habitpro-ai`, `openslide-ai`, `darkly-suite`, `detego`, that is a 5-minute per-repo exercise, but it is not required.)

## What this unblocks

- **#268** - two-stage review with prompt templates (reuses `learnings-researcher`)
- **#277** - unified review orchestrator (depends on this module)
- **#292** - ship-readiness dashboard (reads the team learning store)

## Scope guardrails respected

- Did NOT modify `self-improving` - the two modules are complementary, not replacements.
- Did NOT wire `learnings-researcher` into `/xplan` or `/review` in this PR - tracked as separate work in #268 / #277 and a future xplan bump.
- Did NOT register the module in any preset. Adding to `full.json` etc. is a separate choice for the coordinator.
- Did NOT create `docs/solutions/` anywhere in CCGM - the skill bootstraps in each consuming repo on first use.
- No AI attribution anywhere. `.env.clone` not staged.

## Design decisions worth flagging

1. **`dependencies: ["skill-authoring"]`** - both skills follow the skill-authoring discipline (imperative voice, backtick references, one command per Bash call, `!`-backtick environment probes, conditional-content extraction to `references/`). Declaring the dep makes the relationship explicit and ensures the rules file is installed alongside.
2. **`category: "workflow"`** in `module.json` - best fit among the five valid CCGM categories. Not `patterns` (not a coding rule) and not `commands` (skills rather than pure commands).
3. **Agent file under `agents/`** using `type: "agent"` - consistent with the #273 convention that `agents/*.md` installs to `~/.claude/agents/`. First module in the repo to exercise this path; validates the `agents/` direction introduced by that prereq.
4. **Schema in `references/schema.yaml`** rather than inlined in the skill body - per skill-authoring, a schema this size crosses the "extract when ~20%+ of the skill and conditionally used" threshold. Keeps the skill body focused on procedure.
5. **Overlap scoring numbers (8-10 update, 5-7 cross-link, 0-4 new)** are copied from the CE source. If these thresholds turn out to be too permissive in practice (too many merges into existing docs), they are a one-line edit in the skill body.
6. **Staleness thresholds (180/270/365/540 days by severity)** in compound-refresh are a CCGM judgment call - the source was less prescriptive. Picked intervals that match the cadence at which repo-specific learnings typically rot. Easy to tune.

If any of these diverges from what the coordinator expects, flag and I will iterate.

## Tests

```
bash tests/test-modules.sh      -> 760 passed, 0 failed (+16 vs baseline 744)
bash tests/test-no-personal-data.sh  -> only pre-existing cloud-dispatch failures (unrelated)
ruby -ryaml -e 'YAML.load_file(...)'  -> schema.yaml parses clean
jq . module.json                 -> valid JSON
```