### PR TITLE
#457: add sync-ccgm-canonical post-merge hook

### DIFF
--- a/modules/hooks/README.md
+++ b/modules/hooks/README.md
@@ -4,7 +4,7 @@ Python hooks that enforce git workflow rules: issue-first workflow, commit messa
 
 ## What It Does
 
-This module installs thirteen Python hooks, two Python libraries, and a settings partial:
+This module installs fourteen Python hooks, two Python libraries, and a settings partial:
 
 | Hook | Event | Purpose |
 |------|-------|---------|
@@ -21,6 +21,7 @@ This module installs thirteen Python hooks, two Python libraries, and a settings
 | `check-careful.py` | PreToolUse (Bash) | Prompts before destructive Bash commands (rm -rf, SQL DROP/TRUNCATE, force push, hard reset, kubectl delete, docker prune). Build-artifact directories (node_modules, dist, .next, build, __pycache__, .cache, .turbo, coverage) are whitelisted for `rm -rf` |
 | `check-freeze.py` | PreToolUse (Edit/Write) | Denies Edit/Write outside the frozen directory when `~/.claude/freeze-dir.txt` is set. Pair with `/freeze`, `/unfreeze`, `/guard` from `commands-extra` |
 | `session-start-enforce.py` | SessionStart (startup) | Experimental. Injects an Iron-Law rule-enforcement meta-instruction at fresh session start so discipline rules activate under pressure. OFF by default; opt in via `CCGM_RULE_ENFORCEMENT=true` in `~/.claude/.ccgm.env` |
+| `sync-ccgm-canonical.py` | PostToolUse (Bash) | After `gh pr merge` succeeds in the CCGM repo, fast-forwards the canonical CCGM clone (the symlink source for `~/.claude/`) so it never drifts. Default canonical dir: `~/code/ccgm`; override with `CCGM_CANONICAL_DIR` env var. No-op if the dir doesn't exist or the merge wasn't in a CCGM clone |
 
 The `settings.partial.json` wires these hooks into your `~/.claude/settings.json`.
 
@@ -58,6 +59,7 @@ cp hooks/orphan-process-check.py ~/.claude/hooks/orphan-process-check.py
 cp hooks/check-careful.py ~/.claude/hooks/check-careful.py
 cp hooks/check-freeze.py ~/.claude/hooks/check-freeze.py
 cp hooks/session-start-enforce.py ~/.claude/hooks/session-start-enforce.py
+cp hooks/sync-ccgm-canonical.py ~/.claude/hooks/sync-ccgm-canonical.py
 
 # 2. Copy libraries
 mkdir -p ~/.claude/lib
@@ -111,6 +113,7 @@ On fresh session start, the hook injects a short reminder that routes tasks thro
 | `hooks/check-careful.py` | Destructive-command warning (careful safety hook) |
 | `hooks/check-freeze.py` | Scope-lock Edit/Write to `~/.claude/freeze-dir.txt` (freeze safety hook) |
 | `hooks/session-start-enforce.py` | Experimental Iron-Law rule-enforcement meta-instruction at session start (opt in via `CCGM_RULE_ENFORCEMENT=true`) |
+| `hooks/sync-ccgm-canonical.py` | Auto-pull `~/code/ccgm` after CCGM PR merges so symlinked runtime never drifts (override path via `CCGM_CANONICAL_DIR`) |
 | `lib/agent_tracking.py` | Python library for tracking CSV operations |
 | `lib/agent_sessions.py` | Python library for live session detection |
 | `settings.partial.json` | Hook wiring configuration to merge into settings.json |

--- a/modules/hooks/hooks/sync-ccgm-canonical.py
+++ b/modules/hooks/hooks/sync-ccgm-canonical.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+PostToolUse:Bash hook — sync the canonical CCGM clone after a CCGM PR merges.
+
+Why: ~/.claude/ symlinks point at one canonical CCGM checkout. When PRs merge
+in workspace clones, that canonical checkout drifts unless something pulls it.
+This hook removes the manual sync step.
+
+Triggers when:
+- The Bash command was `gh pr merge ...`
+- The cwd's git remote points at a repo named "ccgm" (any owner)
+- The canonical clone exists at $CCGM_CANONICAL_DIR (default ~/code/ccgm)
+
+Behavior:
+- Runs `git fetch origin main && git pull --ff-only origin main` in the
+  canonical clone
+- Logs success/failure to stderr
+- Never blocks on errors (always exit 0)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+CANONICAL_DIR_ENV = "CCGM_CANONICAL_DIR"
+DEFAULT_CANONICAL_DIR = os.path.expanduser("~/code/ccgm")
+CCGM_REPO_NAME = "ccgm"
+
+
+def get_origin_url(cwd: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=3, check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return None
+
+
+def is_ccgm_repo(cwd: str) -> bool:
+    url = get_origin_url(cwd)
+    if not url:
+        return False
+    # Extract repo name from URL (last path segment, strip .git)
+    repo_name = re.sub(r"\.git$", "", url.rstrip("/").rsplit("/", 1)[-1])
+    return repo_name == CCGM_REPO_NAME
+
+
+def sync_canonical(canonical_dir: str) -> tuple[bool, str]:
+    """Pull origin/main into canonical_dir. Returns (success, message)."""
+    if not os.path.isdir(os.path.join(canonical_dir, ".git")):
+        return False, f"canonical dir not a git repo: {canonical_dir}"
+
+    try:
+        fetch = subprocess.run(
+            ["git", "-C", canonical_dir, "fetch", "origin", "main"],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+        if fetch.returncode != 0:
+            return False, f"fetch failed: {fetch.stderr.strip()}"
+
+        pull = subprocess.run(
+            ["git", "-C", canonical_dir, "pull", "--ff-only", "origin", "main"],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+        if pull.returncode != 0:
+            return False, f"pull failed (not fast-forward?): {pull.stderr.strip()}"
+
+        return True, pull.stdout.strip().splitlines()[-1] if pull.stdout.strip() else "up to date"
+    except subprocess.TimeoutExpired:
+        return False, "timeout"
+    except (subprocess.SubprocessError, OSError) as e:
+        return False, str(e)
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    if payload.get("tool_name") != "Bash":
+        sys.exit(0)
+
+    command = (payload.get("tool_input") or {}).get("command", "")
+    if not re.match(r"\s*gh\s+pr\s+merge(\s|$)", command):
+        sys.exit(0)
+
+    cwd = payload.get("cwd") or os.getcwd()
+    if not is_ccgm_repo(cwd):
+        sys.exit(0)
+
+    canonical_dir = os.environ.get(CANONICAL_DIR_ENV, DEFAULT_CANONICAL_DIR)
+    if not os.path.isdir(canonical_dir):
+        sys.stderr.write(
+            f"sync-ccgm-canonical: skipped — {canonical_dir} does not exist "
+            f"(set {CANONICAL_DIR_ENV} or create the dir)\n"
+        )
+        sys.exit(0)
+
+    if os.path.realpath(cwd) == os.path.realpath(canonical_dir):
+        sys.exit(0)
+
+    ok, msg = sync_canonical(canonical_dir)
+    prefix = "sync-ccgm-canonical"
+    if ok:
+        sys.stderr.write(f"{prefix}: {canonical_dir} → {msg}\n")
+    else:
+        sys.stderr.write(f"{prefix}: FAILED — {msg}\n")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/hooks/module.json
+++ b/modules/hooks/module.json
@@ -81,6 +81,11 @@
       "type": "hook",
       "template": false
     },
+    "hooks/sync-ccgm-canonical.py": {
+      "target": "hooks/sync-ccgm-canonical.py",
+      "type": "hook",
+      "template": false
+    },
     "settings.partial.json": {
       "target": "settings.json",
       "type": "config",

--- a/modules/hooks/settings.partial.json
+++ b/modules/hooks/settings.partial.json
@@ -36,6 +36,11 @@
             "type": "command",
             "command": "python3 $HOME/.claude/hooks/agent-tracking-post.py",
             "timeout": 15000
+          },
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/sync-ccgm-canonical.py",
+            "timeout": 35000
           }
         ]
       }

--- a/modules/hooks/tests/test_sync_ccgm_canonical.py
+++ b/modules/hooks/tests/test_sync_ccgm_canonical.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Unit tests for sync-ccgm-canonical hook."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from unittest.mock import patch
+
+_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+_HOOKS_DIR = os.path.abspath(os.path.join(_TEST_DIR, '..', 'hooks'))
+_HOOK_PATH = os.path.join(_HOOKS_DIR, 'sync-ccgm-canonical.py')
+
+sync = SourceFileLoader("sync_ccgm_canonical", _HOOK_PATH).load_module()
+
+
+class TestRepoDetection(unittest.TestCase):
+    def test_is_ccgm_repo_matches_marker(self):
+        with patch.object(sync, 'get_origin_url', return_value='git@github.com:testuser/ccgm.git'):
+            self.assertTrue(sync.is_ccgm_repo('/any/path'))
+
+    def test_is_ccgm_repo_https_url(self):
+        with patch.object(sync, 'get_origin_url', return_value='https://github.com/testuser/ccgm'):
+            self.assertTrue(sync.is_ccgm_repo('/any/path'))
+
+    def test_is_ccgm_repo_other_repo(self):
+        with patch.object(sync, 'get_origin_url', return_value='git@github.com:testuser/other.git'):
+            self.assertFalse(sync.is_ccgm_repo('/any/path'))
+
+    def test_is_ccgm_repo_no_remote(self):
+        with patch.object(sync, 'get_origin_url', return_value=None):
+            self.assertFalse(sync.is_ccgm_repo('/any/path'))
+
+
+class TestSyncCanonical(unittest.TestCase):
+    def test_skips_when_dir_missing_git(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ok, msg = sync.sync_canonical(tmp)
+            self.assertFalse(ok)
+            self.assertIn('not a git repo', msg)
+
+
+class TestHookRouting(unittest.TestCase):
+    """Smoke test the hook's stdin -> behavior routing via subprocess."""
+
+    def _run(self, payload: dict, env: dict | None = None):
+        full_env = os.environ.copy()
+        full_env.update(env or {})
+        return subprocess.run(
+            [sys.executable, _HOOK_PATH],
+            input=json.dumps(payload),
+            capture_output=True, text=True, env=full_env, timeout=10,
+        )
+
+    def test_no_op_on_non_bash_tool(self):
+        result = self._run({"tool_name": "Read", "tool_input": {}})
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "")
+
+    def test_no_op_on_non_merge_command(self):
+        result = self._run({"tool_name": "Bash", "tool_input": {"command": "ls -la"}})
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "")
+
+    def test_skips_when_canonical_dir_missing(self):
+        with tempfile.TemporaryDirectory() as cwd:
+            subprocess.run(["git", "init", "-q", cwd], check=True)
+            subprocess.run(
+                ["git", "-C", cwd, "remote", "add", "origin",
+                 "git@github.com:testuser/ccgm.git"],
+                check=True,
+            )
+            with tempfile.TemporaryDirectory() as fake_home:
+                missing = os.path.join(fake_home, "no-such-dir")
+                result = self._run(
+                    {
+                        "tool_name": "Bash",
+                        "tool_input": {"command": "gh pr merge 1 --squash"},
+                        "cwd": cwd,
+                    },
+                    env={"CCGM_CANONICAL_DIR": missing},
+                )
+                self.assertEqual(result.returncode, 0)
+                self.assertIn("does not exist", result.stderr)
+
+    def test_skips_when_not_ccgm_repo(self):
+        with tempfile.TemporaryDirectory() as cwd:
+            subprocess.run(["git", "init", "-q", cwd], check=True)
+            subprocess.run(
+                ["git", "-C", cwd, "remote", "add", "origin",
+                 "git@github.com:someone/other-repo.git"],
+                check=True,
+            )
+            result = self._run(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "gh pr merge 1 --squash"},
+                    "cwd": cwd,
+                },
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- New PostToolUse:Bash hook (`sync-ccgm-canonical.py`) that fast-forwards the canonical CCGM clone (the symlink source for `~/.claude/`) after a CCGM PR merges, removing the manual sync step.
- Hook detects CCGM repos by remote name (`ccgm`), so no usernames are hardcoded.
- Canonical dir defaults to `~/code/ccgm`; override with `CCGM_CANONICAL_DIR`.
- 9 unit tests covering repo detection, missing canonical dir, non-merge commands, and non-CCGM repos.

Fixes the failure mode that produced today's 38-commit drift in `~/code/ccgm-repos/ccgm-1/`.

## Test plan

- [x] `python3 -m unittest modules.hooks.tests.test_sync_ccgm_canonical` — 9/9 pass
- [x] `bash tests/test-modules.sh` — 1111/1111 pass
- [x] `bash tests/test-no-personal-data.sh` — clean

Closes #457