### PR TITLE
#438: add menu-gen-test intake check

### DIFF
--- a/modules/code-quality/rules/menu-gen-test.md
+++ b/modules/code-quality/rules/menu-gen-test.md
@@ -1,0 +1,75 @@
+# Menu-Gen Test: Apps That Shouldn't Exist
+
+Before committing to build anything — a new app, a script, a feature, a workflow — ask one question first:
+
+> **Could this be a single prompt + multimodal call instead of an app/script/feature? If yes, why are we building anything?**
+
+If you cannot answer "why," stop. The build might be unnecessary.
+
+## The Karpathy Confession
+
+Andrej Karpathy built Menu Gen: an OCR webapp on Vercel that takes a photo of a restaurant menu, calls an image generator for each item, and re-renders the menu with pictures.
+
+Then he saw the Software 3.0 version: hand the photo to Gemini, say "use Nano Banana to overlay the items," and receive the annotated image directly — one multimodal call, no app.
+
+> *"All of my menu gen is spurious. It's working in the old paradigm — that app shouldn't exist."*
+> — Andrej Karpathy, Sequoia Capital, 2026-04-29
+
+The app was not wrong or poorly built. It was answering the right question in the wrong paradigm. The new question is: does the build need to exist at all?
+
+## The Forcing Question
+
+At intake — before research, before planning, before any implementation — answer this in one paragraph:
+
+> Could this be accomplished with a single prompt and a multimodal/agentic call? If yes, what is the specific reason an app, script, or persistent system is still needed?
+
+Valid reasons an app still needs to exist:
+- Runtime injection into another system (e.g., a Chrome extension that modifies page DOM)
+- Persistent server state shared across users or sessions (e.g., a multi-tenant SaaS with a database)
+- Recurring background automation that cannot be triggered manually each time
+- Distribution to non-technical users who cannot operate a prompt
+
+Not valid reasons:
+- "The prompt would be long" — long prompts are fine
+- "We need a UI" — many things that feel like they need UI are just a prompt with output rendering
+- "The logic is complex" — complex logic can live in an agent, not an app
+
+## Dissolvability Score
+
+If the answer is not obvious, score it:
+
+| Score | Meaning |
+|-------|---------|
+| **0** | Clearly needs to exist. Has runtime injection, persistent multi-user state, or distribution requirements. |
+| **2-3** | Mostly needs to exist, but some parts could be dissolved into prompts. Consider which parts. |
+| **5** | Could be a single multimodal or agentic call right now. Strong case for not building. |
+| **4** | Borderline. The app adds enough structure or UX that it is worth building — but name the specific reason explicitly. |
+
+A score of 4 or 5 is not a hard stop. It is a flag. Name the reason you are building anyway. If you cannot name it, the build is not justified.
+
+## Examples
+
+**Should not exist (score: 5)**
+
+Menu Gen — OCR + image gen webapp. One Gemini + Nano Banana call does the same thing.
+
+A script that fetches a URL, runs it through a prompt, and emails the summary on a schedule — if it runs manually each time and the user already has access to a model, this is a prompt, not a script.
+
+**Needs to exist (score: 0)**
+
+A Chrome extension that injects a dark-mode CSS overlay into every page the user visits. It runs inside the browser at runtime, on arbitrary pages the user navigates to. No prompt can do this.
+
+A multi-tenant habit-tracking SaaS with user accounts, persistent streaks, and push notifications. It requires a database, a server, and distribution to users who interact via a native UI.
+
+## When to Apply
+
+Apply this check at every project intake: `/xplan`, `/research`, `/ideate`, or any other scoping exercise before research and planning begins.
+
+Do not apply it to:
+- Work already in progress (this is an intake check, not a retroactive audit)
+- Incremental features on an existing system where the system's existence is already justified
+- Purely exploratory research with no build decision yet
+
+## Relationship to Build Decisions
+
+This check does not reject ideas. It forces explicit justification before committing resources. The answer "this needs to exist because users cannot operate a raw prompt" is a complete and sufficient answer. The problem is building without asking the question at all.

--- a/modules/ideate/skills/ideate/SKILL.md
+++ b/modules/ideate/skills/ideate/SKILL.md
@@ -266,6 +266,14 @@ Present with AskUserQuestion:
 
 ---
 
+### Phase 3.5: Menu-Gen Test
+
+Before proceeding to next steps, apply the Menu-Gen Test. See `modules/code-quality/rules/menu-gen-test.md`.
+
+Forcing question: **Could this concept be accomplished with a single prompt + multimodal call instead of an app/script/feature? If yes, why are we building anything?**
+
+Ask the user to answer in one sentence or short paragraph. If the dissolvability score is 4-5, add an "Existence Justification" field to `concept.md` and require the user to name the specific reason before the concept advances to `/xplan`. If score is 0-3, note it and proceed without interruption.
+
 ### Phase 4: Next Steps
 
 Once the concept is confirmed, update `session.md` status to `confirmed` and ask:

--- a/modules/research/commands/research.md
+++ b/modules/research/commands/research.md
@@ -41,6 +41,14 @@ Extract from arguments:
 
 If no topic is provided, use AskUserQuestion to ask what to research.
 
+### Menu-Gen Test (standalone mode only)
+
+When `/research` is invoked directly by the user (not called from xplan or another skill), apply the Menu-Gen Test before beginning research. See `modules/code-quality/rules/menu-gen-test.md`.
+
+Forcing question: **Could this be a single prompt + multimodal call instead of an app/script/feature?**
+
+If the research topic is clearly exploratory (no build decision implied), skip this check. If the user is scoping a build, ask them to answer the forcing question in one paragraph before proceeding. Note the answer in the output's Executive Summary under a "Build Justification" heading.
+
 ### Cross-Session Continuity (--extend)
 
 If `--extend` is provided, read the prior research.md and use it as context:

--- a/modules/xplan/commands/xplan.md
+++ b/modules/xplan/commands/xplan.md
@@ -315,6 +315,14 @@ When `--autonomous` is active, use these defaults in place of the user's answers
 | Timeline | Assume no hard deadline. |
 | Research level | **Full** (all 7 agents, unconditionally). |
 
+### 0.5.0 Menu-Gen Test
+
+Before confirming what to build, ask whether it needs to exist at all. See `modules/code-quality/rules/menu-gen-test.md` for the full rule.
+
+Forcing question: **Could this be a single prompt + multimodal call instead of an app/script/feature? If yes, why are we building anything?**
+
+Ask the user to answer in one paragraph, or answer on their behalf in `--autonomous` mode using the concept statement. If the dissolvability score is 4-5, surface it explicitly in the final walkthrough and require a named justification before execution begins.
+
 ### 0.5.1 Confirm Core Understanding
 
 Summarize what you understand from the initial input, then use AskUserQuestion:


### PR DESCRIPTION
Closes #438.

Karpathy's Menu Gen confession from the Sequoia interview (2026-04-29): he built an OCR + image-gen webapp on Vercel, then realized Gemini + Nano Banana does it in one multimodal call.

Quote: "All of my menu gen is spurious. It's working in the old paradigm — that app shouldn't exist."

Source: `/Users/lem/code/docs/transcripts/karpathy-vibe-coding-to-agentic-engineering-2026-04-29.md`

Adds a forcing question to project intake: "Could this be a single prompt + multimodal call instead of an app/script/feature? If yes, why are we building anything?"

## Deliverables

- New rule `modules/code-quality/rules/menu-gen-test.md` — defines the forcing question, dissolvability score (0–5), positive example (Chrome extension that needs runtime injection), negative example (Menu Gen), and when to apply
- `modules/xplan/commands/xplan.md` — new step 0.5.0 in the Discovery Interview phase
- `modules/research/commands/research.md` — Menu-Gen Test section in Phase 0 for standalone invocations
- `modules/ideate/skills/ideate/SKILL.md` — new Phase 3.5 between concept confirmation and next-steps

## Notes

All three intake commands reference the rule by path. Amendments are 5–10 lines each. No neighboring structure was refactored.