### PR TITLE
#376: learnings-store supersede chains + compact-guard helper

### DIFF
--- a/modules/self-improving/bin/ccgm-learnings-log
+++ b/modules/self-improving/bin/ccgm-learnings-log
@@ -9,6 +9,7 @@ Usage:
     ccgm-learnings-log verify <id>                 # bump uses + last_verified
     ccgm-learnings-log contradict <id>             # bump contradictions counter
     ccgm-learnings-log deprecate <id>              # mark deprecated
+    ccgm-learnings-log supersede <old_id> --content "..." [--reason "..."]
     ccgm-learnings-log config cross-project on|off
 
 Fields:
@@ -97,6 +98,35 @@ def _cmd_deprecate(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
+def _cmd_supersede(args: argparse.Namespace) -> int:
+    try:
+        new_entry = ls.supersede_entry(
+            args.old_id,
+            content=args.content,
+            type_=args.new_type,
+            source=args.source or "observed",
+            confidence=args.confidence,
+            tags=args.tag,
+            files=args.file,
+            slug=args.project,
+            reason=args.reason,
+        )
+    except ls.ValidationError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    if new_entry is None:
+        print(f"error: no entry with id {args.old_id!r}", file=sys.stderr)
+        return 1
+
+    print(json.dumps({
+        "id": new_entry["id"],
+        "supersedes": args.old_id,
+        "slug": new_entry["project"],
+    }))
+    return 0
+
+
 def _cmd_config(args: argparse.Namespace) -> int:
     cfg = ls.load_config()
     if args.setting == "cross-project":
@@ -138,6 +168,24 @@ def build_parser() -> argparse.ArgumentParser:
     dep.add_argument("id")
     dep.add_argument("--project")
     dep.set_defaults(func=_cmd_deprecate)
+
+    sup = sub.add_parser(
+        "supersede",
+        help="replace an entry atomically; links old <-> new via supersedes/superseded_by",
+    )
+    sup.add_argument("old_id", help="id of the entry being superseded")
+    sup.add_argument("--content", required=True)
+    sup.add_argument("--type", dest="new_type", choices=sorted(ls.VALID_TYPES),
+                     help="defaults to inheriting the old entry's type")
+    sup.add_argument("--source", choices=sorted(ls.VALID_SOURCES))
+    sup.add_argument("--confidence", type=int)
+    sup.add_argument("--tag", action="append",
+                     help="repeatable; overrides old tags if provided")
+    sup.add_argument("--file", action="append",
+                     help="repeatable; overrides old files if provided")
+    sup.add_argument("--project")
+    sup.add_argument("--reason", help="free-form note on why the supersede happened")
+    sup.set_defaults(func=_cmd_supersede)
 
     cfg_sub = sub.add_parser("config", help="adjust learnings-store config")
     cfg_sub.add_argument("setting", choices=["cross-project"])

--- a/modules/self-improving/bin/ccgm-learnings-search
+++ b/modules/self-improving/bin/ccgm-learnings-search
@@ -87,6 +87,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--max", type=int, dest="max_results")
     p.add_argument("--budget", type=int, dest="token_budget")
     p.add_argument("--include-stale", action="store_true")
+    p.add_argument("--include-superseded", action="store_true",
+                   help="surface entries that have been replaced via supersede")
     p.add_argument("--format", choices=["jsonl", "markdown", "preamble"], default="preamble")
     p.add_argument("--list-projects", action="store_true")
     args = p.parse_args(argv)
@@ -105,6 +107,7 @@ def main(argv: list[str] | None = None) -> int:
         max_results=args.max_results,
         token_budget=args.token_budget,
         include_stale=args.include_stale,
+        include_superseded=args.include_superseded,
     )
 
     if args.format == "jsonl":

--- a/modules/self-improving/lib/learnings_store.py
+++ b/modules/self-improving/lib/learnings_store.py
@@ -30,7 +30,10 @@ Schema per entry:
       "last_verified": "<ISO 8601 UTC>",
       "uses": 0,
       "contradictions": 0,
-      "deprecated": false
+      "deprecated": false,
+      "supersedes": "<id of the entry this one replaces, or null>",
+      "superseded_by": "<id of the entry that replaced this one, or null>",
+      "supersede_reason": "<free-form, optional>"
     }
 
 Read path applies:
@@ -283,6 +286,8 @@ def build_entry(
     files: list[str] | None = None,
     project: str | None = None,
     key: str | None = None,
+    supersedes: str | None = None,
+    supersede_reason: str | None = None,
 ) -> dict[str, Any]:
     """
     Build a schema-valid, sanitized entry. Does NOT write.
@@ -303,6 +308,9 @@ def build_entry(
         "uses": 0,
         "contradictions": 0,
         "deprecated": False,
+        "supersedes": supersedes,
+        "superseded_by": None,
+        "supersede_reason": supersede_reason,
     }
     validate_entry(entry)
     return entry
@@ -510,14 +518,15 @@ def search(
     max_results: int | None = None,
     token_budget: int | None = None,
     include_stale: bool = False,
+    include_superseded: bool = False,
     config: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """
     Return a ranked, filtered, token-capped list of learnings.
 
     The caller is expected to inject this into a command preamble or skill
-    context. Results are already sanitized; deprecated and stale-below-
-    threshold entries are excluded by default.
+    context. Results are already sanitized; deprecated, superseded, and
+    stale-below-threshold entries are excluded by default.
     """
     cfg = config or load_config()
     half_life = float(cfg.get("half_life_days", DEFAULT_HALF_LIFE_DAYS))
@@ -548,6 +557,9 @@ def search(
     if types:
         wanted = set(types)
         pool = [e for e in pool if e.get("type") in wanted]
+
+    if not include_superseded:
+        pool = [e for e in pool if not e.get("superseded_by")]
 
     pool = dedup_latest(pool)
 
@@ -625,3 +637,112 @@ def update_entry_by_id(
     if found:
         _rewrite_jsonl(target_slug, entries)
     return found
+
+
+# ---------------------------------------------------------------------------
+# Supersede (atomic replace with linked chain)
+# ---------------------------------------------------------------------------
+
+def supersede_entry(
+    old_id: str,
+    *,
+    content: str,
+    type_: str | None = None,
+    source: str = "observed",
+    confidence: int | None = None,
+    tags: list[str] | None = None,
+    files: list[str] | None = None,
+    slug: str | None = None,
+    reason: str | None = None,
+) -> dict[str, Any] | None:
+    """
+    Atomically replace one entry with a new one, linking them both ways.
+
+    Creates a NEW entry pointing at `old_id` via `supersedes`, stamps the old
+    entry's `superseded_by` with the new id, and rewrites the JSONL so both
+    records persist. Returns the new entry on success, or None if `old_id`
+    was not found.
+
+    Missing `type_` / `confidence` / `tags` / `files` are inherited from the
+    old entry so a bare `supersede(old_id, content=...)` call does the right
+    thing for the common "same idea, updated wording" case.
+    """
+    target_slug = slug or detect_project_slug()
+    entries = load_all(target_slug)
+    old = next((e for e in entries if e.get("id") == old_id), None)
+    if old is None:
+        return None
+
+    inherited_type = type_ or old.get("type")
+    inherited_conf = confidence if confidence is not None else old.get("confidence", DEFAULT_CONFIDENCE)
+    inherited_tags = tags if tags is not None else list(old.get("tags", []))
+    inherited_files = files if files is not None else list(old.get("files", []))
+
+    new_entry = build_entry(
+        type_=inherited_type,
+        content=content,
+        source=source,
+        confidence=inherited_conf,
+        tags=inherited_tags,
+        files=inherited_files,
+        project=old.get("project") or target_slug,
+        supersedes=old_id,
+        supersede_reason=reason,
+    )
+
+    old["superseded_by"] = new_entry["id"]
+    entries.append(new_entry)
+    _rewrite_jsonl(target_slug, entries)
+    return new_entry
+
+
+# ---------------------------------------------------------------------------
+# Compaction guard (reject lossy rewrites)
+# ---------------------------------------------------------------------------
+
+# Fact-bearing tokens: identifiers, proper nouns, quoted strings, dates,
+# version numbers, acronyms. The regex is intentionally conservative - false
+# positives just mean the guard complains about a rewrite that didn't
+# actually lose meaning, which fails safe.
+_FACT_TOKEN_RE = re.compile(
+    r"""
+    (?P<ident>   [A-Za-z][A-Za-z0-9]*(?:[_.\-][A-Za-z0-9]+)+ )   # foo_bar, Foo.Bar, foo-bar
+  | (?P<proper> \b[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)+\b )       # Proper Noun Phrases (handles McComb, iPhone-free)
+  | (?P<quoted> "[^"\n]{2,}" | '[^'\n]{2,}' )                    # "quoted" or 'quoted'
+  | (?P<date>   \b\d{4}(?:-\d{2}(?:-\d{2})?)?\b )                # 2026 or 2026-04-23
+  | (?P<ver>    \b\d+(?:\.\d+){1,}\b )                           # 1.2.3
+  | (?P<acr>    \b[A-Z]{2,}\b )                                  # ACRONYMS
+    """,
+    re.VERBOSE,
+)
+
+
+def _extract_fact_tokens(text: str) -> set[str]:
+    """Extract the set of fact-bearing tokens from a block of prose."""
+    return {m.group(0) for m in _FACT_TOKEN_RE.finditer(text or "")}
+
+
+def compact_preserves_facts(
+    old_text: str,
+    new_text: str,
+    *,
+    threshold: float = 0.05,
+) -> tuple[bool, list[str]]:
+    """
+    Check that a rewrite preserves the bulk of fact-bearing tokens.
+
+    Extracts identifiers, proper nouns, quoted strings, dates, version
+    numbers, and acronyms from both texts. Returns `(ok, dropped)` where
+    `ok` is True if at most `threshold` of unique old tokens are missing
+    from the new text. `dropped` is the sorted list of tokens lost.
+
+    Use to guard against lossy model-driven compaction: if the check fails,
+    do not commit the rewrite - flag for human review.
+    """
+    old_tokens = _extract_fact_tokens(old_text)
+    if not old_tokens:
+        return True, []
+    new_tokens = _extract_fact_tokens(new_text)
+    dropped = sorted(old_tokens - new_tokens)
+    loss = len(dropped) / len(old_tokens)
+    return loss <= threshold, dropped

--- a/modules/self-improving/rules/learnings-store.md
+++ b/modules/self-improving/rules/learnings-store.md
@@ -54,6 +54,9 @@ Each line is a JSON object:
 | `uses` | integer | no | Increments on verify |
 | `contradictions` | integer | no | Increments on contradict |
 | `deprecated` | bool | no | Hard-excluded from reads when true |
+| `supersedes` | string | no | Id of the entry this one replaces (set on the new entry) |
+| `superseded_by` | string | no | Id of the entry that replaced this one (set on the old entry) |
+| `supersede_reason` | string | no | Free-form note on why the replacement happened |
 
 ### Type vocabulary
 
@@ -81,6 +84,45 @@ effective = base * 0.5 ^ (age_days / half_life_days)
 - `deprecated: true` zeros effective confidence unconditionally.
 
 Entries whose effective confidence falls below the deprecate threshold (default 2.0) are skipped at read time without being deleted from the JSONL. This keeps the audit trail intact.
+
+---
+
+## Supersede Chains
+
+When a learning needs to be explicitly replaced (same topic, updated guidance), use `supersede` instead of `deprecate` + new entry. Supersede is atomic and bidirectional:
+
+- The **new** entry gets `supersedes: <old_id>` and a `supersede_reason`.
+- The **old** entry gets `superseded_by: <new_id>`.
+- `search()` hides the old entry by default. Pass `include_superseded=True` (CLI: `--include-superseded`) to walk the chain.
+
+Unlike `deprecate`, which tells the reader "this is wrong," supersede says "this was replaced by X." The chain is the audit trail: reading old → follow `superseded_by` → reach current state.
+
+Missing `type_`, `confidence`, `tags`, or `files` are inherited from the old entry — the common "refine the wording" case is `supersede <old_id> --content "..."` with no other flags.
+
+Supersede is the right tool when:
+- A pattern evolved (old version still worked, new version is better).
+- A preference changed (user now prefers X over Y).
+- An architecture fact was refined (was "runs at 5s", is now "runs at 2s").
+
+Use `deprecate` (not supersede) when:
+- The learning is outright wrong and has no replacement.
+- The pattern was abandoned; there is no "new version."
+
+---
+
+## Compaction Guard
+
+When a compaction pass (e.g., `/consolidate`) rewrites a learning's content to reduce tokens, call `compact_preserves_facts(old, new, threshold=0.05)` before committing the rewrite. The guard extracts fact-bearing tokens from both texts — identifiers (`foo_bar`, `Foo.Bar`), proper nouns, quoted strings, dates, version numbers, acronyms — and rejects the rewrite if more than `threshold` (default 5%) of unique old tokens go missing.
+
+Intent: model-driven compaction can silently drop facts. The guard is a cheap regex-based backstop that catches the common "rewrote the prose but lost the `users` table name" failure mode. It is not semantic; false positives are fine (they fail safe), false negatives are possible (the guard can only see tokens it recognizes).
+
+```python
+from learnings_store import compact_preserves_facts
+ok, dropped = compact_preserves_facts(old_content, new_content)
+if not ok:
+    # Flag for human review; do not overwrite the original.
+    log_unsafe_rewrite(old_id, dropped)
+```
 
 ---
 
@@ -146,6 +188,23 @@ ccgm-learnings-log verify <id>       # Bumps uses + last_verified
 ccgm-learnings-log contradict <id>   # Bumps contradictions counter
 ccgm-learnings-log deprecate <id>    # Hard-excludes from reads
 ```
+
+### Supersede (atomic replace)
+
+```bash
+# Refine the wording, keep type/tags/files from the old entry
+ccgm-learnings-log supersede <old_id> \
+  --content "Updated guidance..." \
+  --reason "clarified based on 2026-04-22 incident"
+
+# Change tags as well
+ccgm-learnings-log supersede <old_id> \
+  --content "..." \
+  --tag workflow --tag git \
+  --reason "broader scope"
+```
+
+Old entry's `superseded_by` is set atomically; both rows persist in the JSONL. Default search hides the old row; `ccgm-learnings-search --include-superseded` surfaces the chain.
 
 ### Config
 

--- a/modules/self-improving/tests/test_learnings_store.py
+++ b/modules/self-improving/tests/test_learnings_store.py
@@ -248,6 +248,114 @@ class UpdateTests(unittest.TestCase):
         self.assertFalse(ok)
 
 
+class SupersedeTests(unittest.TestCase):
+    def setUp(self):
+        self.slug = f"sup-proj-{int(time.time()*1e6)}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        e = ls.build_entry(
+            type_="pattern",
+            content="original guidance about Foo.bar_baz",
+            confidence=7,
+            tags=["demo"],
+            files=["src/foo.py"],
+        )
+        ls.append_entry(e)
+        self.old_id = e["id"]
+
+    def tearDown(self):
+        path = ls.project_jsonl(self.slug)
+        if path.is_file():
+            path.unlink()
+
+    def test_supersede_links_both_entries(self):
+        new = ls.supersede_entry(
+            self.old_id,
+            content="revised guidance about Foo.bar_baz with new context",
+            slug=self.slug,
+            reason="api renamed",
+        )
+        self.assertIsNotNone(new)
+        entries = {e["id"]: e for e in ls.load_all(self.slug)}
+        self.assertEqual(entries[self.old_id]["superseded_by"], new["id"])
+        self.assertEqual(entries[new["id"]]["supersedes"], self.old_id)
+        self.assertEqual(entries[new["id"]]["supersede_reason"], "api renamed")
+
+    def test_supersede_inherits_type_and_metadata(self):
+        new = ls.supersede_entry(self.old_id, content="revised", slug=self.slug)
+        self.assertEqual(new["type"], "pattern")
+        self.assertEqual(new["tags"], ["demo"])
+        self.assertEqual(new["files"], ["src/foo.py"])
+
+    def test_supersede_explicit_tags_override(self):
+        new = ls.supersede_entry(
+            self.old_id,
+            content="revised",
+            tags=["new-tag"],
+            slug=self.slug,
+        )
+        self.assertEqual(new["tags"], ["new-tag"])
+
+    def test_supersede_missing_id_returns_none(self):
+        result = ls.supersede_entry("nosuchid123", content="x", slug=self.slug)
+        self.assertIsNone(result)
+
+    def test_search_hides_superseded_by_default(self):
+        new = ls.supersede_entry(
+            self.old_id,
+            content="replacement content entirely different",
+            slug=self.slug,
+        )
+        results = ls.search(slug=self.slug)
+        ids = [r["id"] for r in results]
+        self.assertIn(new["id"], ids)
+        self.assertNotIn(self.old_id, ids)
+
+    def test_search_include_superseded_surfaces_chain(self):
+        new = ls.supersede_entry(
+            self.old_id,
+            content="replacement content entirely different",
+            slug=self.slug,
+        )
+        results = ls.search(slug=self.slug, include_superseded=True)
+        ids = {r["id"] for r in results}
+        self.assertIn(new["id"], ids)
+        self.assertIn(self.old_id, ids)
+
+
+class CompactGuardTests(unittest.TestCase):
+    def test_preserves_when_rewrite_keeps_facts(self):
+        old = 'Migration 0042_users adds NOT NULL column to "users" table on 2026-04-21.'
+        new = 'The 2026-04-21 migration 0042_users adds a NOT NULL column to the "users" table.'
+        ok, dropped = ls.compact_preserves_facts(old, new)
+        self.assertTrue(ok, f"unexpectedly dropped: {dropped}")
+
+    def test_rejects_when_rewrite_drops_identifiers(self):
+        old = "Migration 0042_users modifies user_id, company_id, and Acme.Corp columns on 2026-04-21."
+        new = "Migration modifies some user columns."
+        ok, dropped = ls.compact_preserves_facts(old, new)
+        self.assertFalse(ok)
+        self.assertTrue(dropped)
+
+    def test_empty_old_is_trivially_ok(self):
+        ok, dropped = ls.compact_preserves_facts("", "anything here")
+        self.assertTrue(ok)
+        self.assertEqual(dropped, [])
+
+    def test_threshold_is_configurable(self):
+        # Old has ten fact tokens; new drops one (10% loss).
+        old = "tokens: Foo.bar Baz.qux Alpha.beta Gamma.delta Epsilon.zeta Eta.theta Iota.kappa Lambda.mu Nu.xi Omicron.pi"
+        new = "tokens: Foo.bar Baz.qux Alpha.beta Gamma.delta Epsilon.zeta Eta.theta Iota.kappa Lambda.mu Nu.xi"
+        ok_strict, _ = ls.compact_preserves_facts(old, new, threshold=0.05)
+        ok_loose, _ = ls.compact_preserves_facts(old, new, threshold=0.15)
+        self.assertFalse(ok_strict)
+        self.assertTrue(ok_loose)
+
+    def test_extracts_proper_nouns(self):
+        tokens = ls._extract_fact_tokens("Lucas McComb works on OpenChronicle in Shanghai.")
+        # Should grab multi-word proper noun phrases
+        self.assertIn("Lucas McComb", tokens)
+
+
 def _cleanup():
     shutil.rmtree(_TMP, ignore_errors=True)
 


### PR DESCRIPTION
## Summary

Two additions to the learnings store, inspired by OpenChronicle's memory format:

1. **Supersede chains** — atomic replace with bidirectional linkage (`supersedes` / `superseded_by`). Unlike `deprecate` + new entry (which leaves no trace of what replaced what), supersede persists both rows with explicit pointers. Search hides the old row by default; `--include-superseded` walks the chain.

2. **Compact-guard** — `compact_preserves_facts(old, new, threshold=0.05)` helper that extracts fact-bearing tokens (identifiers, proper nouns, quoted strings, dates, versions, acronyms) from both texts and rejects the rewrite if more than 5% of unique old tokens go missing. Cheap regex backstop for model-driven lossy compaction.

## Changes

- `lib/learnings_store.py` — new `supersedes` / `superseded_by` / `supersede_reason` schema fields; `supersede_entry()` (atomic, inherits type/tags/files when not overridden); `compact_preserves_facts()` + `_extract_fact_tokens()`; `search()` now filters superseded entries by default with `include_superseded` escape hatch.
- `bin/ccgm-learnings-log` — `supersede <old_id> --content "..." [--reason ...] [--tag ...]` subcommand.
- `bin/ccgm-learnings-search` — `--include-superseded` flag.
- `tests/test_learnings_store.py` — 11 new tests (6 supersede, 5 compact-guard); full suite **37/37 passing**.
- `rules/learnings-store.md` — updated schema table, new Supersede Chains + Compaction Guard sections, CLI examples.

## Test Plan

- [x] `python3 modules/self-improving/tests/test_learnings_store.py` → 37/37 pass
- [x] End-to-end CLI: write → supersede → default search hides old, `--include-superseded` surfaces both
- [x] Compact-guard rejects rewrites that drop dates/identifiers, accepts semantic rewrites that preserve fact tokens

## Non-Goals

- Wiring compact-guard into `/consolidate` (follow-up)
- Retroactively migrating old deprecate+append pairs into supersede chains (existing dedup still works)

Closes #376