### PR TITLE
#356: annotate tmux-backed live sessions with attached/detached state

### DIFF
--- a/modules/hooks/lib/agent_sessions.py
+++ b/modules/hooks/lib/agent_sessions.py
@@ -94,6 +94,51 @@ def _get_git_context(cwd: str) -> tuple[str | None, str | None]:
     return repo, branch
 
 
+def _get_tmux_pane_pids() -> dict[int, str]:
+    """Return {pane_pid: session_name} for all tmux panes, or {} if tmux unavailable."""
+    out = _run(["tmux", "list-panes", "-a", "-F", "#{pane_pid} #{session_name}"])
+    panes: dict[int, str] = {}
+    for line in out.splitlines():
+        parts = line.split(None, 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            panes[int(parts[0])] = parts[1]
+    return panes
+
+
+def _get_tmux_attached_sessions() -> set[str]:
+    """Return set of tmux session names with at least one attached client."""
+    out = _run(["tmux", "list-clients", "-F", "#{session_name}"])
+    return {line.strip() for line in out.splitlines() if line.strip()}
+
+
+def _get_ppid_map() -> dict[int, int]:
+    """Return {pid: ppid} for all running processes."""
+    out = _run(["ps", "-eo", "pid,ppid"])
+    ppid_map: dict[int, int] = {}
+    for line in out.splitlines()[1:]:
+        parts = line.split()
+        if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
+            ppid_map[int(parts[0])] = int(parts[1])
+    return ppid_map
+
+
+def _find_tmux_session(
+    pid: int,
+    ppid_map: dict[int, int],
+    pane_pids: dict[int, str],
+) -> str | None:
+    """Walk parent chain from pid; return tmux session name if an ancestor is a tmux pane."""
+    cur = pid
+    for _ in range(32):
+        if cur in pane_pids:
+            return pane_pids[cur]
+        parent = ppid_map.get(cur)
+        if parent is None or parent <= 1 or parent == cur:
+            return None
+        cur = parent
+    return None
+
+
 def _get_agent_id(cwd: str) -> str | None:
     """
     Derive agent identity from .env.clone or directory name pattern.
@@ -139,13 +184,18 @@ def get_active_sessions(repo_filter: str | None = None, exclude_cwd: str | None 
             "tty":      str,    # Terminal (e.g. ttys003, ?? for background)
             "uptime":   str,    # Elapsed time (e.g. "01-02:30:45", "15:30")
             "cwd":      str,    # Working directory
-            "repo":     str,    # Git repo name (or None)
-            "branch":   str,    # Current git branch (or None)
-            "agent_id": str,    # Derived agent ID (or None)
+            "repo":       str,    # Git repo name (or None)
+            "branch":     str,    # Current git branch (or None)
+            "agent_id":   str,    # Derived agent ID (or None)
+            "tmux_state": str,    # "attached", "detached", or None (not in tmux)
         }
     """
     sessions: list[dict] = []
     my_cwd = os.path.realpath(exclude_cwd) if exclude_cwd else None
+
+    pane_pids = _get_tmux_pane_pids()
+    attached_sessions = _get_tmux_attached_sessions() if pane_pids else set()
+    ppid_map = _get_ppid_map() if pane_pids else {}
 
     for pid, tty, etime in _get_claude_pids():
         cwd = _get_cwd(pid)
@@ -162,14 +212,23 @@ def get_active_sessions(repo_filter: str | None = None, exclude_cwd: str | None 
         if repo_filter and repo != repo_filter:
             continue
 
+        tmux_session = _find_tmux_session(pid, ppid_map, pane_pids) if pane_pids else None
+        if tmux_session is None:
+            tmux_state: str | None = None
+        elif tmux_session in attached_sessions:
+            tmux_state = "attached"
+        else:
+            tmux_state = "detached"
+
         sessions.append({
-            "pid":      pid,
-            "tty":      tty,
-            "uptime":   etime,
-            "cwd":      cwd,
-            "repo":     repo,
-            "branch":   branch,
-            "agent_id": _get_agent_id(cwd),
+            "pid":        pid,
+            "tty":        tty,
+            "uptime":     etime,
+            "cwd":        cwd,
+            "repo":       repo,
+            "branch":     branch,
+            "agent_id":   _get_agent_id(cwd),
+            "tmux_state": tmux_state,
         })
 
     return sessions
@@ -194,14 +253,17 @@ def format_sessions_text(sessions: list[dict], header: bool = True) -> str:
         tty = s["tty"]
         cwd = s["cwd"]
 
+        tmux_state = s.get("tmux_state")
+        suffix = f"  [tmux:{tmux_state}]" if tmux_state else ""
+
         if s["repo"]:
             lines.append(
                 f"  PID {pid_str:6} | {repo:25} | branch: {branch:30} | "
-                f"up: {uptime:12} | {tty}"
+                f"up: {uptime:12} | {tty}{suffix}"
             )
         else:
             lines.append(
-                f"  PID {pid_str:6} | (no repo) {cwd:40} | up: {uptime:12} | {tty}"
+                f"  PID {pid_str:6} | (no repo) {cwd:40} | up: {uptime:12} | {tty}{suffix}"
             )
     return "\n".join(lines)
 

--- a/modules/hooks/tests/test_agent_sessions.py
+++ b/modules/hooks/tests/test_agent_sessions.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Unit tests for agent_sessions tmux state annotation."""
+
+import os
+import sys
+import unittest
+
+_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+_LIB_DIR = os.path.join(_TEST_DIR, '..', 'lib')
+sys.path.insert(0, os.path.abspath(_LIB_DIR))
+import agent_sessions
+
+
+class TestFindTmuxSession(unittest.TestCase):
+    def test_returns_session_when_ancestor_is_pane(self):
+        # pid 100 -> ppid 50 (tmux pane for session "agents")
+        ppid_map = {100: 50, 50: 1}
+        pane_pids = {50: "agents"}
+        self.assertEqual(
+            agent_sessions._find_tmux_session(100, ppid_map, pane_pids),
+            "agents",
+        )
+
+    def test_walks_multiple_levels(self):
+        # pid 100 -> 90 -> 80 -> 50 (pane for "dev")
+        ppid_map = {100: 90, 90: 80, 80: 50, 50: 1}
+        pane_pids = {50: "dev"}
+        self.assertEqual(
+            agent_sessions._find_tmux_session(100, ppid_map, pane_pids),
+            "dev",
+        )
+
+    def test_returns_none_when_no_tmux_ancestor(self):
+        ppid_map = {100: 50, 50: 1}
+        pane_pids = {999: "other"}
+        self.assertIsNone(
+            agent_sessions._find_tmux_session(100, ppid_map, pane_pids),
+        )
+
+    def test_handles_missing_parent(self):
+        ppid_map = {100: 50}  # 50 has no entry
+        pane_pids = {}
+        self.assertIsNone(
+            agent_sessions._find_tmux_session(100, ppid_map, pane_pids),
+        )
+
+
+class TestFormatSessionsText(unittest.TestCase):
+    def _base_session(self, **overrides):
+        s = {
+            "pid": 1234,
+            "tty": "ttys001",
+            "uptime": "01:00",
+            "cwd": "/tmp/foo",
+            "repo": "myrepo",
+            "branch": "main",
+            "agent_id": None,
+            "tmux_state": None,
+        }
+        s.update(overrides)
+        return s
+
+    def test_no_tmux_suffix_when_not_in_tmux(self):
+        out = agent_sessions.format_sessions_text([self._base_session()])
+        self.assertNotIn("[tmux:", out)
+
+    def test_detached_suffix(self):
+        out = agent_sessions.format_sessions_text(
+            [self._base_session(tmux_state="detached")]
+        )
+        self.assertIn("[tmux:detached]", out)
+
+    def test_attached_suffix(self):
+        out = agent_sessions.format_sessions_text(
+            [self._base_session(tmux_state="attached")]
+        )
+        self.assertIn("[tmux:attached]", out)
+
+    def test_suffix_on_no_repo_row(self):
+        out = agent_sessions.format_sessions_text(
+            [self._base_session(repo=None, branch=None, tmux_state="detached")]
+        )
+        self.assertIn("[tmux:detached]", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #356. The `/startup` Live Sessions panel was showing `claude` processes inside detached tmux sessions as if they were active — real example: two 11-day-old `biotechstonks` claudes in a tmux `agents` session with no attached client appeared on today's dashboard.

## Changes

- `modules/hooks/lib/agent_sessions.py`
  - New helpers: `_get_tmux_pane_pids`, `_get_tmux_attached_sessions`, `_get_ppid_map`, `_find_tmux_session`.
  - Each session dict gets a `tmux_state` field: `"attached"`, `"detached"`, or `None` (not in tmux).
  - `format_sessions_text` appends `  [tmux:attached]` or `  [tmux:detached]` so the user can see which sessions are orphaned vs. actually interactive.
  - Tmux queries gracefully no-op when tmux isn't installed (empty output → no annotation).
- `modules/hooks/tests/test_agent_sessions.py` — unit tests for parent-chain walking and formatting suffix.

## Test plan

- [x] Unit tests pass (`python3 modules/hooks/tests/test_agent_sessions.py`)
- [x] `test-no-personal-data.sh` passes
- [x] E2E: created a detached tmux session with `sleep 300`, ran `_find_tmux_session` against the sleep's pid — correctly returned the session name and `state=detached`.
- [x] E2E: ran `python3 ~/.claude/lib/agent_sessions.py --text` against live machine state; tmux-backed processes are annotated, non-tmux processes are unchanged.