### PR TITLE
#337: plain-text dashboard formatting

### DIFF
--- a/modules/session-logging/lib/startup-dashboard.sh
+++ b/modules/session-logging/lib/startup-dashboard.sh
@@ -170,13 +170,22 @@ elif printf '%s\n' "$PREV_TAIL" | grep -qE '#in-progress'; then
 fi
 
 # ---- Emit dashboard ----
+# Output is pure plain text — no markdown, no ANSI. Claude Code renders
+# Bash tool output literally, so formatting relies on spacing and Unicode.
 
 REPO_DISPLAY="$REPO"
 [ -z "$REPO_DISPLAY" ] && REPO_DISPLAY="(no repo)"
 
-printf '**%s** | `%s` | %s\n' "$AGENT_ID" "$REPO_DISPLAY" "$DATE"
-printf '**Branch:** `%s` | **Status:** %s | **Sync:** %s\n' "$BRANCH" "$STATUS_LABEL" "$SYNC_LABEL"
-printf '**Previous** - %s\n' "$PREV_SUMMARY"
+# Pretty date: YYYYMMDD -> YYYY-MM-DD
+if [ ${#DATE} -eq 8 ]; then
+  DATE_PRETTY="${DATE:0:4}-${DATE:4:2}-${DATE:6:2}"
+else
+  DATE_PRETTY="$DATE"
+fi
+
+printf '%s  ·  %s  ·  %s\n' "$AGENT_ID" "$REPO_DISPLAY" "$DATE_PRETTY"
+printf 'Branch    %-30s  Status  %-8s  Sync  %s\n' "$BRANCH" "$STATUS_LABEL" "$SYNC_LABEL"
+printf 'Previous  %s\n' "$PREV_SUMMARY"
 
 emit_section() {
   local label="$1" body="$2"
@@ -185,14 +194,14 @@ emit_section() {
   [ -z "$trimmed" ] && return 0
   [ "$trimmed" = "none" ] && return 0
   [ "$trimmed" = "(coordinator workspace - tracking shown by individual clones)" ] && return 0
-  printf '\n**%s**\n' "$label"
+  printf '\n%s\n' "$label"
   printf '%s\n' "$body" | indent
 }
 
 emit_section "Live Sessions" "$SESSIONS_BODY"
 
 if [ "$PR_COUNT" -gt 0 ] 2>/dev/null; then
-  printf '\n**Open PRs** (%s)\n' "$PR_COUNT"
+  printf '\nOpen PRs (%s)\n' "$PR_COUNT"
   printf '%s\n' "$PRS_BODY" | indent
 fi
 
@@ -202,13 +211,13 @@ emit_section "Siblings" "$SIBLINGS_BODY"
 
 ORPHANS_TRIMMED=$(trim "$ORPHANS_BODY")
 if [ -n "$ORPHANS_TRIMMED" ]; then
-  printf '\n**Orphans**\n'
+  printf '\nOrphans\n'
   printf '%s\n' "$ORPHANS_BODY" | indent
 fi
 
 if [ "$UPDATE_AVAILABLE" = "1" ]; then
-  printf '\n**Update:** v%s -> v%s (`npm i -g @anthropic-ai/claude-code@latest`)\n' \
+  printf '\nUpdate    v%s -> v%s   (npm i -g @anthropic-ai/claude-code@latest)\n' \
     "$(trim "$RELEASE_CURRENT")" "$(trim "$RELEASE_LATEST")"
 fi
 
-printf '\n**Next:** %s\n' "$NEXT"
+printf '\nNext  %s\n' "$NEXT"


### PR DESCRIPTION
Closes #337

## Before

`**agent-0**`, `**Branch:**` etc. showed as literal asterisks in Claude Code because Bash tool output is rendered as plain text (not markdown). Verified ANSI escape codes also don't render.

## After

```
agent-w0-c0  ·  ccgm  ·  2026-04-18
Branch    337-dashboard-plain-text        Status  dirty     Sync  up to date
Previous  Session started, no updates logged yet

Live Sessions
  PID 11769  | (no repo) ...

Tracking
  ...

Next  Review uncommitted changes or continue previous work
```

## Changes

- Header line: `agent-id  ·  repo  ·  YYYY-MM-DD` (pretty-formatted date, Unicode middle-dot separator)
- Branch/Status/Sync line: column-aligned with `printf %-Ns`
- Section labels: plain `Live Sessions` instead of `**Live Sessions**`
- Next line: `Next  text` instead of `**Next:** text`
- Update notice: `Update    v1 -> v2   (npm ...)` instead of `**Update:** v1 -> v2 (\`npm ...\`)`

No logic changes — only the emit section was rewritten.

## Verification

- `bash tests/test-modules.sh` — 971 passed, 0 failed
- `bash modules/session-logging/lib/startup-dashboard.sh` renders correctly in this workspace