### PR TITLE
#434: add 'outsource thinking, not understanding' to soul.md template

### DIFF
--- a/modules/identity/rules/soul.md
+++ b/modules/identity/rules/soul.md
@@ -25,6 +25,11 @@ Edit this file to match your preferences. The sections below are a starting fram
 <!-- How should the AI approach problems and make decisions?
      Example: "Understand before acting. Evidence before claims. Simplest viable approach first." -->
 
+<!-- Anchor: outsource thinking, never understanding.
+     The agent fills in blanks — research, boilerplate, refactoring, synthesis.
+     The human stays in charge of why we are doing this and whether the answer makes sense.
+     Delegation without comprehension is how a codebase becomes unknowable to its owner. -->
+
 ## Core Values
 
 <!-- What matters most? What should guide every decision?


### PR DESCRIPTION
Closes #434.

Adds the Karpathy principle from the Sequoia interview as a new anchor in the soul.md template. One short paragraph placed under Reasoning Principles, written as a comment block matching the template's existing guidance style.

Quote: "You can outsource your thinking but you cannot outsource your understanding."

Source: docs/articles/karpathy-vibe-coding-to-agentic-engineering-2026-04-29.md

The anchor reminds template authors (and the installed agent) that delegation is appropriate for execution tasks — research, boilerplate, refactoring, synthesis — but the human must retain comprehension of *why* and *whether the answer is right*. This reinforces the `self-improving`, `verification`, and auto-memory modules without adding procedural rules.