### PR TITLE
#285: evaluate CE permissions-optimizer

### DIFF
--- a/modules/settings/README.md
+++ b/modules/settings/README.md
@@ -44,3 +44,17 @@ cp settings.base.json ~/.claude/settings.json
 | File | Description |
 |------|-------------|
 | `settings.base.json` | Complete settings.json template with all permissions |
+
+## Maintaining the Allow List
+
+The `settings.base.json` allow list is a static, hand-curated baseline. To extend it for commands you actually run, use Claude Code's built-in `/less-permission-prompts` skill:
+
+> "Scan your transcripts for common read-only Bash and MCP tool calls, then add a prioritized allowlist to project `.claude/settings.json` to reduce permission prompts."
+
+Run `/less-permission-prompts` in any project to generate a project-local `.claude/settings.json` with allowlist additions derived from your session history. If patterns from a project-local file turn out to be universal across your work, promote them into this module's `settings.base.json` via a PR.
+
+### Evaluation: CE claude-permissions-optimizer (issue #285)
+
+EveryInc/compound-engineering-plugin previously shipped a `claude-permissions-optimizer` skill with similar goals (scan session history, classify commands, write allowlist entries). As of CE PR #578/#583 the skill was **removed from CE** and the CHANGELOG states: "drop skill in favor of `/less-permission-prompts`". CE's authors explicitly adopted Anthropic's first-party built-in as the recommended path.
+
+**CCGM action**: none required. CCGM does not ship a permissions-optimizer skill (the `settings` module ships only a static allow list), and the CE version is no longer maintained. Users rely on the Anthropic-shipped `/less-permission-prompts` skill for dynamic allowlist additions. The transferable pipeline-design lessons from CE's defunct skill (ordering of filter / normalize / group / threshold / re-classify) are captured in their `docs/solutions/skill-design/claude-permissions-optimizer-classification-fix.md` if a future CCGM-native optimizer is ever written; they are not re-documented here to avoid duplicating upstream content.


### PR DESCRIPTION
Closes #285

## Summary

Evaluated EveryInc/compound-engineering-plugin's `claude-permissions-optimizer` skill against CCGM's tooling for reducing permission prompts.

**Outcome: nothing to port.** CE removed the skill in PRs #578/#583 and their CHANGELOG states it was dropped "in favor of `/less-permission-prompts`", the Anthropic first-party built-in. CCGM does not ship a competing skill — the `settings` module only provides a static `settings.base.json` allow list — so there's no existing tooling to replace.

## Changes

- `modules/settings/README.md`: add a "Maintaining the Allow List" section that points users at Claude Code's `/less-permission-prompts` skill for dynamic project-local additions, and records the CE evaluation outcome so this question doesn't get re-investigated.

## Evidence

- CE PR #583 body: "The change itself is a routine deprecation -- the `claude-permissions-optimizer` skill was superseded by Anthropic's first-party `/less-permission-prompts`"
- CE CHANGELOG entry: `**claude-permissions-optimizer:** drop skill in favor of /less-permission-prompts ([#583](https://github.com/EveryInc/compound-engineering-plugin/issues/583))`

## Test plan

- [x] `bash tests/test-modules.sh` -> 937 passed, 0 failed