### PR TITLE
#360: /startup — workspace-aware repo detection, per-clone table, 48h merges, smarter Next

### DIFF
--- a/modules/startup-dashboard/lib/startup-dashboard.sh
+++ b/modules/startup-dashboard/lib/startup-dashboard.sh
@@ -19,7 +19,6 @@ if [ -z "$GATHER" ]; then
 fi
 
 # ---- Section extraction ----
-# Print lines between "=== NAME ===" and the next "=== ... ===" (exclusive).
 section() {
   local name="$1"
   printf '%s\n' "$GATHER" | awk -v marker="=== $name ===" '
@@ -29,13 +28,11 @@ section() {
   '
 }
 
-# Read a "key:value" from a section. Returns the value verbatim (everything after the first colon).
 kv() {
   local name="$1" key="$2"
   section "$name" | awk -F: -v k="$key" '$1 == k { sub(/^[^:]*:/, ""); print; exit }'
 }
 
-# Trim leading/trailing whitespace.
 trim() {
   local s="$1"
   s="${s#"${s%%[![:space:]]*}"}"
@@ -43,7 +40,6 @@ trim() {
   printf '%s' "$s"
 }
 
-# Indent every non-empty line by two spaces.
 indent() {
   awk 'NF { print "  " $0 } !NF { print }'
 }
@@ -52,6 +48,7 @@ indent() {
 AGENT_ID=$(kv IDENTITY agent_id)
 REPO=$(kv IDENTITY repo)
 DATE=$(kv IDENTITY date)
+IS_WORKSPACE_ROOT=$(kv IDENTITY is_workspace_root)
 
 GIT_SECTION=$(section GIT)
 if printf '%s' "$GIT_SECTION" | grep -q '^NOT_A_GIT_REPO$'; then
@@ -70,12 +67,15 @@ else
   ')
 fi
 
+CLONES_BODY=$(section CLONES)
 PRS_BODY=$(section PRS)
 TRACKING_BODY=$(section TRACKING)
 SESSIONS_BODY=$(section SESSIONS)
 SIBLINGS_BODY=$(section SIBLINGS)
 ORPHANS_BODY=$(section ORPHANS)
 RECENT_BODY=$(section RECENT_ACTIVITY)
+RECENT_MERGES_BODY=$(section RECENT_MERGES)
+CANDIDATE_ISSUES_BODY=$(section CANDIDATE_ISSUES)
 
 RELEASE_CURRENT=$(kv RELEASE current)
 RELEASE_LATEST=$(kv RELEASE latest)
@@ -86,7 +86,6 @@ fi
 
 # ---- Summaries ----
 
-# Status label: clean/dirty/n-a
 if [ "$BRANCH" = "(not a git repo)" ]; then
   STATUS_LABEL="n/a"
   SYNC_LABEL="n/a"
@@ -110,6 +109,19 @@ if [ "$BRANCH" != "(not a git repo)" ]; then
   esac
 fi
 
+# Parse CLONES body to find dirty clones (workspace mode).
+DIRTY_CLONES=""
+if [ "$IS_WORKSPACE_ROOT" = "true" ] && [ -n "$(trim "$CLONES_BODY")" ]; then
+  while IFS=$'\t' read -r clone branch status sync; do
+    [ -z "$clone" ] && continue
+    case "$status" in
+      dirty*) DIRTY_CLONES="${DIRTY_CLONES:+$DIRTY_CLONES, }${clone}" ;;
+    esac
+  done <<EOF
+$CLONES_BODY
+EOF
+fi
+
 # PR count for header
 PR_COUNT=0
 if [ -n "$(trim "$PRS_BODY")" ] && [ "$(trim "$PRS_BODY")" != "none" ]; then
@@ -117,22 +129,44 @@ if [ -n "$(trim "$PRS_BODY")" ] && [ "$(trim "$PRS_BODY")" != "none" ]; then
   [ -z "$PR_COUNT" ] && PR_COUNT=0
 fi
 
-# Recommendation
+# Recent merge count
+MERGE_COUNT=0
+if [ -n "$(trim "$RECENT_MERGES_BODY")" ]; then
+  MERGE_COUNT=$(printf '%s\n' "$RECENT_MERGES_BODY" | grep -c . || true)
+  [ -z "$MERGE_COUNT" ] && MERGE_COUNT=0
+fi
+
+# First candidate issue (if any)
+FIRST_CANDIDATE=""
+if [ -n "$(trim "$CANDIDATE_ISSUES_BODY")" ]; then
+  FIRST_CANDIDATE=$(printf '%s\n' "$CANDIDATE_ISSUES_BODY" | head -1)
+fi
+
+# Recommendation priority:
+# 1. Open PRs (review/merge)
+# 2. Dirty working tree (in-clone) or dirty clones (workspace mode)
+# 3. Unclaimed open issue
+# 4. Fallback
 NEXT="What would you like to work on?"
 if [ "$PR_COUNT" -gt 0 ] 2>/dev/null; then
   NEXT="Review ${PR_COUNT} open PR(s)"
 elif [ "$STATUS_LABEL" = "dirty" ]; then
   NEXT="Review uncommitted changes or continue previous work"
+elif [ -n "$DIRTY_CLONES" ]; then
+  NEXT="Uncommitted changes in: ${DIRTY_CLONES}"
+elif [ -n "$FIRST_CANDIDATE" ]; then
+  # Render as "Pick up <first candidate>"
+  NEXT="Pick up $(printf '%s' "$FIRST_CANDIDATE" | awk -F'\t' '{printf "%s: %s", $1, $2}')"
 fi
 
 # ---- Emit dashboard ----
-# Output is pure plain text — no markdown, no ANSI. Claude Code renders
-# Bash tool output literally, so formatting relies on spacing and Unicode.
 
 REPO_DISPLAY="$REPO"
 [ -z "$REPO_DISPLAY" ] && REPO_DISPLAY="(no repo)"
+if [ "$IS_WORKSPACE_ROOT" = "true" ] && [ "$REPO_DISPLAY" != "(no repo)" ] && [ "$REPO_DISPLAY" != "unknown" ]; then
+  REPO_DISPLAY="${REPO_DISPLAY} (workspace)"
+fi
 
-# Pretty date: YYYYMMDD -> YYYY-MM-DD
 if [ ${#DATE} -eq 8 ]; then
   DATE_PRETTY="${DATE:0:4}-${DATE:4:2}-${DATE:6:2}"
 else
@@ -140,7 +174,18 @@ else
 fi
 
 printf '%s  ·  %s  ·  %s\n' "$AGENT_ID" "$REPO_DISPLAY" "$DATE_PRETTY"
-printf 'Branch    %-30s  Status  %-8s  Sync  %s\n' "$BRANCH" "$STATUS_LABEL" "$SYNC_LABEL"
+
+# Header line differs by mode. In workspace mode, the Clones section carries the
+# per-clone detail, so the header just summarizes repo-level state.
+if [ "$IS_WORKSPACE_ROOT" = "true" ]; then
+  CLONE_COUNT=0
+  if [ -n "$(trim "$CLONES_BODY")" ]; then
+    CLONE_COUNT=$(printf '%s\n' "$CLONES_BODY" | grep -c . || true)
+  fi
+  printf 'Workspace  %s clone(s)\n' "${CLONE_COUNT:-0}"
+else
+  printf 'Branch    %-30s  Status  %-8s  Sync  %s\n' "$BRANCH" "$STATUS_LABEL" "$SYNC_LABEL"
+fi
 
 emit_section() {
   local label="$1" body="$2"
@@ -148,16 +193,35 @@ emit_section() {
   trimmed=$(trim "$body")
   [ -z "$trimmed" ] && return 0
   [ "$trimmed" = "none" ] && return 0
+  [ "$trimmed" = "(unknown repo - tracking unavailable)" ] && return 0
   [ "$trimmed" = "(coordinator workspace - tracking shown by individual clones)" ] && return 0
   printf '\n%s\n' "$label"
   printf '%s\n' "$body" | indent
 }
+
+# Clones table (workspace mode only)
+if [ "$IS_WORKSPACE_ROOT" = "true" ] && [ -n "$(trim "$CLONES_BODY")" ]; then
+  printf '\nClones\n'
+  printf '%s\n' "$CLONES_BODY" | awk -F'\t' '{printf "  %-4s  %-36s  %-12s  %s\n", $1, $2, $3, $4}'
+fi
 
 emit_section "Live Sessions" "$SESSIONS_BODY"
 
 if [ "$PR_COUNT" -gt 0 ] 2>/dev/null; then
   printf '\nOpen PRs (%s)\n' "$PR_COUNT"
   printf '%s\n' "$PRS_BODY" | indent
+fi
+
+# Recent merges (last 48h)
+if [ "$MERGE_COUNT" -gt 0 ] 2>/dev/null; then
+  printf '\nMerged (last 48h, %s)\n' "$MERGE_COUNT"
+  printf '%s\n' "$RECENT_MERGES_BODY" | awk -F'\t' '{
+    # Shorten mergedAt YYYY-MM-DDThh:mm:ssZ -> MM-DD hh:mm
+    t = $2
+    date = substr(t, 6, 5)
+    time = substr(t, 12, 5)
+    printf "  %s  %s %s  %s  %s\n", $1, date, time, $3, $4
+  }'
 fi
 
 emit_section "Tracking" "$TRACKING_BODY"

--- a/modules/startup-dashboard/lib/startup-gather.sh
+++ b/modules/startup-dashboard/lib/startup-gather.sh
@@ -19,13 +19,48 @@ else
   AGENT_ID="agent-${AGENT_NUM}"
 fi
 
-REPO_NAME=$(git remote get-url origin 2>/dev/null | xargs basename 2>/dev/null | sed 's/\.git$//' || echo "unknown")
+# Workspace-root detection: cwd itself isn't a git repo, but child clones exist.
+IS_WORKSPACE_ROOT=false
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  for child in "$PWD"/*-c[0-9]*/; do
+    if [ -d "$child" ] && git -C "$child" rev-parse --git-dir >/dev/null 2>&1; then
+      IS_WORKSPACE_ROOT=true
+      break
+    fi
+  done
+fi
+
+# Repo detection: direct if in a git repo, otherwise infer from a child clone.
+REPO_NAME=$(git remote get-url origin 2>/dev/null | xargs basename 2>/dev/null | sed 's/\.git$//' || echo "")
+if [ -z "$REPO_NAME" ] && [ "$IS_WORKSPACE_ROOT" = true ]; then
+  for child in "$PWD"/*-c[0-9]*/; do
+    [ -d "$child" ] || continue
+    cand=$(git -C "$child" remote get-url origin 2>/dev/null | xargs basename 2>/dev/null | sed 's/\.git$//')
+    if [ -n "$cand" ]; then
+      REPO_NAME="$cand"
+      break
+    fi
+  done
+fi
+[ -z "$REPO_NAME" ] && REPO_NAME="unknown"
+
 TODAY=$(date +%Y%m%d)
 NOW_TIME=$(date +%H:%M)
 
+# Where to run gh (needs a git-repo cwd). In workspace mode, any child clone works.
+GH_CWD="$PROJECT_DIR"
+if [ "$IS_WORKSPACE_ROOT" = true ]; then
+  for child in "$PWD"/*-c[0-9]*/; do
+    if [ -d "$child" ] && git -C "$child" rev-parse --git-dir >/dev/null 2>&1; then
+      GH_CWD="${child%/}"
+      break
+    fi
+  done
+fi
+
 # --- Parallel jobs (all independent) ---
 
-# 1. Git status + sync
+# 1. Git status + sync (clone mode only; workspace mode emits per-clone summary instead)
 (
   cd "$PROJECT_DIR"
   if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
@@ -48,18 +83,48 @@ NOW_TIME=$(date +%H:%M)
   git log --oneline -5 2>/dev/null
 ) > "$TMPDIR/git" 2>/dev/null &
 
+# 1b. Per-clone summary (workspace mode only)
+(
+  if [ "$IS_WORKSPACE_ROOT" != true ]; then
+    exit 0
+  fi
+  for child in "$PROJECT_DIR"/*-c[0-9]*/; do
+    [ -d "$child" ] || continue
+    git -C "$child" rev-parse --git-dir >/dev/null 2>&1 || continue
+    name=$(basename "$child")
+    # Drop the workspace prefix for a compact label (e.g. ccgm-w0-c1 -> c1)
+    short=$(echo "$name" | grep -oE 'c[0-9]+$' || echo "$name")
+    branch=$(git -C "$child" branch --show-current 2>/dev/null || echo "detached")
+    dirty_count=$(git -C "$child" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$dirty_count" = "0" ]; then
+      status="clean"
+    else
+      status="dirty(${dirty_count})"
+    fi
+    ab=$(git -C "$child" rev-list --left-right --count origin/main...HEAD 2>/dev/null || echo "")
+    behind=$(echo "$ab" | awk '{print $1}')
+    ahead=$(echo "$ab" | awk '{print $2}')
+    if [ -z "$ab" ] || { [ "$behind" = "0" ] && [ "$ahead" = "0" ]; }; then
+      sync="up to date"
+    else
+      sync="ahead ${ahead:-0}, behind ${behind:-0}"
+    fi
+    printf '%s\t%s\t%s\t%s\n' "$short" "$branch" "$status" "$sync"
+  done
+) > "$TMPDIR/clones" 2>/dev/null &
+
 # 2. Open PRs
 (
-  cd "$PROJECT_DIR"
+  cd "$GH_CWD" 2>/dev/null || exit 0
   gh pr list --state open --limit 10 2>/dev/null || echo "none"
 ) > "$TMPDIR/prs" 2>/dev/null &
 
-# 3. Tracking dashboard (active claims only - skip stale-claim GC, skip in coordinator dirs)
+# 3. Tracking dashboard (active claims only)
 (
-  if [ -n "$REPO_NAME" ]; then
+  if [ -n "$REPO_NAME" ] && [ "$REPO_NAME" != "unknown" ]; then
     python3 ~/.claude/lib/agent_tracking.py list --repo "$REPO_NAME" 2>/dev/null || echo "unavailable"
   else
-    echo "(coordinator workspace - tracking shown by individual clones)"
+    echo "(unknown repo - tracking unavailable)"
   fi
 ) > "$TMPDIR/tracking" 2>/dev/null &
 
@@ -68,8 +133,11 @@ NOW_TIME=$(date +%H:%M)
   python3 ~/.claude/lib/agent_sessions.py --text --exclude-cwd "$PROJECT_DIR" 2>/dev/null || true
 ) > "$TMPDIR/sessions" 2>/dev/null &
 
-# 5. Sibling branches
+# 5. Sibling branches (clone mode only; workspace mode uses the CLONES section)
 (
+  if [ "$IS_WORKSPACE_ROOT" = true ]; then
+    exit 0
+  fi
   cd "$PROJECT_DIR"
   WC=$(basename "$PWD" | grep -oE 'w[0-9]+-c[0-9]+$' 2>/dev/null || true)
   if [ -n "$WC" ]; then
@@ -104,12 +172,39 @@ NOW_TIME=$(date +%H:%M)
   fi
 ) > "$TMPDIR/release" 2>/dev/null &
 
-# 8. Recent activity (unified session history across all clones of this repo)
+# 8. Recent activity (7-day session history)
 (
   if [ -n "$REPO_NAME" ] && [ "$REPO_NAME" != "unknown" ] && [ -x "$(command -v python3)" ]; then
     python3 "$HOME/.claude/scripts/recall.py" --summary --limit 3 --days 7 2>/dev/null || true
   fi
 ) > "$TMPDIR/recent" 2>/dev/null &
+
+# 9. Recent merges (last 48h on main)
+(
+  cd "$GH_CWD" 2>/dev/null || exit 0
+  cutoff=$(python3 -c "import datetime; print((datetime.datetime.utcnow()-datetime.timedelta(hours=48)).strftime('%Y-%m-%dT%H:%M:%SZ'))" 2>/dev/null)
+  [ -z "$cutoff" ] && exit 0
+  gh pr list --state merged --limit 30 --json number,title,mergedAt,author \
+    --jq ".[] | select(.mergedAt > \"$cutoff\") | \"#\\(.number)\\t\\(.mergedAt)\\t\\(.author.login)\\t\\(.title)\"" \
+    2>/dev/null || true
+) > "$TMPDIR/recent_merges" 2>/dev/null &
+
+# 10. Candidate issues to pick up (open, no linked open PR, not already claimed)
+(
+  cd "$GH_CWD" 2>/dev/null || exit 0
+  # Build set of issue numbers referenced by open PRs (Closes #N / Fixes #N / Resolves #N).
+  open_pr_bodies=$(gh pr list --state open --limit 30 --json body,headRefName --jq '.[] | "\(.body) \(.headRefName)"' 2>/dev/null)
+  claimed_issues=$(echo "$open_pr_bodies" | grep -oiE '(closes|fixes|resolves) +#[0-9]+' | grep -oE '[0-9]+' | sort -u)
+  # Also treat branch names like "123-foo" as a claim on #123.
+  branch_claims=$(echo "$open_pr_bodies" | grep -oE '\b[0-9]+-[a-z0-9-]+' | grep -oE '^[0-9]+' | sort -u)
+  claimed=$(printf '%s\n%s\n' "$claimed_issues" "$branch_claims" | sort -u | grep -v '^$')
+  gh issue list --state open --limit 20 --json number,title,labels \
+    --jq '.[] | "\(.number)\t\(.title)"' 2>/dev/null | while IFS=$'\t' read -r n title; do
+      if ! echo "$claimed" | grep -qx "$n"; then
+        printf '#%s\t%s\n' "$n" "$title"
+      fi
+    done | head -5
+) > "$TMPDIR/candidate_issues" 2>/dev/null &
 
 # Wait for all background jobs
 wait
@@ -123,9 +218,13 @@ repo:${REPO_NAME}
 date:${TODAY}
 time:${NOW_TIME}
 project_dir:${PROJECT_DIR}
+is_workspace_root:${IS_WORKSPACE_ROOT}
 
 === GIT ===
 $(cat "$TMPDIR/git")
+
+=== CLONES ===
+$(cat "$TMPDIR/clones")
 
 === PRS ===
 $(cat "$TMPDIR/prs")
@@ -147,4 +246,10 @@ $(cat "$TMPDIR/release")
 
 === RECENT_ACTIVITY ===
 $(cat "$TMPDIR/recent")
+
+=== RECENT_MERGES ===
+$(cat "$TMPDIR/recent_merges")
+
+=== CANDIDATE_ISSUES ===
+$(cat "$TMPDIR/candidate_issues")
 GATHER_EOF


### PR DESCRIPTION
Closes #360.

## Summary

`/startup` now delivers the same value from a workspace root as from a clone. It detects the repo, summarizes every clone, shows what's merged in the last 48h, and picks a smarter Next action.

## Before (workspace dir)

```
agent-0  ·  (no repo)  ·  2026-04-18
Branch    (not a git repo)                Status  n/a       Sync  n/a

Live Sessions
    ...

Next  What would you like to work on?
```

## After (workspace dir)

```
agent-0  ·  ccgm (workspace)  ·  2026-04-19
Workspace  4 clone(s)

Clones
  c0    337-dashboard-plain-text              dirty(1)      ahead 1, behind 0
  c1    360-startup-workspace-value           dirty(3)      up to date
  c2    350-scrub-personal-data               dirty(1)      ahead 1, behind 0
  c3    351-update-repair-stale-symlinks      dirty(1)      ahead 1, behind 0

Live Sessions
    ...

Merged (last 48h, 12)
  #359  04-19 18:29  lucasmccomb  #358: show effort level abbreviation next to model in statusline
  #357  04-18 19:53  lucasmccomb  #356: annotate tmux-backed live sessions ...
  ...

Tracking
  ...

Recent Activity
  ...

Next  Uncommitted changes in: c0, c1, c2, c3
```

## Changes

- **`lib/startup-gather.sh`**
  - Detects `IS_WORKSPACE_ROOT` when cwd isn't a git repo but has `*-c[0-9]*` children.
  - Infers `REPO_NAME` from a child clone's `origin` when cwd isn't a git repo. Unlocks PRs / tracking / recall in workspace mode.
  - Picks a `GH_CWD` (any child clone) so `gh pr list` works at the workspace root.
  - New **`=== CLONES ===`** section: per-clone `short_name \t branch \t clean|dirty(N) \t up-to-date|ahead/behind`.
  - New **`=== RECENT_MERGES ===`** section: `gh pr list --state merged` filtered by `mergedAt > now - 48h`.
  - New **`=== CANDIDATE_ISSUES ===`** section: open issues with no linked open PR (claims detected via "Closes/Fixes/Resolves #N" or branch name pattern `N-slug`).
  - Suppresses the clone-mode Sibling section in workspace mode (CLONES supersedes it).

- **`lib/startup-dashboard.sh`**
  - Renders the per-clone table (workspace mode) in place of the single Branch/Status/Sync header.
  - Renders "Merged (last 48h, N)" with compact timestamp `MM-DD hh:mm`.
  - "Next" priority: open PRs → dirty tree (clone) → dirty clones (workspace) → first unclaimed issue → generic fallback.
  - `REPO_DISPLAY` gets `(workspace)` suffix when at workspace root.

## Test plan

- [x] `bash startup-dashboard.sh` at workspace root (`~/code/ccgm-workspaces/ccgm-w0`) produces Clones + Merged + Tracking + Recent Activity.
- [x] `bash startup-dashboard.sh` inside a clone (`ccgm-w0-c1`) preserves Branch/Status/Sync header and now adds the Merged section.
- [x] "Next" routes correctly: dirty clones in workspace mode, dirty tree in clone mode, open-PR suggestion when PRs exist.
- [x] `test-no-personal-data.sh` passes.