### PR TITLE
#274: add SessionStart rule-enforcement hook

### DIFF
--- a/modules/hooks/README.md
+++ b/modules/hooks/README.md
@@ -4,7 +4,7 @@ Python hooks that enforce git workflow rules: issue-first workflow, commit messa
 
 ## What It Does
 
-This module installs eleven Python hooks, two Python libraries, and a settings partial:
+This module installs twelve Python hooks, two Python libraries, and a settings partial:
 
 | Hook | Event | Purpose |
 |------|-------|---------|
@@ -19,6 +19,7 @@ This module installs eleven Python hooks, two Python libraries, and a settings p
 | `check-migration-timestamps.py` | PreToolUse | Validates Supabase migration file timestamps for duplicates before commit |
 | `check-careful.py` | PreToolUse (Bash) | Prompts before destructive Bash commands (rm -rf, SQL DROP/TRUNCATE, force push, hard reset, kubectl delete, docker prune). Build-artifact directories (node_modules, dist, .next, build, __pycache__, .cache, .turbo, coverage) are whitelisted for `rm -rf` |
 | `check-freeze.py` | PreToolUse (Edit/Write) | Denies Edit/Write outside the frozen directory when `~/.claude/freeze-dir.txt` is set. Pair with `/freeze`, `/unfreeze`, `/guard` from `commands-extra` |
+| `session-start-enforce.py` | SessionStart (startup) | Experimental. Injects an Iron-Law rule-enforcement meta-instruction at fresh session start so discipline rules activate under pressure. OFF by default; opt in via `CCGM_RULE_ENFORCEMENT=true` in `~/.claude/.ccgm.env` |
 
 The `settings.partial.json` wires these hooks into your `~/.claude/settings.json`.
 
@@ -70,6 +71,16 @@ You can add additional protected branches by creating `~/.claude/git-flow-protec
 
 The default protected branches are: main, master, production, prod, staging, stag, develop, dev, release, trunk.
 
+### Experimental: rule-enforcement meta-instruction
+
+`session-start-enforce.py` is OFF by default. To pilot it, add this to `~/.claude/.ccgm.env`:
+
+```
+CCGM_RULE_ENFORCEMENT=true
+```
+
+On fresh session start, the hook injects a short reminder that routes tasks through loaded Iron-Law rules (TDD, systematic-debugging, verification, subagent-patterns, confusion-protocol). Remove or set to `false` to disable.
+
 ## Files
 
 | File | Description |
@@ -85,6 +96,7 @@ The default protected branches are: main, master, production, prod, staging, sta
 | `hooks/check-migration-timestamps.py` | Supabase migration timestamp validation |
 | `hooks/check-careful.py` | Destructive-command warning (careful safety hook) |
 | `hooks/check-freeze.py` | Scope-lock Edit/Write to `~/.claude/freeze-dir.txt` (freeze safety hook) |
+| `hooks/session-start-enforce.py` | Experimental Iron-Law rule-enforcement meta-instruction at session start (opt in via `CCGM_RULE_ENFORCEMENT=true`) |
 | `lib/agent_tracking.py` | Python library for tracking CSV operations |
 | `lib/agent_sessions.py` | Python library for live session detection |
 | `settings.partial.json` | Hook wiring configuration to merge into settings.json |

--- a/modules/hooks/hooks/session-start-enforce.py
+++ b/modules/hooks/hooks/session-start-enforce.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+SessionStart hook that injects a rule-enforcement meta-instruction.
+
+Adapted from obra/superpowers `hooks/session-start`. The idea: CCGM installs
+discipline rules (TDD, systematic-debugging, verification, confusion-protocol,
+etc.) to `~/.claude/rules/` where Claude Code auto-loads them, but there is no
+*meta-instruction* that forces the agent to route through those rules under
+pressure. This hook injects a short reminder at fresh session start so the
+agent treats the Iron Laws as real gates, not background reading.
+
+Experimental: OFF by default. Opt in by setting CCGM_RULE_ENFORCEMENT=true in
+`~/.claude/.ccgm.env`. Fires only on source == "startup" so it does not fire
+on resume or compaction.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+
+# The meta-instruction injected into the session. Kept short on purpose:
+# long context at session start competes with the user's first prompt for
+# attention. The goal is to bias routing toward loaded rules, not to restate
+# them.
+META_INSTRUCTION = """\
+<ccgm-rule-enforcement>
+Before your first response in this session, scan the loaded rules in
+~/.claude/rules/ and in any CLAUDE.md files for Iron Laws (all-caps "NO X
+WITHOUT Y" declarations). For any task with a plausible match, route through
+the relevant rule before acting:
+
+- Writing or modifying code -> test-driven-development (failing test first).
+- Fixing a bug or unexpected behavior -> systematic-debugging (root cause before fix).
+- Claiming a task is done, tests pass, or a build works -> verification (fresh evidence).
+- Dispatching work to subagents -> subagent-patterns (spec + status protocol).
+- Unclear requirements, contradictions, or missing context -> confusion-protocol (stop and ask).
+
+"Violating the letter of a rule is violating the spirit." Do not negotiate
+Iron Laws under time pressure, user pressure, or sunk-cost pressure. If a rule
+seems to block the task, surface the conflict instead of routing around it.
+</ccgm-rule-enforcement>
+"""
+
+
+def is_enabled() -> bool:
+    """Check if rule-enforcement injection is enabled in .ccgm.env."""
+    if not ENV_FILE.exists():
+        return False
+    try:
+        with open(ENV_FILE) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("CCGM_RULE_ENFORCEMENT="):
+                    value = line.split("=", 1)[1].strip().lower()
+                    return value in ("true", "1", "yes")
+    except (OSError, IOError):
+        pass
+    return False
+
+
+def main() -> None:
+    # Read stdin (required by hook contract)
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, not resume or compact. Resume already has
+    # the rules in-context from the prior session; compact has its own
+    # (different) context-preservation mechanism.
+    source = hook_input.get("source", "")
+    if source != "startup":
+        return
+
+    if not is_enabled():
+        return
+
+    # Print to stdout - Claude Code injects this as additionalContext for the
+    # SessionStart event.
+    sys.stdout.write(META_INSTRUCTION)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/hooks/module.json
+++ b/modules/hooks/module.json
@@ -76,6 +76,11 @@
       "type": "hook",
       "template": false
     },
+    "hooks/session-start-enforce.py": {
+      "target": "hooks/session-start-enforce.py",
+      "type": "hook",
+      "template": false
+    },
     "settings.partial.json": {
       "target": "settings.json",
       "type": "config",

--- a/modules/hooks/settings.partial.json
+++ b/modules/hooks/settings.partial.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/session-start-enforce.py",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [


### PR DESCRIPTION
Closes #274

## Summary

Adapts obra/superpowers' session-start meta-instruction pattern (copycat analysis item 11). CCGM installs discipline rules to `~/.claude/rules/` where Claude Code auto-loads them, but there is no meta-instruction forcing the agent to route through those rules under pressure. This hook injects a short Iron-Law routing reminder at fresh session start so the loaded rules activate as real gates, not background reading.

Experimental: **OFF by default**. Opt in via `CCGM_RULE_ENFORCEMENT=true` in `~/.claude/.ccgm.env`. Fires only on `source == "startup"`, so resume and compact sessions are untouched. Easy to disable by removing the env line or setting it to `false`.

## Changes

- `modules/hooks/hooks/session-start-enforce.py` - new hook, matches CCGM style (stdin JSON in, stdout injection out, env-gated like `auto-startup.py` and `ccgm-update-check.py`).
- `modules/hooks/module.json` - registers the hook file.
- `modules/hooks/settings.partial.json` - wires a `SessionStart` entry with `matcher: "startup"`.
- `modules/hooks/README.md` - hook-count, table rows, and a short "Experimental" subsection.

## Test plan

- [x] `bash tests/test-modules.sh` - 868 passed, 0 failed
- [x] Manual run with `source: "startup"` and flag off - no output, exit 0
- [x] Manual run with `source: "startup"` and `CCGM_RULE_ENFORCEMENT=true` - emits the meta-instruction block, exit 0
- [x] Manual run with `source: "resume"` and flag on - no output (only fires on fresh startup)
- [x] Manual run with garbage stdin - exit 0, no crash