### PR TITLE
#455: remove disable-model-invocation from debug command

### DIFF
--- a/modules/debugging/commands/debug.md
+++ b/modules/debugging/commands/debug.md
@@ -2,7 +2,6 @@
 description: Deep root-cause debugging with Opus 4.6 - reproduce, hypothesize, instrument, diagnose, fix, verify. Use when asked to fix bugs, debug errors, investigate failures, or troubleshoot unexpected behavior.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch, AskUserQuestion
 argument-hint: <problem description or error message>
-disable-model-invocation: false
 ---
 
 # /debug - Deep Root Cause Debugging


### PR DESCRIPTION
## Summary

Removes `disable-model-invocation: false` from `modules/debugging/commands/debug.md` frontmatter. The field is a `SKILL.md` schema field, not a command schema field — its mere presence (even when set to `false`) caused Claude Code's harness to block model invocation of `/debug` via the Skill tool with:

> Skill debug cannot be used with Skill tool due to disable-model-invocation

## Test plan

- [ ] After install, type `/debug <problem>` and confirm the skill runs (model can invoke `Skill(debug)` without the harness blocking it)

Closes #455