### PR TITLE
#380: fetch origin per clone in workspace mode startup gather

### DIFF
--- a/modules/startup-dashboard/lib/startup-gather.sh
+++ b/modules/startup-dashboard/lib/startup-gather.sh
@@ -88,6 +88,14 @@ fi
   if [ "$IS_WORKSPACE_ROOT" != true ]; then
     exit 0
   fi
+  # Refresh origin/main in parallel so ahead/behind counts aren't stale.
+  # Read-only: no pull, no rebase. See issue #380.
+  for child in "$PROJECT_DIR"/*-c[0-9]*/; do
+    [ -d "$child" ] || continue
+    git -C "$child" rev-parse --git-dir >/dev/null 2>&1 || continue
+    git -C "$child" fetch origin --quiet 2>/dev/null &
+  done
+  wait
   for child in "$PROJECT_DIR"/*-c[0-9]*/; do
     [ -d "$child" ] || continue
     git -C "$child" rev-parse --git-dir >/dev/null 2>&1 || continue


### PR DESCRIPTION
## Summary

In workspace mode, `startup-gather.sh` was reading each clone's `origin/main` without fetching first, so `ahead/behind` counts were stale and "up to date" claims could be hours or days old.

## Changes

- `modules/startup-dashboard/lib/startup-gather.sh`: before the per-clone status loop, fetch every clone's origin in parallel (background + `wait`). Read-only — no pull, no rebase.

## Why not auto-pull or auto-rebase?

The existing git flow handles that through `gfrom` and the branch-from-`origin/main` rule. Mutating working trees from a startup summary would surprise sibling agents mid-work.

## Verification

Before the fix, workspace-root startup reported c3 as "up to date." After the fix, the same startup now correctly reports `c3 main clean ahead 0, behind 92`. Total gather runtime ~1.6s with parallel fetches.

Closes #380