### PR TITLE
#400: sync module README files tables with module.json across 11 modules

### DIFF
--- a/modules/code-quality/README.md
+++ b/modules/code-quality/README.md
@@ -20,9 +20,15 @@ Copy `rules/code-quality.md` into your Claude configuration:
 ```bash
 # Global (all projects)
 cp rules/code-quality.md ~/.claude/rules/code-quality.md
+cp rules/change-philosophy.md ~/.claude/rules/change-philosophy.md
+cp rules/completeness.md ~/.claude/rules/completeness.md
+cp rules/receiving-code-review.md ~/.claude/rules/receiving-code-review.md
 
 # Project-level
 cp rules/code-quality.md .claude/rules/code-quality.md
+cp rules/change-philosophy.md .claude/rules/change-philosophy.md
+cp rules/completeness.md .claude/rules/completeness.md
+cp rules/receiving-code-review.md .claude/rules/receiving-code-review.md
 ```
 
 ## Files

--- a/modules/commands-core/README.md
+++ b/modules/commands-core/README.md
@@ -25,6 +25,7 @@ Also ships two reusable skills:
 | `commands/pr.md` | command | Push branch and create PR closing an issue |
 | `commands/cpm.md` | command | Commit, create PR, and merge in one shot |
 | `commands/gs.md` | command | Git status dashboard with project info |
+| `lib/gs-gather.sh` | lib | Helper script that gathers git and project info for /gs |
 | `commands/ghi.md` | command | Create GitHub issue with labels |
 | `skills/cpm/SKILL.md` | skill | Sequenced commit-PR-merge workflow |
 | `skills/pr-description/SKILL.md` | skill | Pure PR title and body writer (returns structured output, no publishing) |
@@ -48,6 +49,10 @@ cp commands/pr.md ~/.claude/commands/pr.md
 cp commands/cpm.md ~/.claude/commands/cpm.md
 cp commands/gs.md ~/.claude/commands/gs.md
 cp commands/ghi.md ~/.claude/commands/ghi.md
+
+# Lib helper
+mkdir -p ~/.claude/lib
+cp lib/gs-gather.sh ~/.claude/lib/gs-gather.sh
 
 # Skills
 mkdir -p ~/.claude/skills/cpm ~/.claude/skills/pr-description/references

--- a/modules/commands-extra/README.md
+++ b/modules/commands-extra/README.md
@@ -30,6 +30,10 @@ cp commands/unfreeze.md ~/.claude/commands/unfreeze.md
 cp commands/guard.md ~/.claude/commands/guard.md
 cp commands/checkpoint.md ~/.claude/commands/checkpoint.md
 
+# Skill
+mkdir -p ~/.claude/skills/audit
+cp skills/audit/SKILL.md ~/.claude/skills/audit/SKILL.md
+
 # Project-level
 cp commands/audit.md .claude/commands/audit.md
 cp commands/pwv.md .claude/commands/pwv.md
@@ -53,3 +57,4 @@ cp commands/checkpoint.md .claude/commands/checkpoint.md
 | `commands/unfreeze.md` | Clear the freeze scope (deletes `~/.claude/freeze-dir.txt`) |
 | `commands/guard.md` | Compose careful + freeze for focused, safe sessions |
 | `commands/checkpoint.md` | Save or resume a WIP session-state checkpoint under `~/.claude/checkpoints/{repo}/` |
+| `skills/audit/SKILL.md` | Skill definition backing the /audit command (audit methodology and categories) |

--- a/modules/commands-utility/README.md
+++ b/modules/commands-utility/README.md
@@ -45,4 +45,15 @@ Produces `docs/user-test-problems.md` and `docs/user-test-solutions.md` in the p
 cp commands/cws-submit.md ~/.claude/commands/cws-submit.md
 cp commands/ccgm-sync.md ~/.claude/commands/ccgm-sync.md
 cp commands/user-test.md ~/.claude/commands/user-test.md
+
+# Statusline
+cp statusline-command.sh ~/.claude/statusline-command.sh
+chmod +x ~/.claude/statusline-command.sh
+
+# Scripts
+mkdir -p ~/.claude/scripts
+cp scripts/ccgm-sync.sh ~/.claude/scripts/ccgm-sync.sh
+cp scripts/agent-team ~/.claude/scripts/agent-team
+chmod +x ~/.claude/scripts/ccgm-sync.sh
+chmod +x ~/.claude/scripts/agent-team
 ```

--- a/modules/hooks/README.md
+++ b/modules/hooks/README.md
@@ -4,7 +4,7 @@ Python hooks that enforce git workflow rules: issue-first workflow, commit messa
 
 ## What It Does
 
-This module installs twelve Python hooks, two Python libraries, and a settings partial:
+This module installs thirteen Python hooks, two Python libraries, and a settings partial:
 
 | Hook | Event | Purpose |
 |------|-------|---------|
@@ -17,6 +17,7 @@ This module installs twelve Python hooks, two Python libraries, and a settings p
 | `agent-tracking-pre.py` | PreToolUse (Bash) | Warns when claiming an issue already claimed by another agent |
 | `agent-tracking-post.py` | PostToolUse (Bash) | Records issue claims and status transitions in tracking CSV |
 | `check-migration-timestamps.py` | PreToolUse | Validates Supabase migration file timestamps for duplicates before commit |
+| `orphan-process-check.py` | PreToolUse (Bash) | Detects and warns about orphaned background processes (stale dev servers, zombie workers) before running commands that would conflict with them |
 | `check-careful.py` | PreToolUse (Bash) | Prompts before destructive Bash commands (rm -rf, SQL DROP/TRUNCATE, force push, hard reset, kubectl delete, docker prune). Build-artifact directories (node_modules, dist, .next, build, __pycache__, .cache, .turbo, coverage) are whitelisted for `rm -rf` |
 | `check-freeze.py` | PreToolUse (Edit/Write) | Denies Edit/Write outside the frozen directory when `~/.claude/freeze-dir.txt` is set. Pair with `/freeze`, `/unfreeze`, `/guard` from `commands-extra` |
 | `session-start-enforce.py` | SessionStart (startup) | Experimental. Injects an Iron-Law rule-enforcement meta-instruction at fresh session start so discipline rules activate under pressure. OFF by default; opt in via `CCGM_RULE_ENFORCEMENT=true` in `~/.claude/.ccgm.env` |
@@ -43,21 +44,33 @@ During installation, `__USERNAME__/ccgm` in the `DIRECT_TO_MAIN_REPOS` list will
 
 ```bash
 # 1. Copy hooks
+mkdir -p ~/.claude/hooks
 cp hooks/enforce-git-workflow.py ~/.claude/hooks/enforce-git-workflow.py
 cp hooks/enforce-issue-workflow.py ~/.claude/hooks/enforce-issue-workflow.py
 cp hooks/auto-approve-bash.py ~/.claude/hooks/auto-approve-bash.py
 cp hooks/auto-approve-file-ops.py ~/.claude/hooks/auto-approve-file-ops.py
+cp hooks/ccgm-update-check.py ~/.claude/hooks/ccgm-update-check.py
+cp hooks/port-check.py ~/.claude/hooks/port-check.py
+cp hooks/agent-tracking-pre.py ~/.claude/hooks/agent-tracking-pre.py
+cp hooks/agent-tracking-post.py ~/.claude/hooks/agent-tracking-post.py
+cp hooks/check-migration-timestamps.py ~/.claude/hooks/check-migration-timestamps.py
+cp hooks/orphan-process-check.py ~/.claude/hooks/orphan-process-check.py
+cp hooks/check-careful.py ~/.claude/hooks/check-careful.py
+cp hooks/check-freeze.py ~/.claude/hooks/check-freeze.py
+cp hooks/session-start-enforce.py ~/.claude/hooks/session-start-enforce.py
 
-# 2. Make executable
-chmod +x ~/.claude/hooks/enforce-git-workflow.py
-chmod +x ~/.claude/hooks/enforce-issue-workflow.py
-chmod +x ~/.claude/hooks/auto-approve-bash.py
-chmod +x ~/.claude/hooks/auto-approve-file-ops.py
+# 2. Copy libraries
+mkdir -p ~/.claude/lib
+cp lib/agent_tracking.py ~/.claude/lib/agent_tracking.py
+cp lib/agent_sessions.py ~/.claude/lib/agent_sessions.py
 
-# 3. Replace template variable in enforce-git-workflow.py
+# 3. Make hooks executable
+chmod +x ~/.claude/hooks/*.py
+
+# 4. Replace template variable in enforce-git-workflow.py
 # Edit the DIRECT_TO_MAIN_REPOS list to use your GitHub username
 
-# 4. Merge settings.partial.json into ~/.claude/settings.json
+# 5. Merge settings.partial.json into ~/.claude/settings.json
 # Add the "hooks" section from settings.partial.json
 ```
 
@@ -94,6 +107,7 @@ On fresh session start, the hook injects a short reminder that routes tasks thro
 | `hooks/agent-tracking-pre.py` | Pre-execution issue claim warning |
 | `hooks/agent-tracking-post.py` | Post-execution tracking CSV updates |
 | `hooks/check-migration-timestamps.py` | Supabase migration timestamp validation |
+| `hooks/orphan-process-check.py` | Orphaned background process detection before conflicting Bash commands |
 | `hooks/check-careful.py` | Destructive-command warning (careful safety hook) |
 | `hooks/check-freeze.py` | Scope-lock Edit/Write to `~/.claude/freeze-dir.txt` (freeze safety hook) |
 | `hooks/session-start-enforce.py` | Experimental Iron-Law rule-enforcement meta-instruction at session start (opt in via `CCGM_RULE_ENFORCEMENT=true`) |

--- a/modules/multi-agent/README.md
+++ b/modules/multi-agent/README.md
@@ -21,6 +21,10 @@ Key capabilities:
 | `rules/multi-agent.md` | rule | Parallel work preference and port allocation rules |
 | `multi-agent-system.md` | doc | Full multi-agent coordination documentation |
 | `commands/mawf.md` | command | Multi-Agent Workflow command (/mawf) |
+| `commands/workspace-setup.md` | command | Creates a workspace-based multi-clone directory structure (/workspace-setup) |
+| `commands/handoff.md` | command | Writes a handoff note for peer clones (/handoff) |
+| `lib/handoff.py` | lib | Helper library backing the /handoff command |
+| `port-registry.json` | config | Per-repo port allocation registry (template) |
 
 ## Dependencies
 
@@ -38,9 +42,18 @@ cp rules/multi-agent.md ~/.claude/rules/multi-agent.md
 # Copy the documentation
 cp multi-agent-system.md ~/.claude/multi-agent-system.md
 
-# Copy the mawf command
+# Copy the commands
 mkdir -p ~/.claude/commands
 cp commands/mawf.md ~/.claude/commands/mawf.md
+cp commands/workspace-setup.md ~/.claude/commands/workspace-setup.md
+cp commands/handoff.md ~/.claude/commands/handoff.md
+
+# Copy the lib helper
+mkdir -p ~/.claude/lib
+cp lib/handoff.py ~/.claude/lib/handoff.py
+
+# Copy the port registry (template expanded at install time)
+cp port-registry.json ~/.claude/port-registry.json
 ```
 
 ### 2. Set Up Multi-Clone Architecture

--- a/modules/session-history/README.md
+++ b/modules/session-history/README.md
@@ -16,6 +16,7 @@ Files installed globally to `~/.claude/`:
 | `scripts/extract-metadata.py` | `scripts/extract-metadata.py` | Batch-extract session metadata (branch, cwd, timestamps) |
 | `scripts/recall.py` | `scripts/recall.py` | `/recall` implementation — unified session view across clones |
 | `scripts/repo_detect.py` | `scripts/repo_detect.py` | Canonical repo-name detection + multi-clone project-dir matching |
+| `scripts/add-agents-md-symlinks.sh` | `scripts/add-agents-md-symlinks.sh` | Sets up AGENTS.md symlinks so Codex transcripts share the same rule surface as Claude Code |
 
 Two consumption patterns:
 
@@ -51,6 +52,10 @@ chmod +x ~/.claude/scripts/discover-sessions.sh
 cp modules/session-history/scripts/extract-metadata.py \
    ~/.claude/scripts/extract-metadata.py
 chmod +x ~/.claude/scripts/extract-metadata.py
+
+cp modules/session-history/scripts/add-agents-md-symlinks.sh \
+   ~/.claude/scripts/add-agents-md-symlinks.sh
+chmod +x ~/.claude/scripts/add-agents-md-symlinks.sh
 ```
 
 ## Usage

--- a/modules/startup-dashboard/README.md
+++ b/modules/startup-dashboard/README.md
@@ -25,6 +25,8 @@ work on next. Deterministic data gather + model-powered summarization.
 | `lib/startup-summary.sh` | lib | Runs the gather → model → markdown summary pipeline with a fallback chain |
 | `lib/startup-summary-prompt.md` | lib | Fixed summary instructions the model receives |
 | `lib/startup-dashboard.sh` | lib | Deterministic plain-text dashboard (fallback / `--raw` mode) |
+| `hooks/auto-startup.py` | hook | SessionStart hook that runs `/startup` automatically on fresh sessions |
+| `settings.partial.json` | config | Hook wiring configuration to merge into settings.json |
 
 ## Dependencies
 

--- a/modules/subagent-patterns/README.md
+++ b/modules/subagent-patterns/README.md
@@ -26,6 +26,16 @@ mkdir -p ~/.claude/agents
 cp agents/implementer.md ~/.claude/agents/implementer.md
 cp agents/spec-compliance-reviewer.md ~/.claude/agents/spec-compliance-reviewer.md
 cp agents/code-quality-reviewer.md ~/.claude/agents/code-quality-reviewer.md
+
+# Hooks
+mkdir -p ~/.claude/hooks
+cp hooks/subagent-stop-check.py ~/.claude/hooks/subagent-stop-check.py
+cp hooks/task-completed-check.py ~/.claude/hooks/task-completed-check.py
+chmod +x ~/.claude/hooks/subagent-stop-check.py
+chmod +x ~/.claude/hooks/task-completed-check.py
+
+# Merge settings.partial.json into ~/.claude/settings.json
+# Add the relevant hook wiring from settings.partial.json
 ```
 
 ## Files
@@ -36,3 +46,6 @@ cp agents/code-quality-reviewer.md ~/.claude/agents/code-quality-reviewer.md
 | `agents/implementer.md` | Reusable prompt template for implementer subagents - enforces scope discipline and four-state status |
 | `agents/spec-compliance-reviewer.md` | Stage 1 reviewer - adversarial stance, verifies deliverables and constraints independently of the implementer's self-report |
 | `agents/code-quality-reviewer.md` | Stage 2 reviewer - refuses to run unless Stage 1 returned DONE; checks project patterns, edge cases, simplicity |
+| `hooks/subagent-stop-check.py` | SubagentStop hook that verifies subagent returns a valid four-state status before returning control |
+| `hooks/task-completed-check.py` | PostToolUse hook that nudges the dispatcher to verify subagent artifacts before accepting DONE |
+| `settings.partial.json` | Hook wiring configuration to merge into settings.json |

--- a/modules/systematic-debugging/README.md
+++ b/modules/systematic-debugging/README.md
@@ -24,12 +24,14 @@ The parent rule is backed by three focused sub-rules that give agents named move
 ```bash
 # Global (all projects)
 cp rules/systematic-debugging.md ~/.claude/rules/systematic-debugging.md
+cp rules/debugging.md ~/.claude/rules/debugging.md
 cp rules/root-cause-tracing.md ~/.claude/rules/root-cause-tracing.md
 cp rules/defense-in-depth.md ~/.claude/rules/defense-in-depth.md
 cp rules/condition-based-waiting.md ~/.claude/rules/condition-based-waiting.md
 
 # Project-level
 cp rules/systematic-debugging.md .claude/rules/systematic-debugging.md
+cp rules/debugging.md .claude/rules/debugging.md
 cp rules/root-cause-tracing.md .claude/rules/root-cause-tracing.md
 cp rules/defense-in-depth.md .claude/rules/defense-in-depth.md
 cp rules/condition-based-waiting.md .claude/rules/condition-based-waiting.md

--- a/modules/xplan/README.md
+++ b/modules/xplan/README.md
@@ -34,6 +34,7 @@ Companion commands:
 | `commands/xplan.md` | command | Main planning and execution command (/xplan) |
 | `commands/xplan-status.md` | command | Plan progress dashboard (/xplan-status) |
 | `commands/xplan-resume.md` | command | Resume interrupted execution (/xplan-resume) |
+| `lib/xplan-status-gather.sh` | lib | Helper script that gathers plan progress data for /xplan-status |
 
 ## Dependencies
 
@@ -62,6 +63,10 @@ mkdir -p ~/.claude/commands
 cp commands/xplan.md ~/.claude/commands/xplan.md
 cp commands/xplan-status.md ~/.claude/commands/xplan-status.md
 cp commands/xplan-resume.md ~/.claude/commands/xplan-resume.md
+
+# Copy lib files
+mkdir -p ~/.claude/lib
+cp lib/xplan-status-gather.sh ~/.claude/lib/xplan-status-gather.sh
 ```
 
 ### Plans Directory


### PR DESCRIPTION
## Summary

Back-fills drift from 11 module READMEs where files were added to \`module.json\` over time but never mirrored in the README's Files table or Manual Installation section.

## Modules updated

- **xplan**: +\`lib/xplan-status-gather.sh\`
- **hooks**: intro \"twelve\" → \"thirteen\"; +\`orphan-process-check.py\`; Manual Install expanded from 4 hooks to all 13 + 2 libs
- **multi-agent**: +\`commands/workspace-setup.md\`, \`commands/handoff.md\`, \`lib/handoff.py\`, \`port-registry.json\`
- **commands-core**: +\`lib/gs-gather.sh\`
- **subagent-patterns**: +2 hooks, +\`settings.partial.json\`
- **commands-utility**: +\`statusline-command.sh\`, \`scripts/ccgm-sync.sh\`, \`scripts/agent-team\` (no Files table in this README, Manual Install only)
- **commands-extra**: +\`skills/audit/SKILL.md\`
- **startup-dashboard**: +\`hooks/auto-startup.py\`, \`settings.partial.json\` (Files table only, no Manual Install section)
- **session-history**: +\`scripts/add-agents-md-symlinks.sh\`
- **systematic-debugging**: Manual Install +\`rules/debugging.md\` copy command
- **code-quality**: Manual Install +3 rules files

## Deliberately out of scope

\`cloud-dispatch\`: README documents ~10 lib scripts + \`packer/\` + \`terraform/\` directories that exist on disk but are NOT in \`module.json\`'s \`files\` array. This is a bigger change (installer won't ship them) — split into follow-up.

## Verification

\`\`\`
bash tests/test-no-personal-data.sh  # PASS
\`\`\`

No \`module.json\` touched. Only module README.md files edited.

Closes #400