### PR TITLE
#351: repair stale symlinks on installer run

### DIFF
--- a/lib/repair.sh
+++ b/lib/repair.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# CCGM - Repair stale symlinks left behind by module renames/removals.
+#
+# When modules are renamed (e.g. session-logging -> startup-dashboard) or files
+# are moved within a module, any existing symlinks under ~/.claude/ that point
+# at the old source path become dangling. The installer would normally recreate
+# the new link at a new target, but the stale link at the old target remains
+# and breaks commands like /startup ("Unknown command").
+#
+# Strategy: dangling symlink pruning.
+#   - Walk a fixed set of CCGM-managed subdirectories under the target dir.
+#   - For every symlink whose target does not exist (`! -e`), remove it.
+#   - Never remove regular files or directories.
+#
+# Rationale: this is independent of manifest format, strictly idempotent, and
+# only touches links the installer itself created (the scanned subdirectories
+# are CCGM-owned).
+
+# Requires: lib/ui.sh sourced (ui_info, ui_success)
+
+# --- Directories CCGM installs symlinks into ---
+# Keep this list in sync with module.json `target` prefixes.
+_CCGM_LINK_DIRS=(
+  "commands"
+  "rules"
+  "hooks"
+  "lib"
+  "scripts"
+  "agents"
+  "skills"
+)
+
+# --- Remove dangling symlinks under a target directory ---
+# Usage: repair_dangling_symlinks "/Users/foo/.claude"
+# Prints removed links via ui_info; prints a summary via ui_success.
+# Returns 0 always (no dangling links is a success, not a failure).
+repair_dangling_symlinks() {
+  local target_dir="$1"
+  local removed_count=0
+
+  if [ -z "$target_dir" ] || [ ! -d "$target_dir" ]; then
+    return 0
+  fi
+
+  local subdir full_subdir link
+  for subdir in "${_CCGM_LINK_DIRS[@]}"; do
+    full_subdir="${target_dir}/${subdir}"
+    [ -d "$full_subdir" ] || continue
+
+    # `find -type l` matches symlinks regardless of target state.
+    # We filter to ones whose target does not exist (-e follows the link).
+    while IFS= read -r link; do
+      [ -z "$link" ] && continue
+      # Symlink exists (-L) but its target doesn't (! -e) -> dangling.
+      if [ -L "$link" ] && [ ! -e "$link" ]; then
+        if rm -f "$link"; then
+          ui_info "  Removed stale symlink: ${link#$HOME/}"
+          removed_count=$((removed_count + 1))
+        fi
+      fi
+    done < <(find "$full_subdir" -type l 2>/dev/null)
+  done
+
+  if [ $removed_count -gt 0 ]; then
+    ui_success "Repaired $removed_count stale symlink(s) in ${target_dir#$HOME/}"
+  fi
+
+  return 0
+}

--- a/start.sh
+++ b/start.sh
@@ -18,6 +18,8 @@ source "${CCGM_ROOT}/lib/template.sh"
 source "${CCGM_ROOT}/lib/merge.sh"
 # shellcheck source=lib/backup.sh
 source "${CCGM_ROOT}/lib/backup.sh"
+# shellcheck source=lib/repair.sh
+source "${CCGM_ROOT}/lib/repair.sh"
 
 # --- Write manifest helper ---
 write_manifest() {
@@ -791,6 +793,12 @@ main() {
   # Create target directories
   [ "$install_global" = true ] && mkdir -p "$global_dir"
   [ "$install_project" = true ] && mkdir -p "$project_dir"
+
+  # Remove stale symlinks from prior installs (e.g. modules renamed upstream).
+  # Must run before `ln -s` below, because `ln -s` fails if a dangling symlink
+  # already occupies the target path (`[ -e ... ]` doesn't detect it).
+  [ "$install_global" = true ] && repair_dangling_symlinks "$global_dir"
+  [ "$install_project" = true ] && repair_dangling_symlinks "$project_dir"
 
   # Write .ccgm.env
   local env_file="${global_dir}/.ccgm.env"

--- a/update.sh
+++ b/update.sh
@@ -10,6 +10,7 @@ CCGM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # --- Source libraries ---
 source "${CCGM_ROOT}/lib/ui.sh"
 source "${CCGM_ROOT}/lib/modules.sh"
+source "${CCGM_ROOT}/lib/repair.sh"
 
 # ============================================================
 # Helper: Check installed file drift
@@ -21,6 +22,11 @@ _check_installed_drift() {
   fi
 
   ui_header "Drift Check"
+
+  # Prune symlinks whose source file no longer exists in the CCGM repo
+  # (e.g. after a module rename). Missing files surface as drift below
+  # and can be reinstalled via the existing "Install missing?" prompt.
+  repair_dangling_symlinks "${HOME}/.claude"
 
   local link_mode
   link_mode=$(jq -r '.linkMode // false' "$manifest" 2>/dev/null)


### PR DESCRIPTION
Closes #351

## Summary

PR #347 renamed `modules/session-logging/` → `modules/startup-dashboard/`. On existing CCGM installs, the symlinks in `~/.claude/` (e.g. `commands/startup.md`, `lib/startup-dashboard.sh`) still pointed at the deleted `session-logging/` path, so `/startup` failed with "Unknown command" until users manually re-ran `start.sh`. This will recur on every future module rename.

## Approach: dangling symlink pruning

Added `lib/repair.sh` with `repair_dangling_symlinks()` — walks a fixed allowlist of CCGM-managed subdirectories (`commands`, `rules`, `hooks`, `lib`, `scripts`, `agents`, `skills`) and removes any symlink whose target does not exist (`! -e`). Regular files and symlinks outside the allowlist are never touched.

Called from two places:
- **`update.sh`** — inside `_check_installed_drift`, before drift detection. Missing links re-surface as drift that the existing "Install missing?" prompt fixes.
- **`start.sh`** — before the install loop. Required because `ln -s` fails if a dangling symlink already occupies the target path (`[ -e ... ]` follows the link and doesn't detect a dangling one — verified empirically).

Chose this over manifest-aware cleanup because it's strictly idempotent, independent of manifest schema, and surgical. No schema changes, no restructuring.

## Test plan

- [x] Unit-level: created dangling symlinks in `commands/` and `lib/`, a live symlink, a regular file, and a dangling symlink outside the allowlist. After `repair_dangling_symlinks`: only the allowlisted dangling links were removed; everything else was untouched.
- [x] `bash tests/test-modules.sh` → 972 passed, 0 failed
- [x] `bash -n start.sh update.sh lib/repair.sh` → all syntactically valid
- [ ] Fresh-install smoke test (no stale state): `start.sh` should behave identically to before — `repair_dangling_symlinks` is a no-op when nothing is dangling.
- [ ] Existing-install smoke test: on a user with stale `session-logging` symlinks, `update.sh` should remove them and re-surface the relevant files as drift.