### PR TITLE
#388: replace personal name in test_learnings_store.py fixture

### DIFF
--- a/modules/self-improving/tests/test_learnings_store.py
+++ b/modules/self-improving/tests/test_learnings_store.py
@@ -351,9 +351,9 @@ class CompactGuardTests(unittest.TestCase):
         self.assertTrue(ok_loose)
 
     def test_extracts_proper_nouns(self):
-        tokens = ls._extract_fact_tokens("Lucas McComb works on OpenChronicle in Shanghai.")
+        tokens = ls._extract_fact_tokens("Ada Lovelace works on OpenChronicle in Shanghai.")
         # Should grab multi-word proper noun phrases
-        self.assertIn("Lucas McComb", tokens)
+        self.assertIn("Ada Lovelace", tokens)
 
 
 def _cleanup():


### PR DESCRIPTION
## Summary

Fixes CI failure on main. The \`test-no-personal-data.sh\` scanner matches \"Lucas McComb\" anywhere in modules/, and PR #377 introduced that string as a test fixture for the proper-noun extractor. Replaced with \"Ada Lovelace\" — same multi-word proper-noun shape, no personal data.

## Verification

\`\`\`
bash tests/test-no-personal-data.sh  # PASS
python3 modules/self-improving/tests/test_learnings_store.py  # 37 tests OK
\`\`\`

Closes #388