### PR TITLE
#435: add docs-for-agents module (AGENTS.md template + rule)

### DIFF
--- a/modules/docs-for-agents/README.md
+++ b/modules/docs-for-agents/README.md
@@ -1,0 +1,47 @@
+# docs-for-agents
+
+Rule and template for shipping machine-readable docs alongside human docs. Any project an agent will install, build, test, deploy, or debug should have an `AGENTS.md` with copy-pasteable command blocks.
+
+The rule enforces what Karpathy called out in the Sequoia vibe-coding interview: docs written for humans tell an agent what to do in prose. Docs written for agents give the agent one command to run. `AGENTS.md` is the agent-readable contract.
+
+## What This Module Provides
+
+| Source | Target | Purpose |
+|--------|--------|---------|
+| `rules/docs-for-agents.md` | `~/.claude/rules/docs-for-agents.md` | When to ship AGENTS.md, what it contains, format conventions, anti-patterns |
+| `templates/AGENTS.md` | (use in your project) | Skeleton with labeled sections and example commands |
+
+The rule file is installed globally so Claude applies it to every project. The template is a copy-paste starting point — it is not installed anywhere automatically.
+
+## Manual Installation
+
+```bash
+# From the CCGM repo root:
+mkdir -p ~/.claude/rules
+cp modules/docs-for-agents/rules/docs-for-agents.md ~/.claude/rules/docs-for-agents.md
+```
+
+To start an `AGENTS.md` in a project:
+
+```bash
+cp modules/docs-for-agents/templates/AGENTS.md /path/to/your/project/AGENTS.md
+# Edit to replace example commands with the real ones for your project
+```
+
+## Usage
+
+Once the rule is installed, Claude will:
+
+- Prompt you to create `AGENTS.md` when starting work on a project that does not have one and that an agent would reasonably need to operate
+- Enforce the labeled-block format (Install, Build, Test, Deploy, Debug) when authoring or reviewing `AGENTS.md`
+- Flag anti-patterns: dashboard navigation instructions, missing env vars, vague debug steps
+
+To author an `AGENTS.md` from scratch, copy the template and fill in the labeled sections with the real commands for your project. Remove the comment blocks before committing.
+
+## What AGENTS.md Is Not
+
+- Not a replacement for `README.md` — README explains what the project is; AGENTS.md tells the agent how to operate it
+- Not a replacement for `CLAUDE.md` — CLAUDE.md carries repo conventions and workflow rules; AGENTS.md carries operational commands
+- Not a changelog or a design doc — one command per operation, nothing more
+
+See `rules/docs-for-agents.md` for the full distinction table and format rules.

--- a/modules/docs-for-agents/module.json
+++ b/modules/docs-for-agents/module.json
@@ -1,0 +1,17 @@
+{
+  "name": "docs-for-agents",
+  "displayName": "Docs for Agents (AGENTS.md)",
+  "description": "Rule and template for shipping machine-readable docs alongside human docs. Any project an agent will install, build, test, deploy, or debug should have an AGENTS.md with copy-pasteable command blocks — not prose, not dashboard instructions.",
+  "category": "patterns",
+  "scope": ["global", "project"],
+  "dependencies": [],
+  "files": {
+    "rules/docs-for-agents.md": {
+      "target": "rules/docs-for-agents.md",
+      "type": "rule",
+      "template": false
+    }
+  },
+  "tags": ["documentation", "agents", "dx", "AGENTS.md", "llms.txt"],
+  "configPrompts": []
+}

--- a/modules/docs-for-agents/rules/docs-for-agents.md
+++ b/modules/docs-for-agents/rules/docs-for-agents.md
@@ -1,0 +1,80 @@
+# Docs for Agents (AGENTS.md)
+
+Every project that an agent will install, build, test, deploy, or debug needs an `AGENTS.md`. Human docs (README, CLAUDE.md) explain context and intent. `AGENTS.md` gives the agent exactly what it needs to act: one command per operation, nothing more.
+
+Karpathy's pet peeve from the Sequoia vibe-coding interview: *"They still have docs that are fundamentally written for humans... why are people still telling me what to do? What is the thing I should copy-paste to my agent?"*
+
+## How AGENTS.md Differs from README and CLAUDE.md
+
+| File | Audience | Format | Purpose |
+|------|----------|--------|---------|
+| `README.md` | Human, first visit | Narrative prose | Explain what the project is and why it exists |
+| `CLAUDE.md` | Claude Code, this repo | Mixed (prose + commands) | Repo conventions, gotchas, workflow rules |
+| `AGENTS.md` | Any agent, any tool | Command blocks only | Copy-paste commands for every operation an agent must perform |
+
+`AGENTS.md` has no narrative. It has labeled blocks. An agent reads the label, pastes the block, runs it.
+
+## When to Ship an AGENTS.md
+
+Ship `AGENTS.md` when any of the following are true:
+
+- An agent will clone or install the project
+- An agent will run a build, test, or lint step
+- An agent will deploy the project
+- An agent will debug a failure by reading logs or running diagnostics
+- The project has non-obvious setup (env vars to set, migrations to run, secrets to provision)
+
+Skip `AGENTS.md` if the project is a one-off script, a personal prototype, or has no expected agent consumers.
+
+## What Goes in AGENTS.md
+
+Exactly six labeled sections. Each section is one code block or a small sequence of code blocks. No prose between sections except one-line clarifications when the command alone is ambiguous.
+
+### Section labels and what each contains
+
+**Install:** All steps to get the project to a runnable state from a fresh clone. Package install, env file setup, migrations, secret provisioning. Every step, in order.
+
+**Build:** The single command that produces the deployable artifact. If there are multiple targets (client + server, extension + background), list each command on its own labeled line inside the block.
+
+**Test:** The command that runs the full test suite. If there is more than one suite (unit, integration, e2e), list each. Include the flag for watch mode if it exists, but label it separately.
+
+**Deploy:** The command that ships to production. If deployment is multi-step (build, then push, then migrate), list each step in order. If the deploy requires a secret, name the env var; do not describe the dashboard.
+
+**Debug:** One subsection per common failure mode. Label each `Debug <symptom>:`. Each block contains the command to inspect that symptom. Prefer log tails, status checks, and diagnostic queries over "open the dashboard."
+
+## Format Conventions
+
+- Use the file's section labels exactly as shown above. Agents pattern-match on them.
+- Commands are absolute or explicitly relative to the repo root.
+- Env var placeholders use `YOUR_VALUE_HERE` form, not angle brackets.
+- No "click here", "navigate to", or "open the dashboard". If the operation requires a browser, say so explicitly (`# requires browser: go to Cloudflare Dashboard > Pages > Deployments`) and immediately follow with whatever CLI equivalent exists.
+- Keep each block self-contained. An agent should be able to copy one block and run it without reading the others.
+- If a command requires a prior command to have run, say so with a one-line comment (`# run Install first`).
+
+## Anti-Patterns
+
+| Pattern | Problem | Fix |
+|---------|---------|-----|
+| "Go to Settings > API Keys and copy your key" | Dashboard navigation; the agent cannot do this | `export API_KEY=YOUR_VALUE_HERE` — then tell the human where to get the value, in a comment |
+| "Click the Deploy button" | UI action | Provide the CLI equivalent: `npx wrangler deploy` |
+| "See README for setup" | Link to prose | Paste the relevant commands directly in Install |
+| Long prose before each command | Agents skip prose to find the command | One-line comments only (`# installs dependencies`) |
+| Partial commands (`npm install` without specifying the workspace) | Ambiguous; breaks in monorepos | `cd packages/api && npm install` |
+| Vague debug: "Check the logs" | Agent does not know where logs are | `tail -n 50 /var/log/app/error.log` or `wrangler tail --env production` |
+| Skipping env vars | Agent hits a missing-env error mid-operation | List every required env var in Install, even if the value must come from a human |
+
+## Maintenance
+
+Update `AGENTS.md` whenever:
+
+- A new required env var is added
+- A build command changes
+- A new test suite is added
+- The deploy procedure changes
+- A new common failure mode is identified
+
+`AGENTS.md` is a contract. A stale contract is worse than no contract because the agent runs a broken command with confidence.
+
+## Template
+
+See `modules/docs-for-agents/templates/AGENTS.md` for a skeleton with example commands based on a small static-site CLI project.

--- a/modules/docs-for-agents/templates/AGENTS.md
+++ b/modules/docs-for-agents/templates/AGENTS.md
@@ -1,0 +1,143 @@
+# AGENTS.md
+
+<!-- AGENTS.md is machine-readable ops docs.
+     Each section is a labeled command block. No narrative prose.
+     An agent reads the label, pastes the block, runs it.
+     Replace all YOUR_VALUE_HERE placeholders with real values.
+
+     This template uses "pagegen" (a fictional static-site CLI) as the example project.
+     Delete this comment block before shipping. -->
+
+## Install
+
+```bash
+# Clone and enter the repo
+git clone git@github.com:your-org/your-repo.git
+cd your-repo
+
+# Install dependencies
+npm install
+
+# Copy env template and fill in values
+cp .env.example .env
+# Required vars (see .env.example for descriptions):
+#   PAGEGEN_API_KEY=YOUR_VALUE_HERE
+#   PAGEGEN_SITE_ID=YOUR_VALUE_HERE
+#   DATABASE_URL=YOUR_VALUE_HERE
+
+# Run database migrations
+npx pagegen migrate up
+
+# Verify the setup
+npx pagegen doctor
+```
+
+<!-- Install: list every step in order. Missing steps cause mid-run failures.
+     Include env vars even if the agent cannot fill them — it will pause and ask. -->
+
+## Build
+
+```bash
+# Build all output (runs type-check + bundler)
+npm run build
+
+# Output lands in ./dist/
+```
+
+<!-- Build: the single command that produces the deployable artifact.
+     If you have multiple targets, label them:
+       # client
+       npm run build:client
+       # server
+       npm run build:server -->
+
+## Test
+
+```bash
+# Full test suite (unit + integration)
+npm test
+
+# Watch mode (development)
+npm run test:watch
+
+# E2E tests (requires a running dev server — see Debug: dev server below)
+npm run test:e2e
+```
+
+<!-- Test: one command per suite. Include the watch-mode command labeled separately.
+     If a suite requires a precondition (running server, seeded DB), say so with a comment. -->
+
+## Deploy
+
+```bash
+# Build first
+npm run build
+
+# Deploy to production (uses PAGEGEN_API_KEY from .env)
+npx pagegen deploy --env production
+
+# Run post-deploy migrations
+npx pagegen migrate up --env production
+
+# Verify deployment is live
+curl -I https://your-site.example.com
+```
+
+<!-- Deploy: list every step in order, including post-deploy steps like migrations.
+     If a step requires a secret the agent does not have, name the env var.
+     Never say "click Deploy" — if that is the only path, say so explicitly and
+     note it requires a human with browser access. -->
+
+## Debug
+
+### Debug: build fails
+
+```bash
+# See full type errors
+npx tsc --noEmit
+
+# See bundler errors with verbose output
+npm run build -- --verbose
+
+# Check for missing env vars
+npx pagegen doctor
+```
+
+### Debug: tests fail
+
+```bash
+# Run only the failing test file
+npx jest path/to/failing.test.ts --verbose
+
+# Show last 50 lines of test output
+npm test 2>&1 | tail -50
+```
+
+### Debug: deploy fails
+
+```bash
+# Check deploy logs
+npx pagegen deploy:logs --env production --lines 100
+
+# Check whether the API key is valid
+npx pagegen auth:verify
+
+# Roll back to the previous deployment
+npx pagegen rollback --env production
+```
+
+### Debug: dev server
+
+```bash
+# Start the dev server (needed for E2E tests)
+npm run dev
+# Server starts at http://localhost:3000
+
+# Check whether the server is up
+curl -s http://localhost:3000/health | jq .
+```
+
+<!-- Debug: add one subsection per common failure mode.
+     Label each "Debug: <symptom>" so agents can jump to the right block.
+     Prefer tailable logs, CLI status checks, and diagnostic queries
+     over "open the dashboard." If the dashboard is the only option, say so. -->


### PR DESCRIPTION
Closes #435.

New module `docs-for-agents` capturing Karpathy's pet peeve from the Sequoia interview about docs being written for humans.

Quote: "Why are people still telling me what to do? What is the thing I should copy-paste to my agent?"

## Deliverables

- `rules/docs-for-agents.md` — when to ship AGENTS.md, what it contains, format conventions, anti-patterns table
- `templates/AGENTS.md` — skeleton with copy-pasteable blocks for Install/Build/Test/Deploy/Debug, using a fictional `pagegen` static-site CLI as the concrete example
- `README.md` — module purpose, distinction from README/CLAUDE.md, manual install path
- `module.json` — manifest matching CCGM convention

## Key design choices

- Rule has a three-way comparison table: README.md vs CLAUDE.md vs AGENTS.md — distinct audiences, formats, and purposes
- Template uses a concrete fictional project (not just empty headings) so the format is immediately clear
- Anti-patterns table covers the five most common mistakes: dashboard navigation, UI-action instructions, "see README for setup" redirects, missing env vars, vague debug steps
- Debug section uses labeled subsections ("Debug: build fails", "Debug: tests fail") so agents can pattern-match to the right block

## Out of scope

- Retroactively writing AGENTS.md for existing modules (follow-up)
- Tooling to auto-generate AGENTS.md (future)