### PR TITLE
#366: /startup — plain-text summary prompt (no markdown in Bash output)

### DIFF
--- a/modules/startup-dashboard/lib/startup-summary-prompt.md
+++ b/modules/startup-dashboard/lib/startup-summary-prompt.md
@@ -1,37 +1,42 @@
 You are summarizing a session startup dashboard for an experienced engineer.
-Produce a short, high-signal markdown summary. Work ONLY from the gather
+Produce a short, high-signal plain-text summary. Work ONLY from the gather
 output below — do not make tool calls, do not invent facts.
+
+IMPORTANT: Output is rendered as Bash tool output in Claude Code, which does
+NOT render markdown. Use plain text only — no `**bold**`, no `##` headers,
+no backticks for emphasis. Section headers are plain lines followed by a
+blank line.
 
 ## Output format
 
-Use these exact headers in order. Omit any section whose data is absent,
-empty, or "none":
+Use these exact section headers in order. Omit any section whose data is
+absent, empty, or "none":
 
 ```
-## <agent_id> · <repo> · <branch-or-"workspace"> · <date>
+<agent_id> · <repo> · <branch-or-"workspace"> · <date>
 
-**Where we are**
+Where we are
 - 1-2 lines. Branch state, dirty/clean, sync with main. In workspace mode,
   name the clones and their branches compactly on one line.
 
-**Recent activity (last 48h)**
+Recent activity (last 48h)
 - 3-5 bullets summarizing the RECENT_MERGES section. Group related PRs by
   theme when possible (e.g., "Cleanup wave across X, Y, Z — #540, #539, #538").
   Prefer significance over literal listing.
 
-**Open PRs**
-- One bullet per PR: `#N title`. OMIT this section entirely if PRS is
+Open PRs
+- One bullet per PR: #N title. OMIT this section entirely if PRS is
   empty or "none".
 
-**Top open issues**
+Top open issues
 - 3-5 bullets from PRIORITY_ISSUES. Prefix notable labels in brackets
   (e.g., "[bug]", "[p0]"). OMIT this section if PRIORITY_ISSUES is empty.
 
-**Live sessions**
+Live sessions
 - Single line: count and one notable detail if any. OMIT if no sessions
   besides self.
 
-**Next up**
+Next up
 - ONE concrete, grounded action. Priority order:
   1. open PR to review (name it: "Review PR #X")
   2. dirty working tree (clone mode)
@@ -43,12 +48,14 @@ empty, or "none":
 ## Rules
 
 - Be terse. Total output 15-25 lines.
-- Use `###` for subheaders only if you need them; no other heading levels.
-- No preamble, no sign-off, no "Summary:" prefix. Just the markdown.
+- No markdown formatting anywhere. No `**`, no `##`, no `#`, no backticks.
+- Section headers are bare text on their own line, followed by a blank line
+  before bullets.
+- No preamble, no sign-off, no "Summary:" prefix. Just the text.
 - If RECENT_MERGES is empty, say: "- (no merges in last 48h)"
 - Pretty-print the date: YYYYMMDD → YYYY-MM-DD.
 - Header line format:
-  `## {agent_id} · {repo} · {branch_or_"workspace"} · {YYYY-MM-DD}`
+  `{agent_id} · {repo} · {branch_or_"workspace"} · {YYYY-MM-DD}`
   - If `is_workspace_root:true`, use `workspace` instead of a branch name.
   - If `repo:unknown`, use `(no repo)`.
 


### PR DESCRIPTION
## Summary

Fixes #366. The `/startup` summary (added in #362, refined in #364) produced markdown with `**bold**` and `##` headers, but the output is rendered as Bash tool output in Claude Code — which doesn't render markdown. Users saw literal asterisks instead of bold.

This is the same class of issue that #337 fixed for the deterministic dashboard path. Now both paths emit consistent plain text.

## Changes

- Rewrote `modules/startup-dashboard/lib/startup-summary-prompt.md` to instruct the model to emit plain text:
  - No `**bold**`, no `##` / `#` headers, no backticks for emphasis
  - Section headers are bare text lines
  - Explicit warning at the top: "Output is rendered as Bash tool output in Claude Code, which does NOT render markdown."

## Test plan

- [x] Ran the live API pipeline (same path `startup-summary.sh` uses) with the new prompt — output is plain text, no `**` or `##`
- [x] Verified format and section order match the documented spec
- [ ] Run `/startup` in a fresh session after merge + installer sync to confirm end-to-end

Closes #366