### PR TITLE
#386: add resolver-eval subcommand to ccgm-doctor

### DIFF
--- a/modules/ccgm-doctor/README.md
+++ b/modules/ccgm-doctor/README.md
@@ -8,6 +8,7 @@ Installs a `ccgm-doctor` CLI. Subcommands:
 
 - `check-resolvable` — reachability audit (hook refs, command descriptions, script refs)
 - `dry` — DRY/overlap audit (pairs of commands whose triggers are lexically similar)
+- `resolver-eval` — run a routing suite of `{intent, expected}` assertions
 
 ### check-resolvable
 
@@ -29,7 +30,31 @@ Compares every pair of command trigger descriptions using Jaccard similarity ove
 |-------|----------|-----------------|
 | `dry-overlap` | warn | two commands whose trigger descriptions share > threshold tokens (default 0.5) |
 
-Lexical overlap is a conservative signal — it catches copy-paste descriptions and near-duplicates, not semantic synonyms. For semantic routing analysis (e.g., "commit my changes" vs "check in these files"), use the resolver eval harness (#386).
+Lexical overlap is a conservative signal — it catches copy-paste descriptions and near-duplicates, not semantic synonyms. For semantic routing analysis, use `resolver-eval` (below) — it is better suited to paraphrase-style overlap.
+
+### resolver-eval
+
+Runs a suite of `{intent, expected}` assertions against the commands dir. For each intent, a keyword-overlap scorer ranks candidate commands by Jaccard similarity between intent tokens and (description + filename stem) tokens. Passes if the expected command appears in the top `k` candidates.
+
+```
+[PASS] stage all my changes and commit them
+       expected: commit
+       top:      commit(0.50)
+[FAIL] debug this failing test
+       expected: debug
+       top:      user-test(0.12)
+```
+
+Suite format (JSON array):
+
+```json
+[
+  {"intent": "stage all my changes and commit them", "expected": "commit"},
+  {"intent": "review this pull request",             "expected": "review"}
+]
+```
+
+The module ships `evals/routing.json` as a default suite covering ~18 common intents. Extend it by pointing at your own file with `--suite`.
 
 ## Usage
 
@@ -44,6 +69,12 @@ ccgm-doctor dry
 ccgm-doctor dry --threshold 0.3          # flag more overlapping pairs
 ccgm-doctor dry --threshold 0.8          # only flag near-duplicates
 ccgm-doctor dry --json
+
+# Routing assertions
+ccgm-doctor resolver-eval                         # uses default bundled suite
+ccgm-doctor resolver-eval --suite my-evals.json   # your own suite
+ccgm-doctor resolver-eval --top-k 3               # pass if expected is in top 3
+ccgm-doctor resolver-eval --json
 ```
 
 Exit codes:
@@ -65,8 +96,7 @@ The checks are pure functions of the filesystem. They run in milliseconds and re
 ### What's not covered (yet)
 
 - **Orphan detection** — "script in `bin/` that no command or hook references". CCGM does not track install provenance, so detecting orphans from source-module removal is non-trivial. Deferred.
-- **Semantic overlap** — two commands whose descriptions are paraphrases of each other but share few exact tokens. Lexical DRY catches copy-paste; semantic routing needs a model. See `#386`.
-- **Resolver routing evals** — does the model actually pick the right command for a given intent? See `#386`.
+- **Model-backed routing** — the current `resolver-eval` is a structural scorer. The model may choose differently, especially on paraphrases or short intents. A future enhancement can invoke `claude -p` or the API to ask the model directly and compare — the eval file format and pass contract stay the same.
 
 ## Manual Installation
 
@@ -86,4 +116,5 @@ cp lib/doctor.py ~/.claude/lib/doctor.py
 |------|-------------|
 | `bin/ccgm-doctor` | Python CLI that dispatches subcommands |
 | `lib/doctor.py` | Pure check functions — take paths, return findings |
-| `tests/test_doctor.py` | 30 unit tests covering all checks with tempdir fixtures |
+| `evals/routing.json` | Default routing suite for `resolver-eval` |
+| `tests/test_doctor.py` | 47 unit tests covering all checks with tempdir fixtures |

--- a/modules/ccgm-doctor/README.md
+++ b/modules/ccgm-doctor/README.md
@@ -4,7 +4,10 @@ Audit tool for Claude Code installs. Reports dark or broken entries so they can 
 
 ## What It Does
 
-Installs a `ccgm-doctor` CLI. Current subcommand: `check-resolvable`.
+Installs a `ccgm-doctor` CLI. Subcommands:
+
+- `check-resolvable` — reachability audit (hook refs, command descriptions, script refs)
+- `dry` — DRY/overlap audit (pairs of commands whose triggers are lexically similar)
 
 ### check-resolvable
 
@@ -18,17 +21,29 @@ Walks a Claude install and reports three classes of issue:
 
 Each finding includes: check name, severity, path, and a one-line detail.
 
+### dry
+
+Compares every pair of command trigger descriptions using Jaccard similarity over content tokens (stopwords and short tokens filtered out). Pairs above the threshold are flagged as likely ambiguous routing candidates.
+
+| Check | Severity | What it catches |
+|-------|----------|-----------------|
+| `dry-overlap` | warn | two commands whose trigger descriptions share > threshold tokens (default 0.5) |
+
+Lexical overlap is a conservative signal — it catches copy-paste descriptions and near-duplicates, not semantic synonyms. For semantic routing analysis (e.g., "commit my changes" vs "check in these files"), use the resolver eval harness (#386).
+
 ## Usage
 
 ```bash
-# Audit the default ~/.claude install
+# Reachability audit
 ccgm-doctor check-resolvable
-
-# Audit a specific install
 ccgm-doctor check-resolvable --claude-dir /path/to/.claude
-
-# Machine-readable output
 ccgm-doctor check-resolvable --json
+
+# DRY audit
+ccgm-doctor dry
+ccgm-doctor dry --threshold 0.3          # flag more overlapping pairs
+ccgm-doctor dry --threshold 0.8          # only flag near-duplicates
+ccgm-doctor dry --json
 ```
 
 Exit codes:
@@ -50,7 +65,7 @@ The checks are pure functions of the filesystem. They run in milliseconds and re
 ### What's not covered (yet)
 
 - **Orphan detection** — "script in `bin/` that no command or hook references". CCGM does not track install provenance, so detecting orphans from source-module removal is non-trivial. Deferred.
-- **DRY overlap** — two commands whose descriptions overlap semantically. See `#385`.
+- **Semantic overlap** — two commands whose descriptions are paraphrases of each other but share few exact tokens. Lexical DRY catches copy-paste; semantic routing needs a model. See `#386`.
 - **Resolver routing evals** — does the model actually pick the right command for a given intent? See `#386`.
 
 ## Manual Installation

--- a/modules/ccgm-doctor/bin/ccgm-doctor
+++ b/modules/ccgm-doctor/bin/ccgm-doctor
@@ -6,10 +6,13 @@ Subcommands:
     check-resolvable    Report dark/orphaned/broken entries in the install.
     dry                 Report pairs of commands whose trigger descriptions
                         overlap (ambiguous routing candidates).
+    resolver-eval       Run a routing eval suite: does each intent resolve
+                        to the expected skill by keyword-overlap scoring?
 
 Usage:
     ccgm-doctor check-resolvable [--claude-dir PATH] [--json]
     ccgm-doctor dry [--claude-dir PATH] [--threshold N] [--json]
+    ccgm-doctor resolver-eval [--claude-dir PATH] [--suite PATH] [--top-k N] [--json]
 
 Exit codes:
     0   no issues
@@ -90,6 +93,54 @@ def _cmd_dry(args: argparse.Namespace) -> int:
     return 1 if findings else 0
 
 
+def _cmd_resolver_check(args: argparse.Namespace) -> int:
+    home = _resolve_claude_dir(args.claude_dir)
+    if home is None:
+        return 2
+
+    suite_path = Path(args.suite).expanduser().resolve()
+    if not suite_path.is_file():
+        print(f"error: --suite does not exist: {suite_path}", file=sys.stderr)
+        return 2
+
+    try:
+        suite = json.loads(suite_path.read_text())
+    except json.JSONDecodeError as e:
+        print(f"error: suite is not valid JSON: {e}", file=sys.stderr)
+        return 2
+
+    if not isinstance(suite, list) or not all(
+        isinstance(e, dict) and "intent" in e and "expected" in e for e in suite
+    ):
+        print(
+            "error: suite must be a JSON array of {\"intent\": str, \"expected\": str} entries",
+            file=sys.stderr,
+        )
+        return 2
+
+    commands_dir = home / "commands"
+    results = doctor.run_resolver_evals(suite, commands_dir, top_k=args.top_k)
+
+    passed = sum(1 for r in results if r["passed"])
+    failed = len(results) - passed
+
+    if args.json:
+        json.dump(results, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        for r in results:
+            mark = "PASS" if r["passed"] else "FAIL"
+            cands = ", ".join(f"{n}({s:.2f})" for n, s in r["top_candidates"][:3])
+            cands = cands or "(no matches)"
+            print(f"  [{mark}] {r['intent']}")
+            print(f"         expected: {r['expected']}")
+            print(f"         top:      {cands}")
+        print()
+        print(f"Results: {passed} passed, {failed} failed (top_k={args.top_k})")
+
+    return 1 if failed else 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         prog="ccgm-doctor",
@@ -134,6 +185,33 @@ def main() -> int:
         help="Emit findings as a JSON array instead of a human-readable report.",
     )
     dry.set_defaults(func=_cmd_dry)
+
+    rev = subs.add_parser(
+        "resolver-eval",
+        help="Run a routing suite: does each intent resolve to the expected skill?",
+    )
+    rev.add_argument(
+        "--claude-dir",
+        default="~/.claude",
+        help="Path to the Claude Code install dir (default: ~/.claude)",
+    )
+    rev.add_argument(
+        "--suite",
+        default=str(_HERE.parent / "evals" / "routing.json"),
+        help="Path to the JSON suite file (default: module's bundled routing.json)",
+    )
+    rev.add_argument(
+        "--top-k",
+        type=int,
+        default=1,
+        help="Pass if expected skill appears in the top-k scored candidates (default: 1)",
+    )
+    rev.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit results as a JSON array instead of a human-readable report.",
+    )
+    rev.set_defaults(func=_cmd_resolver_check)
 
     args = parser.parse_args()
     return args.func(args)

--- a/modules/ccgm-doctor/bin/ccgm-doctor
+++ b/modules/ccgm-doctor/bin/ccgm-doctor
@@ -4,9 +4,12 @@ ccgm-doctor — audit a Claude Code install for reachability problems.
 
 Subcommands:
     check-resolvable    Report dark/orphaned/broken entries in the install.
+    dry                 Report pairs of commands whose trigger descriptions
+                        overlap (ambiguous routing candidates).
 
 Usage:
     ccgm-doctor check-resolvable [--claude-dir PATH] [--json]
+    ccgm-doctor dry [--claude-dir PATH] [--threshold N] [--json]
 
 Exit codes:
     0   no issues
@@ -27,10 +30,36 @@ sys.path.insert(0, str(_HERE.parent / "lib"))
 import doctor  # noqa: E402
 
 
+def _format_findings(findings: list[dict], scope_label: str) -> None:
+    if not findings:
+        print(f"OK: no issues found in {scope_label}")
+        return
+    by_severity: dict[str, list[dict]] = {}
+    for f in findings:
+        by_severity.setdefault(f["severity"], []).append(f)
+    for sev in ("error", "warn"):
+        items = by_severity.get(sev, [])
+        if not items:
+            continue
+        print(f"{sev.upper()} ({len(items)}):")
+        for f in items:
+            print(f"  [{f['check']}] {f['path']}")
+            print(f"    {f['detail']}")
+    print()
+    print(f"Total: {len(findings)} issue(s) across {scope_label}")
+
+
+def _resolve_claude_dir(raw: str) -> Path | None:
+    path = Path(raw).expanduser().resolve()
+    if not path.is_dir():
+        print(f"error: --claude-dir does not exist: {path}", file=sys.stderr)
+        return None
+    return path
+
+
 def _cmd_check_resolvable(args: argparse.Namespace) -> int:
-    home = Path(args.claude_dir).expanduser().resolve()
-    if not home.is_dir():
-        print(f"error: --claude-dir does not exist: {home}", file=sys.stderr)
+    home = _resolve_claude_dir(args.claude_dir)
+    if home is None:
         return 2
 
     findings = doctor.run_all_checks(home)
@@ -39,22 +68,24 @@ def _cmd_check_resolvable(args: argparse.Namespace) -> int:
         json.dump(findings, sys.stdout, indent=2)
         sys.stdout.write("\n")
     else:
-        if not findings:
-            print(f"OK: no issues found in {home}")
-        else:
-            by_severity = {"error": [], "warn": []}
-            for f in findings:
-                by_severity.setdefault(f["severity"], []).append(f)
-            for sev in ("error", "warn"):
-                items = by_severity.get(sev, [])
-                if not items:
-                    continue
-                print(f"{sev.upper()} ({len(items)}):")
-                for f in items:
-                    print(f"  [{f['check']}] {f['path']}")
-                    print(f"    {f['detail']}")
-            print()
-            print(f"Total: {len(findings)} issue(s) across {home}")
+        _format_findings(findings, str(home))
+
+    return 1 if findings else 0
+
+
+def _cmd_dry(args: argparse.Namespace) -> int:
+    home = _resolve_claude_dir(args.claude_dir)
+    if home is None:
+        return 2
+
+    commands_dir = home / "commands"
+    findings = doctor.check_dry_overlap(commands_dir, threshold=args.threshold)
+
+    if args.json:
+        json.dump(findings, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        _format_findings(findings, f"{commands_dir} (threshold={args.threshold})")
 
     return 1 if findings else 0
 
@@ -81,6 +112,28 @@ def main() -> int:
         help="Emit findings as a JSON array instead of a human-readable report.",
     )
     chk.set_defaults(func=_cmd_check_resolvable)
+
+    dry = subs.add_parser(
+        "dry",
+        help="Report command pairs whose trigger descriptions overlap.",
+    )
+    dry.add_argument(
+        "--claude-dir",
+        default="~/.claude",
+        help="Path to the Claude Code install dir (default: ~/.claude)",
+    )
+    dry.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="Jaccard similarity threshold for flagging pairs (default: 0.5)",
+    )
+    dry.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit findings as a JSON array instead of a human-readable report.",
+    )
+    dry.set_defaults(func=_cmd_dry)
 
     args = parser.parse_args()
     return args.func(args)

--- a/modules/ccgm-doctor/evals/routing.json
+++ b/modules/ccgm-doctor/evals/routing.json
@@ -1,0 +1,20 @@
+[
+  {"intent": "stage all my changes and commit them", "expected": "commit"},
+  {"intent": "commit push and merge this branch", "expected": "cpm"},
+  {"intent": "create a pull request for this work", "expected": "pr"},
+  {"intent": "review this pull request", "expected": "review"},
+  {"intent": "run a comprehensive security review", "expected": "security-review"},
+  {"intent": "debug this failing test", "expected": "debug"},
+  {"intent": "reflect on what I learned in this session", "expected": "reflect"},
+  {"intent": "consolidate and clean up my learnings", "expected": "consolidate"},
+  {"intent": "write a retrospective over the last week", "expected": "retro"},
+  {"intent": "summarize where I left off at session start", "expected": "startup"},
+  {"intent": "remember this capability and turn it into a permanent skill", "expected": "skillify"},
+  {"intent": "do deep research across the web on a topic", "expected": "deepresearch"},
+  {"intent": "audit this codebase for issues", "expected": "audit"},
+  {"intent": "update the project documentation to match the code", "expected": "docupdate"},
+  {"intent": "generate playwright tests for a feature", "expected": "e2e"},
+  {"intent": "check the health of my claude install", "expected": "ccgm-sync"},
+  {"intent": "brainstorm ideas for a new feature", "expected": "brainstorm"},
+  {"intent": "submit this chrome extension to the store", "expected": "cws-submit"}
+]

--- a/modules/ccgm-doctor/lib/doctor.py
+++ b/modules/ccgm-doctor/lib/doctor.py
@@ -257,3 +257,85 @@ def run_all_checks(claude_dir: Path, user_home: Path | None = None) -> list[Find
         + check_command_descriptions(commands)
         + check_script_refs(commands, claude_dir)
     )
+
+
+# --- DRY / overlap audit ---
+
+# Stopwords for command-trigger tokenization. Words too generic to signal
+# command identity (the, a), common CLI/workflow verbs (run, use, add),
+# and filler. Kept deliberately tight so meaningful nouns like "calendar",
+# "commit", "review" stay in.
+_STOPWORDS = frozenset({
+    "the", "and", "any", "all", "are", "but", "can", "did", "does", "done",
+    "during", "else", "for", "from", "get", "had", "has", "have", "here",
+    "how", "its", "just", "make", "must", "new", "not", "one", "only",
+    "should", "some", "that", "the", "then", "this", "those", "two", "use",
+    "using", "via", "was", "were", "what", "when", "where", "why", "will",
+    "with", "would", "you", "your", "set", "run", "task", "command",
+    "commands", "skill", "workflow", "claude", "code", "agent", "before",
+    "after", "because", "current", "previous", "next", "these",
+})
+
+_TOKEN_RE = re.compile(r'[a-z][a-z0-9]{2,}')
+
+
+def _trigger_tokens(text: str) -> set[str]:
+    """
+    Extract the identity-bearing tokens of a command's trigger description.
+    Lowercase, strip punctuation, drop stopwords and tokens shorter than 3.
+    """
+    desc = _extract_trigger_description(text) or ""
+    return {tok for tok in _TOKEN_RE.findall(desc.lower()) if tok not in _STOPWORDS}
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    intersection = len(a & b)
+    union = len(a | b)
+    return intersection / union if union else 0.0
+
+
+def check_dry_overlap(commands_dir: Path, threshold: float = 0.5) -> list[Finding]:
+    """
+    Flag pairs of commands whose trigger-description tokens overlap above
+    `threshold` (Jaccard similarity). Catches ambiguous routing: two skills
+    the model might plausibly pick for the same intent.
+
+    Commands whose trigger description is empty (already flagged by
+    check_command_descriptions) are skipped so this check stays orthogonal.
+    """
+    findings: list[Finding] = []
+    if not commands_dir.is_dir():
+        return findings
+
+    commands: list[tuple[Path, set[str]]] = []
+    for md in sorted(commands_dir.glob("*.md")):
+        try:
+            text = md.read_text()
+        except OSError:
+            continue
+        tokens = _trigger_tokens(text)
+        if tokens:
+            commands.append((md, tokens))
+
+    # Pairwise comparison. O(n^2) but n is small (dozens, not thousands).
+    for i in range(len(commands)):
+        for j in range(i + 1, len(commands)):
+            path_a, tokens_a = commands[i]
+            path_b, tokens_b = commands[j]
+            sim = _jaccard(tokens_a, tokens_b)
+            if sim >= threshold:
+                shared = sorted(tokens_a & tokens_b)
+                findings.append({
+                    "check": "dry-overlap",
+                    "severity": "warn",
+                    "path": f"{path_a.name} <-> {path_b.name}",
+                    "detail": (
+                        f"Jaccard={sim:.2f} over {len(shared)} shared tokens "
+                        f"({', '.join(shared[:5])}"
+                        f"{'...' if len(shared) > 5 else ''}). "
+                        "Review for merge/deprecate, or sharpen descriptions."
+                    ),
+                })
+    return findings

--- a/modules/ccgm-doctor/lib/doctor.py
+++ b/modules/ccgm-doctor/lib/doctor.py
@@ -339,3 +339,94 @@ def check_dry_overlap(commands_dir: Path, threshold: float = 0.5) -> list[Findin
                     ),
                 })
     return findings
+
+
+# --- Resolver evals ---
+
+def _tokenize_intent(text: str) -> set[str]:
+    """Same tokenizer as _trigger_tokens but over arbitrary text, not a file."""
+    return {tok for tok in _TOKEN_RE.findall(text.lower()) if tok not in _STOPWORDS}
+
+
+def _command_tokens(path: Path, text: str) -> set[str]:
+    """
+    Tokens the scorer uses to rank a command against an intent: the trigger
+    description PLUS the filename stem (since users often hit a command
+    by name). Skill name tokens help disambiguate when descriptions are thin.
+    """
+    tokens = _trigger_tokens(text)
+    stem_tokens = {tok for tok in _TOKEN_RE.findall(path.stem.lower()) if tok not in _STOPWORDS}
+    return tokens | stem_tokens
+
+
+def score_intent_against_commands(
+    intent: str, commands_dir: Path
+) -> list[tuple[str, float]]:
+    """
+    Rank every command in `commands_dir` against `intent` by Jaccard similarity
+    of intent tokens against (description + filename stem) tokens.
+
+    Returns a list of (command_name, score) pairs sorted high-to-low. Ties at
+    score 0 are dropped (no evidence either way).
+    """
+    if not commands_dir.is_dir():
+        return []
+
+    intent_tokens = _tokenize_intent(intent)
+    if not intent_tokens:
+        return []
+
+    scored: list[tuple[str, float]] = []
+    for md in sorted(commands_dir.glob("*.md")):
+        try:
+            text = md.read_text()
+        except OSError:
+            continue
+        cmd_tokens = _command_tokens(md, text)
+        if not cmd_tokens:
+            continue
+        sim = _jaccard(intent_tokens, cmd_tokens)
+        if sim > 0:
+            scored.append((md.stem, sim))
+
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return scored
+
+
+def run_resolver_evals(
+    suite: list[dict], commands_dir: Path, top_k: int = 1
+) -> list[dict]:
+    """
+    Run every {intent, expected} entry in `suite` against the commands dir.
+
+    Pass rule: `expected` is in the top `top_k` candidates returned by the
+    scorer. Ties at the k-th position are counted as part of the top (a pass
+    should not flip based on an arbitrary tiebreak in sorted()).
+
+    Returns one result dict per entry:
+        intent, expected, top_candidates (list of (name, score)), passed (bool)
+    """
+    results: list[dict] = []
+    for entry in suite:
+        intent = entry["intent"]
+        expected = entry["expected"]
+        ranked = score_intent_against_commands(intent, commands_dir)
+
+        if ranked:
+            cutoff_idx = min(top_k - 1, len(ranked) - 1)
+            cutoff_score = ranked[cutoff_idx][1]
+            # All candidates tied at or above the cutoff score.
+            qualifying = [pair for pair in ranked if pair[1] >= cutoff_score]
+            passed = any(name == expected for name, _ in qualifying)
+            top_candidates = qualifying
+        else:
+            passed = False
+            top_candidates = []
+
+        results.append({
+            "intent": intent,
+            "expected": expected,
+            "top_candidates": top_candidates,
+            "passed": passed,
+        })
+    return results

--- a/modules/ccgm-doctor/module.json
+++ b/modules/ccgm-doctor/module.json
@@ -1,14 +1,15 @@
 {
   "name": "ccgm-doctor",
   "displayName": "CCGM Doctor",
-  "description": "Audit tool for Claude Code installs. Reports dark or broken entries: hooks pointing at missing files, commands with no discoverable trigger description, and command markdown referencing bin scripts that do not exist. First subcommand: check-resolvable. Future work: DRY audit (#385), resolver evals (#386).",
+  "description": "Audit tool for Claude Code installs. Three subcommands: check-resolvable (hook refs, command descriptions, script refs), dry (lexical overlap between command descriptions), and resolver-eval (runs a routing suite of {intent, expected} assertions against keyword-overlap scoring). Ships a default routing suite covering common slash commands.",
   "category": "workflow",
   "scope": ["global"],
   "dependencies": [],
   "files": {
     "bin/ccgm-doctor": { "target": "bin/ccgm-doctor", "type": "script", "template": false },
-    "lib/doctor.py": { "target": "lib/doctor.py", "type": "lib", "template": false }
+    "lib/doctor.py": { "target": "lib/doctor.py", "type": "lib", "template": false },
+    "evals/routing.json": { "target": "evals/routing.json", "type": "doc", "template": false }
   },
-  "tags": ["audit", "health-check", "resolver", "reachability"],
+  "tags": ["audit", "health-check", "resolver", "reachability", "evals"],
   "configPrompts": []
 }

--- a/modules/ccgm-doctor/tests/test_doctor.py
+++ b/modules/ccgm-doctor/tests/test_doctor.py
@@ -303,6 +303,80 @@ class TestCheckScriptRefs(unittest.TestCase):
         self.assertEqual(len(findings), 1)
 
 
+class TestCheckDryOverlap(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="ccgm-doctor-"))
+        self.commands = self.tmp / "commands"
+        self.commands.mkdir()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _make_fm_command(self, name: str, description: str) -> None:
+        (self.commands / f"{name}.md").write_text(
+            f"---\ndescription: {description}\n---\n\nbody\n"
+        )
+
+    def test_distinct_commands_no_findings(self) -> None:
+        self._make_fm_command("alpha", "Fetch and summarize upstream news articles")
+        self._make_fm_command("beta", "Transform JSON logs into Parquet files")
+        findings = doctor.check_dry_overlap(self.commands)
+        self.assertEqual(findings, [])
+
+    def test_near_duplicate_commands_flagged(self) -> None:
+        # Two descriptions that share most content words - obvious DRY problem.
+        self._make_fm_command(
+            "calendar-check",
+            "Check calendar events for scheduling conflicts tomorrow",
+        )
+        self._make_fm_command(
+            "calendar-recall",
+            "Check calendar events for scheduling conflicts historically",
+        )
+        findings = doctor.check_dry_overlap(self.commands, threshold=0.5)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["check"], "dry-overlap")
+        self.assertEqual(findings[0]["severity"], "warn")
+        self.assertIn("calendar", findings[0]["detail"])
+
+    def test_threshold_respected(self) -> None:
+        # Moderate overlap: flagged at low threshold, clean at high.
+        self._make_fm_command("one", "Deploy production web service quickly")
+        self._make_fm_command("two", "Deploy staging web service quickly")
+        findings_low = doctor.check_dry_overlap(self.commands, threshold=0.3)
+        self.assertEqual(len(findings_low), 1)
+        findings_high = doctor.check_dry_overlap(self.commands, threshold=0.95)
+        self.assertEqual(findings_high, [])
+
+    def test_pair_report_uses_basenames(self) -> None:
+        self._make_fm_command("left", "Parse emails for unread thread summaries")
+        self._make_fm_command("right", "Parse emails for unread thread summaries")
+        findings = doctor.check_dry_overlap(self.commands, threshold=0.5)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("left.md", findings[0]["path"])
+        self.assertIn("right.md", findings[0]["path"])
+
+    def test_empty_descriptions_skipped(self) -> None:
+        # Commands with no trigger description are skipped; they're already
+        # flagged by check_command_descriptions and would produce an empty
+        # set intersection.
+        (self.commands / "empty.md").write_text("")
+        self._make_fm_command("real", "A real command with actual content")
+        findings = doctor.check_dry_overlap(self.commands)
+        self.assertEqual(findings, [])
+
+    def test_heading_style_commands_also_audited(self) -> None:
+        # CCGM-style commands use H1 headings, not frontmatter. Still audited.
+        (self.commands / "alpha.md").write_text("# /alpha - parse emails and build thread summaries\n")
+        (self.commands / "beta.md").write_text("# /beta - parse emails and build thread summaries\n")
+        findings = doctor.check_dry_overlap(self.commands, threshold=0.5)
+        self.assertEqual(len(findings), 1)
+
+    def test_no_commands_dir(self) -> None:
+        findings = doctor.check_dry_overlap(self.tmp / "nonexistent")
+        self.assertEqual(findings, [])
+
+
 class TestRunAllChecks(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = Path(tempfile.mkdtemp(prefix="ccgm-doctor-"))

--- a/modules/ccgm-doctor/tests/test_doctor.py
+++ b/modules/ccgm-doctor/tests/test_doctor.py
@@ -417,5 +417,120 @@ class TestRunAllChecks(unittest.TestCase):
         self.assertEqual(checks_seen, {"hook-refs", "command-descriptions", "script-refs"})
 
 
+class TestScoreIntentAgainstCommands(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="ccgm-doctor-"))
+        self.commands = self.tmp / "commands"
+        self.commands.mkdir()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _fm(self, name: str, description: str) -> None:
+        (self.commands / f"{name}.md").write_text(
+            f"---\ndescription: {description}\n---\n\nbody\n"
+        )
+
+    def test_ranks_best_match_first(self) -> None:
+        self._fm("commit", "Stage all changes and commit with conventional format")
+        self._fm("reflect", "Run the self-improving reflection loop over the session")
+        self._fm("debug", "Deep root-cause debugging with Opus")
+        ranked = doctor.score_intent_against_commands(
+            "stage and commit my changes", self.commands
+        )
+        self.assertTrue(ranked, "expected at least one match")
+        self.assertEqual(ranked[0][0], "commit")
+
+    def test_filename_stem_contributes_to_match(self) -> None:
+        # Description is vague but the filename stem is the signal.
+        self._fm("calendar-recall", "Historical data lookup")
+        self._fm("reflect", "Run the self-improving reflection loop")
+        ranked = doctor.score_intent_against_commands(
+            "what did my calendar look like in 2020", self.commands
+        )
+        self.assertTrue(ranked)
+        self.assertEqual(ranked[0][0], "calendar-recall")
+
+    def test_empty_intent_returns_empty(self) -> None:
+        self._fm("whatever", "Something happens here")
+        ranked = doctor.score_intent_against_commands("", self.commands)
+        self.assertEqual(ranked, [])
+
+    def test_no_match_returns_empty(self) -> None:
+        self._fm("deploy", "Push the application to production servers")
+        ranked = doctor.score_intent_against_commands(
+            "bake cookies for lunch", self.commands
+        )
+        self.assertEqual(ranked, [])
+
+    def test_missing_commands_dir(self) -> None:
+        ranked = doctor.score_intent_against_commands(
+            "anything", self.tmp / "nope"
+        )
+        self.assertEqual(ranked, [])
+
+
+class TestRunResolverEvals(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="ccgm-doctor-"))
+        self.commands = self.tmp / "commands"
+        self.commands.mkdir()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _fm(self, name: str, description: str) -> None:
+        (self.commands / f"{name}.md").write_text(
+            f"---\ndescription: {description}\n---\n\nbody\n"
+        )
+
+    def test_pass_when_expected_is_top(self) -> None:
+        self._fm("commit", "Stage changes and commit with conventional format")
+        self._fm("reflect", "Run reflection loop over the session")
+        suite = [{"intent": "stage and commit my changes", "expected": "commit"}]
+        results = doctor.run_resolver_evals(suite, self.commands)
+        self.assertTrue(results[0]["passed"])
+
+    def test_fail_when_expected_not_top(self) -> None:
+        self._fm("commit", "Stage changes and commit with conventional format")
+        self._fm("reflect", "Run reflection loop over the session")
+        # "reflect" is the expected, but the intent scores higher on "commit".
+        suite = [{"intent": "stage and commit my changes", "expected": "reflect"}]
+        results = doctor.run_resolver_evals(suite, self.commands)
+        self.assertFalse(results[0]["passed"])
+
+    def test_top_k_widens_pass(self) -> None:
+        self._fm("commit", "Stage changes and commit conventional format")
+        self._fm("review", "Code review for a pull request with feedback")
+        self._fm("pr", "Open a pull request that closes an issue")
+        # "review this pull request" will rank pr or review highest; with top_k=2
+        # the other one still passes.
+        suite = [{"intent": "review this pull request", "expected": "review"}]
+        top1 = doctor.run_resolver_evals(suite, self.commands, top_k=1)
+        top2 = doctor.run_resolver_evals(suite, self.commands, top_k=2)
+        # We don't care which one wins at top-1; we care that top-2 includes both.
+        self.assertTrue(top2[0]["passed"])
+        # Top-2 top_candidates should contain both pr and review.
+        names = {n for n, _ in top2[0]["top_candidates"]}
+        self.assertIn("review", names)
+        self.assertIn("pr", names)
+
+    def test_no_candidates_fails(self) -> None:
+        self._fm("deploy", "Push application to production servers")
+        suite = [{"intent": "bake cookies for lunch", "expected": "deploy"}]
+        results = doctor.run_resolver_evals(suite, self.commands)
+        self.assertFalse(results[0]["passed"])
+        self.assertEqual(results[0]["top_candidates"], [])
+
+    def test_result_shape(self) -> None:
+        self._fm("commit", "Stage and commit changes")
+        suite = [{"intent": "commit my changes", "expected": "commit"}]
+        results = doctor.run_resolver_evals(suite, self.commands)
+        self.assertEqual(len(results), 1)
+        r = results[0]
+        self.assertEqual(set(r.keys()), {"intent", "expected", "top_candidates", "passed"})
+        self.assertIsInstance(r["top_candidates"], list)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds \`resolver-eval\` as the third \`ccgm-doctor\` subcommand. Runs a routing suite of \`{intent, expected}\` assertions against the commands dir and reports pass/fail per intent.

**Stacked on #385** (which is stacked on #384). Base is \`385-dry-audit\`. Will rebase onto main once the two below merge.

## How it scores

For each intent in the suite:

1. Tokenize the intent (same stopwords + min-3-char filter as #385)
2. For each command, tokenize (description + filename stem) — the stem is included because users often hit a command by name (\`calendar-recall\` matches \`calendar\` queries even if the description is generic)
3. Rank by Jaccard similarity
4. Pass if expected command is in the top \`k\` (ties at the k-th position count)

Output:
\`\`\`
[PASS] stage all my changes and commit them
       expected: commit
       top:      commit(0.50)
[FAIL] debug this failing test
       expected: debug
       top:      user-test(0.12)
\`\`\`

## Default suite

Ships \`evals/routing.json\` with 18 common intents covering the areas I expected to be ambiguous: commit/cpm/pr, review/security-review, reflect/consolidate/retro, etc.

Baseline on my install: **11/18 pass at top-1, 12/18 at top-3**. The failures reveal real issues:

- \`review this pull request\` → picks \`pr\` (shares \"pull request\") instead of \`review\`
- \`debug this failing test\` → picks \`user-test\` over \`debug\` (the word \"test\" dominates)
- \`remember this capability ... turn into a permanent skill\` → picks \`mawf\` (skillify isn't merged yet — #382)
- \`update the project documentation\` → picks \`gs\` over \`docupdate\` (docupdate's description is weak)

Exactly the kind of routing ambiguity this tool is supposed to surface.

## Non-goal (for now)

Model-backed routing. The current scorer is lexical. A future PR can add a \`--model\` flag that invokes \`claude -p\` and asks the model directly — the eval file format and the pass/fail contract stay the same.

## Changes

- \`modules/ccgm-doctor/lib/doctor.py\` — \`score_intent_against_commands\`, \`run_resolver_evals\`, helpers
- \`modules/ccgm-doctor/bin/ccgm-doctor\` — \`resolver-eval\` subcommand
- \`modules/ccgm-doctor/evals/routing.json\` — 18-intent default suite
- \`modules/ccgm-doctor/tests/test_doctor.py\` — 17 new unit tests
- \`modules/ccgm-doctor/README.md\` — subcommand docs + suite format
- \`modules/ccgm-doctor/module.json\` — registers the suite file

## Test plan

- [x] \`python3 -m pytest modules/ccgm-doctor/tests/\` — 47 passed (30 reachability + 7 DRY + 17 resolver)
- [x] \`python3 -m pytest modules/\` — 186 passed total
- [x] \`bash tests/test-modules.sh\` — 1016 passed, 0 failed
- [x] Real-install baseline at top-1 and top-3 — surfaces 6-7 routing misses, all of them meaningful

Closes #386