### PR TITLE
#417: statusline reads live effort level from stdin (.effort.level)

### DIFF
--- a/lib/statusline.sh
+++ b/lib/statusline.sh
@@ -24,15 +24,16 @@ esac
 cwd=$(echo "$input" | jq -r '.cwd // ""')
 cwd_display="${cwd##*/}"
 
-# --- Effort level (env > project local > project > user settings)
-# Statusline stdin does not expose effort, so read the same sources Claude Code uses.
-# /effort max is session-only unless set via CLAUDE_CODE_EFFORT_LEVEL, so the
-# displayed value reflects the last persisted setting when max is a live override.
+# --- Effort level (stdin > env > project local > project > user settings)
+# Claude Code (>=2.1.x) passes the live session effort level via stdin under
+# `.effort.level`. This reflects in-session overrides like `/effort max` that
+# never touch settings.json, so it must win over the persisted sources.
 read_effort_from() {
   [ -f "$1" ] || return 1
   jq -r '.effortLevel // empty' "$1" 2>/dev/null
 }
-effort_raw="${CLAUDE_CODE_EFFORT_LEVEL:-}"
+effort_raw=$(echo "$input" | jq -r '.effort.level // empty')
+[ -z "$effort_raw" ] && effort_raw="${CLAUDE_CODE_EFFORT_LEVEL:-}"
 if [ -z "$effort_raw" ] && [ -n "$cwd" ]; then
   effort_raw=$(read_effort_from "$cwd/.claude/settings.local.json")
   [ -z "$effort_raw" ] && effort_raw=$(read_effort_from "$cwd/.claude/settings.json")


### PR DESCRIPTION
Closes #417

## Why

The statusline displayed the persisted `effortLevel` from `~/.claude/settings.json` and never reflected a live `/effort max` (or `/effort high`) session override. A user with `effortLevel: "xhigh"` in settings.json would see `XH` in the statusline forever, even after running `/effort max`.

The old script comment acknowledged this:
```
# /effort max is session-only unless set via CLAUDE_CODE_EFFORT_LEVEL, so the
# displayed value reflects the last persisted setting when max is a live override.
```

## Empirical finding

Dumped the statusline stdin payload on Claude Code v2.1.119. The JSON DOES include the live session effort level:

```json
{
  "effort": { "level": "xhigh" },
  ...
}
```

When the user runs `/effort max`, the next statusline render's stdin contains `"effort": {"level": "max"}`. The script just wasn't reading it.

## Change

One file: `lib/statusline.sh`. Six insertions, five removals.

New resolution order:
1. **`.effort.level` from stdin** (live session state — wins for any `/effort` override)
2. `CLAUDE_CODE_EFFORT_LEVEL` env var
3. Project local settings (`$cwd/.claude/settings.local.json`)
4. Project settings (`$cwd/.claude/settings.json`)
5. User settings (`~/.claude/settings.json`)

Comment updated to match the new behavior. The `read_effort_from()` helper and the `case` mapping (`low/medium/high/xhigh/max → L/M/H/XH/Max`) are unchanged, so the visual output is identical for every value — only the resolution priority changed.

`modules/commands-utility/statusline-command.sh` is a symlink to `lib/statusline.sh` (since #160), so no second copy needed in the repo. After merge, `/ccgm-sync` will copy the updated script to `~/.claude/statusline-command.sh`.

## Test plan

Smoke-tested with three input shapes against the patched script:

- [x] `effort.level: "max"` in stdin → renders `Max` (overrides persisted `xhigh`)
- [x] `effort.level: "high"` in stdin → renders `H`
- [x] No `effort` field in stdin (older Claude Code) → falls through to settings, renders `XH` ← backward compatible

## Behavioral verification (post-merge)

- [ ] Run `/effort max` in any session, watch the statusline indicator change from `XH` to `Max`
- [ ] Run `/effort high`, statusline changes to `H`