### PR TITLE
#354: fix E3 regressions blocking CI (alias_ccgms + log-system.md)

### DIFF
--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -25,7 +25,6 @@ create_backup() {
     "rules"
     "commands"
     "hooks"
-    "log-system.md"
     "multi-agent-system.md"
     "github-repo-protocols.md"
   )

--- a/modules/multi-agent/multi-agent-system.md
+++ b/modules/multi-agent/multi-agent-system.md
@@ -441,7 +441,7 @@ All agents write to the agent log repo at `{log-repo-name}/{repo-name}/YYYYMMDD/
 - Workspace model: `agent-w1-c2.md`
 - Flat clone model: `agent-0.md`
 
-Per-agent files = no merge conflicts. See `~/.claude/log-system.md` for full protocol.
+Per-agent files = no merge conflicts. See `docs/session-memory.md` for how session memory and `/recall` work.
 
 At session start, read other agents' logs in the same date subdirectory for cross-agent awareness.
 

--- a/start.sh
+++ b/start.sh
@@ -1207,8 +1207,8 @@ TMPL
 
   ui_info "Next steps:"
   local step=1
-  if [ "$alias_ccgm_installed" = true ] || [ "$alias_ccgms_installed" = true ]; then
-    echo "  ${step}. Run 'source ${rc_file}' to activate the new aliases"
+  if [ "$alias_ccgm_installed" = true ]; then
+    echo "  ${step}. Run 'source ${rc_file}' to activate the new alias"
     step=$((step + 1))
   else
     echo "  ${step}. Open a new Claude Code session to pick up the new config"
@@ -1226,10 +1226,7 @@ TMPL
   echo ""
   ui_info "Useful commands:"
   if [ "$alias_ccgm_installed" = true ]; then
-    echo "  ccgm             Quick session start (log init only)"
-  fi
-  if [ "$alias_ccgms_installed" = true ]; then
-    echo "  ccgms            Full startup (git status, issues, agent dashboard)"
+    echo "  ccgm             Session startup (git status, tracking, live sessions, recent activity)"
   fi
   echo "  ./update.sh      Check for upstream updates"
   echo "  ./uninstall.sh   Remove installed modules"

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -233,7 +233,6 @@ expected_files=(
   "rules/cloudflare.md"
   "commands/commit.md"
   "commands/xplan.md"
-  "log-system.md"
   "multi-agent-system.md"
   "github-repo-protocols.md"
 )


### PR DESCRIPTION
Closes #354. Unblocks CI on PRs #352 and #353.

## Summary
- \`start.sh\`: drop references to the removed \`alias_ccgms_installed\` variable that broke \`set -u\` installs with \`unbound variable\` in the Next Steps section. Collapse the alias-hint block to the single \`ccgm\` alias introduced in E3.
- \`tests/test-installer.sh\`: stop asserting \`log-system.md\` is installed (deleted in E3).
- \`lib/backup.sh\`: drop \`log-system.md\` from the pre-install backup manifest.
- \`modules/multi-agent/multi-agent-system.md\`: replace the dead \`~/.claude/log-system.md\` pointer with \`docs/session-memory.md\`.

## Test plan
- [x] \`bash tests/test-installer.sh\` → 32/32 pass locally
- [x] \`bash -n start.sh\` → OK
- [x] No remaining \`alias_ccgms\` / \`log-system.md\` references outside this PR's diff