### PR TITLE
#393: docupdate drift — module count and missing hook docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ The installer offers four presets, or you can select modules one by one:
 | **minimal** | Core autonomy + git workflow rules | Trying CCGM for the first time |
 | **standard** | Minimal + hooks, settings, core commands | Most individual developers |
 | **team** | Standard + github-protocols, code-quality, debugging, verification | Teams with shared repos |
-| **full** | All 35 modules | Power users who want everything |
+| **full** | All 56 modules | Power users who want everything |
 
 See [Presets](presets.md) for detailed breakdowns.
 
@@ -140,7 +140,7 @@ Removes only CCGM-installed files (tracked via a manifest). Your personal files 
 
 ## Next steps
 
-- [Module Catalog](modules.md) - explore all 35 modules in detail
+- [Module Catalog](modules.md) - explore all 56 modules in detail
 - [Commands Reference](commands.md) - learn every slash command
 - [Hooks Reference](hooks.md) - understand the workflow automation
 - [Configuration](configuration.md) - customize CCGM after installation

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -18,7 +18,7 @@ Hooks are registered in `settings.json` under the `hooks` key. Each hook specifi
 
 ## Installed hooks
 
-The **hooks** module installs 10 hooks, 2 Python libraries, and a settings partial. The **self-improving** module installs 2 additional hooks. Total: 12 hooks across 2 modules.
+The **hooks** module installs 13 hooks, 2 Python libraries, and a settings partial. The **self-improving** module installs 2 additional hooks. Total: 15 hooks across 2 modules.
 
 ---
 
@@ -245,6 +245,42 @@ Reminds Claude to capture unwritten patterns before context compaction compresse
 **When it fires**: Before context compression begins. By the time PostCompact fires, session context is already compressed and learnings may be lost.
 
 **Output**: `<precompact-reflection>` instruction prompting Claude to run the reflection checklist or invoke `/reflect`.
+
+---
+
+### check-careful.py
+
+**Type**: PreToolUse:Bash
+**Module**: hooks
+**Can block**: Yes (returns `permissionDecision: "ask"`)
+
+Pauses destructive Bash commands for confirmation. Catches `rm -rf`, SQL `DROP`/`TRUNCATE`, `git push --force`, `git reset --hard`, `git checkout .`, `kubectl delete`, and `docker rm -f` / `docker system prune`.
+
+**Smart allow-list**: Build-artifact directories (`node_modules`, `dist`, `.next`, `build`, `__pycache__`, `.cache`, `.turbo`, `coverage`) bypass the prompt for `rm -rf`.
+
+---
+
+### check-freeze.py
+
+**Type**: PreToolUse:Edit/Write
+**Module**: hooks
+**Can block**: Yes
+
+Scope-locks file edits to a frozen directory. When `~/.claude/freeze-dir.txt` contains a directory path, any Edit or Write outside that directory is denied. Paths are normalised (symlinks resolved, `..` collapsed) before the containment check.
+
+**Activation**: `/freeze <dir>` to set, `/unfreeze` to clear.
+
+---
+
+### session-start-enforce.py
+
+**Type**: SessionStart
+**Module**: hooks
+**Can block**: No (context injection only)
+
+Experimental (OFF by default). Injects a rule-enforcement meta-instruction at fresh session start, reminding the agent to route through the discipline rules (TDD, systematic-debugging, verification) as real gates.
+
+**Opt in**: Set `CCGM_RULE_ENFORCEMENT=true` in `~/.claude/.ccgm.env`. Fires only on `source == "startup"`, not on resume or compaction.
 
 ---
 


### PR DESCRIPTION
## Summary

Caught by /docupdate after recent merges:

- \`docs/getting-started.md\`: \"All 35 modules\" → \"All 56 modules\" (two places — presets table and see-also link). Matches README.md and docs/modules.md which already said 56.
- \`docs/hooks.md\`: intro count 10 → 13 (hooks module) and total 12 → 15. Added sections for three undocumented hooks: \`check-careful.py\` (destructive-command prompt), \`check-freeze.py\` (edit scope lock), \`session-start-enforce.py\` (rule-enforcement meta-instruction, experimental).

## Verification

\`\`\`
bash tests/test-no-personal-data.sh  # PASS
\`\`\`

Closes #393