### PR TITLE
#413: reframe Predictive Completion as 'finish the round trip'

### DIFF
--- a/modules/autonomy/rules/autonomy.md
+++ b/modules/autonomy/rules/autonomy.md
@@ -42,7 +42,7 @@ Only involve the user when you **genuinely cannot proceed** without them:
 
 # Predictive Completion
 
-**After making changes, anticipate what the user needs next and do it.** Don't wait to be asked. Think one step ahead.
+**After making changes, finish the full round trip so the user can test immediately.** A feature or fix is not done at "code edited" or "build succeeded" - it is done when the rebuilt app is running again. Whatever platform it runs on (web, macOS, iOS, browser extension, daemon, CLI), stop the old instance, rebuild from your edits, and relaunch it before reporting the work as complete. Anticipate what the user needs next, do it, think one step ahead.
 
 ## Common Sequences to Execute Automatically
 
@@ -68,7 +68,7 @@ Before reporting a task as done, ask yourself: **if a senior engineer made these
 - Fixed a bug but left the old broken version still running? Unfinished.
 - Updated a config but didn't deploy it? Unfinished.
 
-**The user should be able to immediately test or use your changes without any manual steps.**
+**The user should be able to immediately test your changes without doing anything themselves - no rebuild, no relaunch, no "open the app", no "reload the simulator". "Build succeeded" is not the finish line; the relaunched, running app is.**
 
 ---
 


### PR DESCRIPTION
Closes #413

## Why

Agents working in macOS/iOS app repos routinely stop at "code edited" or "build succeeded" and leave the kill-build-relaunch cycle to the user. Agents in web app repos correctly rebuild and restart the dev server. The asymmetry traces to two structural biases in `modules/autonomy/rules/autonomy.md`:

1. The Predictive Completion intro said "anticipate what the user needs next" - too vague to overcome the cognitive trap of "I edited the code, my job is done."
2. The Common Sequences table, Anti-Patterns list, and Senior-Engineer test are dominated by web/server examples; the single macOS row at line 55 is too low-contrast to fight the bias.

The harness system prompt itself reinforces the web bias with *"For UI or frontend changes, start the dev server and use the feature in a browser before reporting the task as complete."* No equivalent native-app sentence exists.

## Change

Two surgical edits to `modules/autonomy/rules/autonomy.md`. ~4 net new lines, no new sections, no enumeration of platform-specific commands (those stay in per-project CLAUDE.md, with `sightagent`'s "MANDATORY: kill-build-relaunch cycle" as the existing precedent).

1. Reframe the Predictive Completion intro as "finish the full round trip so the user can test immediately." Names the platforms generically (web, macOS, iOS, browser extension, daemon, CLI) so the rule generalizes without enumerating commands.
2. Tighten the closing line of the Senior-Engineer test to make "build succeeded ≠ test ready" explicit.

## Why this approach over a per-platform expansion

Considered adding a dedicated macOS/iOS subsection (~30 lines with `pkill`/`xcodebuild`/`simctl` examples). Rejected because:
- The principle is platform-agnostic; the failure is in the framing, not in missing per-platform recipes.
- Project-specific commands and paths belong in the per-project CLAUDE.md, where they can be exact (sightagent already has this).
- A shorter, stronger principle has more gravity than a longer enumeration.

## Test plan

- [x] `bash tests/test-no-personal-data.sh` passes
- [x] Pre-commit hooks pass (gitleaks, large-file check, conflict markers)
- [ ] Behavioral verification: next time an agent edits Swift code, it should run the kill-build-relaunch cycle without prompting