### PR TITLE
#374: /docupdate — sync docs with 56-module catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Modular configuration system for [Claude Code](https://docs.anthropic.com/en/doc
 
 ## What is CCGM?
 
-CCGM is a curated collection of 40 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
+CCGM is a curated collection of 56 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
 
 Each module is self-contained with its own README, so you can also [copy individual files manually](#manual-installation) without the installer.
 
@@ -94,7 +94,7 @@ For a quick install with a preset:
 |--------|---------|----------|
 | **minimal** | global-claude-md, autonomy, git-workflow | Getting started |
 | **standard** | global-claude-md, autonomy, identity, git-workflow, hooks, settings, commands-core, commands-utility | Most users |
-| **full** | All 38 stable modules | Power users |
+| **full** | All 41 stable modules | Power users |
 | **team** | global-claude-md, autonomy, git-workflow, hooks, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification | Teams |
 
 ### Other install options
@@ -124,6 +124,10 @@ For a quick install with a preset:
 | **commands-core** | commands | /commit, /pr, /cpm (commit-PR-merge), /gs (git status), /ghi (create issue) | - |
 | **commands-extra** | commands | /audit (codebase audit), /pwv (Playwright verify), /walkthrough, /promote-rule | - |
 | **commands-utility** | commands | /cws-submit (Chrome Web Store walkthrough), /ccgm-sync (sync config to CCGM + lem-deepresearch), /user-test (browser user testing) | - |
+| **ce-review** | commands | /ce-review unified code-review orchestrator. Composes scope-drift, learnings-researcher, tier-sharpener, and review-synthesizer with structured JSON findings | - |
+| **onboarding** | commands | /onboarding - analyzes a repository and generates a structured ONBOARDING.md for new contributors | - |
+| **pr-review-toolkit** | commands | Augments the external pr-review-toolkit plugin with scope-drift detection on top of the standard code/test/comment/silent-failure/type passes | - |
+| **ship-readiness** | commands | /ship-ready - at-a-glance merge-gate dashboard for the current branch: checks, conflicts, diff size, reviewer state | - |
 | **documentation** | commands | /docupdate (comprehensive documentation audit: README, TOC, onboarding, packages, module coverage) | - |
 | **copycat** | commands | /copycat (analyze external Claude Code config repos for CCGM improvements) | - |
 | **debugging** | commands | /debug (structured root-cause debugging with Opus) | - |
@@ -145,6 +149,12 @@ For a quick install with a preset:
 | **cloud-dispatch** | workflow | Delegate GitHub issues to autonomous Claude Code agents on Hetzner Cloud VMs. Includes /dispatch, /dispatch-status, /dispatch-stop, /vm-manage commands | - |
 | **self-improving** | workflow | Meta-learning system: /reflect and /consolidate commands, PostToolUse hook (PR merge/issue close reminders), PreCompact hook (pre-compaction capture), prescriptive reflection triggers | - |
 | **subagent-patterns** | workflow | Subagent dispatch: task decomposition, spec-driven delegation, two-stage review, parallel coordination | - |
+| **commands-preamble** | workflow | [EXPERIMENTAL] UserPromptSubmit hook that injects a compact preamble of iron-law principles into every prompt | - |
+| **compound-knowledge** | workflow | Team-shared learnings in `docs/solutions/`. After solving a non-trivial problem, capture the pattern in a versioned schema | - |
+| **document-review** | workflow | Seven-lens plan-quality gate. /document-review fans out to 7 role-specific reviewers (coherence, feasibility, product, scope, design, security, adversarial) with structured JSON findings | skill-authoring, subagent-patterns |
+| **git-worktrees** | workflow | Solo-agent worktree-based isolation for feature work. Lighter alternative to multi-clone | - |
+| **pr-feedback** | workflow | /resolve-pr-feedback - fetches unresolved PR review threads via GraphQL, clusters 3+ items by category, dispatches parallel resolver agents | skill-authoring, subagent-patterns |
+| **todos** | workflow | File-based review-finding tracker. Review findings, PR nitpicks, and tech debt tracked with structured YAML | - |
 | **code-quality** | patterns | Code standards, testing requirements, error handling, security, build verification | - |
 | **browser-automation** | patterns | Browser tool selection (Chrome, Playwright, WebMCP), verification priority, UI testing workflow | - |
 | **common-mistakes** | patterns | 8 battle-tested anti-patterns: shallow exploration, dependency blindness, ESLint Fast Refresh, more | - |
@@ -152,6 +162,10 @@ For a quick install with a preset:
 | **systematic-debugging** | patterns | 4-phase root cause investigation: investigate, analyze, test hypotheses, implement fix | - |
 | **test-driven-development** | patterns | Strict red-green-refactor TDD discipline. No production code without a failing test first | - |
 | **verification** | patterns | Evidence-before-claims: fresh execution of verification commands, read full output before asserting done | - |
+| **agent-native** | patterns | Principles and audit skill for building applications where an agent is a first-class client | - |
+| **make-interfaces-feel-better** | patterns | Design-engineering details that compound into polished interfaces. Model-invoked skill covering typography, surfaces, animations, performance | - |
+| **rule-authoring** | patterns | Discipline for writing rules that hold up under pressure. Treats rule authoring as a first-class skill with iron-law structure | - |
+| **skill-authoring** | patterns | Discipline for writing skills and slash commands that stay efficient, portable, and structured across models | - |
 | **cloudflare** | tech-specific | Pages vs Workers selection, deployment methods, Git integration requirements | - |
 | **supabase** | tech-specific | API key terminology, env var naming, migration validation, database workflow | - |
 | **mcp-development** | tech-specific | Building MCP servers: project structure, tool design, error handling, testing, evaluation patterns | - |
@@ -264,7 +278,7 @@ The `docs/` directory contains comprehensive documentation:
 | Document | Description |
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
-| [Module Catalog](docs/modules.md) | Detailed reference for all 40 modules |
+| [Module Catalog](docs/modules.md) | Detailed reference for all 56 modules |
 | [Commands Reference](docs/commands.md) | All 36 slash commands with usage examples |
 | [Hooks Reference](docs/hooks.md) | All 13 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,6 @@
 # Module Catalog
 
-CCGM contains 40 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
+CCGM contains 56 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
 
 ## How modules work
 
@@ -696,6 +696,25 @@ Principles for building distinctive, production-grade web interfaces.
 - **Motion**: Purposeful animations (feedback, orientation, delight), not decoration
 - **What to avoid**: Default framework styles, generic card grids, excessive gradients
 - **Implementation checklist**: Questions to ask before writing UI code
+
+**Dependencies**: None
+
+---
+
+### make-interfaces-feel-better
+
+Design-engineering details that compound into polished interfaces. Vendored from [jakubkrehel/make-interfaces-feel-better](https://github.com/jakubkrehel/make-interfaces-feel-better) (MIT).
+
+**Installs**: `skills/make-interfaces-feel-better/` (SKILL.md + typography.md, surfaces.md, animations.md, performance.md)
+
+**What it does**: A model-invoked skill. Claude loads it automatically when the conversation is about UI polish, animations, shadows, borders, typography, micro-interactions, or any visual-detail work. Covers:
+
+- **Typography**: `text-wrap: balance` / `pretty`, font smoothing on macOS, tabular numbers for dynamic values
+- **Surfaces**: Concentric border radius, optical vs geometric alignment, shadows instead of borders, image outlines, hit areas
+- **Animations**: Interruptible animations (transitions vs keyframes), enter/exit transitions, icon micro-interactions, scale on press
+- **Performance**: Transition specificity, `will-change` usage
+
+Complements `frontend-design` (aesthetic direction) and `design-review` (automated review) with implementation-level details.
 
 **Dependencies**: None
 


### PR DESCRIPTION
Closes #374. Post-merge /docupdate run after #373.

## Summary

- Module counts were stale: README and `docs/modules.md` said **40 modules**, actual is **56**.
- README catalog table was missing 14 entries.
- New module `make-interfaces-feel-better` from #373 had no catalog entry.

## Changes

**README.md**
- Intro: 40 → 56 configuration modules
- Full preset: \"All 38 stable modules\" → \"All 41 stable modules\"
- Docs link: \"all 40 modules\" → \"all 56 modules\"
- Catalog table: added 14 missing rows (4 commands, 6 workflow, 4 patterns)

**docs/modules.md**
- Count: 40 → 56
- Added full section for `make-interfaces-feel-better` under Category: patterns

## Remaining debt (flagged, not in this PR)

`docs/modules.md` still lacks full sections for 14 modules (see #374 body). Also: README's command/hook counts ("All 36 slash commands" / "All 13 hooks") may be stale — actual `.md` command files: 47, production hooks: ~19. docs/commands.md documents 35, docs/hooks.md documents 12. These are pre-existing drift, unrelated to #373.

## Test plan

- [x] Module count verified: `find modules -name module.json | wc -l` = 56
- [x] Preset count verified: `full` = 41, `cloud-agent` = 42
- [x] README catalog diff against actual modules — all 56 now present
- [x] \`bash tests/test-modules.sh\` — 1000 pass (unchanged)