### PR TITLE
#471: /cpm merges with --admin by default; symlink Read note in repo CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,18 @@ bash tests/test-installer.sh
 5. Add to relevant presets in `presets/`
 6. Run tests
 
+### Editing Module Files via Symlinks
+
+CCGM module files are installed at `~/.claude/{commands,lib,hooks,rules}/` as **symlinks** pointing at `~/code/ccgm/modules/.../`. The Edit tool tracks reads by absolute path and does NOT follow symlinks — reading an installed copy does not satisfy Edit's read-gate for the workspace source path.
+
+When editing a module file from a workspace clone:
+
+- Source (edit here): `modules/{name}/.../file` under the current workspace clone
+- Installed symlink: `~/.claude/lib/file.py` or similar — fine to Read for inspection, but does NOT count toward the Edit gate for the workspace source path
+- Canonical clone: `~/code/ccgm/modules/...` — same: do not edit here, do not rely on its read state
+
+Habit: always Read the workspace `modules/` path before any Edit, even if you read the installed copy first.
+
 ## Commit Message Format
 
 ```

--- a/modules/commands-core/commands/cpm.md
+++ b/modules/commands-core/commands/cpm.md
@@ -133,13 +133,15 @@ Closes #{issue_number}"
 
 ### 8. Merge the PR
 
-Wait briefly for any fast CI checks, then merge:
+Merge immediately with admin bypass — do not wait for GitHub Actions:
 
 ```bash
-gh pr merge --squash --delete-branch
+gh pr merge --squash --delete-branch --admin
 ```
 
-If merge fails (CI required, review required), report the blocker and stop. The user may need to adjust repo settings or wait for CI.
+Local pre-push verification (lint + type-check + tests + build) is the source of truth. Remote CI is best-effort: Actions minutes budget runs out, runners stall, queues back up — none of those are reasons to block a merge. `--admin` bypasses the BLOCKED state from "checks pending" or "no required reviewer present" when you ARE the repo admin. It does NOT force-merge through an actually-FAILED check; if a check is in FAILURE state (not PENDING), stop and investigate — local pre-push should have caught it.
+
+If `--admin` itself fails — merge conflict, missing PR, you are not the admin in this repo — report and stop. Do not retry the same command; investigate the cause.
 
 ### 9. Close the Issue
 

--- a/modules/commands-core/skills/cpm/SKILL.md
+++ b/modules/commands-core/skills/cpm/SKILL.md
@@ -41,8 +41,11 @@ If there are no changes and no unpushed commits, stop and report "Nothing to com
 
 ### Phase 4: Merge
 
-1. Merge the PR: `gh pr merge --squash --delete-branch`
+1. Merge with admin bypass so you do not wait on GitHub Actions:
+   `gh pr merge --squash --delete-branch --admin`
 2. Confirm the merge succeeded.
+
+Local pre-push verification is the source of truth. Remote Actions stall, run out of budget, and queue — those are not reasons to block a merge. `--admin` bypasses the BLOCKED state caused by "checks pending" or "no required reviewer present" when you are the repo admin. It does NOT force-merge through an actually-FAILED check; a FAILURE check (not PENDING) means local verification missed something — stop and investigate, do not retry with `--admin`.
 
 ### Phase 5: Close Issue
 
@@ -73,6 +76,7 @@ Output a summary in this format:
 
 ## Error Handling
 
-- If `gh pr merge` fails (e.g., checks pending), report the failure and the PR URL. Do not force merge.
+- If `gh pr merge --admin` fails for a real reason — merge conflict, missing PR, you are not the admin in this repo, a check in FAILURE state — report and stop. Do not retry the same command; investigate the cause.
+- A FAILURE check (not PENDING) is the one signal that should block a merge. Pre-push verification should have caught it. If a remote check disagrees with local, investigate before merging.
 - If `git pull --ff-only` fails, fall back to `git fetch origin && git reset --hard origin/main`.
 - If any step fails, stop and report what succeeded and what failed.


### PR DESCRIPTION
Closes #471.

Two preventive fixes for stumbles surfaced while merging #468 and #470.

## 1. /cpm now merges with --admin by default

\`/cpm\` will now run \`gh pr merge --squash --delete-branch --admin\` as the default merge command in both \`commands-core/commands/cpm.md\` (Step 8) and \`commands-core/skills/cpm/SKILL.md\` (Phase 4 + Error Handling). The prior wording told the agent to wait for CI / stop on BLOCKED — which is wrong for this workflow.

**Why**:
- Local pre-push verification (lint + type-check + tests + build, enforced globally by the code-quality rule) is the authoritative gate.
- GitHub Actions is best-effort: minutes budget runs out, runners stall, queues back up. None of those are reasons to block a merge.
- Recent ccgm PRs (#464, #466, #468, #470) all needed \`--admin\` manually. Making it the default removes the stumble.

**Important: \`--admin\` is not a force-merge through failing checks.** A check in FAILURE state (not PENDING) still stops the merge — that means local verification missed something and warrants investigation. \`--admin\` only bypasses the BLOCKED state from "checks pending" or "no required reviewer present" when you are the repo admin. The wording explicitly distinguishes the two.

## 2. Symlink Read-before-Edit note in repo CLAUDE.md

New section "Editing Module Files via Symlinks" under "Key Rules" in the repo CLAUDE.md.

The Edit tool tracks reads by absolute path and does not follow symlinks. Reading \`~/.claude/lib/handoff.py\` does not satisfy Edit's read-gate for \`~/code/ccgm-workspaces/.../modules/multi-agent/lib/handoff.py\` — they are different absolute paths. Burned 7 wasted Edit calls on #468 before realizing this. The new rule says: always Read the workspace \`modules/\` path before any Edit.

## Out of scope

- \`modules/git-workflow/rules/git-workflow.md\` has no "wait for CI before merging" directive (its merge content is about rebase-vs-merge). No change needed.
- \`modules/hooks/hooks/enforce-git-workflow.py\` blocks raw \`git push --force\` / \`--no-verify\` but does not interact with \`gh pr merge --admin\` (different command surface). Both behaviors are correct and unchanged.
- \`modules/rule-authoring/rules/pressure-testing.md\` includes a pressure-test example whose correct answer is "C: don't merge with --admin" — but that scenario is about a different failure mode (flaky failing test, not budget-exhausted CI). Educational content, not policy. Unchanged.

## Test plan

- [x] /cpm command file shows --admin in Step 8 plus rationale on what it does and doesn't bypass
- [x] /cpm SKILL.md shows --admin in Phase 4 plus updated Error Handling that distinguishes FAILURE from PENDING
- [x] CLAUDE.md gains an "Editing Module Files via Symlinks" section under Key Rules
- [ ] This PR itself merges via \`gh pr merge --admin\` (the new default; same command that merged the four preceding PRs)