### PR TITLE
#398: fix 7 critical docs drift items across installer/config/multi-agent/presets

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,17 +76,20 @@ Some hooks read values from this file at runtime:
 ```json
 {
   "version": "1.0.0",
-  "timestamp": "2026-03-29T12:00:00Z",
+  "installedAt": "2026-03-29T12:00:00Z",
   "preset": "standard",
   "scope": "global",
   "linkMode": false,
+  "ccgmRoot": "/Users/jane/ccgm",
   "modules": ["autonomy", "git-workflow", "settings", "hooks", "commands-core"],
   "files": [
     "~/.claude/rules/autonomy.md",
     "~/.claude/rules/git-workflow.md",
     "~/.claude/commands/commit.md"
   ],
-  "ccgmRoot": "/Users/jane/ccgm"
+  "backups": [
+    "~/.claude.backup-2026-03-29-120000"
+  ]
 }
 ```
 

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -42,7 +42,7 @@ Choose where to install:
 
 ### Step 5: Module selection
 
-Choose a preset (minimal, standard, full, team) or select individual modules from a checkbox menu. The menu groups modules by category (core, commands, workflow, patterns, tech-specific).
+Choose a preset (minimal, standard, full, team) or select individual modules from a checkbox menu. The menu lists stable modules first, with beta modules (labelled `[BETA]`) at the end.
 
 ### Step 6: Dependency resolution
 
@@ -95,7 +95,7 @@ Checks that all installed files exist on disk, scans for unexpanded `__PLACEHOLD
 
 ### Step 14: Shell alias
 
-Optionally adds `alias ccgm="claude /startup"` to `~/.zshrc` or `~/.bashrc`. Detects existing aliases to avoid duplicates.
+Optionally adds `alias ccgm="claude /startup --dangerously-skip-permissions"` to `~/.zshrc` or `~/.bashrc`. Detects existing aliases to avoid duplicates.
 
 ### Step 15: Next steps
 

--- a/docs/multi-agent.md
+++ b/docs/multi-agent.md
@@ -61,10 +61,11 @@ The agent ID is also stored in `.env.clone`:
 
 ```bash
 AGENT_ID=agent-w0-c2
-WORKSPACE_NUM=0
-CLONE_NUM=2
-FRONTEND_PORT=3102
-BACKEND_PORT=3103
+WORKSPACE_NUMBER=0
+CLONE_NUMBER=2
+PORT_OFFSET=2
+FRONTEND_PORT=5175
+BACKEND_PORT=8789
 ```
 
 ## Port allocation
@@ -73,25 +74,29 @@ Each clone gets unique ports to prevent dev server collisions.
 
 ### How ports are assigned
 
-Ports are managed in `~/.claude/port-registry.json`:
+Ports are managed in `~/.claude/port-registry.json`. Each repo has separate base ports for its frontend and backend services:
 
 ```json
 {
-  "my-repo": {
-    "basePort": 3100,
-    "clones": 4
+  "repos": {
+    "my-repo": {
+      "frontend": 5173,
+      "backend": 8787
+    }
   }
 }
 ```
 
-Each repo gets a 16-port block. Within that block, each clone gets 2 ports (frontend + backend):
+Each clone receives a `PORT_OFFSET` (workspace-mode: `workspace_number * clones_per_workspace + clone_number`; flat-clone mode: `clone_number`). The clone's ports are computed by adding `PORT_OFFSET` to each base:
 
-| Clone | Frontend | Backend |
-|-------|----------|---------|
-| Clone 0 | basePort + 0 | basePort + 1 |
-| Clone 1 | basePort + 2 | basePort + 3 |
-| Clone 2 | basePort + 4 | basePort + 5 |
-| Clone 3 | basePort + 6 | basePort + 7 |
+| Clone | `PORT_OFFSET` | Frontend | Backend |
+|-------|---------------|----------|---------|
+| Clone 0 | 0 | frontend + 0 | backend + 0 |
+| Clone 1 | 1 | frontend + 1 | backend + 1 |
+| Clone 2 | 2 | frontend + 2 | backend + 2 |
+| Clone 3 | 3 | frontend + 3 | backend + 3 |
+
+Each repo gets a 16-port block per service to support up to 16 clones.
 
 ### Using ports
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -46,7 +46,7 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 **Best for**: Power users who want the complete CCGM experience, including multi-agent coordination, brand research, and tech-specific guides.
 
-**Modules (38)**: All stable modules. The `agent-manager` (beta) and `cloud-dispatch` modules are not included by default; install them individually via the module selector.
+**Modules (41)**: All stable modules. The `agent-manager` (beta) and `cloud-dispatch` modules are not included by default; install them individually via the module selector (or use the `cloud-agent` preset).
 
 **What you get**: The full suite. Includes multi-agent workflows, planning frameworks, tech-specific patterns (Cloudflare, Supabase, Tailwind, shadcn, MCP development), and specialized commands.
 


### PR DESCRIPTION
## Summary

Critical-only slice of a /docupdate deep pass. Each item is a doc claim that conflicts with source reality and would actively mislead a user.

| # | File | Fix |
|---|------|-----|
| 1 | \`docs/presets.md\` | \`full\` preset count: 38 → 41 (matches \`presets/full.json\`); added note that \`cloud-agent\` preset includes \`agent-manager\` + \`cloud-dispatch\` |
| 2 | \`docs/installer.md\` | Custom menu grouping: \"by category\" → \"stable first, beta last\" (matches \`start.sh:490-516\`) |
| 3 | \`docs/installer.md\` | \`ccgm\` alias: added \`--dangerously-skip-permissions\` (matches \`start.sh:1195\`) |
| 4 | \`docs/configuration.md\` | Manifest example: \`timestamp\` → \`installedAt\`; added \`backups\` array (matches \`start.sh:58,65,72,97\`) |
| 5 | \`docs/multi-agent.md\` | \`.env.clone\` fields: \`WORKSPACE_NUM\`/\`CLONE_NUM\` → \`WORKSPACE_NUMBER\`/\`CLONE_NUMBER\`; added \`PORT_OFFSET\` |
| 6 | \`docs/multi-agent.md\` | \`port-registry.json\` structure: \`{repo: {basePort, clones}}\` → \`{repos: {name: {frontend, backend}}}\` (matches \`modules/multi-agent/port-registry.json\`) |
| 7 | \`docs/multi-agent.md\` | Port allocation table: basePort+0/+2/+4/+6 → separate frontend/backend bases offset by \`PORT_OFFSET\` (matches \`modules/multi-agent/commands/workspace-setup.md:118-119\`) |

## Out of scope for this PR

Module README drift (13 modules with file-table gaps) and undocumented commands (~15 slash commands + skills) are tracked separately — will land in follow-up PRs.

## Verification

\`\`\`
bash tests/test-no-personal-data.sh  # PASS
\`\`\`

Each drift claim verified against the referenced source file before editing.

Closes #398