### PR TITLE
#427: switch MCP setup docs to `claude mcp add` + add migration tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The installer sets up SearXNG, Ollama, the Python environment, and copies the co
 |------|-----|
 | Personal rules | Create `~/.claude/rules/personal.md` - CCGM won't overwrite it |
 | Settings overrides | Use `~/.claude/settings.local.json` (native Claude Code feature) |
-| MCP servers | Configure in `~/.claude/mcp.json` (not managed by CCGM) |
+| MCP servers | Add via `claude mcp add --scope user ...` (writes to `~/.claude.json`, not managed by CCGM) |
 
 ### Template variables
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,7 +36,23 @@ This file takes precedence over `settings.json` for the keys it defines. CCGM do
 
 ## MCP servers
 
-MCP (Model Context Protocol) server configuration lives in `~/.claude/mcp.json`, which is not managed by CCGM. Configure your MCP servers there independently.
+MCP (Model Context Protocol) server configuration is managed by the `claude mcp` CLI and stored in `~/.claude.json`. CCGM does not write this file directly. Add servers with:
+
+```bash
+# stdio server with env vars (note the `--` before name)
+claude mcp add --scope user --env KEY=value -- <name> <command> <args...>
+
+# stdio server without env vars
+claude mcp add --scope user -- <name> <command> <args...>
+
+# complex/JSON config
+claude mcp add-json --scope user <name> '<json>'
+
+# verify
+claude mcp get <name>
+```
+
+> **Migrating from `~/.claude/mcp.json`?** Older Claude Code versions (and old CCGM docs) used `~/.claude/mcp.json`. Current Claude Code does not read that file. If you have one, run `bash lib/mcp-migrate.sh` from the CCGM checkout to re-register every entry via the `claude mcp` CLI.
 
 ## Template variables
 
@@ -100,7 +116,7 @@ Some modules ask questions during installation that affect their behavior:
 | **settings** | Permission mode | `ask` / `dontAsk` | Controls whether Claude asks before running tools or auto-approves |
 | **hooks** | Protected branches | Custom list | Additional branch names to protect from direct commits |
 | **hooks** | Auto update check | yes / no | Whether to check for CCGM updates once daily |
-| **brand-naming** | Add MCP server | yes / no | Whether to add Instant Domain Search MCP server to `mcp.json` |
+| **brand-naming** | Add MCP server | yes / no | Whether to register Instant Domain Search MCP server via `claude mcp add --scope user` |
 
 ## Customizing hooks
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -194,7 +194,7 @@ Research tools for naming products, companies, or projects.
 
 Commands use a sub-agent model for parallel word exploration and verification phases, optimized for throughput across the multi-source checks.
 
-**Config prompts**: Whether to add the Instant Domain Search MCP server to `mcp.json`
+**Config prompts**: Whether to register the Instant Domain Search MCP server via `claude mcp add --scope user`
 
 **Dependencies**: None
 

--- a/lib/mcp-migrate.sh
+++ b/lib/mcp-migrate.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Migrate ~/.claude/mcp.json (legacy, unread by current Claude Code) to ~/.claude.json
+# via the `claude mcp add-json --scope user` CLI.
+#
+# Idempotent: entries that already exist (per `claude mcp get`) are skipped.
+# Backs up the legacy file with a .migrated.bak suffix on success.
+
+set -euo pipefail
+
+LEGACY_FILE="${1:-${HOME}/.claude/mcp.json}"
+
+c_red=$'\033[0;31m'
+c_grn=$'\033[0;32m'
+c_ylw=$'\033[0;33m'
+c_dim=$'\033[2m'
+c_rst=$'\033[0m'
+
+log_info()  { printf '%s\n' "$*"; }
+log_ok()    { printf '%s%s%s\n' "$c_grn" "$*" "$c_rst"; }
+log_warn()  { printf '%s%s%s\n' "$c_ylw" "$*" "$c_rst"; }
+log_err()   { printf '%s%s%s\n' "$c_red" "$*" "$c_rst" >&2; }
+
+if ! command -v claude &>/dev/null; then
+  log_err "ERROR: 'claude' CLI not found on PATH; install Claude Code first."
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  log_err "ERROR: 'jq' required for MCP migration."
+  exit 1
+fi
+
+if [ ! -f "$LEGACY_FILE" ]; then
+  log_info "${c_dim}No legacy MCP file at $LEGACY_FILE - nothing to migrate.${c_rst}"
+  exit 0
+fi
+
+if ! jq empty "$LEGACY_FILE" 2>/dev/null; then
+  log_err "ERROR: $LEGACY_FILE is not valid JSON; aborting."
+  exit 1
+fi
+
+server_count=$(jq -r '.mcpServers // {} | length' "$LEGACY_FILE")
+if [ "$server_count" -eq 0 ]; then
+  log_info "${c_dim}$LEGACY_FILE has no mcpServers entries - nothing to migrate.${c_rst}"
+  exit 0
+fi
+
+log_info "Found $server_count server entries in $LEGACY_FILE"
+log_info ""
+
+migrated=0
+skipped=0
+failed=0
+failed_names=()
+
+# Resolve ${VAR} references against the current environment.
+# Only substitutes simple ${NAME} forms; leaves $NAME or unset references alone
+# (claude mcp will record the literal, which the user can fix later).
+expand_env_refs() {
+  local input="$1"
+  python3 -c '
+import os, re, sys
+def repl(m):
+    name = m.group(1)
+    return os.environ.get(name, m.group(0))
+text = sys.stdin.read()
+print(re.sub(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", repl, text), end="")
+' <<< "$input"
+}
+
+while IFS= read -r name; do
+  [ -z "$name" ] && continue
+
+  if claude mcp get "$name" &>/dev/null; then
+    log_info "${c_dim}skip${c_rst}     $name (already registered)"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  raw=$(jq -c --arg n "$name" '.mcpServers[$n]' "$LEGACY_FILE")
+
+  # Add a "type" field if the legacy entry omits it. Heuristic: url -> sse, command -> stdio.
+  shaped=$(jq -c '
+    if has("type") then .
+    elif has("url") then .type = "sse"
+    elif has("command") then .type = "stdio"
+    else .
+    end' <<< "$raw")
+
+  expanded=$(expand_env_refs "$shaped")
+
+  if claude mcp add-json --scope user "$name" "$expanded" >/dev/null 2>&1; then
+    log_ok "migrate  $name"
+    migrated=$((migrated + 1))
+  else
+    log_err "FAILED   $name"
+    log_err "         payload: $expanded"
+    failed=$((failed + 1))
+    failed_names+=("$name")
+  fi
+done < <(jq -r '.mcpServers // {} | keys[]' "$LEGACY_FILE")
+
+log_info ""
+log_info "Summary: ${c_grn}${migrated} migrated${c_rst}, ${c_dim}${skipped} skipped${c_rst}, ${c_red}${failed} failed${c_rst}"
+
+if [ "$failed" -eq 0 ]; then
+  backup="${LEGACY_FILE}.migrated.bak"
+  mv "$LEGACY_FILE" "$backup"
+  log_info ""
+  log_ok "Legacy file moved to: $backup"
+  log_info "Verify with 'claude mcp list', then delete the backup when satisfied."
+else
+  log_info ""
+  log_warn "Legacy file kept in place because ${failed} entries failed to migrate."
+  log_warn "Failed: ${failed_names[*]}"
+  log_warn "Re-run after resolving, or migrate those entries by hand:"
+  log_warn "  claude mcp add-json --scope user <name> '<json>'"
+  exit 1
+fi

--- a/modules/brand-naming/README.md
+++ b/modules/brand-naming/README.md
@@ -42,16 +42,11 @@ Deep verification of one or more specific brand name candidates. Checks everythi
 
 ## MCP Server (Optional)
 
-The installer can add the **Instant Domain Search** MCP server to your `mcp.json`:
+The installer's config prompt can guide you through adding the **Instant Domain Search** MCP server. Register it with:
 
-```json
-{
-  "mcpServers": {
-    "instant-domain-search": {
-      "url": "https://instantdomainsearch.com/mcp/sse"
-    }
-  }
-}
+```bash
+claude mcp add-json --scope user instant-domain-search '{"type":"sse","url":"https://instantdomainsearch.com/mcp/sse"}'
+claude mcp get instant-domain-search   # expect: Status: ✓ Connected
 ```
 
 - Free, no authentication required
@@ -80,9 +75,10 @@ cp commands/brand.md ~/.claude/commands/brand.md
 cp commands/brand-check.md ~/.claude/commands/brand-check.md
 ```
 
-Optionally add the MCP server to `~/.claude/mcp.json`:
+Optionally register the MCP server:
 
 ```bash
-# Add instant-domain-search to your mcp.json mcpServers object:
-# "instant-domain-search": { "url": "https://instantdomainsearch.com/mcp/sse" }
+claude mcp add-json --scope user instant-domain-search '{"type":"sse","url":"https://instantdomainsearch.com/mcp/sse"}'
 ```
+
+Restart Claude Code for the MCP server to load.

--- a/modules/brand-naming/module.json
+++ b/modules/brand-naming/module.json
@@ -14,7 +14,7 @@
   "configPrompts": [
     {
       "key": "addMcp",
-      "prompt": "Add Instant Domain Search MCP server to mcp.json? (Recommended - free, no auth, 800+ TLDs, sub-25ms checks)",
+      "prompt": "Register Instant Domain Search MCP server via `claude mcp add --scope user`? (Recommended - free, no auth, 800+ TLDs, sub-25ms checks)",
       "default": "yes",
       "options": ["yes", "no"]
     }

--- a/modules/deepresearch/README.md
+++ b/modules/deepresearch/README.md
@@ -33,7 +33,7 @@ Topic -> Claude generates N diverse queries
   - Free tier: 1000 searches/mo
   - Pro tier: ~$10/mo for 10k searches
 - **`EXA_API_KEY`** set in the shell environment.
-- **Exa MCP server** registered in `~/.claude/mcp.json`.
+- **Exa MCP server** registered with the `claude mcp` CLI (writes to `~/.claude.json`).
 - **Node + npx** available on `PATH` (the MCP server runs via `npx -y exa-mcp-server`).
 
 ## Setup
@@ -44,18 +44,12 @@ Topic -> Claude generates N diverse queries
    echo 'export EXA_API_KEY=your_key_here' >> ~/.zshrc
    source ~/.zshrc
    ```
-3. Add the Exa MCP server to `~/.claude/mcp.json` under `mcpServers`:
-   ```json
-   "exa": {
-     "command": "npx",
-     "args": ["-y", "exa-mcp-server"],
-     "env": {
-       "EXA_API_KEY": "${EXA_API_KEY}"
-     }
-   }
+3. Register the Exa MCP server (note the `--` before the server name; without it the CLI parses `exa` as a value to `--env`):
+   ```bash
+   claude mcp add --scope user --env EXA_API_KEY="$EXA_API_KEY" -- exa npx -y exa-mcp-server
    ```
 4. **Restart Claude Code** so the MCP server loads.
-5. Verify the tools are present - in a Claude Code session, the `web_search_exa` tool (and friends) should be callable. If they are not, the MCP server did not load; check `claude mcp` output.
+5. Verify with `claude mcp get exa` - expect `Status: ✓ Connected`. In a fresh Claude Code session, the `web_search_exa` tool (and friends) should be callable.
 
 ## Usage
 
@@ -78,11 +72,12 @@ The earlier draft of this module shipped a Python CLI that called the Exa REST A
 - No shell-out, no Python venv dependency, no JSON-handshake between CLI and skill
 - Parallel fan-out is native (Claude issues N tool calls in one message)
 - Specialized Exa endpoints (papers, GitHub, companies, Wikipedia) are exposed as separate tools the skill can route to per topic-type
-- Auth flows through `mcp.json` env block; no separate env-var checks in our code
+- Auth flows through the MCP server's env block (registered via `claude mcp add --env`); no separate env-var checks in our code
 
 ## Troubleshooting
 
-- **Skill says "Exa MCP tools unavailable."** The MCP server did not load. Check that the `exa` block exists in `~/.claude/mcp.json`, that `EXA_API_KEY` is set in the shell that started Claude Code, and that you restarted Claude Code after the change.
+- **Skill says "Exa MCP tools unavailable."** The MCP server did not load. Verify with `claude mcp get exa` (expect `Status: ✓ Connected`). If it's not registered, run the `claude mcp add` command from Setup. Confirm `EXA_API_KEY` is set in the shell that started Claude Code, and that you restarted Claude Code after the change.
+- **Stale `~/.claude/mcp.json` from old CCGM docs.** Pre-#427 docs told you to hand-edit `~/.claude/mcp.json`, but current Claude Code reads `~/.claude.json` (managed by the `claude mcp` CLI). Run `bash lib/mcp-migrate.sh` from the CCGM checkout to re-register every entry, or re-run `./start.sh` (the installer migrates on update).
 - **Tool call returns 401 / unauthorized.** API key invalid or revoked. Generate a new one at https://exa.ai/dashboard, update your shell rc, restart Claude Code.
 - **All queries return zero results.** Topic may be too narrow or oddly phrased; try `--depth lite` to confirm the path works, then revise the topic.
 - **`exa-mcp-server` install fails on first run.** `npx -y` downloads on first invocation. Confirm `node` and `npm` are on `PATH`. Check network access.

--- a/modules/deepresearch/commands/deepresearch.md
+++ b/modules/deepresearch/commands/deepresearch.md
@@ -14,16 +14,12 @@ Generate diverse search queries from a topic, run them in parallel via the Exa M
 - From any skill that needs deep research
 
 **Prerequisites:**
-- Exa MCP server registered in `mcp.json`. The expected entry is:
-  ```json
-  "exa": {
-    "command": "npx",
-    "args": ["-y", "exa-mcp-server"],
-    "env": { "EXA_API_KEY": "${EXA_API_KEY}" }
-  }
+- Exa MCP server registered via the `claude mcp` CLI (writes to `~/.claude.json`). Register with:
+  ```bash
+  claude mcp add --scope user --env EXA_API_KEY="$EXA_API_KEY" -- exa npx -y exa-mcp-server
   ```
 - `EXA_API_KEY` set in the shell environment (https://exa.ai - free tier covers 1000 searches/mo).
-- After adding the entry, restart Claude Code so the MCP server loads.
+- Restart Claude Code after registering so the MCP server loads. Verify with `claude mcp get exa`.
 
 If the Exa MCP tools (`web_search_exa` etc.) are not available in this session, stop immediately and tell the user how to set them up. Do not fall back to `/research` or `WebSearch` silently.
 

--- a/modules/deepresearch/module.json
+++ b/modules/deepresearch/module.json
@@ -1,7 +1,7 @@
 {
   "name": "deepresearch",
   "displayName": "Deep Research (Exa MCP)",
-  "description": "/deepresearch - Multi-query semantic research using the Exa MCP server. Claude generates diverse queries from your topic, fans them out via parallel Exa MCP tool calls, and synthesizes a structured research.md from full page contents. Requires the Exa MCP server in mcp.json and an Exa API key.",
+  "description": "/deepresearch - Multi-query semantic research using the Exa MCP server. Claude generates diverse queries from your topic, fans them out via parallel Exa MCP tool calls, and synthesizes a structured research.md from full page contents. Requires the Exa MCP server registered via `claude mcp add` and an Exa API key.",
   "category": "commands",
   "scope": ["global"],
   "dependencies": [],
@@ -12,7 +12,7 @@
   "configPrompts": [
     {
       "key": "exaMcpAcknowledged",
-      "prompt": "/deepresearch needs the Exa MCP server (free tier: 1000 searches/mo at https://exa.ai). Step-by-step Exa + mcp.json setup: modules/deepresearch/README.md. Continue?",
+      "prompt": "/deepresearch needs the Exa MCP server (free tier: 1000 searches/mo at https://exa.ai). Step-by-step setup (Exa signup + `claude mcp add`): modules/deepresearch/README.md. Continue?",
       "default": "yes",
       "options": ["yes", "no"]
     }

--- a/start.sh
+++ b/start.sh
@@ -1196,6 +1196,21 @@ TMPL
   fi
 
   # ===========================================================
+  # Step 14b: Migrate legacy ~/.claude/mcp.json (issue #427)
+  # Pre-#427 docs told users to hand-edit ~/.claude/mcp.json. Current
+  # Claude Code reads ~/.claude.json (managed by `claude mcp` CLI).
+  # Re-register each entry; idempotent (skips on no legacy file or
+  # already-registered names).
+  # ===========================================================
+  if [ -f "${HOME}/.claude/mcp.json" ] && [ -x "${CCGM_ROOT}/lib/mcp-migrate.sh" ]; then
+    ui_header "Legacy MCP Migration"
+    ui_info "Re-registering entries via 'claude mcp add-json --scope user'."
+    echo ""
+    bash "${CCGM_ROOT}/lib/mcp-migrate.sh" "${HOME}/.claude/mcp.json" || ui_warn "Some entries failed; see output above."
+    echo ""
+  fi
+
+  # ===========================================================
   # Step 15: Next steps
   # ===========================================================
   ui_header "Installation Complete!"

--- a/update.sh
+++ b/update.sh
@@ -262,9 +262,36 @@ _offer_reinstall() {
 }
 
 # ============================================================
+# Helper: Migrate legacy ~/.claude/mcp.json (issue #427)
+# Current Claude Code reads MCP config from ~/.claude.json (managed by the
+# `claude mcp` CLI), not ~/.claude/mcp.json. Pre-#427 CCGM docs told users
+# to hand-edit the legacy file; entries there are silently ignored.
+# This re-registers each entry via `claude mcp add-json --scope user`.
+# ============================================================
+_migrate_legacy_mcp_json() {
+  local legacy="${HOME}/.claude/mcp.json"
+  [ ! -f "$legacy" ] && return 0
+
+  local migrate_script="${CCGM_ROOT}/lib/mcp-migrate.sh"
+  if [ ! -x "$migrate_script" ]; then
+    return 0
+  fi
+
+  ui_header "Legacy MCP Migration"
+  ui_info "Found ${legacy} - current Claude Code reads ~/.claude.json instead."
+  ui_info "Re-registering entries via 'claude mcp add-json --scope user'."
+  echo ""
+  bash "$migrate_script" "$legacy" || ui_warn "Some entries failed; see output above."
+  echo ""
+}
+
+# ============================================================
 # Main
 # ============================================================
 main() {
+  # Step 0: Migrate legacy MCP config if present (idempotent; skips on empty)
+  _migrate_legacy_mcp_json
+
   # Step 1: Check for CCGM repo updates
   ui_header "CCGM Update Check"
 


### PR DESCRIPTION
## Summary

Closes #427.

Pre-#427 CCGM docs told users to hand-edit `~/.claude/mcp.json`, but current Claude Code reads `~/.claude.json` (managed by the `claude mcp` CLI). Entries in the legacy file were silently ignored — `claude mcp list` didn't show them, tool calls like `web_search_exa` and `mcp__github__*` failed.

CCGM has zero programmatic MCP-write code (confirmed via `grep -rn "mcpServers"`); every reference is in docs telling users to hand-edit. So the bug is doc drift + missing migration tool.

## Changes

### Doc updates (use `claude mcp add` everywhere)

- `README.md` Customization table
- `docs/configuration.md` MCP servers section + brand-naming config-prompt row
- `docs/modules.md` brand-naming config-prompts line
- `modules/brand-naming/README.md` MCP Server section + Manual Installation
- `modules/brand-naming/module.json` configPrompt text
- `modules/deepresearch/README.md` Prerequisites, Setup, Why MCP, Troubleshooting
- `modules/deepresearch/module.json` description + configPrompt
- `modules/deepresearch/commands/deepresearch.md` Prerequisites

All examples now use the `claude mcp add --scope user --env KEY=value -- <name> <command> <args...>` pattern (with the `--` before name — without it the CLI parses name as a flag value). Migration note added to `docs/configuration.md` and `modules/deepresearch/README.md` Troubleshooting.

### Migration tool

`lib/mcp-migrate.sh` (new):
- Reads `~/.claude/mcp.json` (configurable first arg)
- For each `mcpServers.<name>`: skips if `claude mcp get <name>` succeeds; otherwise re-registers via `claude mcp add-json --scope user`
- Expands `${VAR}` references in env values from the current shell
- Tags entries with `type: stdio`/`sse` if the legacy file omits it (heuristic: `url` -> sse, `command` -> stdio)
- Archives the legacy file as `.migrated.bak` on success; leaves it in place with a clear error if any entries failed
- Idempotent: re-running on an already-migrated machine is a no-op (or archives a fully-skipped legacy file)

Wired into:
- `start.sh` Step 14b (post-install, before "Installation Complete!")
- `update.sh` Step 0 (pre-fetch — runs unconditionally so even no-update runs catch the migration)

Both call sites are guarded on `[ -f ~/.claude/mcp.json ]` so they're free no-ops on machines without a legacy file.

## Test plan

Verified manually with synthetic fixtures (stdio + sse) before committing:

- [x] First run on fresh fixture: both servers registered, legacy file archived to `.migrated.bak`
- [x] Re-run after restoring fixture: both `skip (already registered)`, legacy file archived again
- [x] `${HOME}` reference in env block correctly expanded to actual path
- [x] sse heuristic (only `url` field) correctly tagged `Type: sse`
- [x] Test entries cleaned up via `claude mcp remove --scope user`; user's real `~/.claude/mcp.json` untouched throughout
- [x] `bash tests/run-all.sh` — all green (186 pytest, 1 shell suite)
- [x] `bash tests/test-modules.sh` — 1048/1048 passed
- [x] `bash tests/test-no-personal-data.sh` — clean
- [x] `bash -n start.sh update.sh lib/mcp-migrate.sh` — syntax ok

## Out of scope

- Pre-existing `docs/modules.md:311,329` references to standalone `lem-deepresearch` repo (#422 follow-ups). Logged in #423's punch list.
- Plugin-installed MCPs (`plugin:imessage:imessage`, etc.) and OAuth-flow servers (`claude.ai Gmail`) are unaffected; the migration only touches entries it owns.