### PR TITLE
#467: tighten /sds Phase 8 + surface handoffs in /startup

### DIFF
--- a/modules/multi-agent/lib/handoff.py
+++ b/modules/multi-agent/lib/handoff.py
@@ -35,9 +35,11 @@ File format (markdown with YAML frontmatter):
 
 This module provides:
     write_handoff(body, repo, agent, ...): persist a handoff file
-    list_peer_handoffs(repo, this_agent, days=7): recent handoffs from OTHER agents
+    list_peer_handoffs(repo, this_agent, days=7, include_self=False): recent handoffs
+        (peers by default; pass include_self=True for self-continuity, e.g. /sds → /startup)
     prune_old_handoffs(repo=None, days=30): delete handoffs older than the window
-    summarize_for_startup(repo, this_agent, max_items=5): compact text block for context injection
+    summarize_for_startup(repo, this_agent, max_items=5, include_self=False): compact text
+        block for context injection
 
 Import-safe: stdlib only, no side effects at import time.
 """
@@ -134,10 +136,17 @@ def list_peer_handoffs(
     repo: str,
     this_agent: str,
     days: int = 7,
+    include_self: bool = False,
 ) -> list[dict]:
-    """Return recent handoffs for `repo` authored by agents OTHER than `this_agent`.
+    """Return recent handoffs for `repo`.
 
-    Each dict has: path, agent, timestamp, body (first ~60 lines).
+    By default, returns only handoffs from agents OTHER than `this_agent`
+    (the sibling-coordination case). Pass `include_self=True` to also include
+    handoffs written by `this_agent` itself — used for self-continuity flows
+    like /sds → /startup, where the writer wants the next session to see
+    what they handed off to "future-me".
+
+    Each dict has: path, agent, timestamp, body, is_self.
     Sorted newest-first.
     """
     repo_dir = _repo_dir(repo)
@@ -154,7 +163,8 @@ def list_peer_handoffs(
         ts, agent = parsed
         if ts < cutoff:
             continue
-        if agent == this_agent_safe:
+        is_self = agent == this_agent_safe
+        if is_self and not include_self:
             continue
         try:
             body = p.read_text()
@@ -165,6 +175,7 @@ def list_peer_handoffs(
             "agent": agent,
             "timestamp": ts,
             "body": body,
+            "is_self": is_self,
         })
     out.sort(key=lambda d: d["timestamp"], reverse=True)
     return out
@@ -207,28 +218,40 @@ def summarize_for_startup(
     max_items: int = 5,
     days: int = 7,
     body_lines: int = 4,
+    include_self: bool = False,
 ) -> str | None:
-    """Build a compact context block summarizing peer handoffs, or None if none.
+    """Build a compact context block summarizing handoffs, or None if none.
+
+    By default surfaces peer handoffs only (sibling coordination). Pass
+    `include_self=True` to also include the writer's own handoffs — needed
+    by self-continuity flows like /sds → /startup. Self entries are marked
+    `(you)` after the agent name so the source is unambiguous.
 
     Returns a string suitable for injecting into session context. Each entry
     shows agent, age, title (from frontmatter) or first heading, and the
     first `body_lines` of the body.
     """
-    peers = list_peer_handoffs(repo, this_agent, days=days)
-    if not peers:
+    items = list_peer_handoffs(repo, this_agent, days=days, include_self=include_self)
+    if not items:
         return None
 
-    peers = peers[:max_items]
+    items = items[:max_items]
     now = _ts_now()
-    lines = ["<peer-handoffs>", f"Recent handoffs from other {repo} clones (last {days}d):"]
-    for h in peers:
+    has_self = any(h.get("is_self") for h in items)
+    if include_self and has_self:
+        header = f"Recent {repo} handoffs (you + peers, last {days}d):"
+    else:
+        header = f"Recent handoffs from other {repo} clones (last {days}d):"
+    lines = ["<peer-handoffs>", header]
+    for h in items:
         age = now - h["timestamp"]
         age_str = _human_age(age)
         fm, rest = _split_frontmatter(h["body"])
         title = fm.get("title") or _first_heading(rest) or "(no title)"
         preview = _first_lines(rest, body_lines)
+        self_marker = " (you)" if h.get("is_self") else ""
         lines.append(f"")
-        lines.append(f"- **{h['agent']}** ({age_str}): {title}")
+        lines.append(f"- **{h['agent']}{self_marker}** ({age_str}): {title}")
         if preview:
             for pl in preview.splitlines():
                 lines.append(f"  {pl}")
@@ -453,7 +476,13 @@ def _cli_summary(args) -> int:
     if not repo:
         return 0
     agent = args.agent or detect_agent()
-    s = summarize_for_startup(repo, agent, max_items=args.max, days=args.days)
+    s = summarize_for_startup(
+        repo,
+        agent,
+        max_items=args.max,
+        days=args.days,
+        include_self=getattr(args, "include_self", False),
+    )
     if s:
         print(s)
     return 0
@@ -497,6 +526,11 @@ def main(argv: list[str] | None = None) -> int:
     su.add_argument("--agent")
     su.add_argument("--days", type=int, default=7)
     su.add_argument("--max", type=int, default=5)
+    su.add_argument(
+        "--include-self",
+        action="store_true",
+        help="Include handoffs written by the current agent (self-continuity, e.g. /sds → /startup)",
+    )
     su.set_defaults(func=_cli_summary)
 
     # Default subcommand: write

--- a/modules/session-lifecycle/commands/sds.md
+++ b/modules/session-lifecycle/commands/sds.md
@@ -178,6 +178,8 @@ Sibling state:
 Next: <one line — "exiting session now" or "consider running /sds in dirty sibling X">
 ```
 
+The status lines stop at Phase 6 by design. Do NOT add a "Phase 7 — Summary:" or "Phase 8 — Exit:" line — Phase 7 IS this summary text, and Phase 8 IS the kill tool call that follows it. They are not items inside the report; they are the report and what happens after it.
+
 ### Phase 8 — Exit the session
 
 This is the terminal action of `/sds`. Skip entirely if `--no-exit` or `--dry-run` was passed.
@@ -188,7 +190,9 @@ kill -TERM $PPID
 
 `$PPID` from inside the Bash tool resolves to the parent `claude` process. SIGTERM gives it a chance to flush transcripts and run `SessionEnd` hooks before dying — equivalent to the user typing `/exit`.
 
-**Order matters**: render the Phase 7 summary as plain text in your response FIRST, then issue the kill as your final tool call. If you bundle the summary into a heredoc inside the kill command, the user will not see it before the process dies. If the kill bash call returns at all (race condition), do not print anything further — the session is going down regardless.
+**No narration between Phase 7 and the kill.** After the Phase 7 summary's "Next:" line, the next thing in your output MUST be the Bash tool call running `kill -TERM $PPID`. Do not print a "Phase 8 — Exit:" header, do not print "Exiting now" or any farewell, do not bundle the summary into a heredoc inside the kill command. The Phase 7 summary is the last text the user sees; the kill is the last tool call. If you find yourself about to type anything after the "Next:" line, stop and issue the kill instead.
+
+If the kill bash call returns at all (race condition), do not print anything further — the session is going down regardless.
 
 If `--no-exit` was passed, replace the kill with a one-line text reminder: `Run /exit when ready.`
 

--- a/modules/startup-dashboard/lib/startup-gather.sh
+++ b/modules/startup-dashboard/lib/startup-gather.sh
@@ -169,6 +169,18 @@ fi
   python3 ~/.claude/hooks/orphan-process-check.py 2>/dev/null || true
 ) > "$TMPDIR/orphans" 2>/dev/null &
 
+# 6b. Recent handoffs (peer + self, last 3d)
+# Surfaces handoffs the previous session wrote via /sds or /handoff so the
+# next /startup picks them up. --include-self covers the /sds → /startup
+# self-continuity case; peer handoffs from sibling clones come along too.
+(
+  if [ -z "$REPO_NAME" ] || [ "$REPO_NAME" = "unknown" ]; then
+    exit 0
+  fi
+  python3 ~/.claude/lib/handoff.py summary \
+    --repo "$REPO_NAME" --include-self --max 3 --days 3 2>/dev/null || true
+) > "$TMPDIR/handoffs" 2>/dev/null &
+
 # 7. Release check
 (
   CURRENT=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
@@ -263,6 +275,9 @@ $(cat "$TMPDIR/sessions")
 
 === SIBLINGS ===
 $(cat "$TMPDIR/siblings")
+
+=== HANDOFFS ===
+$(cat "$TMPDIR/handoffs")
 
 === ORPHANS ===
 $(cat "$TMPDIR/orphans")

--- a/modules/startup-dashboard/lib/startup-summary-prompt.md
+++ b/modules/startup-dashboard/lib/startup-summary-prompt.md
@@ -19,6 +19,15 @@ Where we are
 - 1-2 lines. Branch state, dirty/clean, sync with main. In workspace mode,
   name the clones and their branches compactly on one line.
 
+Last handoff
+- One bullet per recent handoff from the HANDOFFS section: "agent (age) — title".
+  Mark self-authored entries with "(you)" preserved from the HANDOFFS data —
+  these are notes the previous session in this clone wrote for "future-me"
+  (e.g., from /sds), so prioritize surfacing them.
+- If a handoff entry has a "What's next" line, indent it as a sub-bullet
+  beneath the entry so the next action is visible at a glance.
+- OMIT this section entirely if HANDOFFS is empty or missing.
+
 Recent activity (last 48h)
 - 3-5 bullets summarizing the RECENT_MERGES section. Group related PRs by
   theme when possible (e.g., "Cleanup wave across X, Y, Z — #540, #539, #538").
@@ -38,11 +47,13 @@ Live sessions
 
 Next up
 - ONE concrete, grounded action. Priority order:
-  1. open PR to review (name it: "Review PR #X")
-  2. dirty working tree (clone mode)
-  3. dirty clones (workspace mode — name them)
-  4. top unclaimed issue (name it: "Pick up #X: title")
-  5. generic: "Pick a task."
+  1. self-handoff "What's next" (HANDOFFS marked "(you)" — the previous
+     session in this clone left a concrete next step; honor it)
+  2. open PR to review (name it: "Review PR #X")
+  3. dirty working tree (clone mode)
+  4. dirty clones (workspace mode — name them)
+  5. top unclaimed issue (name it: "Pick up #X: title")
+  6. generic: "Pick a task."
 ```
 
 ## Rules


### PR DESCRIPTION
Closes #467.

Three coupled bugs surfaced by the first live `/sds` dogfood run after #464 shipped:

## 1. sds.md Phase 8 — narration before kill

The agent printed `Phase 8 — Exit:` as a status header before firing `kill -TERM $PPID`, leaving stale text and a hung `Bash(kill -TERM $PPID)` call (the call doesn't return because the parent process dies). The Phase 7 summary template stops at Phase 6 by design — Phases 7 and 8 ARE the summary text and the kill, not items in the report — but that intent wasn't stated. Phase 8's "Order matters" note was also permissive about post-summary text.

**Fix**: Phase 7 now explicitly says "do NOT add a Phase 7 or Phase 8 line". Phase 8 now reads "No narration between Phase 7 and the kill — after the Next: line, the next thing in your output MUST be the Bash tool call running `kill -TERM $PPID`."

## 2. handoff.py — same-agent filter blocks self-continuity

`list_peer_handoffs()` unconditionally skipped entries where `agent == this_agent_safe`. Built for sibling-clone coordination; broke `/sds` writing a handoff for "future-me" in the same clone.

**Fix**: Added `include_self: bool = False` to `list_peer_handoffs()` and `summarize_for_startup()`. Default behavior preserved (peer-only). Self entries are marked `(you)` after the agent name in rendered output, so the source is unambiguous. CLI gains `--include-self` on the `summary` subcommand. Smoke-tested:

```
$ python3 ~/.../handoff.py summary --repo ccgm --include-self --max 3 --days 7
<peer-handoffs>
Recent ccgm handoffs (you + peers, last 7d):

- **agent-w0-c0 (you)** (26m ago): Designed and shipped /sds + caught docs up
  ...
```

## 3. startup-gather.sh — no HANDOFFS section

Even with Fix 2, the `/startup` pipeline never read handoffs. The 13 gather sections (IDENTITY, GIT, CLONES, ..., PRIORITY_ISSUES) had no HANDOFFS.

**Fix**: New parallel job in `startup-gather.sh` calls `handoff.py summary --include-self --max 3 --days 3`. New `=== HANDOFFS ===` section emitted between SIBLINGS and ORPHANS. `startup-summary-prompt.md` gains a `Last handoff` section in the output format (between "Where we are" and "Recent activity") and promotes the self-handoff "What's next" to priority 1 in `Next up` — so `/sds`'s last instruction to "future-me" becomes the next session's first action.

## Files

- `modules/session-lifecycle/commands/sds.md` — Phase 7/8 wording
- `modules/multi-agent/lib/handoff.py` — `include_self` param + CLI flag (backwards-compatible)
- `modules/startup-dashboard/lib/startup-gather.sh` — new HANDOFFS section
- `modules/startup-dashboard/lib/startup-summary-prompt.md` — Last handoff + Next up priority

## Out of scope

- `CCGM_AUTO_STARTUP` is not set in `~/.claude/.ccgm.env`, so the SessionStart auto-injection hook stays dormant. These fixes make `/startup` surface handoffs without relying on that hook. Enabling the hook is a separate decision.

## Test plan

- [x] `python3 modules/multi-agent/lib/handoff.py summary --help` shows `--include-self`
- [x] `--include-self` surfaces self entries with `(you)` marker; default omits them
- [x] `bash -n` syntax check passes for `startup-gather.sh`
- [x] Module signatures: `list_peer_handoffs(...include_self: bool = False)`, `summarize_for_startup(...include_self: bool = False)`
- [ ] Post-merge: canonical sync hook copies updated files; next `/sds` from any clone followed by `/startup` shows the handoff in the dashboard