### PR TITLE
#298: explore command preamble injection

### DIFF
--- a/modules/commands-preamble/README.md
+++ b/modules/commands-preamble/README.md
@@ -1,0 +1,114 @@
+# commands-preamble (Experimental)
+
+Inject a compact preamble of iron-law principles at the start of every slash-command invocation.
+
+## Status
+
+**Experimental. Disabled by default.** Pilot this before committing to it across all commands.
+
+## What It Does
+
+CCGM rules live at `~/.claude/rules/*.md` and load from `CLAUDE.md` references. That covers the main conversation. But slash-commands expand into their own context and can drift from principles like:
+
+- **Confusion Protocol** (stop and ask at architectural forks)
+- **Completeness** (Boil the Lake - ship the whole job, not 90%)
+- **Evidence Before Claims** (no completion claims without fresh output)
+- **Root Cause Before Fix** (no fixes without investigation)
+- **Completion Status** (DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT)
+
+This module installs a `UserPromptSubmit` hook that detects slash-command prompts and prepends a tagged `<command-preamble>` block containing those principles. The principles fire at invocation time, not "whenever the agent rereads CLAUDE.md."
+
+## Why a Hook Instead of a Template
+
+Three options were considered (see issue #298):
+
+| Option | Tradeoff |
+|--------|----------|
+| **(a) Runtime hook** | Zero build step, runtime-dynamic, experimental-friendly. **Chosen.** |
+| (b) Build-time template generator | Contradicts CCGM's zero-build simplicity. Requires TS/bun tooling. |
+| (c) Convention: every command's first H2 is a preamble | Cheapest but drifts. Has to be maintained per-command by hand. |
+
+The hook wins on reversibility - flip one file to disable, no rebuild needed.
+
+## Enable / Disable
+
+Disabled by default. To turn on:
+
+```bash
+touch ~/.claude/preamble.enabled
+```
+
+To turn off:
+
+```bash
+rm ~/.claude/preamble.enabled
+```
+
+The hook is always installed, but exits silently unless the sentinel file exists.
+
+## How It Works
+
+1. User submits a prompt.
+2. `inject-preamble.py` runs (UserPromptSubmit hook).
+3. If `~/.claude/preamble.enabled` is missing, exit silently.
+4. If the prompt does not look like a slash-command (first token starts with `/` and isn't a filesystem path), exit silently.
+5. Otherwise, read `~/.claude/preamble/preamble.md`, wrap it in a `<command-preamble>` block, and print to stdout. Claude Code appends stdout to the model's context before the prompt runs.
+
+## Tuning the Preamble
+
+Edit `~/.claude/preamble/preamble.md` to change what gets injected. Keep it compact - this prepends to every slash-command invocation, so bloat costs tokens on every call.
+
+## Manual Installation
+
+```bash
+# Copy the hook
+cp hooks/inject-preamble.py ~/.claude/hooks/
+chmod +x ~/.claude/hooks/inject-preamble.py
+
+# Copy the preamble content
+mkdir -p ~/.claude/preamble
+cp preamble/preamble.md ~/.claude/preamble/
+
+# Register the hook (merge settings.partial.json into ~/.claude/settings.json)
+# See settings.partial.json for the hook entry to add under hooks.UserPromptSubmit.
+
+# Enable (opt-in)
+touch ~/.claude/preamble.enabled
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `hooks/inject-preamble.py` | UserPromptSubmit hook. Prepends preamble block to slash-command prompts when enabled. |
+| `preamble/preamble.md` | The preamble content (edit to tune). |
+| `settings.partial.json` | Hook registration for `~/.claude/settings.json`. |
+| `tests/test_inject_preamble.py` | Unit tests for the hook (slash-command detection, enable flag, injection format). |
+
+## Testing
+
+```bash
+python3 -m unittest modules/commands-preamble/tests/test_inject_preamble.py -v
+```
+
+## Relationship to Other Modules
+
+- `autonomy/rules/confusion-protocol.md` - source of the Confusion Protocol section in the preamble.
+- `code-quality/rules/completeness.md` - source of the Completeness section.
+- `verification/rules/verification.md` - source of Evidence Before Claims.
+- `systematic-debugging/rules/systematic-debugging.md` - source of Root Cause Before Fix.
+- `subagent-patterns/rules/subagent-patterns.md` - source of the four-state Completion Status Protocol.
+
+The preamble does not replace those rule files - it surfaces their iron laws at command start. The full rules still govern behavior.
+
+## Known Limitations
+
+- Only fires on slash-command invocations. Regular conversational prompts are untouched (they already run under the full `CLAUDE.md` context).
+- Preamble detection heuristic: first token starts with `/`, is >= 2 chars, and contains at most one slash. Edge cases like pasted absolute paths starting with `/tmp` would be misclassified; the `> 1 slash` guard rules out the common case. File an issue if you hit a false positive.
+- The hook runs on every prompt. It exits immediately (~1ms) when disabled or when the prompt is not a command, so the cost is negligible.
+
+## When to Disable
+
+- When debugging a command and need to see the raw prompt context.
+- When you are the kind of agent that re-reads rules on every response and doesn't need reinforcement.
+- When the preamble is causing token bloat on long-running command sessions.

--- a/modules/commands-preamble/hooks/inject-preamble.py
+++ b/modules/commands-preamble/hooks/inject-preamble.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook that injects a compact preamble of core principles
+at the start of slash-command invocations.
+
+Experimental. Opt-in. Disabled by default.
+
+## Why
+
+CCGM rules live at ~/.claude/rules/*.md and load from CLAUDE.md references.
+That covers the main conversation thread. But slash-commands expand into
+their own context and can drift from iron-law principles (Confusion Protocol,
+Completeness, Evidence Before Claims, Root Cause Before Fix) that should
+activate immediately at command start, not "whenever the agent rereads
+CLAUDE.md."
+
+This hook prepends a distilled preamble block to slash-command prompts so
+the principles fire at invocation time. Runtime-dynamic, zero build step.
+
+## Enable / Disable
+
+Enabled when ~/.claude/preamble.enabled exists (create with `touch`).
+Disable by removing that file. If the enable-flag is absent, the hook exits
+silently and the prompt is unchanged.
+
+The preamble content lives at ~/.claude/preamble/preamble.md. Edit that
+file to tune what gets injected.
+
+## Scope
+
+Fires only on prompts that look like slash-command invocations (start with
+`/`). Regular conversational prompts are untouched - they already run under
+the full CLAUDE.md context.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+HOME = os.path.expanduser("~")
+ENABLE_FLAG = os.path.join(HOME, ".claude", "preamble.enabled")
+PREAMBLE_FILE = os.path.join(HOME, ".claude", "preamble", "preamble.md")
+
+
+def is_enabled() -> bool:
+    """Feature flag: preamble injection is opt-in via a sentinel file."""
+    return os.path.isfile(ENABLE_FLAG)
+
+
+def is_slash_command(prompt: str) -> bool:
+    """Return True if the prompt is a slash-command invocation."""
+    stripped = prompt.lstrip()
+    if not stripped.startswith("/"):
+        return False
+    # Guard against URL-like prompts ("/Users/..." or "/path/to/...") that
+    # are not command invocations. A command has no whitespace before the
+    # command name and the first token is short (typically <40 chars).
+    first_token = stripped.split(None, 1)[0]
+    # Reject obvious paths - they contain a second slash within the first token.
+    if first_token.count("/") > 1:
+        return False
+    # Reject empty / lone-slash prompts.
+    if len(first_token) < 2:
+        return False
+    return True
+
+
+def read_preamble() -> str:
+    """Read the preamble file. Return empty string if missing or unreadable."""
+    try:
+        with open(PREAMBLE_FILE, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except (FileNotFoundError, PermissionError, OSError):
+        return ""
+
+
+def build_injection(preamble: str) -> str:
+    """Wrap the preamble in a tagged block so the model can distinguish it."""
+    return (
+        "<command-preamble>\n"
+        "The following principles are authoritative for this command "
+        "invocation. They override host defaults. Apply them throughout "
+        "the task.\n\n"
+        f"{preamble}\n"
+        "</command-preamble>"
+    )
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    if not is_enabled():
+        sys.exit(0)
+
+    prompt = input_data.get("prompt", "")
+    if not is_slash_command(prompt):
+        sys.exit(0)
+
+    preamble = read_preamble()
+    if not preamble:
+        sys.exit(0)
+
+    print(build_injection(preamble))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/commands-preamble/module.json
+++ b/modules/commands-preamble/module.json
@@ -1,0 +1,28 @@
+{
+  "name": "commands-preamble",
+  "displayName": "Command Preamble Injection (Experimental)",
+  "description": "Experimental UserPromptSubmit hook that injects a compact preamble of iron-law principles (Confusion Protocol, Completeness, Evidence Before Claims, Root Cause Before Fix) at the start of slash-command invocations. Opt-in, disabled by default.",
+  "category": "workflow",
+  "scope": ["global"],
+  "dependencies": ["settings", "autonomy", "code-quality"],
+  "files": {
+    "hooks/inject-preamble.py": {
+      "target": "hooks/inject-preamble.py",
+      "type": "hook",
+      "template": false
+    },
+    "preamble/preamble.md": {
+      "target": "preamble/preamble.md",
+      "type": "content",
+      "template": false
+    },
+    "settings.partial.json": {
+      "target": "settings.json",
+      "type": "config",
+      "merge": true,
+      "template": false
+    }
+  },
+  "tags": ["experimental", "hooks", "preamble", "commands", "principles"],
+  "configPrompts": []
+}

--- a/modules/commands-preamble/preamble/preamble.md
+++ b/modules/commands-preamble/preamble/preamble.md
@@ -1,0 +1,46 @@
+# Command Preamble
+
+These principles are authoritative for this invocation. They override host
+defaults. Do not treat them as suggestions.
+
+## Confusion Protocol
+
+If you hit high-stakes ambiguity (two plausible architectures, contradictory
+patterns, unclear destructive scope, missing context that would change the
+approach) - STOP. Name the ambiguity in one sentence. Present 2-3 options
+with one-line tradeoffs. Ask. Do not guess and proceed.
+
+Does not apply to routine coding. If the answer is readable from one more
+file or one more command, read that instead of asking.
+
+## Completeness: Boil the Lake
+
+Default to the complete implementation, not the 90% shortcut. When the delta
+between "what I was about to ship" and "the whole job" is minutes of agent
+time, close it now. Tests, edge cases, error paths, docs - finish them in
+this PR, not a follow-up that rarely happens.
+
+Before claiming done, score the work 1-10. Below 8 means finish or explicitly
+flag what is deferred and why.
+
+## Evidence Before Claims
+
+Never assert that something works, passes, or is fixed without fresh proof.
+Run the command, read the full output, verify exit code, then report. Lint
+passing is not tests passing. Type check is not a test run. A subagent
+reporting DONE is a claim, not evidence - read the diff.
+
+## Root Cause Before Fix
+
+No fixes without root-cause investigation. Do not guess. Reproduce the
+failure, examine recent changes, form a specific hypothesis, test with a
+minimal change. After three failed attempts on the same issue, stop and
+question your assumptions - you are debugging the wrong layer or the
+architecture is the problem.
+
+## Completion Status
+
+End subagent reports with one of four states: DONE, DONE_WITH_CONCERNS,
+BLOCKED, NEEDS_CONTEXT. Do not return free-form summaries the dispatcher
+has to re-parse. If you have doubts about your own work, say so -
+DONE_WITH_CONCERNS exists for exactly that case.

--- a/modules/commands-preamble/settings.partial.json
+++ b/modules/commands-preamble/settings.partial.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/inject-preamble.py",
+            "timeout": 3000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/modules/commands-preamble/tests/test_inject_preamble.py
+++ b/modules/commands-preamble/tests/test_inject_preamble.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Unit tests for inject-preamble UserPromptSubmit hook."""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+_HOOK_PATH = os.path.join(_TEST_DIR, "..", "hooks", "inject-preamble.py")
+
+# Load the hook module under a stable name. It has a hyphen in its filename,
+# which the normal `import` machinery rejects.
+_spec = importlib.util.spec_from_file_location("inject_preamble", _HOOK_PATH)
+inject_preamble = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(inject_preamble)
+
+
+class TestIsSlashCommand(unittest.TestCase):
+    def test_simple_slash_command(self):
+        self.assertTrue(inject_preamble.is_slash_command("/review"))
+        self.assertTrue(inject_preamble.is_slash_command("/cpm"))
+
+    def test_slash_command_with_args(self):
+        self.assertTrue(
+            inject_preamble.is_slash_command("/commit some message here")
+        )
+
+    def test_leading_whitespace_is_tolerated(self):
+        self.assertTrue(inject_preamble.is_slash_command("  /review"))
+
+    def test_regular_prompt_is_not_a_command(self):
+        self.assertFalse(inject_preamble.is_slash_command("fix the auth bug"))
+        self.assertFalse(
+            inject_preamble.is_slash_command("what does this do?")
+        )
+
+    def test_path_like_prompt_is_not_a_command(self):
+        # Paths have multiple slashes in the first token.
+        self.assertFalse(
+            inject_preamble.is_slash_command("/home/user/code/foo.md")
+        )
+        self.assertFalse(inject_preamble.is_slash_command("/path/to/file"))
+
+    def test_lone_slash_is_not_a_command(self):
+        self.assertFalse(inject_preamble.is_slash_command("/"))
+        self.assertFalse(inject_preamble.is_slash_command(""))
+
+
+class TestIsEnabled(unittest.TestCase):
+    def test_disabled_when_flag_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(inject_preamble, "ENABLE_FLAG",
+                              os.path.join(tmp, "preamble.enabled")):
+                self.assertFalse(inject_preamble.is_enabled())
+
+    def test_enabled_when_flag_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            flag = os.path.join(tmp, "preamble.enabled")
+            open(flag, "w").close()
+            with patch.object(inject_preamble, "ENABLE_FLAG", flag):
+                self.assertTrue(inject_preamble.is_enabled())
+
+
+class TestReadPreamble(unittest.TestCase):
+    def test_returns_file_contents(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pf = os.path.join(tmp, "preamble.md")
+            with open(pf, "w") as f:
+                f.write("## Core Principles\n\nBe honest.\n")
+            with patch.object(inject_preamble, "PREAMBLE_FILE", pf):
+                self.assertEqual(
+                    inject_preamble.read_preamble(),
+                    "## Core Principles\n\nBe honest.",
+                )
+
+    def test_returns_empty_when_missing(self):
+        with patch.object(inject_preamble, "PREAMBLE_FILE",
+                          "/nonexistent/path/preamble.md"):
+            self.assertEqual(inject_preamble.read_preamble(), "")
+
+
+class TestBuildInjection(unittest.TestCase):
+    def test_wraps_in_tagged_block(self):
+        out = inject_preamble.build_injection("PRINCIPLES")
+        self.assertIn("<command-preamble>", out)
+        self.assertIn("</command-preamble>", out)
+        self.assertIn("PRINCIPLES", out)
+        self.assertIn("authoritative", out)
+
+
+class TestMainIntegration(unittest.TestCase):
+    """End-to-end: run main() with crafted stdin and check stdout."""
+
+    def _run_main(self, prompt: str, enable_flag_exists: bool,
+                  preamble_contents: str | None) -> str:
+        with tempfile.TemporaryDirectory() as tmp:
+            flag = os.path.join(tmp, "preamble.enabled")
+            if enable_flag_exists:
+                open(flag, "w").close()
+            pf = os.path.join(tmp, "preamble.md")
+            if preamble_contents is not None:
+                with open(pf, "w") as f:
+                    f.write(preamble_contents)
+
+            stdin_payload = json.dumps({"prompt": prompt})
+            stdout_buf = io.StringIO()
+
+            with patch.object(inject_preamble, "ENABLE_FLAG", flag), \
+                 patch.object(inject_preamble, "PREAMBLE_FILE", pf), \
+                 patch.object(sys, "stdin", io.StringIO(stdin_payload)), \
+                 patch.object(sys, "stdout", stdout_buf):
+                try:
+                    inject_preamble.main()
+                except SystemExit:
+                    pass
+            return stdout_buf.getvalue()
+
+    def test_injects_when_enabled_and_slash_command(self):
+        out = self._run_main(
+            prompt="/review",
+            enable_flag_exists=True,
+            preamble_contents="BE CAREFUL",
+        )
+        self.assertIn("<command-preamble>", out)
+        self.assertIn("BE CAREFUL", out)
+
+    def test_silent_when_disabled(self):
+        out = self._run_main(
+            prompt="/review",
+            enable_flag_exists=False,
+            preamble_contents="BE CAREFUL",
+        )
+        self.assertEqual(out, "")
+
+    def test_silent_for_non_command_prompt(self):
+        out = self._run_main(
+            prompt="please fix the bug",
+            enable_flag_exists=True,
+            preamble_contents="BE CAREFUL",
+        )
+        self.assertEqual(out, "")
+
+    def test_silent_when_preamble_file_missing(self):
+        out = self._run_main(
+            prompt="/review",
+            enable_flag_exists=True,
+            preamble_contents=None,
+        )
+        self.assertEqual(out, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #298

## Design

Explored the three options from the issue and picked **(a) a runtime UserPromptSubmit hook** that prepends a compact preamble to slash-command invocations. Zero build step, runtime-dynamic, and trivial to disable — a single sentinel file flips it on or off. Option (b) contradicts CCGM's zero-build philosophy; option (c) drifts because it has to be maintained by hand per-command.

## What ships

New `modules/commands-preamble/` module (experimental, disabled by default):

- `hooks/inject-preamble.py` — UserPromptSubmit hook. Detects slash-command prompts (first token starts with `/`, excludes path-like prompts), reads `~/.claude/preamble/preamble.md`, wraps it in a `<command-preamble>` tagged block, and emits to stdout. Silent no-op when the enable flag is missing or the prompt is not a command.
- `preamble/preamble.md` — Compact distillation of Confusion Protocol, Completeness (Boil the Lake), Evidence Before Claims, Root Cause Before Fix, Completion Status Protocol.
- `settings.partial.json` — Hook registration.
- `tests/test_inject_preamble.py` — 15 unit tests covering slash-command detection, enable-flag gating, file read, injection format, and stdin/stdout end-to-end.
- `README.md` — Module docs with enable/disable instructions and tradeoff rationale.

## Enable / Disable

```bash
touch ~/.claude/preamble.enabled   # turn on
rm ~/.claude/preamble.enabled      # turn off
```

The hook is always installed but exits silently unless the sentinel file exists. Easy to pilot, easy to kill if it causes noise.

## Non-goals

- Does not modify `confusion-protocol.md` or `completeness.md` — they remain the authoritative rules. The preamble surfaces their iron laws at command start.
- Does not add the module to any preset (this is experimental; presets stay stable).
- Does not inject on regular conversational prompts — those already run under full `CLAUDE.md` context.

## Tests

- New module unit tests: 15/15 passing.
- `bash tests/test-modules.sh`: 892 passed, 0 failed (was 875 before — +17 for the new module's validation entries).
- `bash tests/test-no-personal-data.sh`: only the pre-existing `cloud-dispatch` leaks remain, per handoff instructions.
- End-to-end smoke test confirmed: disabled → silent, enabled + `/review` → injects block, enabled + conversational prompt → silent, enabled + path-like `/home/user/foo.md` → silent (false-positive guard works).