### PR TITLE
#385: add ccgm-doctor dry audit

### DIFF
--- a/modules/ccgm-doctor/README.md
+++ b/modules/ccgm-doctor/README.md
@@ -4,7 +4,10 @@ Audit tool for Claude Code installs. Reports dark or broken entries so they can 
 
 ## What It Does
 
-Installs a `ccgm-doctor` CLI. Current subcommand: `check-resolvable`.
+Installs a `ccgm-doctor` CLI. Subcommands:
+
+- `check-resolvable` — reachability audit (hook refs, command descriptions, script refs)
+- `dry` — DRY/overlap audit (pairs of commands whose triggers are lexically similar)
 
 ### check-resolvable
 
@@ -18,17 +21,29 @@ Walks a Claude install and reports three classes of issue:
 
 Each finding includes: check name, severity, path, and a one-line detail.
 
+### dry
+
+Compares every pair of command trigger descriptions using Jaccard similarity over content tokens (stopwords and short tokens filtered out). Pairs above the threshold are flagged as likely ambiguous routing candidates.
+
+| Check | Severity | What it catches |
+|-------|----------|-----------------|
+| `dry-overlap` | warn | two commands whose trigger descriptions share > threshold tokens (default 0.5) |
+
+Lexical overlap is a conservative signal — it catches copy-paste descriptions and near-duplicates, not semantic synonyms. For semantic routing analysis (e.g., "commit my changes" vs "check in these files"), use the resolver eval harness (#386).
+
 ## Usage
 
 ```bash
-# Audit the default ~/.claude install
+# Reachability audit
 ccgm-doctor check-resolvable
-
-# Audit a specific install
 ccgm-doctor check-resolvable --claude-dir /path/to/.claude
-
-# Machine-readable output
 ccgm-doctor check-resolvable --json
+
+# DRY audit
+ccgm-doctor dry
+ccgm-doctor dry --threshold 0.3          # flag more overlapping pairs
+ccgm-doctor dry --threshold 0.8          # only flag near-duplicates
+ccgm-doctor dry --json
 ```
 
 Exit codes:
@@ -50,7 +65,7 @@ The checks are pure functions of the filesystem. They run in milliseconds and re
 ### What's not covered (yet)
 
 - **Orphan detection** — "script in `bin/` that no command or hook references". CCGM does not track install provenance, so detecting orphans from source-module removal is non-trivial. Deferred.
-- **DRY overlap** — two commands whose descriptions overlap semantically. See `#385`.
+- **Semantic overlap** — two commands whose descriptions are paraphrases of each other but share few exact tokens. Lexical DRY catches copy-paste; semantic routing needs a model. See `#386`.
 - **Resolver routing evals** — does the model actually pick the right command for a given intent? See `#386`.
 
 ## Manual Installation

--- a/modules/ccgm-doctor/bin/ccgm-doctor
+++ b/modules/ccgm-doctor/bin/ccgm-doctor
@@ -4,9 +4,12 @@ ccgm-doctor — audit a Claude Code install for reachability problems.
 
 Subcommands:
     check-resolvable    Report dark/orphaned/broken entries in the install.
+    dry                 Report pairs of commands whose trigger descriptions
+                        overlap (ambiguous routing candidates).
 
 Usage:
     ccgm-doctor check-resolvable [--claude-dir PATH] [--json]
+    ccgm-doctor dry [--claude-dir PATH] [--threshold N] [--json]
 
 Exit codes:
     0   no issues
@@ -27,10 +30,36 @@ sys.path.insert(0, str(_HERE.parent / "lib"))
 import doctor  # noqa: E402
 
 
+def _format_findings(findings: list[dict], scope_label: str) -> None:
+    if not findings:
+        print(f"OK: no issues found in {scope_label}")
+        return
+    by_severity: dict[str, list[dict]] = {}
+    for f in findings:
+        by_severity.setdefault(f["severity"], []).append(f)
+    for sev in ("error", "warn"):
+        items = by_severity.get(sev, [])
+        if not items:
+            continue
+        print(f"{sev.upper()} ({len(items)}):")
+        for f in items:
+            print(f"  [{f['check']}] {f['path']}")
+            print(f"    {f['detail']}")
+    print()
+    print(f"Total: {len(findings)} issue(s) across {scope_label}")
+
+
+def _resolve_claude_dir(raw: str) -> Path | None:
+    path = Path(raw).expanduser().resolve()
+    if not path.is_dir():
+        print(f"error: --claude-dir does not exist: {path}", file=sys.stderr)
+        return None
+    return path
+
+
 def _cmd_check_resolvable(args: argparse.Namespace) -> int:
-    home = Path(args.claude_dir).expanduser().resolve()
-    if not home.is_dir():
-        print(f"error: --claude-dir does not exist: {home}", file=sys.stderr)
+    home = _resolve_claude_dir(args.claude_dir)
+    if home is None:
         return 2
 
     findings = doctor.run_all_checks(home)
@@ -39,22 +68,24 @@ def _cmd_check_resolvable(args: argparse.Namespace) -> int:
         json.dump(findings, sys.stdout, indent=2)
         sys.stdout.write("\n")
     else:
-        if not findings:
-            print(f"OK: no issues found in {home}")
-        else:
-            by_severity = {"error": [], "warn": []}
-            for f in findings:
-                by_severity.setdefault(f["severity"], []).append(f)
-            for sev in ("error", "warn"):
-                items = by_severity.get(sev, [])
-                if not items:
-                    continue
-                print(f"{sev.upper()} ({len(items)}):")
-                for f in items:
-                    print(f"  [{f['check']}] {f['path']}")
-                    print(f"    {f['detail']}")
-            print()
-            print(f"Total: {len(findings)} issue(s) across {home}")
+        _format_findings(findings, str(home))
+
+    return 1 if findings else 0
+
+
+def _cmd_dry(args: argparse.Namespace) -> int:
+    home = _resolve_claude_dir(args.claude_dir)
+    if home is None:
+        return 2
+
+    commands_dir = home / "commands"
+    findings = doctor.check_dry_overlap(commands_dir, threshold=args.threshold)
+
+    if args.json:
+        json.dump(findings, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        _format_findings(findings, f"{commands_dir} (threshold={args.threshold})")
 
     return 1 if findings else 0
 
@@ -81,6 +112,28 @@ def main() -> int:
         help="Emit findings as a JSON array instead of a human-readable report.",
     )
     chk.set_defaults(func=_cmd_check_resolvable)
+
+    dry = subs.add_parser(
+        "dry",
+        help="Report command pairs whose trigger descriptions overlap.",
+    )
+    dry.add_argument(
+        "--claude-dir",
+        default="~/.claude",
+        help="Path to the Claude Code install dir (default: ~/.claude)",
+    )
+    dry.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="Jaccard similarity threshold for flagging pairs (default: 0.5)",
+    )
+    dry.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit findings as a JSON array instead of a human-readable report.",
+    )
+    dry.set_defaults(func=_cmd_dry)
 
     args = parser.parse_args()
     return args.func(args)

--- a/modules/ccgm-doctor/lib/doctor.py
+++ b/modules/ccgm-doctor/lib/doctor.py
@@ -257,3 +257,85 @@ def run_all_checks(claude_dir: Path, user_home: Path | None = None) -> list[Find
         + check_command_descriptions(commands)
         + check_script_refs(commands, claude_dir)
     )
+
+
+# --- DRY / overlap audit ---
+
+# Stopwords for command-trigger tokenization. Words too generic to signal
+# command identity (the, a), common CLI/workflow verbs (run, use, add),
+# and filler. Kept deliberately tight so meaningful nouns like "calendar",
+# "commit", "review" stay in.
+_STOPWORDS = frozenset({
+    "the", "and", "any", "all", "are", "but", "can", "did", "does", "done",
+    "during", "else", "for", "from", "get", "had", "has", "have", "here",
+    "how", "its", "just", "make", "must", "new", "not", "one", "only",
+    "should", "some", "that", "the", "then", "this", "those", "two", "use",
+    "using", "via", "was", "were", "what", "when", "where", "why", "will",
+    "with", "would", "you", "your", "set", "run", "task", "command",
+    "commands", "skill", "workflow", "claude", "code", "agent", "before",
+    "after", "because", "current", "previous", "next", "these",
+})
+
+_TOKEN_RE = re.compile(r'[a-z][a-z0-9]{2,}')
+
+
+def _trigger_tokens(text: str) -> set[str]:
+    """
+    Extract the identity-bearing tokens of a command's trigger description.
+    Lowercase, strip punctuation, drop stopwords and tokens shorter than 3.
+    """
+    desc = _extract_trigger_description(text) or ""
+    return {tok for tok in _TOKEN_RE.findall(desc.lower()) if tok not in _STOPWORDS}
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    intersection = len(a & b)
+    union = len(a | b)
+    return intersection / union if union else 0.0
+
+
+def check_dry_overlap(commands_dir: Path, threshold: float = 0.5) -> list[Finding]:
+    """
+    Flag pairs of commands whose trigger-description tokens overlap above
+    `threshold` (Jaccard similarity). Catches ambiguous routing: two skills
+    the model might plausibly pick for the same intent.
+
+    Commands whose trigger description is empty (already flagged by
+    check_command_descriptions) are skipped so this check stays orthogonal.
+    """
+    findings: list[Finding] = []
+    if not commands_dir.is_dir():
+        return findings
+
+    commands: list[tuple[Path, set[str]]] = []
+    for md in sorted(commands_dir.glob("*.md")):
+        try:
+            text = md.read_text()
+        except OSError:
+            continue
+        tokens = _trigger_tokens(text)
+        if tokens:
+            commands.append((md, tokens))
+
+    # Pairwise comparison. O(n^2) but n is small (dozens, not thousands).
+    for i in range(len(commands)):
+        for j in range(i + 1, len(commands)):
+            path_a, tokens_a = commands[i]
+            path_b, tokens_b = commands[j]
+            sim = _jaccard(tokens_a, tokens_b)
+            if sim >= threshold:
+                shared = sorted(tokens_a & tokens_b)
+                findings.append({
+                    "check": "dry-overlap",
+                    "severity": "warn",
+                    "path": f"{path_a.name} <-> {path_b.name}",
+                    "detail": (
+                        f"Jaccard={sim:.2f} over {len(shared)} shared tokens "
+                        f"({', '.join(shared[:5])}"
+                        f"{'...' if len(shared) > 5 else ''}). "
+                        "Review for merge/deprecate, or sharpen descriptions."
+                    ),
+                })
+    return findings

--- a/modules/ccgm-doctor/tests/test_doctor.py
+++ b/modules/ccgm-doctor/tests/test_doctor.py
@@ -303,6 +303,80 @@ class TestCheckScriptRefs(unittest.TestCase):
         self.assertEqual(len(findings), 1)
 
 
+class TestCheckDryOverlap(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="ccgm-doctor-"))
+        self.commands = self.tmp / "commands"
+        self.commands.mkdir()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _make_fm_command(self, name: str, description: str) -> None:
+        (self.commands / f"{name}.md").write_text(
+            f"---\ndescription: {description}\n---\n\nbody\n"
+        )
+
+    def test_distinct_commands_no_findings(self) -> None:
+        self._make_fm_command("alpha", "Fetch and summarize upstream news articles")
+        self._make_fm_command("beta", "Transform JSON logs into Parquet files")
+        findings = doctor.check_dry_overlap(self.commands)
+        self.assertEqual(findings, [])
+
+    def test_near_duplicate_commands_flagged(self) -> None:
+        # Two descriptions that share most content words - obvious DRY problem.
+        self._make_fm_command(
+            "calendar-check",
+            "Check calendar events for scheduling conflicts tomorrow",
+        )
+        self._make_fm_command(
+            "calendar-recall",
+            "Check calendar events for scheduling conflicts historically",
+        )
+        findings = doctor.check_dry_overlap(self.commands, threshold=0.5)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["check"], "dry-overlap")
+        self.assertEqual(findings[0]["severity"], "warn")
+        self.assertIn("calendar", findings[0]["detail"])
+
+    def test_threshold_respected(self) -> None:
+        # Moderate overlap: flagged at low threshold, clean at high.
+        self._make_fm_command("one", "Deploy production web service quickly")
+        self._make_fm_command("two", "Deploy staging web service quickly")
+        findings_low = doctor.check_dry_overlap(self.commands, threshold=0.3)
+        self.assertEqual(len(findings_low), 1)
+        findings_high = doctor.check_dry_overlap(self.commands, threshold=0.95)
+        self.assertEqual(findings_high, [])
+
+    def test_pair_report_uses_basenames(self) -> None:
+        self._make_fm_command("left", "Parse emails for unread thread summaries")
+        self._make_fm_command("right", "Parse emails for unread thread summaries")
+        findings = doctor.check_dry_overlap(self.commands, threshold=0.5)
+        self.assertEqual(len(findings), 1)
+        self.assertIn("left.md", findings[0]["path"])
+        self.assertIn("right.md", findings[0]["path"])
+
+    def test_empty_descriptions_skipped(self) -> None:
+        # Commands with no trigger description are skipped; they're already
+        # flagged by check_command_descriptions and would produce an empty
+        # set intersection.
+        (self.commands / "empty.md").write_text("")
+        self._make_fm_command("real", "A real command with actual content")
+        findings = doctor.check_dry_overlap(self.commands)
+        self.assertEqual(findings, [])
+
+    def test_heading_style_commands_also_audited(self) -> None:
+        # CCGM-style commands use H1 headings, not frontmatter. Still audited.
+        (self.commands / "alpha.md").write_text("# /alpha - parse emails and build thread summaries\n")
+        (self.commands / "beta.md").write_text("# /beta - parse emails and build thread summaries\n")
+        findings = doctor.check_dry_overlap(self.commands, threshold=0.5)
+        self.assertEqual(len(findings), 1)
+
+    def test_no_commands_dir(self) -> None:
+        findings = doctor.check_dry_overlap(self.tmp / "nonexistent")
+        self.assertEqual(findings, [])
+
+
 class TestRunAllChecks(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = Path(tempfile.mkdtemp(prefix="ccgm-doctor-"))


### PR DESCRIPTION
## Summary

Adds a \`dry\` subcommand to \`ccgm-doctor\` that flags command pairs whose trigger descriptions overlap lexically above a configurable threshold.

Original PR #401 was auto-closed when its base branch (#397) merged and was deleted. This re-creates it against main.

## What it does

For every pair of commands in \`{claude_dir}/commands/\`:

1. Extract trigger description (frontmatter \`description:\` or first-line H1)
2. Tokenize: lowercase, strip punctuation, filter stopwords and tokens < 3 chars
3. Compute Jaccard similarity: |A ∩ B| / |A ∪ B|
4. Flag pairs at/above the threshold (default 0.5)

Lexical overlap catches copy-paste and near-duplicates; semantic paraphrases are #386's \`resolver-eval\` job.

## Test plan

- [x] \`python3 -m pytest modules/ccgm-doctor/tests/\` — 37 passed (30 from #397 + 7 new)
- [x] Real-install baseline at thresholds 0.3, 0.5, 0.8 — clean

Closes #385