### PR TITLE
#387: add per-module unit test runner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,22 @@ bash tests/test-modules.sh
 
 # Check for personal data leaks
 bash tests/test-no-personal-data.sh
+
+# Run per-module unit tests (pytest for Python, bash for shell)
+bash tests/run-unit-tests.sh
+
+# Run everything (structural + unit)
+bash tests/run-all.sh
 ```
+
+If a module ships code (scripts under `bin/`, libraries under `lib/`, or
+hooks), put unit tests under `modules/{name}/tests/`:
+
+- `test_*.py` — runs under `python3 -m pytest`; both `unittest.TestCase`
+  and pytest assertion-style tests are discovered.
+- `test_*.sh` — runs under `bash`; exit non-zero on any failure.
+
+The runner discovers these automatically, so no registration is needed.
 
 ## module.json Schema Reference
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -18,6 +18,18 @@ for test_script in "$SCRIPT_DIR"/test-*.sh; do
   fi
 done
 
+# Per-module unit tests (pytest + shell).
+if [[ -x "$SCRIPT_DIR/run-unit-tests.sh" ]]; then
+  echo ""
+  echo "=== Running run-unit-tests.sh ==="
+  if bash "$SCRIPT_DIR/run-unit-tests.sh"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("run-unit-tests.sh")
+  fi
+fi
+
 echo ""
 echo "=== Test Summary ==="
 echo "Passed: $PASS"

--- a/tests/run-unit-tests.sh
+++ b/tests/run-unit-tests.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# run-unit-tests.sh — run per-module unit tests across the CCGM repo.
+#
+# Discovers and runs:
+#   - Python tests (modules/*/tests/test_*.py) via `python3 -m pytest`
+#     (handles both unittest.TestCase and pytest assertion-style tests)
+#   - Shell tests (modules/*/tests/test_*.sh) via `bash`
+#
+# Exits 0 if all suites pass, 1 otherwise.
+#
+# Top-level integration/structural tests (tests/test-*.sh) are run by
+# tests/run-all.sh instead; this runner stays focused on module unit tests.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+PY_STATUS=0
+SH_STATUS=0
+SH_COUNT=0
+SH_FAILED=()
+
+echo "=== CCGM Unit Tests ==="
+echo ""
+
+# --- Python tests via pytest ---
+echo "--- Python (pytest) ---"
+if ! python3 -c "import pytest" 2>/dev/null; then
+    echo "  SKIP: pytest not importable. Install with: python3 -m pip install pytest"
+    PY_STATUS=0
+else
+    # pytest discovers modules/*/tests/test_*.py automatically.
+    if python3 -m pytest modules/ -q --no-header 2>&1; then
+        PY_STATUS=0
+    else
+        PY_STATUS=1
+    fi
+fi
+echo ""
+
+# --- Shell tests ---
+echo "--- Shell (bash) ---"
+while IFS= read -r -d '' test_script; do
+    SH_COUNT=$((SH_COUNT + 1))
+    rel=${test_script#"$REPO_ROOT/"}
+    if bash "$test_script" >/tmp/ccgm-test-$$.log 2>&1; then
+        echo "  PASS: $rel"
+    else
+        echo "  FAIL: $rel"
+        sed 's/^/    | /' /tmp/ccgm-test-$$.log
+        SH_FAILED+=("$rel")
+        SH_STATUS=1
+    fi
+    rm -f /tmp/ccgm-test-$$.log
+done < <(find modules -path '*/tests/test_*.sh' -type f -print0 2>/dev/null)
+
+if [ "$SH_COUNT" -eq 0 ]; then
+    echo "  (no shell unit tests found)"
+fi
+echo ""
+
+# --- Summary ---
+echo "=== Summary ==="
+if [ "$PY_STATUS" -eq 0 ]; then
+    echo "  Python: OK"
+else
+    echo "  Python: FAILED (see output above)"
+fi
+
+if [ "$SH_STATUS" -eq 0 ]; then
+    echo "  Shell:  $SH_COUNT suites, all passed"
+else
+    echo "  Shell:  $SH_COUNT suites, ${#SH_FAILED[@]} failed"
+    for f in "${SH_FAILED[@]}"; do echo "    - $f"; done
+fi
+
+if [ "$PY_STATUS" -ne 0 ] || [ "$SH_STATUS" -ne 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Aggregate runner for per-module unit tests. Discovers and runs them across all modules in a single command.

CCGM has ~139 Python unit tests across 5 modules that were previously invokable only one-at-a-time. No shell unit test support either. This PR establishes the harness without adding new tests — subsequent work (#382 skillify, #384/#385 ccgm-doctor audits, #386 resolver evals) can write tests and know they'll be picked up.

## What it does

\`tests/run-unit-tests.sh\` discovers:

- **Python**: \`modules/*/tests/test_*.py\` via \`python3 -m pytest\` — handles both \`unittest.TestCase\` and pytest assertion-style tests in one pass
- **Shell**: \`modules/*/tests/test_*.sh\` via \`bash\` — exit non-zero on any failure

Wired into \`tests/run-all.sh\` so a single command covers structural + unit tests.

## Baseline

Running against current \`main\`:

\`\`\`
139 passed, 12 warnings in 0.19s
\`\`\`

Suites discovered:
- \`modules/commands-preamble/tests/test_inject_preamble.py\` (15 tests)
- \`modules/hooks/tests/test_agent_sessions.py\` (8)
- \`modules/hooks/tests/test_agent_tracking_hook.py\` (12)
- \`modules/hooks/tests/test_agent_tracking.py\` (34)
- \`modules/multi-agent/tests/test_handoff.py\` (10)
- \`modules/self-improving/tests/test_learnings_store.py\` (37)
- \`modules/session-history/tests/test_recall.py\` (11)
- \`modules/session-history/tests/test_repo_detect.py\` (12)

## Changes

- New: \`tests/run-unit-tests.sh\`
- Updated: \`tests/run-all.sh\` — now chains the unit test runner
- Updated: \`CONTRIBUTING.md\` — documents the naming conventions so contributors' tests are picked up automatically

## Test plan

- [x] \`bash tests/run-unit-tests.sh\` — 139 passed
- [x] \`bash tests/run-all.sh\` — 8 structural + unit runner all pass
- [x] Handles missing pytest gracefully (skips rather than failing)
- [x] Discovers pytest assertion-style tests (session-history) alongside TestCase-style (learnings store)

## Non-goals

Not in this PR (each its own issue if needed):
- New test suites for currently-untested code (startup scripts, statusline.sh)
- CI wiring
- Coverage reports

Closes #387