### PR TITLE
#288: extract PR description writer skill

### DIFF
--- a/modules/commands-core/README.md
+++ b/modules/commands-core/README.md
@@ -12,6 +12,11 @@ Provides five foundational commands that cover the most common development opera
 - **/gs** - Show git status and project overview
 - **/ghi** - Create a GitHub issue with proper labels
 
+Also ships two reusable skills:
+
+- **pr-description** - Pure writer that returns `{title, body}` for a PR in CCGM voice. Callable from `/pr`, `/cpm`, or any agent that needs a PR body without the publishing plumbing. Does NOT invoke `gh pr create` or `gh pr edit`.
+- **cpm** - Sequenced commit-PR-merge workflow encoded as a skill so other commands can embed it.
+
 ## Files
 
 | File | Type | Description |
@@ -21,6 +26,9 @@ Provides five foundational commands that cover the most common development opera
 | `commands/cpm.md` | command | Commit, create PR, and merge in one shot |
 | `commands/gs.md` | command | Git status dashboard with project info |
 | `commands/ghi.md` | command | Create GitHub issue with labels |
+| `skills/cpm/SKILL.md` | skill | Sequenced commit-PR-merge workflow |
+| `skills/pr-description/SKILL.md` | skill | Pure PR title and body writer (returns structured output, no publishing) |
+| `skills/pr-description/references/default-template.md` | skill-reference | Fallback PR body structure when no repo template exists |
 
 ## Dependencies
 
@@ -40,6 +48,12 @@ cp commands/pr.md ~/.claude/commands/pr.md
 cp commands/cpm.md ~/.claude/commands/cpm.md
 cp commands/gs.md ~/.claude/commands/gs.md
 cp commands/ghi.md ~/.claude/commands/ghi.md
+
+# Skills
+mkdir -p ~/.claude/skills/cpm ~/.claude/skills/pr-description/references
+cp skills/cpm/SKILL.md ~/.claude/skills/cpm/SKILL.md
+cp skills/pr-description/SKILL.md ~/.claude/skills/pr-description/SKILL.md
+cp skills/pr-description/references/default-template.md ~/.claude/skills/pr-description/references/default-template.md
 ```
 
-After copying, the commands are available as `/commit`, `/pr`, `/cpm`, `/gs`, and `/ghi` in Claude Code.
+After copying, the commands are available as `/commit`, `/pr`, `/cpm`, `/gs`, and `/ghi` in Claude Code. The `pr-description` and `cpm` skills are invocable by name from other commands or agents.

--- a/modules/commands-core/module.json
+++ b/modules/commands-core/module.json
@@ -12,7 +12,9 @@
     "commands/gs.md": { "target": "commands/gs.md", "type": "command", "template": false },
     "lib/gs-gather.sh": { "target": "lib/gs-gather.sh", "type": "lib", "template": false },
     "commands/ghi.md": { "target": "commands/ghi.md", "type": "command", "template": false },
-    "skills/cpm/SKILL.md": { "target": "skills/cpm/SKILL.md", "type": "skill", "template": false }
+    "skills/cpm/SKILL.md": { "target": "skills/cpm/SKILL.md", "type": "skill", "template": false },
+    "skills/pr-description/SKILL.md": { "target": "skills/pr-description/SKILL.md", "type": "skill", "template": false },
+    "skills/pr-description/references/default-template.md": { "target": "skills/pr-description/references/default-template.md", "type": "skill-reference", "template": false }
   },
   "tags": ["commands", "git", "github", "workflow"],
   "configPrompts": []

--- a/modules/commands-core/skills/pr-description/SKILL.md
+++ b/modules/commands-core/skills/pr-description/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: pr-description
+description: Pure writer for PR titles and bodies. Takes a PR reference (or the current branch), reads diff + commits + linked issue + PR template, and returns structured {title, body}. Does NOT call `gh pr create` or `gh pr edit`. Invoke from `/pr`, `/cpm`, or any caller that needs a CCGM-voice PR body without the publishing plumbing.
+disable-model-invocation: false
+---
+
+# PR Description Writer
+
+A pure writer skill. One job: produce `{title, body}` for a pull request in CCGM voice, value-first, matching the repo's PR template when one exists.
+
+Never publishes. Never calls `gh pr create`, `gh pr edit`, `gh pr comment`, or any mutating GitHub command. The caller is responsible for doing something with the returned text.
+
+## When to Run
+
+- A caller (e.g., `/pr`, `/cpm`, a coordinator agent) needs PR text and wants the voice separated from the publishing flow
+- Rewriting an existing PR body to sharpen it before a second review pass
+- Generating text for a PR that does not yet exist, so the caller can preview before pushing
+
+Do NOT run this skill when the caller already has a finalized title and body - pass them through instead.
+
+## Input Parsing
+
+Accept any of the following as the PR reference:
+
+| Form | Example | Meaning |
+|------|---------|---------|
+| bare number | `561` | PR #561 in the current repo |
+| hash number | `#561` | same |
+| prefixed | `pr:561` | same |
+| full URL | `https://github.com/owner/repo/pull/561` | PR in that repo |
+| branch name | `288-pr-description-writer-skill` | find the open PR for this branch, or fall through to "no PR yet" |
+| empty / current | (no argument) | current branch; PR may or may not exist |
+| steering text | `emphasize the benchmarks` | applied on top of any other input as a tone/content hint |
+
+Multiple forms can coexist. `pr:561 emphasize the perf numbers` means "PR #561, lean on perf."
+
+If no PR exists yet (e.g., the caller is about to create one), operate on the branch: compare `origin/main...HEAD` for the diff and commit set.
+
+## Inputs to Collect
+
+Collect in this order. Stop once each input is captured or confirmed absent.
+
+1. **Linked issue** - from the branch name (`{issue-number}-{description}` convention) or from the PR body's `Closes #N` line. Read with `gh issue view {num}`.
+2. **Commits on the branch** - `git log origin/main..HEAD --pretty=format:"%s%n%n%b%n---"`
+3. **Diff stat** - `git diff origin/main...HEAD --stat`
+4. **Full diff** - `git diff origin/main...HEAD` (sampled; see "Diff Sampling" below)
+5. **PR template** - check in order:
+   - `pull_request_template.md` in the repo root
+   - `PULL_REQUEST_TEMPLATE.md` in the repo root
+   - `.github/pull_request_template.md`
+   - `.github/PULL_REQUEST_TEMPLATE.md`
+   - If none found, use the fallback structure in `references/default-template.md`
+6. **Existing PR body** - if a PR already exists, `gh pr view {num} --json body,title`. Treat as prior art to improve, not replace wholesale.
+7. **Steering text** - whatever hint the caller passed. Apply after drafting; do not let it override the template structure.
+
+### Diff Sampling
+
+For diffs over ~500 lines, sample rather than dump:
+
+- Read the full diff stat (every file, every ± count)
+- Read full diffs for files with substantive changes (>20 lines added or removed)
+- For large generated/lockfile changes, record one line: "`{file}`: {N} lines; generated/lockfile, skipped"
+
+Never claim coverage of a file you did not actually read.
+
+## Title Rules
+
+- Conventional-commit shape: `{type}({scope}): {summary}` or CCGM-style `#{issue}: {summary}` if the branch name carries an issue number
+- Under 72 characters total, including any prefix
+- Imperative mood (`add`, `extract`, `fix`), not past tense
+- Lead with the value or action, not the filename
+- If the repo uses `#{issue}:` prefix (check recent `git log --oneline -20` on main), match that convention
+
+Examples:
+
+| Bad | Good |
+|-----|------|
+| Updated pr.md and cpm.md to use new skill | #288: extract PR description writer as reusable skill |
+| Refactor commands-core | #288: move inline PR body generation into pr-description skill |
+| Big changes to review flow | feat(review): add scope-drift audit before specialist agents |
+
+## Body Rules - Value-First
+
+The body leads with what the PR enables, fixes, or changes in the user's world. File churn is supporting evidence, not the lead.
+
+### Structure (when no PR template exists)
+
+1. **Closes #N** - first line if the PR closes an issue. No other content on this line.
+2. **One-sentence summary** - what this PR does, in user-facing terms. No filenames.
+3. **Why** - what problem this solves or what capability it unlocks. Two sentences max.
+4. **What changed** - bulleted list of concrete changes, each one a noun phrase with a verb:
+   - "Adds `pr-description` skill under `commands-core`"
+   - "Updates `/pr` to delegate body generation to the skill"
+   - "Removes inline body template from `cpm.md`"
+5. **Test plan** - how the change was verified. Name commands: `bash tests/test-modules.sh`, manual smoke test of `/pr` on a test issue, etc.
+6. **Notes / follow-ups** - optional; only include if there is real carry-over work.
+
+### When a PR Template Exists
+
+Fill the template's sections verbatim. Do not add sections the template does not include. Do not remove sections the template marks required.
+
+If a section in the template does not apply to this PR (e.g., "Screenshots" for a backend-only change), write `N/A - {one-line reason}` rather than leaving it blank.
+
+### Value-First Rationalizations to Avoid
+
+| You are about to write... | The reality is... |
+|---------------------------|-------------------|
+| "This PR modifies `foo.ts` and `bar.ts`..." | Lead with what those modifications do for the user. File names are not value. |
+| "I refactored the review flow for cleanliness." | Cleanliness is not a user-visible outcome. What does the refactor enable? |
+| "Adds a new module." | Which module, what does it do, why does that matter? One sentence each. |
+| "Various improvements." | If you cannot name them, do not mention them. Delete the bullet. |
+
+## Output Format
+
+Return exactly this structure as the skill's output. The caller parses it.
+
+```
+### TITLE
+{title, single line, no trailing punctuation}
+
+### BODY
+{full body, markdown, starts with `Closes #N` line if applicable}
+
+### METADATA
+- Issue: #{num} or "none"
+- Branch: {branch-name}
+- Commits: {count}
+- Files changed: {count}
+- Template used: {path} or "default"
+- Steering applied: {yes/no}; {one-line summary if yes}
+```
+
+Do NOT wrap in additional prose. Do NOT invoke `gh` commands with the result. Do NOT emit a "here's your PR body" preamble.
+
+## Non-Goals
+
+- Creating the PR (`gh pr create`)
+- Editing an existing PR (`gh pr edit`)
+- Commenting on the PR
+- Pushing the branch
+- Running verification (tests, lint, build)
+- Deciding whether the PR is mergeable
+
+The caller handles all of the above.
+
+## Integration With Callers
+
+### `/pr` and `/cpm`
+
+Both commands currently write PR bodies inline. A caller that delegates to this skill should:
+
+1. Gather context the skill needs (branch, issue number, template detection) if it already did that work
+2. Pass `$ARGUMENTS` (steering text) straight through
+3. Use the returned `TITLE` and `BODY` blocks as `--title` and `--body` args to `gh pr create`
+4. Leave publishing, merging, and issue-closing to the caller's own flow
+
+This keeps the writer pure and the publisher in charge of side effects.
+
+### Headless Mode
+
+When invoked by another skill or agent (not a human), behave as if `mode:headless`:
+
+- No clarifying questions
+- No asking the user to choose between drafts
+- Return the single best draft given the inputs available
+- If a required input is missing, emit a one-line `BLOCKED` note at the top of the output and stop
+
+## Source
+
+Ported from EveryInc/compound-engineering's `skills/ce-pr-description/SKILL.md`. Adapted to CCGM voice, to match existing commands-core conventions (`{issue}: {description}` title prefix, `Closes #N` body line), and to slot into the skill-authoring rules (imperative voice, no AI attribution, value-first body, references file for the default template).

--- a/modules/commands-core/skills/pr-description/references/default-template.md
+++ b/modules/commands-core/skills/pr-description/references/default-template.md
@@ -1,0 +1,45 @@
+# Default PR Body Template (value-first, no repo template found)
+
+Use this structure when the target repo does not ship a PR template under the four paths the skill checks.
+
+```markdown
+Closes #{issue_number}
+
+{One-sentence summary of what the PR does, in user-facing terms.}
+
+## Why
+
+{Two sentences max. What problem this solves, or what capability it unlocks.
+Lead with the user outcome, not the implementation.}
+
+## What Changed
+
+- {Concrete change as a noun phrase with a verb}
+- {...}
+- {...}
+
+## Test Plan
+
+- {Named command or manual step, one line each}
+- {...}
+
+## Notes
+
+{Optional. Include only if there is real carry-over work, a follow-up issue,
+or a known limitation. Delete the section if empty.}
+```
+
+## Rules
+
+- `Closes #N` goes on the first line, alone. GitHub uses it to auto-close the issue on merge.
+- No `Co-Authored-By: Claude`, `Generated with Claude Code`, or any AI-attribution footer.
+- If a section has nothing real to say, omit it rather than padding with filler.
+- Keep bullets under ~12 words each. Long bullets are a sign the change should be split.
+
+## When to Skip the Default
+
+If any of these are true, do NOT use this template - the skill should have detected and used the repo's own template instead:
+
+- A file named `pull_request_template.md` or `PULL_REQUEST_TEMPLATE.md` exists in the repo root
+- A file exists under `.github/` with either casing
+- The org's `.github` repo ships a default template (rare; check only if repo-level search returns nothing)


### PR DESCRIPTION
Closes #288

Extracts the PR description writer into a standalone `pr-description` skill under `modules/commands-core/skills/` so `/pr`, `/cpm`, and future callers can share one value-first writing voice without each reimplementing body generation.

## Why

`/pr` and `/cpm` each write PR bodies inline, which means the voice drifts between commands and there is no way for another skill (or a future `/pr-stack` / `/pr-revise`) to produce a CCGM-voice body without reimplementing the logic. A pure writer skill separates voice from publishing plumbing.

## What Changed

- Adds `modules/commands-core/skills/pr-description/SKILL.md` - pure writer, never calls `gh pr create` or `gh pr edit`, returns structured TITLE / BODY / METADATA blocks
- Adds `modules/commands-core/skills/pr-description/references/default-template.md` - fallback body structure when no repo PR template exists
- Updates `modules/commands-core/module.json` to register the two new files as `skill` / `skill-reference` types
- Updates `modules/commands-core/README.md` with the skill in the feature list, files table, and manual-install block

## Test Plan

- `bash tests/test-modules.sh` - 939 passed, 0 failed
- Pre-existing `tests/test-no-personal-data.sh` cloud-dispatch failures are unchanged by this PR (not touched)

## Notes

- `/pr` and `/cpm` commands still write bodies inline in this PR. Converting them to delegate to the new skill is a follow-up (touches existing commands, so kept out of the extract-only scope).
- Ported from EveryInc/compound-engineering `ce-pr-description` per the copycat analysis in `plans/ccgm-copycat-analysis/compound-engineering-plugin.md` item 13.