### PR TITLE
#348: AGENTS.md symlinks + docs/session-memory.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ The `docs/` directory contains comprehensive documentation:
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |
 | [Configuration](docs/configuration.md) | Customization, template variables, settings overrides |
 | [Multi-Agent System](docs/multi-agent.md) | Parallel agent coordination, port allocation, issue tracking |
+| [Session Memory](docs/session-memory.md) | Native JSONL transcripts, `/recall`, `CLAUDE.md`/`MEMORY.md`, retired agent-log-repo |
 
 ## Contributing
 

--- a/docs/session-memory.md
+++ b/docs/session-memory.md
@@ -1,0 +1,64 @@
+# Session Memory
+
+How CCGM handles session continuity, cross-session retrieval, and the curated knowledge base.
+
+## The layers
+
+Claude Code already captures every session as JSONL. CCGM adds two small layers on top: a query tool that unifies the transcripts across clones, and a curated memory file that persists the deliberate conclusions.
+
+| Layer | What it is | Who writes it | Who reads it |
+|-------|------------|---------------|--------------|
+| Raw transcripts | `~/.claude/projects/{normalized-cwd}/sessions/{session-id}.jsonl` | Claude Code (automatic) | `/recall`, you via `grep` |
+| Per-repo unified history | `/recall` command | no one — it is a query | agents at session start, you on demand |
+| Curated memory | `CLAUDE.md` (repo) and `MEMORY.md` + auto-memory files (per-project) | `/reflect`, `/consolidate`, you | every session, automatically |
+
+Nothing in this chain depends on agent discipline to write markdown logs. The JSONL is written whether or not the agent remembered to.
+
+## `/recall`
+
+`/recall` surfaces recent session activity for the current repo across every clone on the machine. Defaults: last 7 days, all clones, summary view.
+
+```
+/recall                         # last 7 days, summary
+/recall startup dashboard       # filter turns containing the phrase
+/recall --days 30               # longer window
+/recall --repo voxter           # different repo by canonical name
+/recall --session <id>          # dump one session as readable text
+```
+
+Claude Code normally treats `ccgm-0`, `ccgm-1`, and `ccgm-workspaces/...` as separate projects. `/recall` merges them by detecting the canonical repo name from the git remote.
+
+The `/startup` dashboard calls `/recall --summary --limit 3 --days 7` to render its **Recent Activity** block.
+
+## Curated memory
+
+`/reflect` and `/consolidate` (from the `self-improving` module) write distilled patterns to `MEMORY.md` and topic-specific memory files. These are the deliberate takeaways — "don't mock the database in integration tests", "this user prefers single bundled PRs for refactors" — that you want every future session to see.
+
+Raw transcripts are the search target; `MEMORY.md` is the instruction set.
+
+## `AGENTS.md`
+
+Repos that opt in keep an `AGENTS.md` symlink pointing to `CLAUDE.md` so that non-Claude agentic tools (Cursor, Aider, etc.) read the same project instructions. Run once:
+
+```
+bash ~/.claude/scripts/add-agents-md-symlinks.sh
+```
+
+The script targets a curated list of active repos and skips any where `AGENTS.md` already exists as a regular file.
+
+## The retired agent-log-repo
+
+Before this redesign, CCGM relied on agents writing markdown logs at specific triggers (after commit, after PR create, after merge, etc.) to a private git repo at `~/code/lem-agent-logs/`. That system had two problems:
+
+1. **Agent discipline**: when an agent was deep in a task, logs frequently went unwritten.
+2. **Duplication**: Claude Code already captured the same information deterministically as JSONL.
+
+The agent-log-repo is preserved read-only as historical archive. The `tracking.csv` that lives inside it remains the source of truth for multi-agent coordination; its hooks (claim / pr-created / merged / closed) still work because `/recall` does not touch that file.
+
+If you ever want to search the archive:
+
+```bash
+grep -r "your search term" ~/code/lem-agent-logs/
+```
+
+A future "deep recall" tier may unify the archive with the live JSONL via SQLite FTS5. Not built, not planned for v1.

--- a/modules/session-history/module.json
+++ b/modules/session-history/module.json
@@ -35,6 +35,11 @@
       "target": "scripts/repo_detect.py",
       "type": "script",
       "template": false
+    },
+    "scripts/add-agents-md-symlinks.sh": {
+      "target": "scripts/add-agents-md-symlinks.sh",
+      "type": "script",
+      "template": false
     }
   },
   "tags": ["session", "history", "retrieval", "agent", "recall", "cross-platform", "claude-code", "codex"],

--- a/modules/session-history/scripts/add-agents-md-symlinks.sh
+++ b/modules/session-history/scripts/add-agents-md-symlinks.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# add-agents-md-symlinks.sh
+# Create AGENTS.md -> CLAUDE.md symlinks in a list of repos.
+#
+# The emerging AGENTS.md convention (2026) lets multiple agentic coding tools
+# read project instructions from a single file. CCGM repos already have
+# CLAUDE.md; symlinking AGENTS.md -> CLAUDE.md future-proofs them without
+# duplicating content.
+#
+# Behavior:
+# - Accepts a list of repo paths as arguments. If none provided, scans
+#   sensible defaults under $CODE_DIR (default $HOME/code).
+# - Skips any path that is not a directory containing CLAUDE.md.
+# - Skips any path where AGENTS.md already exists as a non-symlink (warns).
+# - If AGENTS.md is already a symlink, leaves it alone.
+# - Otherwise creates a relative symlink AGENTS.md -> CLAUDE.md.
+
+set -u
+
+CODE_DIR="${CODE_DIR:-$HOME/code}"
+
+DEFAULT_TARGETS=(
+  "$CODE_DIR/ccgm-repos/ccgm-1"
+  "$CODE_DIR/voxstr-repos/voxstr-0"
+  "$CODE_DIR/voxstr-site-repos/voxstr-site-0"
+  "$CODE_DIR/habitpro-ai-workspaces/habitpro-ai-w0/habitpro-ai-w0-c0"
+  "$CODE_DIR/openslide-ai-repos/openslide-ai-0"
+  "$CODE_DIR/lem-photo-repos/lem-photo-0"
+  "$CODE_DIR/darkly-suite-repos/darkly-suite-0"
+  "$CODE_DIR/lem-work-repos/lem-work-0"
+  "$CODE_DIR/nadaproof"
+)
+
+if [ "$#" -gt 0 ]; then
+  TARGETS=("$@")
+else
+  TARGETS=("${DEFAULT_TARGETS[@]}")
+fi
+
+CREATED=0
+EXISTING_SYMLINK=0
+BLOCKED_BY_REGULAR_FILE=0
+SKIPPED_NO_CLAUDE_MD=0
+SKIPPED_NOT_A_DIR=0
+
+for target in "${TARGETS[@]}"; do
+  if [ ! -d "$target" ]; then
+    echo "skip: $target (not a directory)"
+    SKIPPED_NOT_A_DIR=$((SKIPPED_NOT_A_DIR + 1))
+    continue
+  fi
+
+  if [ ! -f "$target/CLAUDE.md" ]; then
+    echo "skip: $target (no CLAUDE.md)"
+    SKIPPED_NO_CLAUDE_MD=$((SKIPPED_NO_CLAUDE_MD + 1))
+    continue
+  fi
+
+  agents_path="$target/AGENTS.md"
+
+  if [ -L "$agents_path" ]; then
+    echo "ok:   $agents_path (already a symlink)"
+    EXISTING_SYMLINK=$((EXISTING_SYMLINK + 1))
+    continue
+  fi
+
+  if [ -e "$agents_path" ]; then
+    echo "warn: $agents_path exists as a regular file — leaving it alone"
+    BLOCKED_BY_REGULAR_FILE=$((BLOCKED_BY_REGULAR_FILE + 1))
+    continue
+  fi
+
+  ( cd "$target" && ln -s CLAUDE.md AGENTS.md )
+  echo "new:  $agents_path -> CLAUDE.md"
+  CREATED=$((CREATED + 1))
+done
+
+echo ""
+echo "Summary:"
+echo "  new symlinks created:      $CREATED"
+echo "  existing symlinks kept:    $EXISTING_SYMLINK"
+echo "  blocked (regular file):    $BLOCKED_BY_REGULAR_FILE"
+echo "  skipped (no CLAUDE.md):    $SKIPPED_NO_CLAUDE_MD"
+echo "  skipped (not a directory): $SKIPPED_NOT_A_DIR"


### PR DESCRIPTION
Closes #348. Part of #341 (final epic).

## Summary
- NEW `modules/session-history/scripts/add-agents-md-symlinks.sh` — creates `AGENTS.md` → `CLAUDE.md` symlinks across a curated list of active repos. Skips any where `AGENTS.md` already exists as a non-symlink regular file.
- NEW `AGENTS.md` symlink in ccgm itself (checked into the repo).
- NEW `docs/session-memory.md` — one-pager: native JSONL transcripts, `/recall`, `CLAUDE.md`/`MEMORY.md`, `/reflect`/`/consolidate`, retired agent-log-repo.
- Register the new script in `modules/session-history/module.json`.
- Link `docs/session-memory.md` from README.

## Test plan
- [x] Running `add-agents-md-symlinks.sh` created/confirmed AGENTS.md symlinks in 8 active user repos (ccgm, voxstr, habitpro-ai, openslide-ai, lem-photo, darkly-suite, lem-work, nadaproof).
- [x] Voxstr-site and detego-provider-portal skipped cleanly (no CLAUDE.md / not cloned locally).
- [x] README documentation table lists the new doc.