### PR TITLE
#415: enforce Cloudflare Pages must be created with Git integration at inception

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -676,7 +676,7 @@ Eight documented anti-patterns extracted from real mistakes.
 5. **Premature solutions** - check linter configs and existing patterns first
 6. **Git multi-clone confusion** - branch from `origin/main`, check sibling clones
 7. **Cloudflare Pages vs Workers** - know which product to use
-8. **CF Pages without Git integration** - always connect for auto-deploy
+8. **CF Pages without Git integration** - must be created with Git integration at inception (cannot be retrofitted)
 
 **Dependencies**: None
 
@@ -793,9 +793,9 @@ Cloudflare Pages and Workers deployment guide.
 **What it does**: Prevents common Cloudflare deployment mistakes:
 
 - **Pages vs Workers**: Comparison table for choosing the right product
-- **Git integration**: Always connect Pages projects to GitHub for auto-deploy
+- **Git integration**: Pages projects MUST be created via Connect-to-Git at inception — Cloudflare cannot retrofit Git integration onto an existing direct-upload project
 - **Red flags**: How to detect a misconfigured Pages project
-- **Fix steps**: What to do when Git integration is missing
+- **Migration**: The destructive remediation procedure if you inherit a Pages project without Git integration
 
 **Dependencies**: None
 

--- a/modules/autonomy/rules/autonomy.md
+++ b/modules/autonomy/rules/autonomy.md
@@ -50,7 +50,7 @@ Only involve the user when you **genuinely cannot proceed** without them:
 |---|---|
 | Update application code | Rebuild and restart the dev server or app so the user can test |
 | Add new environment variables | Set them via CLI (`wrangler secret put`, `.env` files, etc.) |
-| Change Cloudflare config | Run `wrangler deploy` or `wrangler pages deploy` to apply |
+| Change Cloudflare Workers config | Run `wrangler deploy` to apply (Pages projects auto-deploy on push to the connected GitHub branch — `wrangler pages deploy` is only for the rare CI-driven path against an existing Git-connected project, never to create a new project) |
 | Fix a bug in a running app | Restart the app so the fix is live |
 | Update a macOS app's code | Rebuild, kill the old process (`pkill` or `killall`), relaunch it |
 | Add a new dependency | Run the install command (`pnpm install`, `npm install`, etc.) |

--- a/modules/cloudflare/README.md
+++ b/modules/cloudflare/README.md
@@ -8,9 +8,9 @@ This module installs a rules file that instructs Claude to:
 
 - Correctly distinguish between Cloudflare Pages (static sites, SPAs) and Workers (serverless functions, APIs)
 - Choose the right product based on the project's needs
-- Always connect Pages projects to GitHub for automatic deployments
+- Create Pages projects via Connect-to-Git at inception (Cloudflare cannot retrofit Git integration onto an existing direct-upload project)
 - Detect red flags that indicate a misconfigured Pages project
-- Follow proper fix steps when a Pages project lacks Git integration
+- Follow the destructive migration procedure if a Pages project was created without Git integration
 
 ## Manual Installation
 

--- a/modules/cloudflare/rules/cloudflare.md
+++ b/modules/cloudflare/rules/cloudflare.md
@@ -28,34 +28,50 @@ Determine the correct product:
 
 ---
 
-## Pages: Always Connect to Git for Auto-Deploy
+## Pages: MUST Be Created With Git Integration At Inception (CRITICAL)
 
-**Always connect CF Pages projects to GitHub (or GitLab) for auto-deploy.** Manual or CI-based `wrangler pages deploy` is a fallback, not the default.
+**A Cloudflare Pages project MUST be created via the GitHub integration flow at the moment of creation. You CANNOT add Git integration to an existing direct-upload Pages project later — Cloudflare does not support that conversion.** The only "fix" for a wrong-creation is to delete the project and recreate it with Git integration, which means migrating custom domains, environment variables, and bindings. This is multi-session work that affects production traffic.
 
-### When Creating a New CF Pages Project
+This is the single most expensive Cloudflare mistake. Multiple agents have wasted multiple sessions on it. The root cause is always the same: an agent ran `wrangler pages deploy <new-project-name>` to "make progress" and unintentionally created a direct-upload project that can never auto-deploy.
 
-1. **Preferred: Connect to GitHub** via the Cloudflare dashboard (Settings > Builds & Deployments > Git integration). This gives you:
-   - Auto-deploy on push to production branch
-   - Preview deployments on PRs
-   - Deploy status checks on GitHub
-2. **Fallback: CI-based deploy** if Git integration isn't possible (e.g., monorepo build complexity). Add `wrangler pages deploy` to CI with `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets.
-3. **Never rely on manual CLI deploys** as the only deploy mechanism.
+**~99% of the time the intended outcome is a Pages project that auto-deploys from a GitHub repo.** Treat that as the default. The exceptions (deployable artifact lives outside Git, build complexity Cloudflare's environment cannot handle) are rare and should be confirmed with the user before going down the direct-upload path.
 
-### Red Flags for Missing Git Integration
+### Creating a New CF Pages Project (the ONLY correct path)
 
-- CF Pages dashboard shows "Git Provider: No" - project will NOT auto-deploy
-- Last deployment timestamp is hours/days old despite recent merges
-- Only one deployment ever exists (the initial manual deploy)
+1. Push the project to GitHub first (the repo must exist before you create the Pages project).
+2. In the Cloudflare dashboard: **Workers & Pages > Create > Pages > Connect to Git**.
+3. Authorize the GitHub repo and select the branch (typically `main`).
+4. Configure build command + output directory.
+5. Cloudflare provisions the project AND the GitHub integration in a single creation flow. Auto-deploy on push, preview deploys on PRs, and deploy status checks on GitHub all work from this point on.
 
-### How to Check
+The dashboard step requires the user's browser session. **If you are an agent and cannot complete it yourself, stop and ask the user to create the project this way.** Do NOT fall back to `wrangler pages deploy <new-name>` to "get something live" — that creates a direct-upload project that Cloudflare cannot later convert.
 
-```bash
-# In the dashboard: Pages project > Settings > Builds & Deployments
-# Look for "Git Provider" - should show GitHub/GitLab, NOT "No"
-```
+### Acceptable exceptions to inception-time Git integration
 
-### Fix Steps if Discovered Without Integration
+The only legitimate reasons to create a direct-upload Pages project:
+- The deployable artifact is genuinely not in a Git repo (rare; usually means reconsider the architecture).
+- Build complexity that cannot run in Cloudflare's build environment AND cannot be solved by adding a CI step that runs `wrangler pages deploy` against a Git-connected project.
 
-1. **Immediate fix**: Deploy via CLI (`wrangler pages deploy`) to get current code live
-2. **Permanent fix**: Either connect to GitHub in the CF dashboard, or add CI-based deploy step
-3. **Tell the user** so they can connect Git integration in the dashboard (requires browser session)
+If neither applies — and they almost never do — the project goes through the Connect-to-Git creation flow.
+
+### How to Tell a Pages Project Was Created Wrong
+
+- Cloudflare dashboard > Pages project > Settings > Builds & Deployments shows **"Git Provider: No"** — project will never auto-deploy
+- Last deployment is days old despite recent merges to main
+- Only one deployment ever exists (the initial CLI upload)
+- The project page is missing the **Production / Preview** branch separator
+- `wrangler pages project list` shows the project, but the dashboard shows no connected repo
+
+### If You Inherit a Pages Project Without Git Integration
+
+There is no in-place fix. Remediation is destructive:
+
+1. **Confirm the gap with the user** — show `wrangler pages project list` output or a dashboard screenshot
+2. **Inventory what must migrate**: custom domains, environment variables, KV/D1/R2 bindings, build settings, access policies
+3. **Create a replacement project via Connect-to-Git** (steps above), using a temporary name if the production hostname is in use
+4. **Move custom domains** from the old project to the new one once the new project is deploying cleanly
+5. **Delete the old direct-upload project**
+
+This affects production traffic. Do not start it without explicit user authorization.
+
+**Stopgap until migration:** keep deploying via `wrangler pages deploy <existing-project-name>` so the site does not go stale. This buys time, not a fix.

--- a/modules/common-mistakes/README.md
+++ b/modules/common-mistakes/README.md
@@ -13,7 +13,7 @@ This module installs a rules file that teaches Claude to avoid these common mist
 5. **Premature Solutions** - Proposing fixes without understanding the full codebase
 6. **Git Multi-Clone Issues** - Forgetting to branch from origin/main in multi-clone setups
 7. **Cloudflare Pages vs Workers** - Choosing the wrong product for the use case
-8. **Missing Git Integration** - Creating Cloudflare Pages without auto-deploy
+8. **Missing Git Integration** - Creating Cloudflare Pages without Git integration at inception (cannot be added later)
 
 ## Manual Installation
 

--- a/modules/common-mistakes/rules/common-mistakes.md
+++ b/modules/common-mistakes/rules/common-mistakes.md
@@ -184,40 +184,15 @@ Key reminders:
 
 ---
 
-## 8. Cloudflare Pages Without Git Integration (No Auto-Deploy)
+## 8. Cloudflare Pages Created Without Git Integration
 
-**Problem**: A CF Pages project was created without connecting it to GitHub. Pushes to main didn't trigger deploys, so the production site went stale after merges. The only way to deploy was manually via `wrangler pages deploy`.
+**Problem**: An agent runs `wrangler pages deploy <new-project-name>` to "get something live", which creates a direct-upload Pages project. The project never auto-deploys from GitHub — pushes to main are silently ignored, and the production site goes stale after every merge. **Cloudflare does not support retrofitting Git integration onto an existing direct-upload project.** The only fix is to delete the project and recreate it with Git integration, which means migrating custom domains, env vars, and bindings — multi-session production work. This mistake recurs across projects and burns hours every time it happens.
 
-**Rule**: **Always connect CF Pages projects to GitHub for auto-deploy.** Manual or CI-based `wrangler pages deploy` is a fallback, not the default.
+**Rule**: **Cloudflare Pages projects MUST be created via the Connect-to-Git flow at inception.** Workers & Pages > Create > Pages > Connect to Git, in the Cloudflare dashboard. Never via `wrangler pages deploy <new-name>` for a project that should auto-deploy from a repo (which is ~99% of cases).
 
-### When Creating a New CF Pages Project
+If the dashboard step requires the user's browser session and you are an agent, **stop and ask the user** to create the project. Do NOT fall back to direct-upload "to make progress" — you are creating a project the user will have to throw away later.
 
-1. **Preferred: Connect to GitHub** via the Cloudflare dashboard (Settings > Builds & Deployments > Git integration). This gives you:
-   - Auto-deploy on push to production branch
-   - Preview deployments on PRs
-   - Deploy status checks on GitHub
-2. **Fallback: CI-based deploy** if Git integration isn't possible (e.g., monorepo build complexity). Add `wrangler pages deploy` to CI with `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets.
-3. **Never rely on manual CLI deploys** as the only deploy mechanism.
-
-### How to Check if a Pages Project Has Git Integration
-
-```bash
-# Check the CF Pages project settings
-# In the dashboard: Pages project > Settings > Builds & Deployments
-# Look for "Git Provider" - should show GitHub/GitLab, NOT "No"
-```
-
-### Red Flags
-
-- CF Pages dashboard shows "Git Provider: No" - project will NOT auto-deploy
-- Last deployment timestamp is hours/days old despite recent merges
-- Only one deployment ever exists (the initial manual deploy)
-
-### If You Discover a Pages Project Without Git Integration
-
-1. **Immediate fix**: Deploy via CLI (`wrangler pages deploy`) to get current code live
-2. **Permanent fix**: Either connect to GitHub in the CF dashboard, or add CI-based deploy step
-3. **Tell the user** so they can connect Git integration in the dashboard (requires browser session)
+See `modules/cloudflare/rules/cloudflare.md` for the full creation procedure, red flags, and the destructive remediation steps if you inherit a broken project.
 
 ---
 


### PR DESCRIPTION
Closes #415

## Why

Multiple agents across multiple sessions have made the same expensive mistake: running `wrangler pages deploy <new-project-name>` to "get something live", which creates a direct-upload Pages project. Cloudflare does not support retrofitting Git integration onto a direct-upload project — the only fix is to delete the project and recreate it with Git integration, which means migrating custom domains, env vars, and bindings.

Both `modules/cloudflare/rules/cloudflare.md` and `modules/common-mistakes/rules/common-mistakes.md` previously said:

> **Permanent fix**: Either connect to GitHub in the CF dashboard, or add CI-based deploy step

That advice was wrong — the dashboard does not offer "connect to Git" for an existing direct-upload project — and was actively teaching agents a fix that does not exist.

## Change

Six files updated. Net `-9` lines (the new wording is tighter than the old multi-step fallback procedure):

- **`modules/cloudflare/rules/cloudflare.md`** — rewrote the "Always Connect to Git" section. Renamed to "MUST Be Created With Git Integration At Inception (CRITICAL)". Inception rule is the centerpiece. Explicit statement that Cloudflare cannot retrofit Git integration. Replaced the bogus "permanent fix" with the actual destructive remediation (delete + recreate + domain migration). Added a "stopgap until migration" note (`wrangler pages deploy <existing-name>`) so agents do not start the migration prematurely.
- **`modules/common-mistakes/rules/common-mistakes.md`** — tightened entry #8 to lead with the inception requirement and point at the cloudflare rule for the full procedure. Removed duplicate "fallback" steps.
- **`modules/cloudflare/README.md`** — bullet summary now says "at inception" and "Cloudflare cannot retrofit".
- **`modules/common-mistakes/README.md`** — entry #8 summary updated to match.
- **`docs/modules.md`** — both brief module summaries updated.
- **`modules/autonomy/rules/autonomy.md`** — clarified the "Change Cloudflare config" Common Sequences row so it does not implicitly endorse `wrangler pages deploy` for a brand-new project. Now scoped to Workers and notes that Pages auto-deploys on push.

## Verification

- [x] No stale "permanent fix" or "Either connect to GitHub in the CF dashboard" wording remains anywhere in the repo (verified via grep)
- [x] `bash tests/test-no-personal-data.sh` passes
- [x] `bash tests/test-modules.sh` passes — 1034/1034
- [x] Pre-commit hooks pass (gitleaks, large-file check, conflict markers)

## Test plan

- [ ] Behavioral: next time an agent is asked to set up Cloudflare Pages hosting, it should stop and ask the user to create the project via Connect-to-Git in the dashboard, not fall back to `wrangler pages deploy`.