### PR TITLE
#364: /startup — macOS Keychain → direct Anthropic API (cheap path) with fallback chain

### DIFF
--- a/modules/startup-dashboard/README.md
+++ b/modules/startup-dashboard/README.md
@@ -1,43 +1,88 @@
 # startup-dashboard
 
-Plain-text dashboard rendered by `/startup`. Surfaces the state an agent needs at the start of a session without writing any markdown logs.
+`/startup` produces a short, nicely-formatted markdown summary of the current
+repo state — what's happened in the last 48 hours, what's open, and what to
+work on next. Deterministic data gather + model-powered summarization.
 
 ## What This Module Does
 
-- **`/startup` command**: Runs the gather pipeline and emits a formatted dashboard straight from Bash — no model tokens for formatting.
-- **Gather pipeline**: Collects git state, open PRs, `tracking.csv` claims, live Claude Code sessions, sibling branches, orphan processes, release info, and recent session activity in parallel.
-- **Recent Activity**: Unified 7-day view of session transcripts across every clone of the current repo, powered by the `session-history` module's `/recall`.
-
-The module used to be called `session-logging` and wrote markdown logs to `~/code/lem-agent-logs/`. That was retired once Claude Code's native JSONL transcripts + `/recall` covered the same ground deterministically. See `docs/session-memory.md` for the full story.
+- **`/startup` command**: runs the gather pipeline, feeds the output to a
+  headless Sonnet model, and emits a high-signal summary with sections for
+  Where we are / Recent activity / Open PRs / Top open issues / Live sessions /
+  Next up.
+- **Gather pipeline**: collects git state, open PRs, 48h merges, priority
+  issues, `tracking.csv` claims, live Claude Code sessions, sibling branches,
+  orphan processes, release info, and recent session activity in parallel.
+- **Recent Activity**: unified 7-day view of session transcripts across every
+  clone of the current repo, powered by the `session-history` module's `/recall`.
 
 ## Files
 
 | File | Type | Description |
 |------|------|-------------|
-| `commands/startup.md` | command | `/startup` invokes the dashboard script |
+| `commands/startup.md` | command | `/startup` invokes the summary script |
 | `lib/startup-gather.sh` | lib | Parallel data gather, emits `=== SECTION ===` blocks |
-| `lib/startup-dashboard.sh` | lib | Formats gather output into a plain-text dashboard |
+| `lib/startup-summary.sh` | lib | Runs the gather → model → markdown summary pipeline with a fallback chain |
+| `lib/startup-summary-prompt.md` | lib | Fixed summary instructions the model receives |
+| `lib/startup-dashboard.sh` | lib | Deterministic plain-text dashboard (fallback / `--raw` mode) |
 
 ## Dependencies
 
 - `session-history` — supplies `~/.claude/scripts/recall.py`, which powers the Recent Activity block.
 
-## Running the Dashboard
+## Running
 
 ```
-/startup
+/startup           # Intelligent markdown summary
+/startup --raw     # Deterministic plain-text dashboard (bypasses model)
 ```
 
 Or directly:
 
 ```
-bash ~/.claude/lib/startup-dashboard.sh
+bash ~/.claude/lib/startup-summary.sh
+bash ~/.claude/lib/startup-dashboard.sh   # raw dashboard only
+bash ~/.claude/lib/startup-gather.sh      # raw structured sections for debugging
 ```
+
+## How summarization works — fallback chain
+
+`startup-summary.sh` tries three paths in order, stopping at the first that
+returns non-empty output:
+
+1. **macOS Keychain → direct Anthropic API** (`~$0.015/run`). Requires a
+   one-time Keychain entry (see below). Never exports `ANTHROPIC_API_KEY`, so
+   new `claude` sessions keep their subscription / Max auth.
+2. **`claude -p` subprocess** (`~$0.16/run`). No setup. Loads the full Claude
+   Code CLI harness as a system prompt, hence the higher cost.
+3. **Deterministic dashboard**. Zero model tokens. Used when no `claude`
+   binary is installed or every model path fails.
+
+### Enabling the cheap path (macOS only)
+
+```bash
+security add-generic-password -s ccgm-anthropic-api-key -a "$USER" -w sk-ant-...
+```
+
+macOS will prompt "Always Allow" the first time `security` reads the entry;
+after that it is silent. To remove it:
+
+```bash
+security delete-generic-password -s ccgm-anthropic-api-key
+```
+
+### Tuning
+
+All override-able via env vars at the top of `startup-summary.sh`:
+
+| Variable | Default |
+|----------|---------|
+| `CCGM_SUMMARY_MODEL` (for `claude -p`) | `sonnet` |
+| `CCGM_SUMMARY_MODEL_API` (for direct API) | `claude-sonnet-4-6` |
+| `CCGM_KEYCHAIN_SERVICE` | `ccgm-anthropic-api-key` |
 
 ## Customizing
 
-`startup-gather.sh` emits structured sections. `startup-dashboard.sh` parses them and renders the layout. To change what shows up, edit the parser and/or add new sections to the gather script.
-
-## Configuration
-
-None. The dashboard uses data already available from git, the tracking system, and Claude Code's session transcripts.
+- Tune the summary style by editing `lib/startup-summary-prompt.md`.
+- Add new sections to the gather by editing `lib/startup-gather.sh`; the
+  prompt will see them automatically.

--- a/modules/startup-dashboard/lib/startup-summary.sh
+++ b/modules/startup-dashboard/lib/startup-summary.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 # startup-summary.sh - Intelligent summary for /startup.
-# Pipeline: startup-gather.sh → claude -p (sonnet) → markdown summary.
-# Falls back to the deterministic startup-dashboard.sh whenever the model
-# pipeline is unavailable or produces empty output.
+#
+# Fallback chain (each step runs only if the previous failed or was empty):
+#   1. macOS Keychain → direct Anthropic API call (cheap, ~$0.015/run)
+#   2. claude -p subprocess (loads CLI harness, ~$0.16/run, no setup needed)
+#   3. Deterministic startup-dashboard.sh (no model tokens)
+#
+# To enable the cheap path, store your API key in Keychain once:
+#   security add-generic-password -s ccgm-anthropic-api-key -a "$USER" -w <sk-ant-...>
+# The script never exports ANTHROPIC_API_KEY to the parent shell, so new
+# `claude` sessions continue to use Max / subscription auth.
 #
 # Usage: bash startup-summary.sh [--raw]
 #   --raw : skip the model pipeline, emit the deterministic dashboard directly.
@@ -13,6 +20,8 @@ GATHER_SCRIPT="${CCGM_GATHER_SCRIPT:-$HOME/.claude/lib/startup-gather.sh}"
 DASHBOARD_SCRIPT="${CCGM_DASHBOARD_SCRIPT:-$HOME/.claude/lib/startup-dashboard.sh}"
 PROMPT_FILE="${CCGM_SUMMARY_PROMPT:-$HOME/.claude/lib/startup-summary-prompt.md}"
 SUMMARY_MODEL="${CCGM_SUMMARY_MODEL:-sonnet}"
+SUMMARY_MODEL_API="${CCGM_SUMMARY_MODEL_API:-claude-sonnet-4-6}"
+KEYCHAIN_SERVICE="${CCGM_KEYCHAIN_SERVICE:-ccgm-anthropic-api-key}"
 
 run_dashboard() {
   if [ -x "$(command -v bash)" ] && [ -f "$DASHBOARD_SCRIPT" ]; then
@@ -21,6 +30,45 @@ run_dashboard() {
     echo "startup-summary: dashboard fallback unavailable" >&2
     return 1
   fi
+}
+
+# Try the cheap path: Keychain lookup → direct Anthropic API via curl.
+# Returns the summary on stdout if successful; empty stdout on any failure.
+# Never exports ANTHROPIC_API_KEY to the parent shell.
+try_direct_api() {
+  command -v security >/dev/null 2>&1 || return 1
+  command -v curl >/dev/null 2>&1 || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+
+  local api_key
+  api_key=$(security find-generic-password -s "$KEYCHAIN_SERVICE" -w 2>/dev/null) || return 1
+  [ -z "$api_key" ] && return 1
+
+  local prompt_content
+  prompt_content=$(cat "$PROMPT_FILE" "$1" 2>/dev/null)
+  [ -z "$prompt_content" ] && return 1
+
+  local payload
+  payload=$(jq -nc \
+    --arg m "$SUMMARY_MODEL_API" \
+    --arg p "$prompt_content" \
+    '{model: $m, max_tokens: 1500, messages: [{role: "user", content: $p}]}' 2>/dev/null) || return 1
+
+  local response
+  response=$(printf '%s' "$payload" | curl -sS --max-time 30 \
+    https://api.anthropic.com/v1/messages \
+    -H "x-api-key: $api_key" \
+    -H "anthropic-version: 2023-06-01" \
+    -H "content-type: application/json" \
+    -d @- 2>/dev/null) || return 1
+
+  [ -z "$response" ] && return 1
+
+  local text
+  text=$(printf '%s' "$response" | jq -r '.content[0].text // empty' 2>/dev/null)
+  [ -z "$text" ] && return 1
+
+  printf '%s' "$text"
 }
 
 # --raw skips the model pipeline entirely.
@@ -47,11 +95,16 @@ if [ ! -s "$TMPGATHER" ]; then
   exit $?
 fi
 
-# Claude -p reads the prompt from stdin when no prompt argv is given.
-# Combine the summary instructions with the gather output as one stream.
-SUMMARY=$(cat "$PROMPT_FILE" "$TMPGATHER" 2>/dev/null \
-  | claude --model "$SUMMARY_MODEL" --no-session-persistence -p 2>/dev/null)
+# Path 1: Keychain → direct Anthropic API (cheap).
+SUMMARY=$(try_direct_api "$TMPGATHER")
 
+# Path 2: claude -p subprocess (loads CLI harness, no setup required).
+if [ -z "$SUMMARY" ]; then
+  SUMMARY=$(cat "$PROMPT_FILE" "$TMPGATHER" 2>/dev/null \
+    | claude --model "$SUMMARY_MODEL" --no-session-persistence -p 2>/dev/null)
+fi
+
+# Path 3: deterministic dashboard fallback.
 if [ -z "$SUMMARY" ]; then
   echo "startup-summary: model pipeline returned empty; falling back to dashboard" >&2
   run_dashboard


### PR DESCRIPTION
Closes #364.

## Summary

Adds a cheap API path to `/startup` without breaking Claude Code subscription auth. Reads the API key from macOS Keychain at runtime; never exports `ANTHROPIC_API_KEY` to the parent shell.

## Fallback chain

1. **Keychain → direct Anthropic API** via `curl`. Expected **~$0.015/run**.
2. **`claude -p` subprocess** (current path, ~$0.16/run). No setup required.
3. **Deterministic dashboard** (`startup-dashboard.sh`). Zero model tokens.

Each path only runs if the previous returned empty, missing, or errored.

## One-time setup (user)

```bash
security add-generic-password -s ccgm-anthropic-api-key -a "$USER" -w sk-ant-...
```

macOS prompts "Always Allow" the first time `security` reads the entry; subsequent reads are silent. The key lives in the user's login keychain, not on disk in plaintext.

Remove with:
```bash
security delete-generic-password -s ccgm-anthropic-api-key
```

## Files

- `modules/startup-dashboard/lib/startup-summary.sh` — adds `try_direct_api()`. Uses `security`, `curl`, `jq`. Skips gracefully if any tool is missing or Keychain entry is absent.
- `modules/startup-dashboard/README.md` — documents the fallback chain, setup, and tuning env vars.

## Tuning

Override defaults via env vars:

| Variable | Default |
|----------|---------|
| `CCGM_SUMMARY_MODEL_API` | `claude-sonnet-4-6` |
| `CCGM_KEYCHAIN_SERVICE` | `ccgm-anthropic-api-key` |

## Test plan

- [x] Without keychain entry: runs the `claude -p` fallback and produces a valid summary (~12s, confirmed locally).
- [x] Pre-commit checks pass (`test-no-personal-data.sh`, gitleaks, large-file, conflict markers).
- [ ] **With keychain entry**: to be verified by the user after they add their API key. Expected: first run prompts "Always Allow", subsequent runs are silent and ~10x cheaper.