### PR TITLE
#469: post-merge docupdate after #468

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -902,6 +902,33 @@ Runs on demand at the start of a session. Prints a plain-text dashboard with eve
 
 ---
 
+### /sds
+
+**Session shutdown sequence — autonomous end-of-session wrap-up.**
+
+Bookend to `/startup`. Composes existing primitives instead of duplicating them.
+
+**What it does** (8 phases):
+1. Detects agent identity and sibling state via `sds-broadcast.sh`
+2. Checks for active background tasks (TaskList); waits or asks if stalled
+3. Commits dirty work as a WIP commit and pushes (feature branches only; asks on `main`)
+4. Comments on referenced issues with a session summary; auto-closes only when a merged PR's body has `closes/fixes/resolves #N`
+5. Runs `/reflect` inline to capture learnings via `ccgm-learnings-log`
+6. Writes a handoff via `handoff.py write` (auto-picked up by the next `/startup` thanks to the HANDOFFS section)
+7. Appends a `session-ended` event to `~/.claude/sessions/{repo}/events.jsonl` and reports sibling state
+8. Prints a one-screen summary, then exits the session with `kill -TERM $PPID`
+
+**Usage**:
+```
+/sds              Run the full shutdown sequence and exit the session
+/sds --no-exit    Run the wrap-up but leave the session open
+/sds --dry-run    Show what would happen without doing anything (implies --no-exit)
+```
+
+**Installed by**: session-lifecycle module
+
+---
+
 ## Remote server commands
 
 Installed by the **remote-server** module.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -434,7 +434,7 @@ Issue-first workflow, PR conventions, label taxonomy, and code review standards.
 
 Plain-text `/startup` dashboard for Claude Code sessions.
 
-**Installs**: `commands/startup.md`, `lib/startup-gather.sh`, `lib/startup-dashboard.sh`
+**Installs**: `commands/startup.md`, `lib/startup-gather.sh`, `lib/startup-summary.sh`, `lib/startup-summary-prompt.md`, `lib/startup-dashboard.sh`, `hooks/auto-startup.py`
 
 **What it does**: Emits a single-screen dashboard at session start:
 
@@ -442,6 +442,7 @@ Plain-text `/startup` dashboard for Claude Code sessions.
 - **Live sessions**: other Claude Code processes on the machine
 - **Open PRs and tracking.csv claims** for the current repo
 - **Sibling branches** across clones in the same workspace
+- **Last handoff**: recent handoffs from peer clones (and from the same clone's previous `/sds` run, marked `(you)`) so the next session picks up where the last one stopped
 - **Recent activity**: last 7 days of session transcripts across every clone of the repo, powered by the `session-history` module's `/recall`
 - **Update banner** when a new Claude Code release is available
 
@@ -457,7 +458,7 @@ There are no agent-discipline logging rules, no log repo writes, and no triggers
 
 Multi-clone architecture for running multiple Claude agents in parallel on the same repo.
 
-**Installs**: `rules/multi-agent.md`, `multi-agent-system.md` (reference doc), `commands/mawf.md`, `commands/workspace-setup.md`, `port-registry.json`
+**Installs**: `rules/multi-agent.md`, `multi-agent-system.md` (reference doc), `commands/mawf.md`, `commands/workspace-setup.md`, `commands/handoff.md`, `lib/handoff.py`, `port-registry.json`
 
 **What it does**: Enables parallel development with multiple Claude Code instances:
 

--- a/modules/startup-dashboard/README.md
+++ b/modules/startup-dashboard/README.md
@@ -12,6 +12,7 @@ work on next. Deterministic data gather + model-powered summarization.
   Next up.
 - **Gather pipeline**: collects git state, open PRs, 48h merges, priority
   issues, `tracking.csv` claims, live Claude Code sessions, sibling branches,
+  recent handoffs (peer + self via `handoff.py summary --include-self`),
   orphan processes, release info, and recent session activity in parallel.
 - **Recent Activity**: unified 7-day view of session transcripts across every
   clone of the current repo, powered by the `session-history` module's `/recall`.


### PR DESCRIPTION
Closes #469.

Routine post-merge documentation pass after #468 (the /sds + /startup handoff plumbing fix). Surfaced four gaps — two introduced by #468, two pre-existing from #464 that the prior docupdate (#466) missed.

## Changes

| File | Section | What changed |
|---|---|---|
| \`docs/commands.md\` | Workflow commands | New \`/sds\` section under \`/startup\` (was completely missing) |
| \`docs/modules.md\` | startup-dashboard | Installs list extended from 3 to 6 files; "Last handoff" added to "What it does" |
| \`docs/modules.md\` | multi-agent | Installs list now lists \`commands/handoff.md\` and \`lib/handoff.py\` |
| \`modules/startup-dashboard/README.md\` | Module overview | Gather pipeline bullet now mentions handoffs |

## Out of scope

\`modules/multi-agent/tests/test_handoff.py\` needs new cases for the \`include_self=True\` path added in #468. Tests aren't documentation; logged here so it isn't forgotten but not done in this PR.

## Test plan

- [x] /sds section follows the same format as /startup, /handoff, and other Workflow commands in docs/commands.md
- [x] Installs lists for startup-dashboard and multi-agent match the actual files in their module.json manifests
- [x] No anchor links / TOC entries broken (commands.md has no TOC; modules.md has no per-module anchor index)