### PR TITLE
#459: update install paths from ccgm-repos/ccgm-1 to ccgm

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Install CCGM (Claude Code God Mode) for me.
 Steps:
 1. Detect my OS (uname -s), shell ($SHELL), and home directory ($HOME).
 2. Clone the repo if it does not already exist:
-     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm-repos/ccgm-1
+     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm
    If it already exists, pull the latest main:
-     cd ~/code/ccgm-repos/ccgm-1 && git fetch origin && git checkout main && git pull --ff-only origin main
-3. Read the available presets: ls ~/code/ccgm-repos/ccgm-1/presets/
+     cd ~/code/ccgm && git fetch origin && git checkout main && git pull --ff-only origin main
+3. Read the available presets: ls ~/code/ccgm/presets/
    Available presets and what they include:
      - minimal  : global-claude-md, autonomy, git-workflow
      - standard : the above + identity, hooks, settings, commands-core, commands-utility
@@ -63,7 +63,7 @@ Steps:
 4. Check what is already installed by looking at ~/.claude/rules/, ~/.claude/commands/, ~/.claude/hooks/. List any CCGM files already present and note you will skip overwriting them.
 5. Read ~/.claude/settings.json if it exists and note its content. The installer will merge non-destructively — it will not delete keys that are already there.
 6. Run the installer:
-     cd ~/code/ccgm-repos/ccgm-1
+     cd ~/code/ccgm
      CCGM_NON_INTERACTIVE=1 \
        CCGM_USERNAME="$(gh api user --jq '.login' 2>/dev/null || echo '')" \
        ./start.sh --preset <chosen-preset>

--- a/docs/install-via-agent.md
+++ b/docs/install-via-agent.md
@@ -20,10 +20,10 @@ Install CCGM (Claude Code God Mode) for me.
 Steps:
 1. Detect my OS (uname -s), shell ($SHELL), and home directory ($HOME).
 2. Clone the repo if it does not already exist:
-     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm-repos/ccgm-1
+     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm
    If it already exists, pull the latest main:
-     cd ~/code/ccgm-repos/ccgm-1 && git fetch origin && git checkout main && git pull --ff-only origin main
-3. Read the available presets: ls ~/code/ccgm-repos/ccgm-1/presets/
+     cd ~/code/ccgm && git fetch origin && git checkout main && git pull --ff-only origin main
+3. Read the available presets: ls ~/code/ccgm/presets/
    Available presets and what they include:
      - minimal  : global-claude-md, autonomy, git-workflow
      - standard : the above + identity, hooks, settings, commands-core, commands-utility
@@ -34,7 +34,7 @@ Steps:
 4. Check what is already installed by looking at ~/.claude/rules/, ~/.claude/commands/, ~/.claude/hooks/. List any CCGM files already present and note you will skip overwriting them.
 5. Read ~/.claude/settings.json if it exists and note its content. The installer will merge non-destructively — it will not delete keys that are already there.
 6. Run the installer:
-     cd ~/code/ccgm-repos/ccgm-1
+     cd ~/code/ccgm
      CCGM_NON_INTERACTIVE=1 \
        CCGM_USERNAME="$(gh api user --jq '.login' 2>/dev/null || echo '')" \
        ./start.sh --preset <chosen-preset>
@@ -59,13 +59,13 @@ Install CCGM (Claude Code God Mode) with the minimal preset.
 Steps:
 1. Detect my OS (uname -s), shell ($SHELL), and home directory ($HOME).
 2. Clone the repo if it does not already exist:
-     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm-repos/ccgm-1
+     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm
    If it already exists, pull the latest main:
-     cd ~/code/ccgm-repos/ccgm-1 && git fetch origin && git checkout main && git pull --ff-only origin main
+     cd ~/code/ccgm && git fetch origin && git checkout main && git pull --ff-only origin main
 3. Check what is already installed: ls ~/.claude/rules/ ~/.claude/commands/ 2>/dev/null
 4. Read ~/.claude/settings.json if it exists and note its content.
 5. Run the installer:
-     cd ~/code/ccgm-repos/ccgm-1
+     cd ~/code/ccgm
      CCGM_NON_INTERACTIVE=1 \
        CCGM_USERNAME="$(gh api user --jq '.login' 2>/dev/null || echo '')" \
        ./start.sh --preset minimal
@@ -83,13 +83,13 @@ Install CCGM (Claude Code God Mode) with the standard preset.
 Steps:
 1. Detect my OS (uname -s), shell ($SHELL), and home directory ($HOME).
 2. Clone the repo if it does not already exist:
-     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm-repos/ccgm-1
+     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm
    If it already exists, pull the latest main:
-     cd ~/code/ccgm-repos/ccgm-1 && git fetch origin && git checkout main && git pull --ff-only origin main
+     cd ~/code/ccgm && git fetch origin && git checkout main && git pull --ff-only origin main
 3. Check what is already installed: ls ~/.claude/rules/ ~/.claude/commands/ 2>/dev/null
 4. Read ~/.claude/settings.json if it exists and note its content.
 5. Run the installer:
-     cd ~/code/ccgm-repos/ccgm-1
+     cd ~/code/ccgm
      CCGM_NON_INTERACTIVE=1 \
        CCGM_USERNAME="$(gh api user --jq '.login' 2>/dev/null || echo '')" \
        ./start.sh --preset standard
@@ -107,13 +107,13 @@ Install CCGM (Claude Code God Mode) with the team preset.
 Steps:
 1. Detect my OS (uname -s), shell ($SHELL), and home directory ($HOME).
 2. Clone the repo if it does not already exist:
-     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm-repos/ccgm-1
+     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm
    If it already exists, pull the latest main:
-     cd ~/code/ccgm-repos/ccgm-1 && git fetch origin && git checkout main && git pull --ff-only origin main
+     cd ~/code/ccgm && git fetch origin && git checkout main && git pull --ff-only origin main
 3. Check what is already installed: ls ~/.claude/rules/ ~/.claude/commands/ ~/.claude/hooks/ 2>/dev/null
 4. Read ~/.claude/settings.json if it exists and note its content.
 5. Run the installer:
-     cd ~/code/ccgm-repos/ccgm-1
+     cd ~/code/ccgm
      CCGM_NON_INTERACTIVE=1 \
        CCGM_USERNAME="$(gh api user --jq '.login' 2>/dev/null || echo '')" \
        ./start.sh --preset team
@@ -131,13 +131,13 @@ Install CCGM (Claude Code God Mode) with the cloud-agent preset.
 Steps:
 1. Detect my OS (uname -s), shell ($SHELL), and home directory ($HOME).
 2. Clone the repo if it does not already exist:
-     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm-repos/ccgm-1
+     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm
    If it already exists, pull the latest main:
-     cd ~/code/ccgm-repos/ccgm-1 && git fetch origin && git checkout main && git pull --ff-only origin main
+     cd ~/code/ccgm && git fetch origin && git checkout main && git pull --ff-only origin main
 3. Check what is already installed: ls ~/.claude/rules/ ~/.claude/commands/ ~/.claude/hooks/ ~/.claude/agents/ 2>/dev/null
 4. Read ~/.claude/settings.json if it exists and note its content.
 5. Run the installer:
-     cd ~/code/ccgm-repos/ccgm-1
+     cd ~/code/ccgm
      CCGM_NON_INTERACTIVE=1 \
        CCGM_USERNAME="$(gh api user --jq '.login' 2>/dev/null || echo '')" \
        ./start.sh --preset cloud-agent
@@ -155,13 +155,13 @@ Install CCGM (Claude Code God Mode) with the full preset (every stable module).
 Steps:
 1. Detect my OS (uname -s), shell ($SHELL), and home directory ($HOME).
 2. Clone the repo if it does not already exist:
-     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm-repos/ccgm-1
+     git clone https://github.com/lucasmccomb/ccgm.git ~/code/ccgm
    If it already exists, pull the latest main:
-     cd ~/code/ccgm-repos/ccgm-1 && git fetch origin && git checkout main && git pull --ff-only origin main
+     cd ~/code/ccgm && git fetch origin && git checkout main && git pull --ff-only origin main
 3. Check what is already installed: ls ~/.claude/rules/ ~/.claude/commands/ ~/.claude/hooks/ ~/.claude/agents/ 2>/dev/null
 4. Read ~/.claude/settings.json if it exists and note its content.
 5. Run the installer:
-     cd ~/code/ccgm-repos/ccgm-1
+     cd ~/code/ccgm
      CCGM_NON_INTERACTIVE=1 \
        CCGM_USERNAME="$(gh api user --jq '.login' 2>/dev/null || echo '')" \
        ./start.sh --preset full
@@ -197,7 +197,7 @@ Spin up a clean Linux VM or Docker container, install Claude Code, and paste the
 The paste-block runs `./start.sh --preset <name>`. You can test that step standalone without the agent scaffolding:
 
 ```bash
-cd ~/code/ccgm-repos/ccgm-1
+cd ~/code/ccgm
 CCGM_NON_INTERACTIVE=1 ./start.sh --preset minimal
 ```
 

--- a/modules/copycat/commands/copycat.md
+++ b/modules/copycat/commands/copycat.md
@@ -101,7 +101,7 @@ Read the current CCGM module list for comparison:
 
 ```bash
 # List all CCGM modules
-ls ~/code/ccgm-repos/ccgm-1/modules/ 2>/dev/null || ls modules/ 2>/dev/null
+ls ~/code/ccgm/modules/ 2>/dev/null || ls modules/ 2>/dev/null
 
 # List all CCGM rule files
 find ~/.claude/rules/ -name "*.md" 2>/dev/null | sort

--- a/modules/session-history/scripts/add-agents-md-symlinks.sh
+++ b/modules/session-history/scripts/add-agents-md-symlinks.sh
@@ -20,7 +20,7 @@ set -u
 CODE_DIR="${CODE_DIR:-$HOME/code}"
 
 DEFAULT_TARGETS=(
-  "$CODE_DIR/ccgm-repos/ccgm-1"
+  "$CODE_DIR/ccgm"
   "$CODE_DIR/voxstr-repos/voxstr-0"
   "$CODE_DIR/voxstr-site-repos/voxstr-site-0"
   "$CODE_DIR/habitpro-ai-workspaces/habitpro-ai-w0/habitpro-ai-w0-c0"

--- a/modules/youtube-transcripts/README.md
+++ b/modules/youtube-transcripts/README.md
@@ -28,7 +28,7 @@ This module installs:
 Install via the standard CCGM flow:
 
 ```bash
-cd ~/code/ccgm-repos/ccgm-1
+cd ~/code/ccgm
 ./start.sh
 # select youtube-transcripts in the module picker
 ```


### PR DESCRIPTION
## Summary

Cleanup follow-up to #457 (canonical clone at \`~/code/ccgm/\` with auto-sync). Updates docs and one script that still pointed users at the old \`~/code/ccgm-repos/ccgm-1/\` path.

Files updated:
- \`README.md\` — install instructions
- \`docs/install-via-agent.md\` — install instructions (multiple presets)
- \`modules/copycat/commands/copycat.md\` — fallback path
- \`modules/youtube-transcripts/README.md\` — cd path
- \`modules/session-history/scripts/add-agents-md-symlinks.sh\` — default target

Files deliberately not updated:
- \`modules/session-history/tests/test_repo_detect.py\`, \`scripts/repo_detect.py\` — example strings testing the flat-clone regex; other CCGM-managed repos still use the \`*-repos/*-N\` pattern
- \`modules/ccgm-doctor/{lib/doctor.py, README.md, tests/test_doctor.py}\` — comments explaining why doctor doesn't false-flag \`*-repos\` paths in fenced blocks

## Test plan

- [x] \`bash tests/test-modules.sh\` — 1111/1111 pass
- [x] \`bash tests/test-no-personal-data.sh\` — clean
- [x] \`git grep ccgm-repos/ccgm-1\` outside excluded files returns nothing

Closes #459