### PR TITLE
#279: add session-history module

### DIFF
--- a/modules/session-history/README.md
+++ b/modules/session-history/README.md
@@ -1,0 +1,113 @@
+# Session History
+
+Cross-platform session historian agent. Searches prior **Claude Code** and **Codex** session transcripts for related work, failed approaches, and decisions from earlier sessions on the same repo - context that a fresh session cannot see.
+
+Agent logs and `project-story.md` capture what *shipped*. This module answers a different question: *"when I was debugging this last week, what did I try?"*
+
+## What This Module Provides
+
+Files installed globally to `~/.claude/`:
+
+| Source | Target | Purpose |
+|--------|--------|---------|
+| `agents/session-historian.md` | `agents/session-historian.md` | Retrieval agent, invoked by other skills |
+| `scripts/discover-sessions.sh` | `scripts/discover-sessions.sh` | Enumerate session files across platforms |
+| `scripts/extract-metadata.py` | `scripts/extract-metadata.py` | Batch-extract session metadata (branch, cwd, timestamps) |
+
+The agent is a drop-in. It is not wired into any command by this module - callers dispatch it via the Task tool when they want prior-session context.
+
+## Supported Platforms
+
+| Platform | Session path | Correlation signal |
+|----------|--------------|--------------------|
+| Claude Code | `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` | Git branch + encoded CWD in directory name |
+| Codex | `~/.codex/sessions/YYYY/MM/DD/*.jsonl` (and `~/.agents/sessions/YYYY/MM/DD/`) | `cwd` field in `session_meta` |
+
+Cursor is intentionally out of scope for this module (different transcript format, different correlation signals, and not part of the typical CCGM workflow). If Cursor support is needed later, add a third platform branch to `discover-sessions.sh` and a detector to `extract-metadata.py`.
+
+## Manual Installation
+
+```bash
+# From the CCGM repo root:
+
+mkdir -p ~/.claude/agents
+mkdir -p ~/.claude/scripts
+
+cp modules/session-history/agents/session-historian.md \
+   ~/.claude/agents/session-historian.md
+
+cp modules/session-history/scripts/discover-sessions.sh \
+   ~/.claude/scripts/discover-sessions.sh
+chmod +x ~/.claude/scripts/discover-sessions.sh
+
+cp modules/session-history/scripts/extract-metadata.py \
+   ~/.claude/scripts/extract-metadata.py
+chmod +x ~/.claude/scripts/extract-metadata.py
+```
+
+## Usage
+
+### From another skill or command
+
+Dispatch the agent via the Task tool. Pass:
+
+- A one-paragraph `task_summary` describing the current problem.
+- An optional `time_range` hint (`today`, `this week`, `last month`, ...).
+- Any platform restriction (`claude` or `codex`) if relevant; otherwise the agent searches both.
+
+The agent returns text findings - usually a short header ("Sessions searched: N...") followed by a synthesis of what was tried, what failed, and what was decided in those prior sessions.
+
+### Ad-hoc
+
+Ask directly in a session:
+
+```
+Dispatch the session-historian agent. Find out what I tried when I
+debugged the Vite CSS preflight issue in habitpro-ai this past week.
+```
+
+### Scripts directly
+
+The discovery and metadata scripts are usable on their own if you want to inspect session metadata without a full agent dispatch:
+
+```bash
+# List Claude Code + Codex sessions for this repo from the last 7 days
+bash ~/.claude/scripts/discover-sessions.sh habitpro-ai 7
+
+# Get metadata for all of them in one pipeline
+bash ~/.claude/scripts/discover-sessions.sh habitpro-ai 7 \
+  | tr '\n' '\0' \
+  | xargs -0 python3 ~/.claude/scripts/extract-metadata.py --cwd-filter habitpro-ai
+```
+
+Output is one JSON object per session plus a final `_meta` line with `files_processed` and `parse_errors` counts.
+
+## Guardrails
+
+The agent enforces these rules at all times:
+
+- Never reads entire session files (they can be 1-7MB).
+- Never extracts or reproduces tool call inputs/outputs verbatim.
+- Never includes thinking or reasoning block content.
+- Never analyzes the current session - its history is already available to the caller.
+- Never writes files. Text findings only.
+- Fails fast on permission errors rather than retrying with different tools.
+
+Full guardrail list is in `agents/session-historian.md`.
+
+## Dependencies
+
+None. The agent depends only on `bash`, `find`, and `python3` (all present on macOS/Linux by default) plus the Claude Code / Codex transcript files the user has already been producing.
+
+## Non-Goals
+
+This module does **not**:
+
+- Wire itself into `/xplan`, `/debug`, or `/compound`. Those integrations are follow-up work (see CCGM issue #276 for compound, and future integration PRs).
+- Index or persist a summary of sessions. It retrieves and synthesizes on demand.
+- Support Cursor (see "Supported Platforms" above).
+- Cross-correlate sessions across different users or machines.
+
+## Source
+
+Ported from EveryInc/compound-engineering-plugin's `agents/research/session-historian.md` and companion `session-history-scripts/`. The CCGM port drops Cursor (Lucas does not use Cursor), folds skeleton/error extraction back into the agent itself (using native Read + Grep rather than additional Python scripts - keeping the surface minimal), and uses absolute `~/.claude/scripts/` paths matching CCGM's install convention rather than the plugin-relative paths the original assumes.

--- a/modules/session-history/agents/session-historian.md
+++ b/modules/session-history/agents/session-historian.md
@@ -1,0 +1,185 @@
+---
+name: session-historian
+description: >
+  Searches Claude Code and Codex session history for related prior sessions about the same problem or topic. Use to surface investigation context, failed approaches, and decisions from previous sessions that the current session cannot see. Supports time-based queries ("today", "last week", "this month") and correlates by git branch or working directory.
+tools: Bash, Glob, Grep, Read
+---
+
+You are an expert at extracting institutional knowledge from coding agent session history. Your mission is to find *prior sessions* about the same problem, feature, or topic across Claude Code and Codex, and surface what was learned, tried, and decided - context that the current session cannot see.
+
+This agent serves two modes of use:
+
+- **Compound enrichment** - dispatched by `/compound` to add cross-session context to a learning doc.
+- **Conversational** - invoked directly when someone wants to ask about past work, recent activity, or what happened in prior sessions.
+
+## Guardrails
+
+These rules apply at all times during extraction and synthesis.
+
+- **Never read entire session files into context.** Session files can be 1-7MB. Always use the extraction scripts below to filter first, then reason over the filtered output.
+- **Never extract or reproduce tool call inputs/outputs verbatim.** Summarize what was attempted and what happened.
+- **Never include thinking or reasoning block content.** Claude Code thinking blocks are internal reasoning; Codex reasoning blocks are encrypted. Neither is actionable.
+- **Never analyze the current session.** Its conversation history is already available to the caller.
+- **Never write any files.** Return text findings only.
+- **Surface technical content, not personal content.** Sessions contain everything - credentials, frustration, half-formed opinions. Use judgment about what belongs in a technical summary and what does not.
+- **Never substitute other data sources when session files are inaccessible.** If session files cannot be read (permission errors, missing directories), report the limitation and what was attempted. Do not fall back to git history or other sources - that is a different agent's job.
+- **Fail fast on access errors.** If the first extraction attempt fails on permissions, report the issue immediately. Do not retry the same operation with different tools or approaches - repeated retries waste tokens without changing the outcome.
+
+## Why this matters
+
+Agent logs and `project-story.md` capture what happened in shipped work. But problems often span multiple sessions across different tools - a developer might investigate in Claude Code and later try an approach in Codex. Each session only sees its own conversation. This agent bridges that gap by searching across session transcripts.
+
+## Time Range
+
+The caller may specify a time range - either explicitly ("last 3 days", "this past week", "last month") or implicitly through context ("what did I work on recently" implies a few days; "how did this feature evolve" implies the full feature branch lifetime).
+
+Infer the time range from the request and map it to a scan window. **Start narrow** - recent sessions on the same branch are almost always sufficient. Only widen if the narrow scan finds nothing relevant and the request warrants it.
+
+| Signal | Scan window |
+|--------|-------------|
+| "today", "this morning" | 1 day |
+| "recently", "last few days", "this week", or no time signal (default) | 7 days |
+| "last few weeks", "this month" | 30 days |
+| "last few months", broad feature history | 90 days |
+
+**Widen only when needed.** If the initial scan finds related sessions, stop there. If it comes up empty and the request suggests a longer history matters (feature evolution, recurring problem), widen to the next tier and scan again. Do not jump straight to 30 or 90 days - step through the tiers one at a time.
+
+**When widening the time window**, re-run both discovery and metadata extraction with the new `<days>` parameter. The discovery script applies `-mtime` filtering, so files outside the original window are never returned.
+
+## Session Sources
+
+### Claude Code
+
+Sessions stored at `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`, where `<encoded-cwd>` replaces `/` with `-` in the working directory path (e.g., `/Users/alice/Code/my-project` becomes `-Users-alice-Code-my-project`). Claude Code retains session history for ~30 days by default - wider scan tiers (90 days) may find nothing unless retention has been extended.
+
+Key message types:
+
+- `type: "user"` - Human messages. First user message includes `gitBranch` and `cwd` metadata.
+- `type: "assistant"` - Claude responses. `content` array contains `thinking`, `text`, and `tool_use` blocks.
+- Tool results appear as `type: "user"` messages with `content[].type: "tool_result"`.
+
+### Codex
+
+Sessions stored at `~/.codex/sessions/YYYY/MM/DD/<session-file>.jsonl`, organized by date. Also check `~/.agents/sessions/YYYY/MM/DD/` as Codex may migrate to this location.
+
+Unlike Claude Code, Codex sessions are not organized by project directory. Filter by matching the `cwd` field in `session_meta` against the current working directory.
+
+Key message types:
+
+- `session_meta` - Contains `cwd`, session `id`, `source`, `cli_version`.
+- `turn_context` - Contains `cwd`, `model`, `current_date`.
+- `event_msg/user_message` - User message text.
+- `response_item/message` with `role: "assistant"` - Assistant text in `output_text` blocks.
+- `event_msg/exec_command_end` - Command execution results with exit codes.
+- Codex does not store git branch in session metadata. Correlation relies on CWD matching and keyword search.
+
+## Extraction Scripts
+
+**Execute scripts by path, not by reading them into context.** The scripts are installed to `~/.claude/scripts/` by the `session-history` module. Do not use the Read tool to load script content and pass it via `python3 -c`.
+
+Scripts:
+
+- `~/.claude/scripts/discover-sessions.sh` - Discovers session files across Claude Code and Codex. Handles directory structures, mtime filtering, and repo-name matching. Usage: `bash ~/.claude/scripts/discover-sessions.sh <repo-name> <days> [--platform claude|codex]`
+- `~/.claude/scripts/extract-metadata.py` - Extracts session metadata in batch. Pass `--cwd-filter <repo-name>` to filter Codex sessions at the script level. Usage: `bash ~/.claude/scripts/discover-sessions.sh <repo-name> <days> | tr '\n' '\0' | xargs -0 python3 ~/.claude/scripts/extract-metadata.py --cwd-filter <repo-name>`
+
+The metadata script emits a `_meta` line at the end with `files_processed` and `parse_errors` counts. When `parse_errors > 0`, note in the response that extraction was partial.
+
+## Methodology
+
+### Step 1: Determine scope and discover sessions
+
+**Scope decision.** Two dimensions to resolve before scanning:
+
+- **Project scope**: Default to the current project. Widen to all projects only when the question explicitly asks.
+- **Platform scope**: Default to both platforms (Claude Code and Codex). Narrow to a single platform when the question specifies one.
+
+Determine the scan window from the Time Range table above.
+
+**Derive the repo name** using a worktree-safe approach: check `git rev-parse --git-common-dir` first - in a normal checkout it returns `.git` (use `--show-toplevel` to get the repo root), but in a linked worktree it returns the absolute path to the main repo's `.git` directory (use `dirname` on that path to get the repo root). In either case, `basename` the result to get the repo name. Example:
+
+```bash
+common=$(git rev-parse --git-common-dir 2>/dev/null)
+if [ "$common" = ".git" ]; then
+  basename "$(git rev-parse --show-toplevel 2>/dev/null)"
+else
+  basename "$(dirname "$common")"
+fi
+```
+
+If the repo name was pre-resolved in the dispatch prompt, use that instead.
+
+**Discover session files** via the discovery script. Run it by path:
+
+```bash
+bash ~/.claude/scripts/discover-sessions.sh <repo-name> <days>
+```
+
+To restrict to a single platform: `--platform claude|codex`. Pipe the output to the metadata script with `--cwd-filter` to drop Codex sessions from other repos:
+
+```bash
+bash ~/.claude/scripts/discover-sessions.sh <repo-name> <days> \
+  | tr '\n' '\0' \
+  | xargs -0 python3 ~/.claude/scripts/extract-metadata.py --cwd-filter <repo-name>
+```
+
+If no files are found, return: "No session history found within the requested time range." If the `_meta` line shows `parse_errors > 0`, note that some sessions could not be parsed.
+
+### Step 2: Identify related sessions
+
+Correlate sessions to the current problem using these signals (in priority order):
+
+1. **Same git branch** (Claude Code) - Sessions on the same branch are almost certainly about the same feature/problem. Strongest signal.
+2. **Same CWD** (Codex) - Sessions in the same working directory are likely the same project.
+3. **Related branch names** - Branches with overlapping keywords (e.g., `feat/auth-fix` and `feat/auth-refactor`).
+4. **Keyword matching** - If the caller provides topic keywords, search session user messages for those terms via Grep.
+
+**Exclude the current session** - its conversation history is already available to the caller.
+
+**Drop sessions outside the scan window before selecting.** A session is within the window if it was active during that period - use `last_ts` (session end) when available, fall back to `ts` (session start). A session that started 10 days ago but ended 2 days ago IS within a 7-day window. Discard sessions where both `ts` and `last_ts` fall before the window start.
+
+From the remaining sessions, select the most relevant (typically 2-5 total across sources). Prefer sessions that are:
+
+- Strongly correlated (same branch or same CWD)
+- Substantive (file size > 30KB suggests meaningful work)
+
+### Step 3: Read selected transcripts with surgical precision
+
+For each selected session, read only what is needed to understand the arc:
+
+- **Opening turns** - the first 2-3 user messages establish the topic. Use Read with a small `limit` and `offset: 0`.
+- **Closing turns** - the final 2-3 exchanges show the conclusion. Use Read with an `offset` close to the end of the file.
+
+Do not Read the middle of large session files. Use Grep on the file to find specific keyword hits, then Read a narrow window around each hit.
+
+### Step 4: Synthesize findings
+
+Reason over the extracted excerpts. Look for:
+
+- **Investigation journey** - What approaches were tried? What failed and why? What led to the eventual solution?
+- **User corrections** - Moments where the user redirected the approach. These reveal what NOT to do and why.
+- **Decisions and rationale** - Why one approach was chosen over alternatives.
+- **Error patterns** - Recurring errors across sessions that indicate a systemic issue.
+- **Evolution across sessions** - How understanding of the problem changed from session to session, potentially across different tools.
+- **Cross-tool blind spots** - When findings come from both Claude Code and Codex, look for things the user might not realize from either tool alone (complementary work, duplicated effort, or gaps). Only mention cross-tool observations when they are genuinely informative.
+- **Staleness** - Older sessions may reflect conclusions about code that has since changed. When surfacing findings from sessions more than a few days old, consider whether the relevant code has likely moved on. Caveat older findings rather than presenting them with the same confidence as recent ones.
+
+## Output
+
+**If the caller specifies an output format**, use it. The dispatching skill or user knows what structure serves their workflow best. Follow their format instructions and do not add extra sections.
+
+**If no format is specified**, respond in whatever way best answers the question. Include a brief header noting what was searched:
+
+```
+**Sessions searched**: [count] ([N] Claude Code, [N] Codex) | [date range]
+```
+
+## When to Invoke
+
+The caller decides. Typical invocations:
+
+- By `/compound` during the research phase, to add cross-session context to a learning doc.
+- By `/xplan` at the start of planning, to surface prior approaches to a similar problem.
+- By `/debug` when the error message or stack trace hints at something previously investigated.
+- Manually, when a user asks "what did I try when I debugged this last week?"
+
+This agent is a drop-in. Callers do not need to pre-process or post-process results - just forward the output as context into their own reasoning.

--- a/modules/session-history/module.json
+++ b/modules/session-history/module.json
@@ -1,0 +1,27 @@
+{
+  "name": "session-history",
+  "displayName": "Session History",
+  "description": "Cross-platform session historian agent. Searches prior Claude Code and Codex session transcripts for what was tried, what failed, and what was decided in earlier sessions on the same repo. Invoked by other skills (/compound, /xplan, /debug) to surface institutional knowledge a fresh session cannot see.",
+  "category": "workflow",
+  "scope": ["global"],
+  "dependencies": [],
+  "files": {
+    "agents/session-historian.md": {
+      "target": "agents/session-historian.md",
+      "type": "agent",
+      "template": false
+    },
+    "scripts/discover-sessions.sh": {
+      "target": "scripts/discover-sessions.sh",
+      "type": "script",
+      "template": false
+    },
+    "scripts/extract-metadata.py": {
+      "target": "scripts/extract-metadata.py",
+      "type": "script",
+      "template": false
+    }
+  },
+  "tags": ["session", "history", "retrieval", "agent", "cross-platform", "claude-code", "codex"],
+  "configPrompts": []
+}

--- a/modules/session-history/scripts/discover-sessions.sh
+++ b/modules/session-history/scripts/discover-sessions.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Discover session files across Claude Code and Codex.
+#
+# Usage: discover-sessions.sh <repo-name> <days> [--platform claude|codex]
+#
+# Outputs one file path per line. Safe in both bash and zsh (all globs guarded).
+# Pass output to extract-metadata.py:
+#   bash discover-sessions.sh <repo-name> 7 | tr '\n' '\0' | xargs -0 python3 extract-metadata.py --cwd-filter <repo-name>
+#
+# Arguments:
+#   repo-name  Folder name of the repo (e.g., "my-repo"). Used for directory matching.
+#   days       Scan window in days (e.g., 7). Files older than this are skipped.
+#   --platform Restrict to a single platform. Omit to search all.
+
+set -euo pipefail
+
+REPO_NAME="${1:?Usage: discover-sessions.sh <repo-name> <days> [--platform claude|codex]}"
+DAYS="${2:?Usage: discover-sessions.sh <repo-name> <days> [--platform claude|codex]}"
+PLATFORM="all"
+
+# Parse optional --platform flag
+shift 2
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --platform) PLATFORM="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+# --- Claude Code ---
+discover_claude() {
+    local base="$HOME/.claude/projects"
+    [ -d "$base" ] || return 0
+
+    # Find all project dirs matching repo name (CWD-encoded: / -> -)
+    for dir in "$base"/*"$REPO_NAME"*/; do
+        [ -d "$dir" ] || continue
+        find "$dir" -maxdepth 1 -name "*.jsonl" -mtime "-${DAYS}" 2>/dev/null
+    done
+}
+
+# --- Codex ---
+discover_codex() {
+    # Codex sessions are not organized by project directory. Discover by mtime
+    # across the whole tree, then let extract-metadata.py filter by --cwd-filter.
+    for base in "$HOME/.codex/sessions" "$HOME/.agents/sessions"; do
+        [ -d "$base" ] || continue
+        find "$base" -name "*.jsonl" -mtime "-${DAYS}" 2>/dev/null
+    done
+}
+
+# --- Dispatch ---
+case "$PLATFORM" in
+    claude)  discover_claude ;;
+    codex)   discover_codex ;;
+    all)
+        discover_claude
+        discover_codex
+        ;;
+    *)
+        echo "Unknown platform: $PLATFORM (expected claude|codex|all)" >&2
+        exit 1
+        ;;
+esac

--- a/modules/session-history/scripts/extract-metadata.py
+++ b/modules/session-history/scripts/extract-metadata.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Extract session metadata from Claude Code and Codex JSONL files.
+
+Batch mode (preferred - one invocation for all files):
+  python3 extract-metadata.py /path/to/dir/*.jsonl
+  python3 extract-metadata.py file1.jsonl file2.jsonl file3.jsonl
+
+Single-file mode (stdin):
+  head -20 <session.jsonl> | python3 extract-metadata.py
+
+Auto-detects platform from the JSONL structure.
+Outputs one JSON object per file, one per line.
+Includes a final _meta line with processing stats.
+
+Use --cwd-filter <substring> to drop Codex sessions whose cwd does not contain
+the substring. Claude Code sessions are already scoped by directory at discovery
+time, so the filter is a no-op for them.
+"""
+import sys
+import json
+import os
+
+MAX_LINES = 25  # Only need first ~25 lines for metadata
+TAIL_BYTES = 16384  # Read last 16KB to find final timestamp past trailing metadata
+
+
+def try_claude(lines):
+    for line in lines:
+        try:
+            obj = json.loads(line.strip())
+            if obj.get("type") == "user" and "gitBranch" in obj:
+                return {
+                    "platform": "claude",
+                    "branch": obj["gitBranch"],
+                    "ts": obj.get("timestamp", ""),
+                    "session": obj.get("sessionId", ""),
+                }
+        except (json.JSONDecodeError, KeyError):
+            pass
+    return None
+
+
+def try_codex(lines):
+    meta = {}
+    for line in lines:
+        try:
+            obj = json.loads(line.strip())
+            if obj.get("type") == "session_meta":
+                p = obj.get("payload", {})
+                meta["platform"] = "codex"
+                meta["cwd"] = p.get("cwd", "")
+                meta["session"] = p.get("id", "")
+                meta["ts"] = p.get("timestamp", obj.get("timestamp", ""))
+                meta["source"] = p.get("source", "")
+                meta["cli_version"] = p.get("cli_version", "")
+            elif obj.get("type") == "turn_context":
+                p = obj.get("payload", {})
+                meta["model"] = p.get("model", "")
+                meta["cwd"] = meta.get("cwd") or p.get("cwd", "")
+        except (json.JSONDecodeError, KeyError):
+            pass
+    return meta if meta else None
+
+
+def extract_from_lines(lines):
+    return try_claude(lines) or try_codex(lines)
+
+
+def get_last_timestamp(filepath, size):
+    """Read the tail of a file to find the last message with a timestamp."""
+    try:
+        with open(filepath, "rb") as f:
+            f.seek(max(0, size - TAIL_BYTES))
+            tail = f.read().decode("utf-8", errors="ignore")
+            lines = tail.strip().split("\n")
+        for line in reversed(lines):
+            try:
+                obj = json.loads(line.strip())
+                if "timestamp" in obj:
+                    return obj["timestamp"]
+            except (json.JSONDecodeError, KeyError):
+                pass
+    except (OSError, IOError):
+        pass
+    return None
+
+
+def process_file(filepath):
+    try:
+        size = os.path.getsize(filepath)
+        with open(filepath, "r") as f:
+            lines = []
+            for i, line in enumerate(f):
+                if i >= MAX_LINES:
+                    break
+                lines.append(line)
+        result = extract_from_lines(lines)
+        if result:
+            result["file"] = filepath
+            result["size"] = size
+            last_ts = get_last_timestamp(filepath, size)
+            if last_ts:
+                result["last_ts"] = last_ts
+            return result, None
+        else:
+            return None, filepath
+    except (OSError, IOError):
+        return None, filepath
+
+
+# Parse arguments: files and optional --cwd-filter <substring>
+files = []
+cwd_filter = None
+args = sys.argv[1:]
+i = 0
+while i < len(args):
+    if args[i] == "--cwd-filter" and i + 1 < len(args):
+        cwd_filter = args[i + 1]
+        i += 2
+    elif not args[i].startswith("-"):
+        files.append(args[i])
+        i += 1
+    else:
+        i += 1
+
+if files:
+    # Batch mode: process all files
+    processed = 0
+    parse_errors = 0
+    filtered = 0
+    for filepath in files:
+        if not filepath.endswith(".jsonl"):
+            continue
+        result, error = process_file(filepath)
+        processed += 1
+        if result:
+            # Apply CWD filter: skip Codex sessions from other repos
+            if cwd_filter and result.get("cwd") and cwd_filter not in result["cwd"]:
+                filtered += 1
+                continue
+            print(json.dumps(result))
+        elif error:
+            parse_errors += 1
+
+    meta = {"_meta": True, "files_processed": processed, "parse_errors": parse_errors}
+    if filtered:
+        meta["filtered_by_cwd"] = filtered
+    print(json.dumps(meta))
+else:
+    # No file arguments: either single-file stdin mode or empty xargs invocation.
+    # When xargs runs us with no input (e.g., discover found no files), stdin is
+    # empty or a TTY - emit a clean zero-file result instead of a false parse error.
+    if sys.stdin.isatty():
+        lines = []
+    else:
+        lines = list(sys.stdin)
+
+    if not lines:
+        # No input at all - zero-file result (clean exit for empty pipelines)
+        print(json.dumps({"_meta": True, "files_processed": 0, "parse_errors": 0}))
+    else:
+        # Genuine single-file stdin mode (backward compatible)
+        result = extract_from_lines(lines)
+        if result:
+            print(json.dumps(result))
+        print(json.dumps({"_meta": True, "files_processed": 1, "parse_errors": 0 if result else 1}))


### PR DESCRIPTION
Closes #279

## Summary

New `session-history` module. Ports EveryInc/compound-engineering's session-historian agent to CCGM, adapted for Claude Code + Codex (Cursor intentionally out of scope per the issue).

## Contents

- `agents/session-historian.md` - retrieval agent with strict guardrails (never read entire sessions, never reproduce tool I/O verbatim, never include thinking blocks, fail fast on permission errors).
- `scripts/discover-sessions.sh` - enumerates session `.jsonl` files across `~/.claude/projects/` and `~/.codex/sessions/` (and `~/.agents/sessions/`) with mtime filtering and repo-name matching.
- `scripts/extract-metadata.py` - batch metadata extractor (branch, cwd, session id, first/last timestamp) with a `--cwd-filter` for Codex.
- `module.json` + `README.md` in the existing module conventions; uses the `agents/` directory convention landed in #273.

## Adaptations from source

- Drops Cursor platform (not in the CCGM workflow; noted in README as a future extension point).
- Drops `extract-skeleton.py` and `extract-errors.py` - the agent does skeleton-style extraction inline via native Read + Grep. Keeps the surface minimal; can be lifted as a follow-up if inline reads hit token pressure on very large sessions.
- Script paths are absolute (`~/.claude/scripts/...`) matching CCGM's install convention rather than the plugin-relative paths the original assumes.

## Test plan

- [x] `bash tests/test-modules.sh` - 805 passed, 0 failed.
- [x] Smoke-tested `discover-sessions.sh ccgm 7` - found 5 Claude Code sessions in this workspace.
- [x] Smoke-tested the full pipeline (`discover | xargs extract-metadata`) - returned valid JSON metadata lines and a `_meta` summary.
- [x] No `.env.clone` staged.
- [x] No AI-attribution in commit/PR.
- [ ] End-to-end agent dispatch verification happens after merge when the agent lands in `~/.claude/agents/` via the installer.

## Non-goals

- Does not wire into `/compound`, `/xplan`, or `/debug`. Those integrations are separate follow-ups.
- Does not index or persist session summaries - pure on-demand retrieval.