### PR TITLE
#431: update instant-domain-search MCP to new Streamable HTTP endpoint

### DIFF
--- a/modules/brand-naming/README.md
+++ b/modules/brand-naming/README.md
@@ -45,7 +45,7 @@ Deep verification of one or more specific brand name candidates. Checks everythi
 The installer's config prompt can guide you through adding the **Instant Domain Search** MCP server. Register it with:
 
 ```bash
-claude mcp add-json --scope user instant-domain-search '{"type":"sse","url":"https://instantdomainsearch.com/mcp/sse"}'
+claude mcp add --transport http --scope user instant-domain-search https://api.instantdomainsearch.com/mcp/streamable-http
 claude mcp get instant-domain-search   # expect: Status: ✓ Connected
 ```
 
@@ -78,7 +78,7 @@ cp commands/brand-check.md ~/.claude/commands/brand-check.md
 Optionally register the MCP server:
 
 ```bash
-claude mcp add-json --scope user instant-domain-search '{"type":"sse","url":"https://instantdomainsearch.com/mcp/sse"}'
+claude mcp add --transport http --scope user instant-domain-search https://api.instantdomainsearch.com/mcp/streamable-http
 ```
 
 Restart Claude Code for the MCP server to load.


### PR DESCRIPTION
## Summary

Closes #431.

The Instant Domain Search MCP migrated from an SSE endpoint to Streamable HTTP at a new host. The old URL (`https://instantdomainsearch.com/mcp/sse`) returns HTTP 404; the current endpoint is `https://api.instantdomainsearch.com/mcp/streamable-http` (HTTP transport).

Resolution path #1 from #431: endpoint moved, just update the URL + transport.

## Verification

```
$ claude mcp add --transport http --scope user instant-domain-search https://api.instantdomainsearch.com/mcp/streamable-http
Added HTTP MCP server instant-domain-search with URL: https://api.instantdomainsearch.com/mcp/streamable-http to user config

$ claude mcp get instant-domain-search
Status: ✓ Connected
Type: http
URL: https://api.instantdomainsearch.com/mcp/streamable-http
```

Source: https://instantdomainsearch.com/mcp lists the new connector URL ("Connect Instant MCP in Claude using this connector URL: https://api.instantdomainsearch.com/mcp/streamable-http").

## Changes

- `modules/brand-naming/README.md`: replace both `claude mcp add-json ... sse` invocations with `claude mcp add --transport http ...` against the new URL (MCP Server section + Manual Installation section).

Tool names exposed by the MCP (`search_domains`, `check_domain_availability`, `generate_domain_variations`) are unchanged, so `commands/brand.md` and `commands/brand-check.md` need no updates.

## Test plan

- [x] `claude mcp get instant-domain-search` shows `Status: ✓ Connected` after registering with the new URL
- [x] `bash tests/test-modules.sh` — 1048/1048 passed
- [x] `bash tests/test-no-personal-data.sh` — clean

## Out of scope

- The `addMcp` configPrompt in `module.json` doesn't reference the URL, so it doesn't need updating.
- Existing users with the old SSE entry in `~/.claude.json` will see `Failed to connect`; they need to `claude mcp remove instant-domain-search -s user` and re-register with the new URL. Worth surfacing in release notes if/when there are any.