### PR TITLE
#411: add web review UI to xplan Phase 6

### DIFF
--- a/modules/xplan/README.md
+++ b/modules/xplan/README.md
@@ -17,7 +17,7 @@ xplan is a human-in-the-loop planning framework with mandatory confirmation gate
 - **Phase 3** - Create parallelized plan with epics and dependency waves
 - **Phase 4** - Peer review by security, architecture, and business logic agents
 - **Phase 5** - Write comprehensive plan.md
-- **Phase 6** - Final confirmation gate before execution
+- **Phase 6** - Web review (default surface) + final confirmation gate before execution
 - **Phase 7** - Create repo, issues, and spawn parallel agents per wave
 - **Phase 8** - Verification, audit, retrospective, optional template generation
 
@@ -35,6 +35,23 @@ xplan is a human-in-the-loop planning framework with mandatory confirmation gate
 
 `--light` and `--autonomous` are mutually exclusive.
 
+### Web Review (Phase 6)
+
+Phase 6's default review surface is a local browser UI served by stdlib `http.server` on 127.0.0.1. xplan renders `plan.md` with `marked.js` (CDN) and attaches a comment button to every `##` and `###` heading. The user can:
+
+- **Submit for deepening** — xplan reads the comments, runs a targeted Deepen Mode pass on each commented section, re-renders the patched plan for a second review round, then proceeds to the Phase 6.5 gate.
+- **Accept as-is** — proceed directly to the Phase 6.5 gate.
+
+The web UI activates when `plan.md` exists and the environment is not headless. Fallbacks to the terminal walkthrough (6.A / 6.1-6.4) when:
+- `XPLAN_NO_WEB=1` is set
+- No `$DISPLAY` on Linux
+- The server cannot bind a loopback port
+- The helper script `~/.claude/lib/xplan-web-review.py` is missing
+
+The Phase 6.5 final execution gate always fires afterward, web or not. The web UI is the review mechanism; 6.5 is the go/no-go.
+
+Comments are persisted to `~/code/plans/{concept-name}/comments.json` before the server shuts down — safe to close the tab or CTRL+C the script after clicking Submit.
+
 Companion commands:
 - **/xplana** - Thin alias for `/xplan --autonomous`
 - **/xplan-status** - Check progress on a running or completed plan
@@ -49,6 +66,7 @@ Companion commands:
 | `commands/xplan-status.md` | command | Plan progress dashboard (/xplan-status) |
 | `commands/xplan-resume.md` | command | Resume interrupted execution (/xplan-resume) |
 | `lib/xplan-status-gather.sh` | lib | Helper script that gathers plan progress data for /xplan-status |
+| `lib/xplan-web-review.py` | lib | Local web server that renders plan.md in browser with section-level comment support for Phase 6 review |
 
 ## Dependencies
 
@@ -82,6 +100,8 @@ cp commands/xplan-resume.md ~/.claude/commands/xplan-resume.md
 # Copy lib files
 mkdir -p ~/.claude/lib
 cp lib/xplan-status-gather.sh ~/.claude/lib/xplan-status-gather.sh
+cp lib/xplan-web-review.py ~/.claude/lib/xplan-web-review.py
+chmod +x ~/.claude/lib/xplan-web-review.py
 ```
 
 ### Plans Directory

--- a/modules/xplan/commands/xplan.md
+++ b/modules/xplan/commands/xplan.md
@@ -1216,11 +1216,101 @@ Re-run 5.6.1, 5.6.2, and 5.6.3 after every round of fixes. Do not advance to Pha
 
 ### 6.0 Mode Split
 
+**First, attempt the web review (section 6.W below) as the default review surface.** If the web server launches successfully and the user interacts with it, use its result (the `comments.json` it writes) to drive the next step:
+- If the user clicked **Submit for deepening** and `comments.json` contains non-empty comments: run Deepen Mode D.5-D.7 against the commented sections (treat each comment as a pre-selected gap, skipping D.3 and D.4), then loop back through 6.W once more so the user can review the patched plan.
+- If the user clicked **Accept as-is**: the plan is approved as reviewed. Proceed to 6.5.
+- If the web server fails to launch (see 6.W fallback conditions): fall through to the mode-specific text walkthroughs below.
+
+**Fallback mode split (when web UI is unavailable):**
+
 **If `--autonomous` flag is active**: Run the autonomous plan walkthrough (section 6.A below) before the final gate (6.5). This presents the completed plan as a single structured artifact with every inferred default called out so the user can redirect if any assumption was wrong.
 
 **If `--light` flag is active**: Run the full interactive walkthrough (sections 6.1-6.4 below) before the final gate (6.5). This is the traditional pre-execution review.
 
 **If default interactive mode (neither flag)**: The user has already reviewed research (Phase 1.5), approved the tech stack (Phase 2.5), approved the high-level scope (Phase 2.6), and confirmed the multi-agent setup (Phase 2.7). Skip sections 6.1-6.4 and 6.A. Go directly to 6.5.
+
+Regardless of which path is taken, **Phase 6.5 always fires** - the web review and the text walkthroughs are the *review* mechanisms; 6.5 is the non-bypassable execution gate.
+
+---
+
+### 6.W Web Review Walkthrough (default review surface, all modes)
+
+**Goal**: Render the completed plan in the user's browser with section-level comment support. Comments drive a targeted Deepen Mode pass; "Accept as-is" proceeds to the final gate.
+
+**Launch preconditions** (ALL must hold; if any fails, skip 6.W and fall through to the text walkthrough for the current mode):
+- `plan.md` exists at `~/code/plans/{concept-name}/plan.md` (Phase 5 + 5.6 complete)
+- Env var `XPLAN_NO_WEB` is NOT set to `1`
+- On Linux, `$DISPLAY` is set (macOS always passes this check)
+- The helper script `~/.claude/lib/xplan-web-review.py` is executable
+
+Announce before launching: "Opening the plan in your browser for review. Add comments on any sections you want deepened, then click Submit or Accept."
+
+#### 6.W.1 Launch the server
+
+Run the helper (foreground; it blocks until the user submits or accepts):
+
+```bash
+python3 ~/.claude/lib/xplan-web-review.py ~/code/plans/{concept-name}
+```
+
+The script:
+- Picks a free port on 127.0.0.1
+- Opens the default browser to the review UI
+- Waits for the user to click **Submit for deepening** or **Accept as-is**
+- Writes `~/code/plans/{concept-name}/comments.json` with the user's action and any comments
+- Prints a single JSON line to stdout: `{"action": "deepen"|"accept", "comment_count": N}`
+- Exits 0 on user action, 1 on launch failure (caller should fall back)
+
+If exit code is non-zero, fall through to the mode-specific text walkthrough below (6.A / 6.1-6.4).
+
+#### 6.W.2 Handle the result
+
+Read `~/code/plans/{concept-name}/comments.json`. It contains:
+
+```json
+{
+  "action": "deepen" | "accept",
+  "ts": "...",
+  "concept": "...",
+  "comments": [
+    {
+      "anchor": "plan.md::2. Scope",
+      "file": "plan.md",
+      "section_title": "2. Scope",
+      "text": "the user's comment",
+      "ts": "...",
+      "status": "pending"
+    }
+  ]
+}
+```
+
+**If `action == "accept"`**: Record "User accepted plan via web review" in `decisions.md` and proceed to Phase 6.5.
+
+**If `action == "deepen"`** and `comments` is non-empty: treat each comment as a pre-selected deepening gap and run Deepen Mode D.5-D.7 **without** asking D.3's gap categorization or D.4's user selection - the user already selected by commenting. For each comment:
+
+- The "target section" for D.5 is the comment's `section_title` in the comment's `file`.
+- The "gap description" is the comment's `text`.
+- Derive the gap bucket heuristically: ambiguity / pattern / test / tech-assumption based on the comment's wording; default to ambiguity if unclear. This feeds the D.5 agent prompt.
+- Dispatch one Task agent per comment (model: sonnet), in parallel when comments target different sections, serialized when they touch the same section.
+
+After the deepening agents return, integrate their results into plan.md via D.6 **without** re-prompting the user per section (the user already stated their intent in the comment - applying the proposed replacement is the direct implementation of that intent). If a deepening pass produces ambiguous or conflicting output, fall back to D.6's interactive AskUserQuestion for that single comment only.
+
+Append a Deepen Pass block to `decisions.md` per D.6's format, noting that the source was web review.
+
+Re-run Phase 5.6 (self-review) against the updated plan, as D.7 requires.
+
+#### 6.W.3 Second-round review
+
+After the deepening pass lands and 5.6 passes clean, **re-launch the web server once** (second round) so the user can verify the patches. Cap at one deepening round per run to avoid loops - on the second round, only **Accept as-is** meaningfully proceeds. If the user submits more comments on the second round, apply them if resource budget allows, otherwise save them to `comments.json` and surface them at the 6.5 gate as "deferred deepening - use `/xplan --deepen` to address."
+
+After the second round (or after a first-round Accept), proceed to Phase 6.5.
+
+#### 6.W.4 Fallback
+
+If 6.W cannot launch (exit code 1), or if the user closes the tab without submitting (the script blocks indefinitely; user can CTRL+C the script to signal "skip"), the orchestrator falls through to the mode-specific text walkthrough for the current mode (6.A for `--autonomous`, 6.1-6.4 for `--light`, straight to 6.5 for default interactive).
+
+Log the fallback reason to `decisions.md` so later debugging can see whether the web path ran.
 
 ---
 

--- a/modules/xplan/lib/xplan-web-review.py
+++ b/modules/xplan/lib/xplan-web-review.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+"""xplan-web-review.py - Local web UI for reviewing an xplan plan directory.
+
+Renders plan.md (and sibling artifacts research.md / decisions.md / naming.md /
+reviews/*.md) in the browser with section-level comment support. On Submit,
+writes comments to {plan_dir}/comments.json and shuts down. The xplan
+orchestrator then reads comments.json and runs a targeted Deepen Mode pass.
+
+Usage:
+  xplan-web-review.py <plan_dir> [--port PORT] [--no-open]
+
+Exit codes:
+  0  - User submitted comments or accepted the plan as-is
+  1  - Server failed to launch (caller should fall back to text walkthrough)
+  2  - Invalid plan directory
+
+Fallback signals (caller should use text walkthrough):
+  - Env var XPLAN_NO_WEB=1
+  - Python exit code 1
+  - $DISPLAY unset on Linux (approximate headless check)
+
+Trust model:
+  Server binds to 127.0.0.1 only. The rendered markdown (plan.md and siblings)
+  is content this same user wrote or that xplan wrote into their own plan dir.
+  It is NOT user-submitted content from an untrusted third party. The review
+  UI uses marked.parse on this trusted content; inline HTML in markdown will
+  render as HTML, same as any local markdown viewer. If a plan contains raw
+  HTML, that is by the plan author's intent (diagrams, tables, etc.). We do
+  escape text-derived values (section titles, toast messages) into DOM text
+  nodes / attributes rather than interpolating them into innerHTML templates.
+
+No runtime dependencies beyond stdlib. HTML uses marked.js via CDN.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+import threading
+import time
+import webbrowser
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+
+def is_headless() -> bool:
+    """Approximate headless check. Returns True if the web UI should not launch."""
+    if os.environ.get("XPLAN_NO_WEB") == "1":
+        return True
+    if sys.platform.startswith("linux") and not os.environ.get("DISPLAY"):
+        return True
+    return False
+
+
+def find_free_port(preferred: int | None = None) -> int:
+    if preferred:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("127.0.0.1", preferred))
+                return preferred
+            except OSError:
+                pass
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def list_plan_files(plan_dir: Path) -> list[dict]:
+    """Return a list of {name, path, kind} for every markdown file in the plan dir."""
+    files: list[dict] = []
+    top_level = ["plan.md", "research.md", "decisions.md", "naming.md", "progress.md"]
+    for name in top_level:
+        p = plan_dir / name
+        if p.is_file():
+            files.append({"name": name, "path": name, "kind": "main"})
+    reviews_dir = plan_dir / "reviews"
+    if reviews_dir.is_dir():
+        for p in sorted(reviews_dir.glob("*.md")):
+            files.append({"name": f"reviews/{p.name}", "path": f"reviews/{p.name}", "kind": "review"})
+    return files
+
+
+INDEX_HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>xplan review</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<style>
+  :root {
+    --bg: #0e1116;
+    --panel: #151a21;
+    --border: #2a3038;
+    --text: #e6edf3;
+    --muted: #8b949e;
+    --accent: #58a6ff;
+    --accent-2: #3fb950;
+    --danger: #f85149;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font: 15px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    grid-template-rows: auto 1fr auto;
+    grid-template-areas:
+      "header header"
+      "sidebar main"
+      "footer footer";
+    min-height: 100vh;
+  }
+  header {
+    grid-area: header;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+  header h1 { font-size: 16px; margin: 0; font-weight: 600; }
+  header .meta { color: var(--muted); font-size: 13px; }
+  nav {
+    grid-area: sidebar;
+    border-right: 1px solid var(--border);
+    padding: 16px 10px;
+    overflow-y: auto;
+  }
+  nav .file-list { display: flex; flex-direction: column; gap: 2px; margin-bottom: 20px; }
+  nav .file-list button {
+    text-align: left;
+    background: transparent;
+    color: var(--text);
+    border: 1px solid transparent;
+    border-radius: 6px;
+    padding: 6px 10px;
+    cursor: pointer;
+    font: inherit;
+  }
+  nav .file-list button:hover { background: var(--panel); }
+  nav .file-list button.active { background: var(--panel); border-color: var(--border); }
+  nav .toc { font-size: 13px; color: var(--muted); }
+  nav .toc a {
+    display: block;
+    color: var(--muted);
+    text-decoration: none;
+    padding: 3px 10px;
+    border-radius: 4px;
+  }
+  nav .toc a:hover { color: var(--text); background: var(--panel); }
+  nav .toc a.h3 { padding-left: 20px; font-size: 12px; }
+  main {
+    grid-area: main;
+    padding: 24px 40px 80px 40px;
+    overflow-y: auto;
+    max-width: 960px;
+  }
+  main h1, main h2, main h3 { scroll-margin-top: 16px; }
+  main h2, main h3 { position: relative; }
+  main h2 .comment-btn, main h3 .comment-btn {
+    position: absolute;
+    left: -32px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border-radius: 50%;
+    border: 1px solid var(--border);
+    background: var(--panel);
+    color: var(--muted);
+    cursor: pointer;
+    font: inherit;
+    font-size: 13px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  main h2 .comment-btn:hover, main h3 .comment-btn:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+  main h2 .comment-btn.has-comment, main h3 .comment-btn.has-comment {
+    color: var(--accent-2);
+    border-color: var(--accent-2);
+  }
+  .comment-box {
+    margin: 8px 0 16px;
+    padding: 10px 12px;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    border-radius: 6px;
+    display: none;
+  }
+  .comment-box.open { display: block; }
+  .comment-box textarea {
+    width: 100%;
+    min-height: 70px;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 8px;
+    font: inherit;
+    resize: vertical;
+  }
+  .comment-box .row { display: flex; gap: 8px; margin-top: 8px; }
+  .comment-box button {
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 4px 10px;
+    cursor: pointer;
+    font: inherit;
+    font-size: 13px;
+  }
+  .comment-box button.save { border-color: var(--accent-2); color: var(--accent-2); }
+  .comment-box button.discard { border-color: var(--danger); color: var(--danger); }
+  pre, code {
+    font: 13px ui-monospace, "SF Mono", Consolas, monospace;
+  }
+  main pre {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px;
+    overflow-x: auto;
+  }
+  main code { background: var(--panel); padding: 1px 5px; border-radius: 3px; }
+  main pre code { background: transparent; padding: 0; }
+  main a { color: var(--accent); }
+  main table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 12px 0;
+  }
+  main th, main td {
+    border: 1px solid var(--border);
+    padding: 6px 10px;
+    text-align: left;
+  }
+  main th { background: var(--panel); }
+  main blockquote {
+    border-left: 3px solid var(--border);
+    padding-left: 12px;
+    color: var(--muted);
+    margin-left: 0;
+  }
+  footer {
+    grid-area: footer;
+    border-top: 1px solid var(--border);
+    padding: 12px 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: var(--panel);
+  }
+  footer .status { color: var(--muted); font-size: 13px; }
+  footer .actions { display: flex; gap: 10px; }
+  footer button {
+    font: inherit;
+    font-size: 14px;
+    padding: 8px 18px;
+    border-radius: 6px;
+    cursor: pointer;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text);
+  }
+  footer button.primary {
+    background: var(--accent);
+    color: #001428;
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  footer button.secondary { border-color: var(--accent-2); color: var(--accent-2); }
+  .toast {
+    position: fixed;
+    bottom: 80px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--panel);
+    border: 1px solid var(--accent-2);
+    color: var(--text);
+    padding: 10px 20px;
+    border-radius: 8px;
+    display: none;
+  }
+  .toast.show { display: block; }
+</style>
+</head>
+<body>
+<header>
+  <h1 id="concept-title">xplan review</h1>
+  <span class="meta" id="comment-count">0 comments</span>
+</header>
+<nav>
+  <div class="file-list" id="file-list"></div>
+  <div class="toc" id="toc"></div>
+</nav>
+<main id="content">Loading…</main>
+<footer>
+  <span class="status" id="status">Ready</span>
+  <div class="actions">
+    <button class="secondary" id="accept-btn">Accept as-is</button>
+    <button class="primary" id="submit-btn">Submit for deepening</button>
+  </div>
+</footer>
+<div class="toast" id="toast"></div>
+<script>
+  const FILES = __FILES_JSON__;
+  const CONCEPT = __CONCEPT_JSON__;
+  document.getElementById("concept-title").textContent = "xplan review: " + CONCEPT;
+
+  const state = {
+    currentFile: FILES[0]?.path || "plan.md",
+    comments: {},
+  };
+
+  const fileListEl = document.getElementById("file-list");
+  const tocEl = document.getElementById("toc");
+  const contentEl = document.getElementById("content");
+  const countEl = document.getElementById("comment-count");
+  const statusEl = document.getElementById("status");
+  const toastEl = document.getElementById("toast");
+
+  FILES.forEach(f => {
+    const btn = document.createElement("button");
+    btn.textContent = f.name;
+    btn.dataset.path = f.path;
+    btn.onclick = () => loadFile(f.path);
+    fileListEl.appendChild(btn);
+  });
+
+  function updateFileListActive() {
+    fileListEl.querySelectorAll("button").forEach(b => {
+      b.classList.toggle("active", b.dataset.path === state.currentFile);
+    });
+  }
+
+  function toast(msg, ms = 2000) {
+    toastEl.textContent = msg;
+    toastEl.classList.add("show");
+    setTimeout(() => toastEl.classList.remove("show"), ms);
+  }
+
+  function updateCount() {
+    const total = Object.values(state.comments)
+      .flat()
+      .filter(c => c && c.text && c.text.trim()).length;
+    countEl.textContent = total === 1 ? "1 comment" : `${total} comments`;
+  }
+
+  function anchorFor(file, title) {
+    return `${file}::${title}`;
+  }
+
+  function attachCommentButtons(file) {
+    const headings = contentEl.querySelectorAll("h2, h3");
+    const tocItems = [];
+    headings.forEach(h => {
+      const title = h.textContent.trim();
+      const level = h.tagName.toLowerCase();
+      const anchor = anchorFor(file, title);
+      const id = "section-" + anchor.replace(/[^a-zA-Z0-9-]/g, "-");
+      h.id = id;
+      tocItems.push({ id, title, level });
+
+      const btn = document.createElement("button");
+      btn.className = "comment-btn";
+      btn.textContent = "+";
+      btn.title = `Comment on: ${title}`;
+      btn.onclick = (e) => {
+        e.preventDefault();
+        const box = h.nextElementSibling?.classList?.contains("comment-box")
+          ? h.nextElementSibling
+          : createCommentBox(h, file, title, anchor);
+        box.classList.toggle("open");
+        if (box.classList.contains("open")) {
+          box.querySelector("textarea").focus();
+        }
+      };
+
+      const existing = (state.comments[anchor] || [])[0];
+      if (existing && existing.text?.trim()) {
+        btn.classList.add("has-comment");
+        const box = createCommentBox(h, file, title, anchor);
+        box.querySelector("textarea").value = existing.text;
+      }
+
+      h.prepend(btn);
+    });
+
+    tocEl.innerHTML = "";
+    tocItems.forEach(item => {
+      const a = document.createElement("a");
+      a.href = `#${item.id}`;
+      a.textContent = item.title;
+      if (item.level === "h3") a.className = "h3";
+      tocEl.appendChild(a);
+    });
+  }
+
+  function createCommentBox(heading, file, title, anchor) {
+    const box = document.createElement("div");
+    box.className = "comment-box";
+
+    const ta = document.createElement("textarea");
+    ta.placeholder = `What would you like to change about: ${title}`;
+
+    const row = document.createElement("div");
+    row.className = "row";
+
+    const saveBtn = document.createElement("button");
+    saveBtn.className = "save";
+    saveBtn.textContent = "Save";
+
+    const discardBtn = document.createElement("button");
+    discardBtn.className = "discard";
+    discardBtn.textContent = "Discard";
+
+    row.appendChild(saveBtn);
+    row.appendChild(discardBtn);
+    box.appendChild(ta);
+    box.appendChild(row);
+    heading.insertAdjacentElement("afterend", box);
+
+    saveBtn.onclick = () => {
+      const text = ta.value.trim();
+      if (!text) {
+        delete state.comments[anchor];
+      } else {
+        state.comments[anchor] = [{
+          anchor,
+          file,
+          section_title: title,
+          text,
+          ts: new Date().toISOString(),
+          status: "pending",
+        }];
+      }
+      const btn = heading.querySelector(".comment-btn");
+      btn.classList.toggle("has-comment", !!text);
+      box.classList.remove("open");
+      updateCount();
+      toast(text ? "Comment saved" : "Comment cleared");
+    };
+    discardBtn.onclick = () => {
+      ta.value = "";
+      delete state.comments[anchor];
+      heading.querySelector(".comment-btn").classList.remove("has-comment");
+      box.classList.remove("open");
+      updateCount();
+    };
+    return box;
+  }
+
+  async function loadFile(path) {
+    state.currentFile = path;
+    updateFileListActive();
+    statusEl.textContent = `Loading ${path}...`;
+    try {
+      const resp = await fetch(`/raw/${path}`);
+      if (!resp.ok) throw new Error(`${resp.status}`);
+      const md = await resp.text();
+      // Trust model note: plan.md and siblings are local trusted content this user
+      // (or xplan running as this user) wrote into ~/code/plans/{concept}/. Rendering
+      // inline HTML in markdown is expected behavior for a local markdown viewer.
+      contentEl.innerHTML = marked.parse(md);
+      attachCommentButtons(path);
+      statusEl.textContent = `Viewing ${path}`;
+    } catch (e) {
+      contentEl.textContent = `Failed to load ${path}: ${e.message}`;
+      statusEl.textContent = "Load error";
+    }
+  }
+
+  async function submitReview(endpoint, payload) {
+    statusEl.textContent = "Submitting...";
+    try {
+      const resp = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!resp.ok) throw new Error(`${resp.status}`);
+      statusEl.textContent = "Submitted. You can close this tab.";
+      document.getElementById("submit-btn").disabled = true;
+      document.getElementById("accept-btn").disabled = true;
+      toast("Submitted. Return to your terminal.", 5000);
+    } catch (e) {
+      statusEl.textContent = `Submit failed: ${e.message}`;
+      toast(`Submit failed: ${e.message}`, 5000);
+    }
+  }
+
+  document.getElementById("submit-btn").onclick = () => {
+    const flat = Object.values(state.comments).flat().filter(c => c && c.text?.trim());
+    if (flat.length === 0) {
+      toast("No comments. Use 'Accept as-is' instead.", 3000);
+      return;
+    }
+    submitReview("/submit", { action: "deepen", comments: flat });
+  };
+
+  document.getElementById("accept-btn").onclick = () => {
+    submitReview("/accept", { action: "accept", comments: [] });
+  };
+
+  loadFile(state.currentFile);
+</script>
+</body>
+</html>
+"""
+
+
+class PlanHandler(BaseHTTPRequestHandler):
+    plan_dir: Path = Path()
+    concept: str = ""
+    result_holder: dict = {}
+
+    def log_message(self, format, *args):
+        pass
+
+    def _send(self, status: int, body: bytes, content_type: str = "text/plain; charset=utf-8"):
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _safe_path(self, rel: str) -> Path | None:
+        """Resolve rel within plan_dir; return None if escape is attempted."""
+        candidate = (self.plan_dir / rel).resolve()
+        try:
+            candidate.relative_to(self.plan_dir.resolve())
+        except ValueError:
+            return None
+        return candidate
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = unquote(parsed.path)
+
+        if path == "/":
+            files = list_plan_files(self.plan_dir)
+            html = (
+                INDEX_HTML
+                .replace("__FILES_JSON__", json.dumps(files))
+                .replace("__CONCEPT_JSON__", json.dumps(self.concept))
+            )
+            self._send(200, html.encode("utf-8"), "text/html; charset=utf-8")
+            return
+
+        if path.startswith("/raw/"):
+            rel = path[len("/raw/"):]
+            target = self._safe_path(rel)
+            if not target or not target.is_file() or target.suffix != ".md":
+                self._send(404, b"not found")
+                return
+            self._send(200, target.read_bytes(), "text/markdown; charset=utf-8")
+            return
+
+        if path == "/health":
+            self._send(200, b"ok")
+            return
+
+        self._send(404, b"not found")
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length) if length else b""
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except Exception:
+            self._send(400, b"invalid json")
+            return
+
+        parsed = urlparse(self.path)
+        path = parsed.path
+
+        if path == "/submit":
+            comments = payload.get("comments", [])
+            self._write_comments(comments, action="deepen")
+            self._send(200, b'{"ok":true}', "application/json")
+            self.result_holder["action"] = "deepen"
+            self.result_holder["comment_count"] = len(comments)
+            self.result_holder["done"] = True
+            return
+
+        if path == "/accept":
+            self._write_comments([], action="accept")
+            self._send(200, b'{"ok":true}', "application/json")
+            self.result_holder["action"] = "accept"
+            self.result_holder["comment_count"] = 0
+            self.result_holder["done"] = True
+            return
+
+        self._send(404, b"not found")
+
+    def _write_comments(self, comments: list, action: str):
+        out = {
+            "action": action,
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "concept": self.concept,
+            "comments": comments,
+        }
+        (self.plan_dir / "comments.json").write_text(json.dumps(out, indent=2))
+
+
+def serve(plan_dir: Path, port: int, open_browser: bool) -> dict:
+    PlanHandler.plan_dir = plan_dir
+    PlanHandler.concept = plan_dir.name
+    PlanHandler.result_holder = {"done": False}
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", port), PlanHandler)
+    url = f"http://127.0.0.1:{port}/"
+
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    print(f"xplan-web-review: serving {plan_dir} at {url}", file=sys.stderr)
+
+    if open_browser:
+        try:
+            webbrowser.open(url)
+        except Exception as e:
+            print(f"xplan-web-review: could not open browser ({e}); open {url} manually", file=sys.stderr)
+
+    try:
+        while not PlanHandler.result_holder.get("done"):
+            time.sleep(0.2)
+    except KeyboardInterrupt:
+        PlanHandler.result_holder["action"] = "interrupted"
+    finally:
+        time.sleep(0.3)
+        httpd.shutdown()
+        httpd.server_close()
+
+    return PlanHandler.result_holder
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("plan_dir", type=str, help="Path to the plan directory (contains plan.md)")
+    parser.add_argument("--port", type=int, default=None, help="Port to bind (default: auto-detect free port)")
+    parser.add_argument("--no-open", action="store_true", help="Do not auto-open the browser")
+    args = parser.parse_args()
+
+    if is_headless():
+        print("xplan-web-review: headless environment (XPLAN_NO_WEB or no $DISPLAY); skipping", file=sys.stderr)
+        return 1
+
+    plan_dir = Path(args.plan_dir).expanduser().resolve()
+    if not plan_dir.is_dir():
+        print(f"xplan-web-review: not a directory: {plan_dir}", file=sys.stderr)
+        return 2
+    if not (plan_dir / "plan.md").is_file():
+        print(f"xplan-web-review: no plan.md in {plan_dir}", file=sys.stderr)
+        return 2
+
+    try:
+        port = find_free_port(args.port)
+    except OSError as e:
+        print(f"xplan-web-review: could not bind a port ({e})", file=sys.stderr)
+        return 1
+
+    try:
+        result = serve(plan_dir, port, open_browser=not args.no_open)
+    except Exception as e:
+        print(f"xplan-web-review: server error ({e})", file=sys.stderr)
+        return 1
+
+    action = result.get("action", "interrupted")
+    count = result.get("comment_count", 0)
+    print(json.dumps({"action": action, "comment_count": count}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/xplan/module.json
+++ b/modules/xplan/module.json
@@ -10,6 +10,7 @@
     "commands/xplana.md": { "target": "commands/xplana.md", "type": "command", "template": false },
     "commands/xplan-status.md": { "target": "commands/xplan-status.md", "type": "command", "template": false },
     "lib/xplan-status-gather.sh": { "target": "lib/xplan-status-gather.sh", "type": "lib", "template": false },
+    "lib/xplan-web-review.py": { "target": "lib/xplan-web-review.py", "type": "lib", "template": false },
     "commands/xplan-resume.md": { "target": "commands/xplan-resume.md", "type": "command", "template": false }
   },
   "tags": ["planning", "execution", "research", "parallel"],

--- a/tests/test-xplan-web-review.sh
+++ b/tests/test-xplan-web-review.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Smoke tests for modules/xplan/lib/xplan-web-review.py
+# Verifies: headless fallback signal, error exit codes, endpoint behavior,
+# path-traversal denial, and comments.json schema.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB="$REPO_ROOT/modules/xplan/lib/xplan-web-review.py"
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+echo "=== xplan-web-review smoke tests ==="
+
+# -- Setup: scratch plan dir
+TMPDIR=$(mktemp -d -t xplan-web-test-XXXXXX)
+cleanup() {
+  # Best-effort port cleanup; the script handles its own shutdown on submit
+  [ -n "${SERVER_PID:-}" ] && kill "$SERVER_PID" 2>/dev/null
+  # shellcheck disable=SC2317
+  :
+}
+trap cleanup EXIT
+
+cat > "$TMPDIR/plan.md" <<'EOF'
+# Test Plan
+
+## 1. Overview
+Hello world.
+
+## 2. Scope
+### 2.1 v1
+- Thing
+EOF
+
+cat > "$TMPDIR/research.md" <<'EOF'
+# Research
+## Finding
+Data.
+EOF
+
+# -- Test 1: file exists and is executable
+if [ -x "$LIB" ]; then
+  pass "lib is executable: $LIB"
+else
+  fail "lib not executable or missing: $LIB"
+  echo "FAIL: Results: $PASS passed, $FAIL failed"
+  exit 1
+fi
+
+# -- Test 2: syntax valid
+if python3 -c "import ast; ast.parse(open('$LIB').read())" 2>/dev/null; then
+  pass "syntactically valid python"
+else
+  fail "syntax error in $LIB"
+fi
+
+# -- Test 3: XPLAN_NO_WEB=1 yields exit 1 (fallback signal)
+XPLAN_NO_WEB=1 python3 "$LIB" "$TMPDIR" --no-open >/dev/null 2>&1
+rc=$?
+if [ "$rc" = "1" ]; then
+  pass "XPLAN_NO_WEB=1 exits 1 (fallback signal)"
+else
+  fail "XPLAN_NO_WEB=1 exited $rc, expected 1"
+fi
+
+# -- Test 4: nonexistent dir yields exit 2
+python3 "$LIB" "$TMPDIR/does-not-exist" --no-open >/dev/null 2>&1
+rc=$?
+if [ "$rc" = "2" ]; then
+  pass "nonexistent plan dir exits 2"
+else
+  fail "nonexistent plan dir exited $rc, expected 2"
+fi
+
+# -- Test 5: dir without plan.md yields exit 2
+EMPTY_DIR=$(mktemp -d -t xplan-empty-XXXXXX)
+python3 "$LIB" "$EMPTY_DIR" --no-open >/dev/null 2>&1
+rc=$?
+if [ "$rc" = "2" ]; then
+  pass "dir without plan.md exits 2"
+else
+  fail "dir without plan.md exited $rc, expected 2"
+fi
+rmdir "$EMPTY_DIR" 2>/dev/null
+
+# -- Test 6: server starts, / returns 200 + HTML
+PORT=47431
+python3 "$LIB" "$TMPDIR" --no-open --port "$PORT" >/tmp/xplan-web-test-stdout.$$ 2>/tmp/xplan-web-test-stderr.$$ &
+SERVER_PID=$!
+sleep 0.8
+
+code=$(curl -s -o /tmp/xplan-web-test-index.$$ -w "%{http_code}" "http://127.0.0.1:$PORT/")
+if [ "$code" = "200" ] && grep -q "xplan review" /tmp/xplan-web-test-index.$$; then
+  pass "GET / returns 200 and expected HTML"
+else
+  fail "GET / returned $code (expected 200)"
+fi
+
+# -- Test 7: /raw/plan.md returns markdown
+code=$(curl -s -o /tmp/xplan-web-test-md.$$ -w "%{http_code}" "http://127.0.0.1:$PORT/raw/plan.md")
+if [ "$code" = "200" ] && grep -q "# Test Plan" /tmp/xplan-web-test-md.$$; then
+  pass "GET /raw/plan.md returns the markdown"
+else
+  fail "GET /raw/plan.md returned $code or wrong content"
+fi
+
+# -- Test 8: /raw/research.md also works
+code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$PORT/raw/research.md")
+if [ "$code" = "200" ]; then
+  pass "GET /raw/research.md returns 200"
+else
+  fail "GET /raw/research.md returned $code"
+fi
+
+# -- Test 9: path traversal denied
+code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$PORT/raw/../../etc/passwd")
+if [ "$code" = "404" ]; then
+  pass "path traversal ../../etc/passwd denied (404)"
+else
+  fail "path traversal returned $code, expected 404"
+fi
+
+# -- Test 10: non-markdown file denied
+echo "secret" > "$TMPDIR/secret.txt"
+code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$PORT/raw/secret.txt")
+if [ "$code" = "404" ]; then
+  pass "non-.md file denied (404)"
+else
+  fail "non-.md file returned $code, expected 404"
+fi
+rm "$TMPDIR/secret.txt" 2>/dev/null
+
+# -- Test 11: POST /submit writes comments.json and shuts down
+curl -s -X POST -H 'Content-Type: application/json' \
+  -d '{"action":"deepen","comments":[{"anchor":"plan.md::2. Scope","file":"plan.md","section_title":"2. Scope","text":"expand this","ts":"2026-04-24T10:00:00Z","status":"pending"}]}' \
+  "http://127.0.0.1:$PORT/submit" >/dev/null
+
+# Give the server ~1s to write and shut down
+wait "$SERVER_PID" 2>/dev/null
+SERVER_PID=""
+
+if [ -f "$TMPDIR/comments.json" ]; then
+  pass "POST /submit wrote comments.json"
+else
+  fail "comments.json not created after /submit"
+fi
+
+if python3 -c "
+import json, sys
+d = json.load(open('$TMPDIR/comments.json'))
+assert d['action'] == 'deepen', 'action != deepen'
+assert len(d['comments']) == 1, 'wrong comment count'
+assert d['comments'][0]['text'] == 'expand this', 'wrong comment text'
+assert d['comments'][0]['section_title'] == '2. Scope', 'wrong section title'
+" 2>/tmp/xplan-web-test-assert.$$; then
+  pass "comments.json has correct schema and payload"
+else
+  fail "comments.json schema mismatch: $(cat /tmp/xplan-web-test-assert.$$)"
+fi
+
+# -- Test 12: POST /accept on a second server writes action=accept
+rm "$TMPDIR/comments.json" 2>/dev/null
+PORT=47432
+python3 "$LIB" "$TMPDIR" --no-open --port "$PORT" >/dev/null 2>&1 &
+SERVER_PID=$!
+sleep 0.8
+
+curl -s -X POST -H 'Content-Type: application/json' \
+  -d '{"action":"accept","comments":[]}' \
+  "http://127.0.0.1:$PORT/accept" >/dev/null
+
+wait "$SERVER_PID" 2>/dev/null
+SERVER_PID=""
+
+if python3 -c "
+import json
+d = json.load(open('$TMPDIR/comments.json'))
+assert d['action'] == 'accept', 'action != accept'
+assert d['comments'] == [], 'comments not empty on accept'
+" 2>/dev/null; then
+  pass "POST /accept writes action=accept with empty comments"
+else
+  fail "/accept did not write expected payload"
+fi
+
+# -- Cleanup scratch files
+rm -f /tmp/xplan-web-test-stdout.$$ /tmp/xplan-web-test-stderr.$$ \
+      /tmp/xplan-web-test-index.$$ /tmp/xplan-web-test-md.$$ \
+      /tmp/xplan-web-test-assert.$$
+
+# Scratch plan dir: best-effort, files only
+rm -f "$TMPDIR/plan.md" "$TMPDIR/research.md" "$TMPDIR/comments.json"
+rmdir "$TMPDIR" 2>/dev/null
+
+echo ""
+echo "==================================="
+echo "  Results: $PASS passed, $FAIL failed"
+echo "==================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a local browser-based review surface to xplan's Phase 6 walkthrough. The completed plan renders with `marked.js`; every `##` and `###` heading gets a Comment button. On **Submit**, comments drive a targeted Deepen Mode pass on the commented sections. On **Accept as-is**, xplan proceeds to the Phase 6.5 final gate.

Closes #411.

Inspired by native Claude Code `/ultraplan`'s web UI, rebuilt locally with no new dependencies (stdlib `http.server` + CDN `marked.js`).

## How it works

No new flags or commands — built into Phase 6 so it activates automatically when it makes sense (plan.md exists, browser available, loopback port bindable). Falls back to the existing text walkthroughs (6.A for `--autonomous`, 6.1-6.4 for `--light`, direct 6.5 for default) when:

- `XPLAN_NO_WEB=1` is set
- `$DISPLAY` is unset on Linux
- The server can't bind a loopback port
- The helper script is missing

Phase 6.5 still fires unconditionally in every mode. The web UI is the review surface; 6.5 is the non-bypassable go/no-go.

## Components

| File | Role |
|------|------|
| `modules/xplan/lib/xplan-web-review.py` | stdlib-only http.server on 127.0.0.1. Renders plan + sibling artifacts (research/decisions/naming/progress/reviews) with `marked.js` via CDN. Submit/Accept endpoints write `comments.json` and shut down. |
| `modules/xplan/commands/xplan.md` | New Phase 6.W Web Review Walkthrough; Phase 6.0 mode split routes through it first. |
| `modules/xplan/module.json` | Registers the new lib file. |
| `modules/xplan/README.md` | Documents the web review flow + fallback conditions. |
| `tests/test-xplan-web-review.sh` | 13 smoke tests. |

## Trust & security

- Server binds to 127.0.0.1 only
- Path traversal (`/raw/../../etc/passwd`) returns 404
- Only `.md` files are served via `/raw/`
- Comment-box DOM is built via `createElement` — no interpolation of section titles into innerHTML templates
- `marked.parse` renders plan.md as any local markdown viewer would; plan.md is trusted content the user (or xplan running as this user) wrote

## Test plan

- [x] `bash tests/test-xplan-web-review.sh` — 13/13 passing (syntax, exit codes, endpoints, traversal denial, non-.md denial, comments.json schema, Submit/Accept flows)
- [x] `bash tests/test-modules.sh` — 1002/1002 passing (was 1001; new file assertion)
- [x] `bash tests/test-no-personal-data.sh` — PASS
- [x] `bash tests/run-all.sh` — 8/8 test scripts pass
- [ ] Manual: run `/xplan` through to Phase 6 against a real plan dir, verify browser opens, verify comment submission triggers deepening, verify accept-as-is proceeds to 6.5
- [ ] Manual: verify fallback by setting `XPLAN_NO_WEB=1` and confirming text walkthrough fires

## Out of scope (potential v2)

- Arbitrary text-selection commenting (v1 is section-level)
- Diff view for applied deepening changes in the second-round review
- Multi-round deepening (v1 caps at one round)
- Hosted (non-localhost) variant