### PR TITLE
#362: /startup — intelligent summary via headless claude -p

### DIFF
--- a/modules/startup-dashboard/commands/startup.md
+++ b/modules/startup-dashboard/commands/startup.md
@@ -1,30 +1,41 @@
 ---
-description: Session startup - check logs, git status, open issues, and orient
+description: Session startup - repo-aware intelligent summary
 allowed-tools: Bash
 ---
 
 # /startup - Session Startup
 
-Run the dashboard script and display its output verbatim:
+Run the summary script and display its output verbatim:
 
 ```bash
-bash ~/.claude/lib/startup-dashboard.sh
+bash ~/.claude/lib/startup-summary.sh $ARGUMENTS
 ```
 
-The script runs the data-gather pipeline, creates today's log if missing, and emits the formatted dashboard to stdout. Display the output as-is to the user, then **stop and wait for the user's next instruction**.
+The script runs the gather pipeline, feeds the output to a headless Sonnet
+model via `claude -p`, and emits a short markdown summary with sections for
+Where we are / Recent activity / Open PRs / Top open issues / Live sessions /
+Next up. Display the output as-is, then **stop and wait** for the user's next
+instruction. Do NOT add commentary, do NOT continue into other work.
 
-Do NOT add commentary, reformat the output, or continue into other work after the dashboard appears.
+## Flags
 
----
+- `/startup --raw` — skip the model pipeline; emit the deterministic plain-text
+  dashboard produced by `startup-dashboard.sh`. Useful for debugging or when
+  offline.
 
-## Why this is a single bash call
+## How it works
 
-The formatting is deterministic (section extraction + string interpolation), so there is no benefit to running it through a model. The previous implementation delegated to a Sonnet sub-agent and routinely burned ~48k tokens per startup while sometimes failing to surface the dashboard at all. The current implementation costs ~0 model tokens for formatting and is fail-fast visible (stderr messages appear directly if anything breaks).
+1. `startup-gather.sh` collects structured data (git state, merges, PRs,
+   tracking, sessions, priority issues, etc.) in parallel — deterministic,
+   zero model tokens.
+2. `startup-summary.sh` pipes the gather output plus a fixed prompt into
+   `claude --model sonnet --no-session-persistence -p`. Summarization is a
+   judgment task, so a model call is warranted.
+3. If `claude` is missing, returns empty, or any step fails, the script falls
+   back to `startup-dashboard.sh` automatically.
 
-If you need to debug what the dashboard is seeing, run the gather script directly:
+To debug the raw data the summary is working from:
 
 ```bash
 bash ~/.claude/lib/startup-gather.sh
 ```
-
-That produces the raw `=== SECTION ===` blocks the dashboard parses.

--- a/modules/startup-dashboard/lib/startup-gather.sh
+++ b/modules/startup-dashboard/lib/startup-gather.sh
@@ -189,7 +189,25 @@ fi
     2>/dev/null || true
 ) > "$TMPDIR/recent_merges" 2>/dev/null &
 
-# 10. Candidate issues to pick up (open, no linked open PR, not already claimed)
+# 10a. Priority issues (top 5 open, ordered by priority labels then recency)
+(
+  cd "$GH_CWD" 2>/dev/null || exit 0
+  # Issues with priority labels first, then most recently updated.
+  gh issue list --state open --limit 40 --json number,title,labels,updatedAt \
+    --jq '[.[] | {n: .number, t: .title, labels: [.labels[].name], u: .updatedAt}]
+          | map(. + {priority: (
+              if any(.labels[]; . == "p0" or . == "P0" or . == "critical") then 0
+              elif any(.labels[]; . == "p1" or . == "P1" or . == "high-priority" or . == "priority") then 1
+              elif any(.labels[]; . == "bug") then 2
+              elif any(.labels[]; . == "p2" or . == "P2") then 3
+              else 4 end)})
+          | sort_by(.priority, (.u | split("T")[0] | split("-") | map(tonumber) | (0-.[0]*10000 - .[1]*100 - .[2])))
+          | .[0:5]
+          | .[] | "#\(.n)\t\((.labels | join(",")) // "")\t\(.t)"' \
+    2>/dev/null || true
+) > "$TMPDIR/priority_issues" 2>/dev/null &
+
+# 10b. Candidate issues to pick up (open, no linked open PR, not already claimed)
 (
   cd "$GH_CWD" 2>/dev/null || exit 0
   # Build set of issue numbers referenced by open PRs (Closes #N / Fixes #N / Resolves #N).
@@ -252,4 +270,7 @@ $(cat "$TMPDIR/recent_merges")
 
 === CANDIDATE_ISSUES ===
 $(cat "$TMPDIR/candidate_issues")
+
+=== PRIORITY_ISSUES ===
+$(cat "$TMPDIR/priority_issues")
 GATHER_EOF

--- a/modules/startup-dashboard/lib/startup-summary-prompt.md
+++ b/modules/startup-dashboard/lib/startup-summary-prompt.md
@@ -1,0 +1,56 @@
+You are summarizing a session startup dashboard for an experienced engineer.
+Produce a short, high-signal markdown summary. Work ONLY from the gather
+output below — do not make tool calls, do not invent facts.
+
+## Output format
+
+Use these exact headers in order. Omit any section whose data is absent,
+empty, or "none":
+
+```
+## <agent_id> · <repo> · <branch-or-"workspace"> · <date>
+
+**Where we are**
+- 1-2 lines. Branch state, dirty/clean, sync with main. In workspace mode,
+  name the clones and their branches compactly on one line.
+
+**Recent activity (last 48h)**
+- 3-5 bullets summarizing the RECENT_MERGES section. Group related PRs by
+  theme when possible (e.g., "Cleanup wave across X, Y, Z — #540, #539, #538").
+  Prefer significance over literal listing.
+
+**Open PRs**
+- One bullet per PR: `#N title`. OMIT this section entirely if PRS is
+  empty or "none".
+
+**Top open issues**
+- 3-5 bullets from PRIORITY_ISSUES. Prefix notable labels in brackets
+  (e.g., "[bug]", "[p0]"). OMIT this section if PRIORITY_ISSUES is empty.
+
+**Live sessions**
+- Single line: count and one notable detail if any. OMIT if no sessions
+  besides self.
+
+**Next up**
+- ONE concrete, grounded action. Priority order:
+  1. open PR to review (name it: "Review PR #X")
+  2. dirty working tree (clone mode)
+  3. dirty clones (workspace mode — name them)
+  4. top unclaimed issue (name it: "Pick up #X: title")
+  5. generic: "Pick a task."
+```
+
+## Rules
+
+- Be terse. Total output 15-25 lines.
+- Use `###` for subheaders only if you need them; no other heading levels.
+- No preamble, no sign-off, no "Summary:" prefix. Just the markdown.
+- If RECENT_MERGES is empty, say: "- (no merges in last 48h)"
+- Pretty-print the date: YYYYMMDD → YYYY-MM-DD.
+- Header line format:
+  `## {agent_id} · {repo} · {branch_or_"workspace"} · {YYYY-MM-DD}`
+  - If `is_workspace_root:true`, use `workspace` instead of a branch name.
+  - If `repo:unknown`, use `(no repo)`.
+
+## Gather output
+

--- a/modules/startup-dashboard/lib/startup-summary.sh
+++ b/modules/startup-dashboard/lib/startup-summary.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# startup-summary.sh - Intelligent summary for /startup.
+# Pipeline: startup-gather.sh → claude -p (sonnet) → markdown summary.
+# Falls back to the deterministic startup-dashboard.sh whenever the model
+# pipeline is unavailable or produces empty output.
+#
+# Usage: bash startup-summary.sh [--raw]
+#   --raw : skip the model pipeline, emit the deterministic dashboard directly.
+
+set -u
+
+GATHER_SCRIPT="${CCGM_GATHER_SCRIPT:-$HOME/.claude/lib/startup-gather.sh}"
+DASHBOARD_SCRIPT="${CCGM_DASHBOARD_SCRIPT:-$HOME/.claude/lib/startup-dashboard.sh}"
+PROMPT_FILE="${CCGM_SUMMARY_PROMPT:-$HOME/.claude/lib/startup-summary-prompt.md}"
+SUMMARY_MODEL="${CCGM_SUMMARY_MODEL:-sonnet}"
+
+run_dashboard() {
+  if [ -x "$(command -v bash)" ] && [ -f "$DASHBOARD_SCRIPT" ]; then
+    bash "$DASHBOARD_SCRIPT"
+  else
+    echo "startup-summary: dashboard fallback unavailable" >&2
+    return 1
+  fi
+}
+
+# --raw skips the model pipeline entirely.
+if [ "${1:-}" = "--raw" ]; then
+  exec bash "$DASHBOARD_SCRIPT"
+fi
+
+# If any input is missing, fall back to the dashboard.
+if ! command -v claude >/dev/null 2>&1; then
+  run_dashboard
+  exit $?
+fi
+if [ ! -f "$GATHER_SCRIPT" ] || [ ! -f "$PROMPT_FILE" ]; then
+  run_dashboard
+  exit $?
+fi
+
+TMPGATHER=$(mktemp -t ccgm-startup-gather.XXXXXX)
+trap "rm -f $TMPGATHER" EXIT
+
+bash "$GATHER_SCRIPT" > "$TMPGATHER" 2>/dev/null
+if [ ! -s "$TMPGATHER" ]; then
+  run_dashboard
+  exit $?
+fi
+
+# Claude -p reads the prompt from stdin when no prompt argv is given.
+# Combine the summary instructions with the gather output as one stream.
+SUMMARY=$(cat "$PROMPT_FILE" "$TMPGATHER" 2>/dev/null \
+  | claude --model "$SUMMARY_MODEL" --no-session-persistence -p 2>/dev/null)
+
+if [ -z "$SUMMARY" ]; then
+  echo "startup-summary: model pipeline returned empty; falling back to dashboard" >&2
+  run_dashboard
+  exit $?
+fi
+
+printf '%s\n' "$SUMMARY"

--- a/modules/startup-dashboard/module.json
+++ b/modules/startup-dashboard/module.json
@@ -8,7 +8,9 @@
   "files": {
     "commands/startup.md": { "target": "commands/startup.md", "type": "command", "template": false },
     "lib/startup-gather.sh": { "target": "lib/startup-gather.sh", "type": "lib", "template": false },
-    "lib/startup-dashboard.sh": { "target": "lib/startup-dashboard.sh", "type": "lib", "template": false }
+    "lib/startup-dashboard.sh": { "target": "lib/startup-dashboard.sh", "type": "lib", "template": false },
+    "lib/startup-summary.sh": { "target": "lib/startup-summary.sh", "type": "lib", "template": false },
+    "lib/startup-summary-prompt.md": { "target": "lib/startup-summary-prompt.md", "type": "lib", "template": false }
   },
   "tags": ["startup", "dashboard", "session"],
   "configPrompts": []


### PR DESCRIPTION
Closes #362.

## Summary

Replaces the raw-data dump with a short, nicely-formatted markdown summary generated by a Sonnet model. Deterministic gather + model-powered summarization.

### Before (voxstr example)

```
#540  04-19 17:22  lucasmccomb  #540: editorial cleanup eval suite
#542  04-19 15:56  lucasmccomb  #539: keep_alive 5m + hotkey-triggered prewarm
#541  04-18 20:01  lucasmccomb  #538: editorial cleanup replaces surgical on qwen3:8b
... (15 more lines) ...
Tracking
    (no claims)
Siblings
  voxstr-1: main
  voxstr-2: main
  ...
Next  Review uncommitted changes or continue previous work
```

### After

```
## agent-0 · ccgm · workspace · 2026-04-19

**Where we are**
- Workspace root. 4 clones all dirty with unpushed work: c0 `337-dashboard-plain-text` (+1), c1 `362-startup-intelligent-summary` (6 dirty), c2 `350-scrub-personal-data` (+1), c3 `351-update-repair-stale-symlinks` (+1).

**Recent activity (last 48h)**
- `/startup` dashboard overhaul wave: workspace-aware detection, per-clone table, 48h merges, smarter Next up — #361, #360, #337, #335
- Statusline + session polish: effort abbreviation (#359), tmux attach/detach state (#357)
- CI fix: E3 regressions (#355)
- Installer hardening: stale symlinks (#353), personal-data scrub (#352)
- Docs/infra: AGENTS.md symlinks, /recall, startup-dashboard rename — #349, #347, #343

**Top open issues**
- #362 /startup: replace raw dashboard with Sonnet-generated summary
- [in-progress] #198 Multi-tool support: Codex CLI + Gemini CLI adapters
- [human-epic] #224 Second Claude Code Max Subscription for VMs
- ...

**Live sessions**
- 4 other sessions: habitpro-ai-w0 (6h), long-running `/Users/lem/code` session (2d+), voxstr main (35m), Eluketronic LLC docs (32m).

**Next up**
- Pick up #362: /startup Sonnet-generated summary (c1 is already on this branch with 6 dirty files).
```

## Architecture

1. `startup-gather.sh` — deterministic bash data collection (unchanged except for new `PRIORITY_ISSUES` section).
2. **`startup-summary.sh`** (new) — pipes gather output + fixed prompt into `claude --model sonnet --no-session-persistence -p`. Falls back to `startup-dashboard.sh` whenever `claude` is missing, the pipeline errors, or the model returns empty.
3. **`startup-summary-prompt.md`** (new) — the summary instructions the model receives, co-located with the script for easy tuning.
4. `commands/startup.md` — now just invokes `startup-summary.sh $ARGUMENTS`. `/startup --raw` forces the deterministic dashboard.

### Why shell out to `claude -p` instead of the Agent tool

The Agent tool (general-purpose subagent) reliably drops its final text message on this machine — reproduced twice during testing, 40k+ tokens spent with zero surfaced output. MEMORY already captures this as a known failure mode. `claude -p` is a clean subprocess: `stdin` → `stdout`, no message-routing layer to drop the response.

### Why summarize at all (reversing #335)

#335 removed a previous Sonnet delegation because **formatting** is deterministic — no judgment needed, so the model was pure cost. **Summarization** is a judgment task: which merges matter? What's the theme? What's the highest priority issue? That's a good use of a model.

## Test plan

- [x] Workspace mode (`~/code/ccgm-workspaces/ccgm-w0`) — produces well-formatted summary with Clones, Recent activity, Top issues, Live sessions, Next up.
- [x] Clone mode (`ccgm-w0-c1`) — produces summary with branch-specific Where we are.
- [x] `--raw` flag — falls through to `startup-dashboard.sh`.
- [x] `test-no-personal-data.sh` passes.