### PR TITLE
#335: replace /startup sub-agent delegation with direct bash formatting

### DIFF
--- a/modules/session-logging/commands/startup.md
+++ b/modules/session-logging/commands/startup.md
@@ -1,108 +1,30 @@
 ---
 description: Session startup - check logs, git status, open issues, and orient
-allowed-tools: Agent
+allowed-tools: Bash
 ---
 
 # /startup - Session Startup
 
-Use the Agent tool to execute this workflow on a cheaper model:
+Run the dashboard script and display its output verbatim:
 
-- **model**: sonnet
-- **description**: session startup
+```bash
+bash ~/.claude/lib/startup-dashboard.sh
+```
 
-Pass the agent all workflow instructions below.
+The script runs the data-gather pipeline, creates today's log if missing, and emits the formatted dashboard to stdout. Display the output as-is to the user, then **stop and wait for the user's next instruction**.
 
-After the agent completes, relay its session summary dashboard to the user exactly as received. Then wait for the user's next instruction.
+Do NOT add commentary, reformat the output, or continue into other work after the dashboard appears.
 
 ---
 
-## Workflow Instructions
+## Why this is a single bash call
 
-### Step 1: Gather Data
+The formatting is deterministic (section extraction + string interpolation), so there is no benefit to running it through a model. The previous implementation delegated to a Sonnet sub-agent and routinely burned ~48k tokens per startup while sometimes failing to surface the dashboard at all. The current implementation costs ~0 model tokens for formatting and is fail-fast visible (stderr messages appear directly if anything breaks).
 
-Run the gather script. It collects all session data in parallel and outputs structured `=== SECTION ===` blocks:
+If you need to debug what the dashboard is seeing, run the gather script directly:
 
 ```bash
 bash ~/.claude/lib/startup-gather.sh
 ```
 
-**IMPORTANT**: The gather output is raw internal data. Do NOT display it to the user. Parse it silently and only output the formatted dashboard in Step 4.
-
-**Do NOT surface stale-claim warnings, "WARNING:" lines, or any cross-repo noise to the user.** If the TRACKING section reads `(coordinator workspace - tracking shown by individual clones)` or is empty/unavailable, simply omit the **Tracking** section from the dashboard. Never invent a "Warnings" section.
-
-### Step 2: Read Previous Log
-
-From the `=== LOG ===` section:
-- If `status:existing`, the `=== PREV_LOG_TAIL ===` section already has the last 20 lines of context.
-- If `status:new` and `prev:` is not "none", read that file with the Read tool for previous session context.
-
-### Step 3: Create Today's Log (if needed)
-
-Only if `status:new` in the LOG section:
-
-1. Run `mkdir -p {dir}` (from LOG section's `dir:` value). Run this as its own bash call, not grouped with other commands.
-2. Create the log file at `file:` path:
-
-```markdown
-# {agent_id} - {date} - {repo}
-
-## Session Start
-- **Time**: {time from IDENTITY section}
-- **Branch**: `{branch from GIT section}`
-- **State**: {Clean if GIT STATUS section is empty, dirty otherwise}
-```
-
-### Step 4: Present Dashboard
-
-Format the gathered data for terminal display. Use **bold** for labels and `backticks` for values. Do NOT use markdown headers (`#`, `##`, `###`) or horizontal rules (`---`). Omit sections with no content.
-
-Output this exact structure (replace placeholders, keep formatting):
-
-```
-**{agent_id}** | `{repo}` | {date}
-**Branch:** `{branch}` | **Status:** {clean/dirty} | **Sync:** {ahead_behind or "up to date"}
-**Previous** - {One-line summary from PREV_LOG_TAIL, or "No prior session found"}
-```
-
-Then add only sections that have content, each separated by a blank line with a bold label:
-
-```
-**Live Sessions**
-  {each session on its own line, indented}
-
-**Open PRs** ({count})
-  {each PR on its own line, indented}
-
-**Tracking**
-  {active claims and unclaimed issues, indented}
-
-**Cross-Agent**
-  {CROSS_AGENT content, indented}
-
-**Siblings**
-  {SIBLINGS content, indented}
-```
-
-End with the recommendation after a blank line:
-
-```
-**Next:** {recommended action per table below}
-```
-
-If RELEASE section contains `UPDATE_AVAILABLE`, add before Next:
-```
-**Update:** v{current} -> v{latest} (`npm i -g @anthropic-ai/claude-code@latest`)
-```
-
-If ORPHANS section has output, include its warning.
-
-**STOP after presenting the dashboard.** Do not continue work. Wait for user instruction.
-
-| State | Recommendation |
-|-------|---------------|
-| PR open from previous session | Report PR URL and CI status |
-| In-progress issue | Report issue and branch |
-| Uncommitted changes | Report what's uncommitted |
-| No active work | Report available issues |
-| All issues done | Ask what to work on next |
-| Update available | Suggest upgrading first |
+That produces the raw `=== SECTION ===` blocks the dashboard parses.

--- a/modules/session-logging/lib/startup-dashboard.sh
+++ b/modules/session-logging/lib/startup-dashboard.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# startup-dashboard.sh - Run gather, create log if needed, emit formatted dashboard.
+# Replaces the model-delegated formatting step of /startup (#335).
+# Called directly by /startup; no Agent tool dispatch, no model tokens for formatting.
+
+set -u
+
+GATHER_SCRIPT="${CCGM_GATHER_SCRIPT:-$HOME/.claude/lib/startup-gather.sh}"
+
+if [ ! -f "$GATHER_SCRIPT" ]; then
+  echo "startup-dashboard: gather script not found at $GATHER_SCRIPT" >&2
+  exit 1
+fi
+
+GATHER=$(bash "$GATHER_SCRIPT" 2>/dev/null)
+if [ -z "$GATHER" ]; then
+  echo "startup-dashboard: gather produced no output" >&2
+  exit 1
+fi
+
+# ---- Section extraction ----
+# Print lines between "=== NAME ===" and the next "=== ... ===" (exclusive).
+section() {
+  local name="$1"
+  printf '%s\n' "$GATHER" | awk -v marker="=== $name ===" '
+    $0 == marker { inside = 1; next }
+    /^=== / && inside { exit }
+    inside { print }
+  '
+}
+
+# Read a "key:value" from a section. Returns the value verbatim (everything after the first colon).
+kv() {
+  local name="$1" key="$2"
+  section "$name" | awk -F: -v k="$key" '$1 == k { sub(/^[^:]*:/, ""); print; exit }'
+}
+
+# Trim leading/trailing whitespace.
+trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+# Indent every non-empty line by two spaces.
+indent() {
+  awk 'NF { print "  " $0 } !NF { print }'
+}
+
+# ---- Extract fields ----
+AGENT_ID=$(kv IDENTITY agent_id)
+REPO=$(kv IDENTITY repo)
+DATE=$(kv IDENTITY date)
+TIME=$(kv IDENTITY time)
+
+LOG_STATUS=$(kv LOG status)
+LOG_FILE=$(kv LOG file)
+LOG_DIR=$(kv LOG dir)
+PREV_LOG=$(kv LOG prev)
+
+GIT_SECTION=$(section GIT)
+if printf '%s' "$GIT_SECTION" | grep -q '^NOT_A_GIT_REPO$'; then
+  BRANCH="(not a git repo)"
+  SYNC=""
+  AHEAD_BEHIND=""
+  GIT_STATUS_BODY=""
+else
+  BRANCH=$(printf '%s\n' "$GIT_SECTION" | awk -F: '$1 == "branch" { sub(/^[^:]*:/, ""); print; exit }')
+  SYNC=$(printf '%s\n' "$GIT_SECTION" | awk -F: '$1 == "sync" { sub(/^[^:]*:/, ""); print; exit }')
+  AHEAD_BEHIND=$(printf '%s\n' "$GIT_SECTION" | awk -F: '$1 == "ahead_behind" { sub(/^[^:]*:/, ""); print; exit }')
+  GIT_STATUS_BODY=$(printf '%s\n' "$GIT_SECTION" | awk '
+    /^---STATUS---$/ { inside = 1; next }
+    /^---COMMITS---$/ { inside = 0 }
+    inside { print }
+  ')
+fi
+
+PRS_BODY=$(section PRS)
+TRACKING_BODY=$(section TRACKING)
+SESSIONS_BODY=$(section SESSIONS)
+CROSS_AGENT_BODY=$(section CROSS_AGENT)
+SIBLINGS_BODY=$(section SIBLINGS)
+ORPHANS_BODY=$(section ORPHANS)
+PREV_TAIL=$(section PREV_LOG_TAIL)
+
+RELEASE_CURRENT=$(kv RELEASE current)
+RELEASE_LATEST=$(kv RELEASE latest)
+UPDATE_AVAILABLE=0
+if printf '%s\n' "$GATHER" | grep -q '^UPDATE_AVAILABLE$'; then
+  UPDATE_AVAILABLE=1
+fi
+
+# ---- Create today's log if missing ----
+if [ "$LOG_STATUS" = "new" ] && [ -n "$LOG_DIR" ] && [ -n "$LOG_FILE" ]; then
+  mkdir -p "$LOG_DIR"
+  if [ ! -f "$LOG_FILE" ]; then
+    STATE="clean"
+    if [ -n "$(trim "$GIT_STATUS_BODY")" ]; then
+      STATE="dirty"
+    fi
+    cat > "$LOG_FILE" <<LOGEOF
+# ${AGENT_ID} - ${DATE} - ${REPO}
+
+## Session Start
+- **Time**: ${TIME}
+- **Branch**: \`${BRANCH}\`
+- **State**: ${STATE}
+LOGEOF
+  fi
+fi
+
+# ---- Summaries ----
+
+# "Previous" one-liner: last meaningful "## " heading from PREV_LOG_TAIL.
+# Skip the "Session Start" stub since it has no information content.
+PREV_SUMMARY="No prior session found"
+if [ -n "$(trim "$PREV_TAIL")" ] && [ "$(trim "$PREV_TAIL")" != "none" ]; then
+  LAST_HEADING=$(printf '%s\n' "$PREV_TAIL" \
+    | grep -E '^## ' \
+    | grep -vE '^## Session Start$' \
+    | tail -1 \
+    | sed -E 's/^## //; s/[[:space:]]*#[a-z-]+$//')
+  if [ -n "$LAST_HEADING" ]; then
+    PREV_SUMMARY="$LAST_HEADING"
+  elif printf '%s\n' "$PREV_TAIL" | grep -qE '^## Session Start$'; then
+    PREV_SUMMARY="Session started, no updates logged yet"
+  fi
+fi
+
+# Status label: clean/dirty/n-a
+if [ "$BRANCH" = "(not a git repo)" ]; then
+  STATUS_LABEL="n/a"
+  SYNC_LABEL="n/a"
+elif [ -n "$(trim "$GIT_STATUS_BODY")" ]; then
+  STATUS_LABEL="dirty"
+else
+  STATUS_LABEL="clean"
+fi
+
+if [ "$BRANCH" != "(not a git repo)" ]; then
+  AB_TRIMMED=$(trim "$AHEAD_BEHIND")
+  case "$AB_TRIMMED" in
+    "0	0"|"0 0"|"")
+      SYNC_LABEL="up to date"
+      ;;
+    *)
+      BEHIND=$(printf '%s' "$AB_TRIMMED" | awk '{print $1}')
+      AHEAD=$(printf '%s' "$AB_TRIMMED" | awk '{print $2}')
+      SYNC_LABEL="ahead ${AHEAD:-0}, behind ${BEHIND:-0}"
+      ;;
+  esac
+fi
+
+# PR count for header
+PR_COUNT=0
+if [ -n "$(trim "$PRS_BODY")" ] && [ "$(trim "$PRS_BODY")" != "none" ]; then
+  PR_COUNT=$(printf '%s\n' "$PRS_BODY" | grep -cE '^[0-9]+' || true)
+  [ -z "$PR_COUNT" ] && PR_COUNT=0
+fi
+
+# Recommendation
+NEXT="What would you like to work on?"
+if [ "$PR_COUNT" -gt 0 ] 2>/dev/null; then
+  NEXT="Review ${PR_COUNT} open PR(s)"
+elif [ "$STATUS_LABEL" = "dirty" ]; then
+  NEXT="Review uncommitted changes or continue previous work"
+elif printf '%s\n' "$PREV_TAIL" | grep -qE '#in-progress'; then
+  NEXT="Continue in-progress work from previous session"
+fi
+
+# ---- Emit dashboard ----
+
+REPO_DISPLAY="$REPO"
+[ -z "$REPO_DISPLAY" ] && REPO_DISPLAY="(no repo)"
+
+printf '**%s** | `%s` | %s\n' "$AGENT_ID" "$REPO_DISPLAY" "$DATE"
+printf '**Branch:** `%s` | **Status:** %s | **Sync:** %s\n' "$BRANCH" "$STATUS_LABEL" "$SYNC_LABEL"
+printf '**Previous** - %s\n' "$PREV_SUMMARY"
+
+emit_section() {
+  local label="$1" body="$2"
+  local trimmed
+  trimmed=$(trim "$body")
+  [ -z "$trimmed" ] && return 0
+  [ "$trimmed" = "none" ] && return 0
+  [ "$trimmed" = "(coordinator workspace - tracking shown by individual clones)" ] && return 0
+  printf '\n**%s**\n' "$label"
+  printf '%s\n' "$body" | indent
+}
+
+emit_section "Live Sessions" "$SESSIONS_BODY"
+
+if [ "$PR_COUNT" -gt 0 ] 2>/dev/null; then
+  printf '\n**Open PRs** (%s)\n' "$PR_COUNT"
+  printf '%s\n' "$PRS_BODY" | indent
+fi
+
+emit_section "Tracking" "$TRACKING_BODY"
+emit_section "Cross-Agent" "$CROSS_AGENT_BODY"
+emit_section "Siblings" "$SIBLINGS_BODY"
+
+ORPHANS_TRIMMED=$(trim "$ORPHANS_BODY")
+if [ -n "$ORPHANS_TRIMMED" ]; then
+  printf '\n**Orphans**\n'
+  printf '%s\n' "$ORPHANS_BODY" | indent
+fi
+
+if [ "$UPDATE_AVAILABLE" = "1" ]; then
+  printf '\n**Update:** v%s -> v%s (`npm i -g @anthropic-ai/claude-code@latest`)\n' \
+    "$(trim "$RELEASE_CURRENT")" "$(trim "$RELEASE_LATEST")"
+fi
+
+printf '\n**Next:** %s\n' "$NEXT"

--- a/modules/session-logging/module.json
+++ b/modules/session-logging/module.json
@@ -11,6 +11,7 @@
     "commands/startup.md": { "target": "commands/startup.md", "type": "command", "template": false },
     "commands/log-init.md": { "target": "commands/log-init.md", "type": "command", "template": false },
     "lib/startup-gather.sh": { "target": "lib/startup-gather.sh", "type": "lib", "template": true },
+    "lib/startup-dashboard.sh": { "target": "lib/startup-dashboard.sh", "type": "lib", "template": false },
     "hooks/auto-startup.py": { "target": "hooks/auto-startup.py", "type": "hook", "template": false },
     "settings.partial.json": { "target": "settings.json", "type": "config", "merge": true, "template": false }
   },


### PR DESCRIPTION
Closes #335

## Summary

`/startup` delegated its dashboard formatting to a Sonnet sub-agent via the Agent tool. This burned ~48k tokens per invocation (full sub-agent context load) and routinely failed to surface the formatted dashboard at all — observed pattern: `Done (1 tool use · 48k tokens)` with no visible output, forcing a fallback to running `startup-gather.sh` manually.

Formatting is pure section extraction + string interpolation, so it belongs in bash, not a model.

## Changes

- **New** `modules/session-logging/lib/startup-dashboard.sh`: runs `startup-gather.sh`, creates today's log if missing (status:new), formats the dashboard, emits to stdout. Zero model tokens.
- **Rewrote** `modules/session-logging/commands/startup.md`: one Bash invocation, display output verbatim, stop. 30 lines down from 109.
- Registered new script in `module.json`.

## Verification

- `bash tests/test-modules.sh` — **971 passed, 0 failed**
- `bash modules/session-logging/lib/startup-dashboard.sh` — produces expected dashboard in this workspace (dirty branch, live sessions, tracking, siblings, correct "Next" recommendation based on uncommitted state)
- Existing `startup-gather.sh` unchanged — the dashboard script is a pure consumer of its output
- `hooks/auto-startup.py` (which auto-runs `/startup` on new sessions) is untouched

## Token savings

Per startup invocation: ~48k → ~2k (just the dashboard text shown to the user). Every new session and every manual `/startup`.

## Compatibility

No breaking changes to the gather script's output format, so any other tooling consuming `=== SECTION ===` blocks keeps working.