### PR TITLE
#350: scrub personal data from cloud-dispatch and repo_detect

### DIFF
--- a/modules/cloud-dispatch/packer/agent-image.pkr.hcl
+++ b/modules/cloud-dispatch/packer/agent-image.pkr.hcl
@@ -34,6 +34,12 @@ variable "claude_code_version" {
   default     = "1.2.3"
 }
 
+variable "ccgm_repo_url" {
+  type        = string
+  description = "Git URL of the CCGM repo to clone into the image (read from CCGM_REPO_URL env var)"
+  default     = env("CCGM_REPO_URL")
+}
+
 source "hcloud" "agent" {
   token       = var.hcloud_token
   image       = "ubuntu-22.04"
@@ -75,8 +81,11 @@ build {
 
   # 2. Create agent users and shared directories
   provisioner "shell" {
-    script          = "scripts/setup.sh"
-    execute_command = "chmod +x '{{ .Path }}' && bash -eu '{{ .Path }}'"
+    script = "scripts/setup.sh"
+    environment_vars = [
+      "CCGM_REPO_URL=${var.ccgm_repo_url}"
+    ]
+    execute_command = "chmod +x '{{ .Path }}' && env {{ .Vars }} bash -eu '{{ .Path }}'"
   }
 
   # 3. Apply security hardening (iptables, sshd config, unattended-upgrades)

--- a/modules/cloud-dispatch/packer/scripts/setup.sh
+++ b/modules/cloud-dispatch/packer/scripts/setup.sh
@@ -9,7 +9,11 @@ SECRETS_BASE="/run/secrets"
 echo "==> Cloning CCGM repo to /opt/ccgm/repo"
 mkdir -p "${CCGM_DIR}"
 chmod 755 "${CCGM_DIR}"
-git clone https://github.com/lucasmccomb/ccgm.git "${CCGM_DIR}/repo"
+if [ -z "${CCGM_REPO_URL:-}" ]; then
+  echo "ERROR: CCGM_REPO_URL env var is required" >&2
+  exit 1
+fi
+git clone "${CCGM_REPO_URL}" "${CCGM_DIR}/repo"
 
 echo "==> Pre-installing CCGM cloud-agent preset for each agent user"
 # The headless installer copies rules and commands from the CCGM repo

--- a/modules/cloud-dispatch/tests/e2e-dispatch.sh
+++ b/modules/cloud-dispatch/tests/e2e-dispatch.sh
@@ -21,7 +21,7 @@
 #   bash tests/e2e-dispatch.sh --skip-cleanup  # Leave VMs running after test
 #
 # Environment variables:
-#   E2E_TEST_REPO   GitHub repo to use (default: lucasmccomb/ccgm)
+#   E2E_TEST_REPO   GitHub repo to use (REQUIRED, e.g. myorg/myrepo)
 #   E2E_VM_COUNT    Number of VMs to create (default: 1)
 #   E2E_MAX_TURNS   Max agent turns before stopping (default: 10)
 
@@ -35,7 +35,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/lib/common.sh"
 
-TEST_REPO="${E2E_TEST_REPO:-lucasmccomb/ccgm}"
+if [ -z "${E2E_TEST_REPO:-}" ]; then
+  echo "ERROR: E2E_TEST_REPO must be set to a GitHub repo slug like myorg/myrepo" >&2
+  exit 1
+fi
+TEST_REPO="$E2E_TEST_REPO"
 VM_COUNT="${E2E_VM_COUNT:-1}"
 MAX_TURNS="${E2E_MAX_TURNS:-10}"
 

--- a/modules/session-history/scripts/repo_detect.py
+++ b/modules/session-history/scripts/repo_detect.py
@@ -62,16 +62,16 @@ def list_project_dirs(repo: str) -> list[Path]:
     the named repo.
 
     Claude Code encodes cwd paths by replacing '/' with '-' in the project-dir
-    name. Example: /Users/lem/code/ccgm-repos/ccgm-1 becomes
-    -Users-lem-code-ccgm-repos-ccgm-1. Decoding is ambiguous because literal
+    name. Example: /home/alice/code/myrepo/myrepo-1 becomes
+    -home-alice-code-myrepo-myrepo-1. Decoding is ambiguous because literal
     '-' chars collide with path-separator encoding, so we match on the TAIL of
     the encoded name with a strict regex instead of decoding.
 
     A project dir matches if its encoded name ends with one of:
-      -{repo}                    (non-multi-clone, e.g. -Users-lem-code-ccgm)
-      -{repo}-\\d+                (flat clone: ccgm-0, ccgm-1, ...)
-      -{repo}-w\\d+               (workspace root: ccgm-w0)
-      -{repo}-w\\d+-c\\d+          (workspace clone: ccgm-w0-c2)
+      -{repo}                    (non-multi-clone, e.g. -home-alice-code-myrepo)
+      -{repo}-\\d+                (flat clone: myrepo-0, myrepo-1, ...)
+      -{repo}-w\\d+               (workspace root: myrepo-w0)
+      -{repo}-w\\d+-c\\d+          (workspace clone: myrepo-w0-c2)
     """
     if not CLAUDE_PROJECTS.exists():
         return []


### PR DESCRIPTION
Closes #350

## Summary

`tests/test-no-personal-data.sh` has been failing on main since PR #343 because three files contained hardcoded personal identifiers. This PR scrubs the literals rather than allowlisting the files, so the check keeps working.

## Changes

- `modules/session-history/scripts/repo_detect.py` — replaced the `/Users/lem/code/ccgm-repos/ccgm-1` docstring example with a generic `/home/alice/code/myrepo/myrepo-1`; updated the rest of the docstring block to stay internally consistent.
- `modules/cloud-dispatch/tests/e2e-dispatch.sh` — dropped the `lucasmccomb/ccgm` default for `E2E_TEST_REPO`. The env var is now required; unset/empty now prints a clear error and exits 1.
- `modules/cloud-dispatch/packer/scripts/setup.sh` — replaced the hardcoded `git clone https://github.com/lucasmccomb/ccgm.git` with a read from `CCGM_REPO_URL` (no default, fails fast if unset).
- `modules/cloud-dispatch/packer/agent-image.pkr.hcl` — wired `CCGM_REPO_URL` through: added a `ccgm_repo_url` Packer variable sourced from the env var, and pass it into the `setup.sh` provisioner's `environment_vars`.

## Test plan

- [x] `bash tests/test-no-personal-data.sh` exits 0
- [x] `bash -n modules/cloud-dispatch/tests/e2e-dispatch.sh` passes
- [x] `bash -n modules/cloud-dispatch/packer/scripts/setup.sh` passes
- [x] `grep -n 'lucasmccomb\|/Users/lem'` across the three scrubbed files returns nothing