### PR TITLE
#339: startup log-session confirmation + previous-session summary

### DIFF
--- a/modules/session-logging/lib/startup-dashboard.sh
+++ b/modules/session-logging/lib/startup-dashboard.sh
@@ -185,7 +185,31 @@ fi
 
 printf '%s  ·  %s  ·  %s\n' "$AGENT_ID" "$REPO_DISPLAY" "$DATE_PRETTY"
 printf 'Branch    %-30s  Status  %-8s  Sync  %s\n' "$BRANCH" "$STATUS_LABEL" "$SYNC_LABEL"
+
+# Confirm logging status so the user knows a session log is active.
+if [ -n "$LOG_FILE" ]; then
+  case "$LOG_STATUS" in
+    new)      printf 'Log       Started new session log at %s\n' "$LOG_FILE" ;;
+    existing) printf 'Log       Continuing session log at %s\n' "$LOG_FILE" ;;
+  esac
+fi
+
 printf 'Previous  %s\n' "$PREV_SUMMARY"
+
+# Previous-session summary: last few ## headings from the prior log's tail.
+# Adds context beyond the single-line Previous field when the prior session
+# hit multiple milestones (commit, PR, merge, etc.).
+if [ -n "$(trim "$PREV_TAIL")" ] && [ "$(trim "$PREV_TAIL")" != "none" ]; then
+  PREV_HEADINGS=$(printf '%s\n' "$PREV_TAIL" \
+    | grep -E '^## ' \
+    | tail -5 \
+    | sed -E 's/^## //; s/[[:space:]]*#[a-z-]+$//')
+  HEADING_COUNT=$(printf '%s\n' "$PREV_HEADINGS" | grep -c . || true)
+  if [ "${HEADING_COUNT:-0}" -gt 1 ]; then
+    printf '\nPrevious Session\n'
+    printf '%s\n' "$PREV_HEADINGS" | indent
+  fi
+fi
 
 emit_section() {
   local label="$1" body="$2"


### PR DESCRIPTION
Closes #339

## Summary

- Adds explicit `Log  Started new session log at <path>` / `Continuing session log at <path>` line to the /startup dashboard so it's unambiguous that a logging session is active.
- Adds a `Previous Session` block listing the last few `## ` headings from the prior log's tail, giving richer context than the single-line `Previous` field.
- Still pure bash, no model tokens added.

## Before

```
agent-1  ·  ccgm  ·  2026-04-18
Branch    339-startup-log-confirmation    Status  dirty     Sync  up to date
Previous  Session started, no updates logged yet
```

## After

```
agent-1  ·  ccgm  ·  2026-04-18
Branch    339-startup-log-confirmation    Status  dirty     Sync  up to date
Log       Started new session log at /Users/lem/code/lem-agent-logs/ccgm/20260418/agent-1.md
Previous  Session started, no updates logged yet

Previous Session
  Session Start
  #62: Closed - /cgr command not feasible
  #72: Comprehensive documentation
```

## Test plan

- [x] Run `bash ~/.claude/lib/startup-dashboard.sh` in a non-repo dir - shows `Continuing session log at ...`
- [x] Run from a live clone - shows `Started new session log at ...` and Previous Session block (when prior log has >1 heading)
- [x] Verified block is suppressed when prior log has 0-1 headings to avoid visual noise