### PR TITLE
#419: color-code statusline effort indicator

### DIFF
--- a/lib/statusline.sh
+++ b/lib/statusline.sh
@@ -95,7 +95,16 @@ sections=()
 # Model with tier indicators + optional effort suffix
 if [ -n "$model_abbr" ]; then
   effort_suffix=""
-  [ -n "$effort_abbr" ] && effort_suffix="$(printf " ${DIM}%s${RESET}" "$effort_abbr")"
+  if [ -n "$effort_abbr" ]; then
+    case "$effort_abbr" in
+      Max) effort_color="$RED" ;;
+      XH)  effort_color="$ORANGE" ;;
+      H)   effort_color="$YELLOW" ;;
+      M)   effort_color="$GREEN" ;;
+      *)   effort_color="$DIM" ;;
+    esac
+    effort_suffix="$(printf " ${effort_color}%s${RESET}" "$effort_abbr")"
+  fi
   case "$model_tier" in
     opus-best)
       sections+=("$(printf "${BLUE}🧠 %s${RESET}%s" "$model_abbr" "$effort_suffix")")


### PR DESCRIPTION
Closes #419

## Change

`lib/statusline.sh`. Replace the always-dim effort suffix with a level-based color:

| Level | Abbrev | Color |
|---|---|---|
| max | Max | red |
| xhigh | XH | orange (256-color) |
| high | H | yellow |
| medium | M | green |
| low | L | dim |
| (unrecognized) | (empty) | n/a |

ORANGE was already defined in the script as `\033[38;5;208m`. RED/YELLOW/GREEN/DIM already defined.

## Why this matters

The effort suffix sits next to the model abbreviation (e.g., `🧠 O-4.7 Max`). At a glance, color-coding makes the cost/heaviness obvious — red = expensive, dim = cheap. Previously every level rendered identically dim, so the visual told you nothing.

## Implementation note (caught in review)

First pass passed `effort_color` as a `printf %s` argument, which made `printf` emit the literal text `\033[31m` instead of the ANSI escape (since `%s` does not reinterpret backslash escapes in the value). Existing colors in the script work because they expand the variable directly into the format string. Fixed pattern matches the existing convention: `printf " ${effort_color}%s${RESET}" "$effort_abbr"`.

## Test plan

- [x] All five levels render with the expected ANSI escape (`max→[31m`, `xhigh→[38;5;208m`, `high→[33m`, `medium→[32m`, `low→[2m`)
- [x] Pre-commit hooks pass
- [ ] Visual: run `/effort max` → indicator turns red; `/effort high` → yellow; etc.