### PR TITLE
#425: replace deepresearch wall-of-text prompt with yes/no + README pointer

### DIFF
--- a/modules/deepresearch/module.json
+++ b/modules/deepresearch/module.json
@@ -11,8 +11,10 @@
   "tags": ["commands", "research", "web-search", "exa", "mcp", "external-api"],
   "configPrompts": [
     {
-      "key": "exaMcpSetup",
-      "prompt": "/deepresearch requires the Exa MCP server. Sign up at https://exa.ai (free tier: 1000 searches/mo; Pro ~$10/mo). Then: (1) add `export EXA_API_KEY=...` to your shell rc and reload; (2) add this entry to ~/.claude/mcp.json under \"mcpServers\": `\"exa\": {\"command\": \"npx\", \"args\": [\"-y\", \"exa-mcp-server\"], \"env\": {\"EXA_API_KEY\": \"${EXA_API_KEY}\"}}`. Restart Claude Code for the MCP server to load. The skill expects `web_search_exa` (and optionally specialized tools like `research_paper_search_exa`, `github_search_exa`) to be available."
+      "key": "exaMcpAcknowledged",
+      "prompt": "/deepresearch needs the Exa MCP server (free tier: 1000 searches/mo at https://exa.ai). Step-by-step Exa + mcp.json setup: modules/deepresearch/README.md. Continue?",
+      "default": "yes",
+      "options": ["yes", "no"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

The `deepresearch` module's installer `configPrompt` was a multi-sentence wall of Exa setup instructions presented at a free-text input prompt — users hit the colon prompt with no idea what to type, and the captured value was never consumed downstream anyway.

Closes #425.

## Changes

- `modules/deepresearch/module.json`: replace the prose dump with a short yes/no acknowledgment that points at `modules/deepresearch/README.md` for the step-by-step Exa + mcp.json walkthrough.
  - Matches the `brand-naming` `addMcp` pattern (yes/no + terse explainer).
  - The README already covers signup, `EXA_API_KEY` export, mcp.json snippet, restart, and verification — no duplication.

## Test plan

- [x] `bash tests/test-modules.sh` — 1048/1048 passed
- [x] `bash tests/test-no-personal-data.sh` — clean
- [x] `jq` validates the rewritten `module.json`
- [x] `get_module_config_prompts deepresearch` parses to `key|prompt|default|options` cleanly
- [ ] Manual: re-run `./start.sh` with `full` preset, confirm the deepresearch step now renders as a yes/no choice with README pointer rather than a free-text input