### PR TITLE
#473: shared hook_utils.py + sched_platform.py + bypass-mode classification

### DIFF
--- a/modules/hooks/hooks/auto-approve-bash.py
+++ b/modules/hooks/hooks/auto-approve-bash.py
@@ -2,6 +2,15 @@
 """
 PreToolUse hook that enforces Bash permissions from settings.json.
 
+Classification (plan.md §5 Epic 1): bypass-suppressible for allow/deny pattern
+matching; smart-rules block runs OUTSIDE the bypass short-circuit so the
+destructive-reset rule survives bypass mode via `hook_utils.hard_block()`.
+
+Execution order in main():
+  1. smart-rules (always run; destructive-reset → hard_block, bypass-proof)
+  2. bypass-mode short-circuit (exit 0)
+  3. settings.json allow/deny pattern matching
+
 This hook exists because Claude Code's built-in permission system has bugs:
 - Issue #15921: VSCode extension ignores Bash permissions
 - Issue #13340: Piped commands bypass permission allowlist
@@ -15,6 +24,9 @@ import os
 import re
 import sys
 from pathlib import Path
+
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
 
 # Settings file locations in precedence order (highest first)
 SETTINGS_FILES = [
@@ -78,11 +90,14 @@ def pattern_matches_command(pattern: str, command: str) -> bool:
 def check_smart_rules(command: str) -> tuple[str | None, str | None]:
     """
     Context-aware rules for commands that are safe in some forms but dangerous in others.
-    These run BEFORE the settings.json deny/allow patterns.
+    These run BEFORE settings.json patterns AND before the bypass-mode short-circuit.
 
-    Returns: (decision, reason) or (None, None) to fall through to pattern matching.
+    Returns: (decision, reason) where decision is:
+      - "allow": auto-approve (e.g. reset to a remote ref)
+      - "hard_block": destroy-loca-history pattern; main() promotes to hard_block()
+      - None: fall through to bypass / pattern matching
     """
-    # git reset --hard: allow when targeting a remote ref, block otherwise
+    # git reset --hard: allow when targeting a remote ref, hard-block otherwise.
     # Safe: git reset --hard origin/main, git reset --hard origin/development
     # Dangerous: git reset --hard (bare), git reset --hard HEAD~3, git reset --hard <local-ref>
     reset_match = re.search(r'\bgit\s+reset\s+--hard\b', command)
@@ -92,23 +107,25 @@ def check_smart_rules(command: str) -> tuple[str | None, str | None]:
         # Also allow git -C <path> reset --hard origin/
         if re.search(r'\bgit\s+-C\s+\S+\s+reset\s+--hard\s+origin/', command):
             return ("allow", "git reset --hard to remote ref in subdir (safe)")
-        return ("deny", "git reset --hard without remote ref is blocked. Use 'git reset --hard origin/<branch>' to reset to a remote ref, or 'git pull --ff-only' to sync.")
+        return (
+            "hard_block",
+            "git reset --hard without remote ref is blocked. "
+            "Use 'git reset --hard origin/<branch>' to reset to a remote ref, "
+            "or 'git pull --ff-only' to sync.",
+        )
 
     return (None, None)
 
 
-def check_command(command: str, allow_patterns: list[str], deny_patterns: list[str]) -> tuple[str | None, str | None]:
+def check_pattern_decision(command: str, allow_patterns: list[str], deny_patterns: list[str]) -> tuple[str | None, str | None]:
     """
-    Check if a command should be allowed or denied.
+    Allow/deny decision from settings.json patterns.
 
-    Returns: (decision, reason)
-        decision: "allow", "deny", or None (let default system handle)
+    Smart-rules are NOT consulted here — main() runs them first so the
+    destructive-reset hard_block fires bypass-proof.
+
+    Returns: (decision, reason) where decision is "allow", "deny", or None.
     """
-    # Smart context-aware rules run first (before pattern matching)
-    decision, reason = check_smart_rules(command)
-    if decision:
-        return (decision, reason)
-
     # Check deny patterns first (deny takes priority)
     for pattern in deny_patterns:
         if pattern_matches_command(pattern, command):
@@ -119,15 +136,11 @@ def check_command(command: str, allow_patterns: list[str], deny_patterns: list[s
         if pattern_matches_command(pattern, command):
             return ("allow", f"Command matches allow pattern: {pattern}")
 
-    # No match - let the default permission system handle it
-    # Return None to not output anything and exit 0
     return (None, None)
 
+
 def main() -> None:
-    try:
-        input_data = json.load(sys.stdin)
-    except json.JSONDecodeError:
-        sys.exit(0)  # Non-blocking exit on invalid input
+    input_data = hook_utils.read_hook_input()
 
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
@@ -140,21 +153,27 @@ def main() -> None:
     if not command:
         sys.exit(0)
 
-    # Load patterns from settings
-    allow_patterns, deny_patterns = load_settings()
+    # 1. Smart-rules run first and OUTSIDE the bypass short-circuit so
+    #    destructive-reset hard-blocks even in bypass mode.
+    smart_decision, smart_reason = check_smart_rules(command)
+    if smart_decision == "hard_block":
+        hook_utils.hard_block(smart_reason or "destructive smart-rule matched")
+    if smart_decision == "allow":
+        hook_utils.emit_decision("allow", smart_reason or "smart-rule allow")
+    # "deny" via smart-rule is unused now (legacy path).
 
-    # Check the command
-    decision, reason = check_command(command, allow_patterns, deny_patterns)
+    # 2. Bypass mode: skip pattern matching. The session has opted out
+    #    of permission noise, and smart-rule hard-blocks have already
+    #    fired for the genuinely dangerous cases.
+    if hook_utils.is_bypass_mode(input_data):
+        sys.exit(0)
+
+    # 3. Pattern matching against settings.json allow/deny lists.
+    allow_patterns, deny_patterns = load_settings()
+    decision, reason = check_pattern_decision(command, allow_patterns, deny_patterns)
 
     if decision:
-        output = {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": decision,
-                "permissionDecisionReason": reason
-            }
-        }
-        print(json.dumps(output))
+        hook_utils.emit_decision(decision, reason or "")
 
     sys.exit(0)
 

--- a/modules/hooks/hooks/check-careful.py
+++ b/modules/hooks/hooks/check-careful.py
@@ -2,11 +2,19 @@
 """
 PreToolUse hook that pauses on destructive Bash commands.
 
-Inspects Bash commands and returns permissionDecision:"ask" with a warning for
-destructive patterns that commonly cause data loss or history destruction:
+Classification (plan.md §5 Epic 1): bypass-suppressible. In bypass-mode
+sessions (bypassPermissions / dontAsk / auto) the routine "ask" decisions
+short-circuit to exit 0 — the user already opted out of permission noise.
+
+The exception is force-push-to-`main`: that case is migrated to
+`hook_utils.hard_block()` so it survives bypass mode. Pushing over a
+protected branch's history is the kind of destructive op `ALLOW_MAIN_COMMIT`
+exists to gate, not a permission-noise prompt.
+
+Inspects Bash commands for destructive patterns:
   - rm -rf (with smart whitelist for build artifacts)
   - SQL DROP / TRUNCATE
-  - git push --force (and --force-with-lease)
+  - git push --force (and --force-with-lease) — escalates to hard_block on `main`
   - git reset --hard (history destroying)
   - git checkout . (dirty discard)
   - kubectl delete
@@ -21,9 +29,12 @@ hook style (JSON stdin/stdout, consistent with auto-approve-bash.py).
 """
 from __future__ import annotations
 
-import json
+import os
 import re
 import sys
+
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
 
 # Build-artifact directory names that are safe to `rm -rf` without asking.
 # If every path on an rm -rf line matches one of these (exactly or as a
@@ -147,14 +158,34 @@ def check_careful(command: str) -> tuple[bool, str]:
     return (False, "")
 
 
-def main() -> None:
-    try:
-        input_data = json.load(sys.stdin)
-    except json.JSONDecodeError:
-        sys.exit(0)
+def _is_force_push_to_main(command: str) -> bool:
+    """Specifically: `git push --force[-f|--force-with-lease] ... main` (and refs that resolve to it).
 
-    tool_name = input_data.get("tool_name", "")
-    tool_input = input_data.get("tool_input", {})
+    Distinct from `_is_force_push_to_branch` because main is the one branch
+    a bypass-mode session should NOT be able to overwrite without an explicit
+    `ALLOW_MAIN_COMMIT=1` escape hatch.
+    """
+    if not re.search(r"\bgit\s+push\b", command):
+        return False
+    if not re.search(r"(--force\b|--force-with-lease\b|\s-f\b)", command):
+        return False
+    # Match: git push --force origin main, git push -f origin main,
+    # git push --force-with-lease origin main, git push origin +main,
+    # git push origin HEAD:main, git push origin main:main, etc.
+    if re.search(r"\b(origin\s+\+?main\b|main:main\b|HEAD:main\b|\s\+main\b)", command):
+        return True
+    # `git push --force` with no remote/refspec defaults to current branch.
+    # Catch that when the current branch is main via env var, but the
+    # hook can't reliably know the branch — leave that case to
+    # enforce-git-workflow.py which DOES read the branch.
+    return False
+
+
+def main() -> None:
+    data = hook_utils.read_hook_input()
+
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
 
     if tool_name != "Bash":
         sys.exit(0)
@@ -163,19 +194,26 @@ def main() -> None:
     if not command:
         sys.exit(0)
 
+    # Bypass-proof: force-push to main is a hard block regardless of mode.
+    # `ALLOW_MAIN_COMMIT=1` opens the explicit emergency channel.
+    if _is_force_push_to_main(command) and os.environ.get("ALLOW_MAIN_COMMIT") != "1":
+        hook_utils.hard_block(
+            "BLOCKED: force-pushing to `main` overwrites shared history. "
+            "If this is truly intended (recovering from a bad merge, etc.), "
+            "re-run with `ALLOW_MAIN_COMMIT=1` set."
+        )
+
     is_destructive, reason = check_careful(command)
     if not is_destructive:
         sys.exit(0)
 
-    output = {
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "ask",
-            "permissionDecisionReason": reason,
-        }
-    }
-    print(json.dumps(output))
-    sys.exit(0)
+    # In bypass mode the user has explicitly opted out of permission noise.
+    # Routine `ask` decisions are suppressed; the hard-block path above
+    # still fires for genuinely dangerous ops.
+    if hook_utils.is_bypass_mode(data):
+        sys.exit(0)
+
+    hook_utils.emit_decision("ask", reason)
 
 
 if __name__ == "__main__":

--- a/modules/hooks/hooks/check-migration-timestamps.py
+++ b/modules/hooks/hooks/check-migration-timestamps.py
@@ -2,10 +2,14 @@
 """
 PreToolUse:Bash hook to prevent duplicate Supabase migration timestamps.
 
-BLOCKS git commit when migration files have duplicate numeric prefixes.
-Duplicate timestamps break `supabase db push` because the CLI can't distinguish
-files that share the same timestamp - one gets applied and the other gets stuck
-as "local only" permanently.
+Classification (plan.md §5 Epic 1): bypass-retained. This is a data-integrity
+check, not permission noise — a duplicate timestamp leaves a migration
+permanently stuck as "local only" in Supabase, which is hard to recover from.
+Block uses `hook_utils.hard_block()` so it survives bypass mode.
+
+BLOCKS git commit (via hard_block, bypass-proof) when migration files have
+duplicate numeric prefixes. Duplicate timestamps break `supabase db push`
+because the CLI cannot distinguish files that share the same timestamp.
 
 Only runs when:
 1. The command is a git commit
@@ -14,19 +18,17 @@ Only runs when:
 
 from __future__ import annotations
 
-import json
 import os
 import re
-import subprocess
 import sys
 from collections import Counter
 
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
+
 
 def main() -> None:
-    try:
-        data = json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
-        return
+    data = hook_utils.read_hook_input()
 
     # Only handle Bash commands
     if data.get("tool_name", "") != "Bash":
@@ -85,13 +87,7 @@ def main() -> None:
         "(e.g., 20260325900000 -> 20260325900001)."
     )
 
-    json.dump({
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
-            "permissionDecisionReason": error_msg
-        }
-    }, sys.stdout)
+    hook_utils.hard_block(error_msg)
 
 
 if __name__ == "__main__":

--- a/modules/hooks/hooks/enforce-git-workflow.py
+++ b/modules/hooks/hooks/enforce-git-workflow.py
@@ -2,7 +2,12 @@
 """
 PreToolUse:Bash hook to enforce GitHub Issues workflow.
 
-BLOCKS:
+Classification (plan.md §5 Epic 1): bypass-retained. Protected-branch
+protections are NOT permission noise — they are the workflow contract.
+`deny()` migrated to `hook_utils.hard_block()` (exit 2) so the rules
+survive bypass mode. `ALLOW_MAIN_COMMIT=1` is the explicit escape hatch.
+
+BLOCKS (via hard_block, bypass-proof):
 1. Commits on protected branches (must use feature branch)
 2. Commit messages without issue number prefix (^#\d+:)
 3. Direct pushes to protected branches (must use PR workflow)
@@ -21,6 +26,9 @@ import os
 import re
 import subprocess
 import sys
+
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
 
 # ─── Protected branches ──────────────────────────────────────────────
 # Any branch matching one of these names (case-insensitive) is blocked
@@ -175,16 +183,14 @@ def validate_commit_message_format(message: str | None) -> bool:
 
 
 def deny(reason: str) -> None:
-    """Return a deny decision."""
-    output = {
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
-            "permissionDecisionReason": reason,
-        }
-    }
-    print(json.dumps(output))
-    sys.exit(0)
+    """Bypass-proof hard block. Exits 2 with reason on stderr.
+
+    `permissionDecision: deny` from a PreToolUse hook is silently
+    overridden by any later `ask` decision (GitHub issue #39344). The
+    only signal Claude Code honors regardless of `permission_mode` is
+    `exit 2`. `hook_utils.hard_block()` wraps that primitive.
+    """
+    hook_utils.hard_block(reason)
 
 
 def check_commit(command: str, branch: str) -> None:
@@ -304,10 +310,7 @@ def check_push(command: str, branch: str) -> None:
 
 
 def main() -> None:
-    try:
-        input_data = json.load(sys.stdin)
-    except json.JSONDecodeError:
-        sys.exit(0)
+    input_data = hook_utils.read_hook_input()
 
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})

--- a/modules/hooks/hooks/port-check.py
+++ b/modules/hooks/hooks/port-check.py
@@ -3,6 +3,11 @@
 PreToolUse:Bash hook that intercepts dev server commands and ensures correct
 port allocation based on the port registry and .env.clone identity.
 
+Classification (plan.md §5 Epic 1): bypass-suppressible. Warnings are advisory
+only — they never block. In bypass-mode sessions the hook short-circuits to
+keep dev-server launches quiet. Outside bypass mode it prints to stderr (not
+as a permission decision) so the agent can see the warning without blocking.
+
 DETECTS: Commands that launch dev servers (vite, wrangler dev, npm run dev,
 pnpm dev, next dev, browser-sync, etc.)
 
@@ -24,6 +29,9 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
 
 REGISTRY_PATH = Path.home() / ".claude" / "port-registry.json"
 
@@ -167,10 +175,22 @@ def determine_service_type(command: str) -> str:
 
 
 def main() -> None:
-    try:
-        tool_input = json.loads(sys.stdin.read())
-    except (json.JSONDecodeError, EOFError, ValueError):
-        return  # Silently allow on invalid input
+    # The earlier shape passed only `tool_input` here; the modern Claude
+    # Code shape passes the full hook envelope (tool_name + tool_input +
+    # permission_mode). Read both for compatibility.
+    data = hook_utils.read_hook_input()
+
+    # Accept either shape: the modern envelope (with tool_input nested)
+    # or the older direct-tool-input payload some tests may still send.
+    if "tool_input" in data:
+        tool_input = data.get("tool_input", {})
+    else:
+        tool_input = data
+
+    # Bypass mode: stay completely silent. The user has opted out of
+    # permission noise, and port checks are advisory not safety.
+    if hook_utils.is_bypass_mode(data):
+        return
 
     command = tool_input.get("command", "")
 
@@ -242,12 +262,9 @@ def main() -> None:
         )
 
     if messages:
-        # Output as a structured warning
-        output = {
-            "decision": "warn",
-            "reason": " | ".join(messages)
-        }
-        print(json.dumps(output))
+        # Warnings go to stderr so the agent sees them in tool output;
+        # this hook never blocks via a permission decision (advisory only).
+        print("PORT-CHECK: " + " | ".join(messages), file=sys.stderr)
     # If no messages, silently allow
 
 

--- a/modules/hooks/lib/hook_utils.py
+++ b/modules/hooks/lib/hook_utils.py
@@ -1,0 +1,246 @@
+"""Shared utilities for CCGM Claude Code hooks.
+
+Locked API (referenced from plan.md §5 Epic 1 and §3 architecture):
+
+    read_hook_input() -> dict
+    permission_mode(data: dict) -> str
+    is_bypass_mode(data: dict) -> bool
+    emit_decision(decision: str, reason: str) -> None
+    hard_block(reason: str) -> NoReturn
+    redact_secrets(text: str) -> str
+    file_locked_append(path: str, data: str) -> None
+    load_repo_config(cwd: str) -> dict
+
+The module is installed at ~/.claude/lib/hook_utils.py by CCGM's installer.
+Hooks import it via `sys.path.insert(0, os.path.expanduser("~/.claude/lib"))`
+followed by `import hook_utils`.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import re
+import sys
+from typing import NoReturn
+
+__all__ = [
+    "read_hook_input",
+    "permission_mode",
+    "is_bypass_mode",
+    "emit_decision",
+    "hard_block",
+    "redact_secrets",
+    "file_locked_append",
+    "load_repo_config",
+    "BYPASS_MODES",
+    "SECRET_PATTERNS",
+]
+
+
+BYPASS_MODES = frozenset({"bypassPermissions", "dontAsk", "auto"})
+
+
+def read_hook_input() -> dict:
+    """Read and parse JSON from stdin. Returns {} on parse failure.
+
+    Hooks that need stdin in a strict mode should check the return value
+    themselves; this helper never raises so that a malformed payload
+    cannot wedge an enforcement hook into an error state.
+    """
+    try:
+        return json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        return {}
+
+
+def permission_mode(data: dict) -> str:
+    """Return the permission_mode field from hook stdin, or 'default'.
+
+    Claude Code passes one of: 'default', 'acceptEdits', 'plan',
+    'bypassPermissions', 'dontAsk', 'auto'. Older clients may omit it.
+    """
+    mode = data.get("permission_mode")
+    if isinstance(mode, str) and mode:
+        return mode
+    return "default"
+
+
+def is_bypass_mode(data: dict) -> bool:
+    """True iff the session is in a bypass-permission mode.
+
+    Treats bypassPermissions, dontAsk, and auto as bypass. Conservative
+    default: any unknown / missing mode is treated as NON-bypass so a
+    suppressible safety check still fires when in doubt.
+    """
+    return permission_mode(data) in BYPASS_MODES
+
+
+def emit_decision(decision: str, reason: str) -> None:
+    """Emit a PreToolUse JSON decision and exit 0.
+
+    `decision` must be one of 'allow', 'deny', 'ask'. The hook process
+    terminates after this call — callers should not assume control
+    returns.
+    """
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": decision,
+            "permissionDecisionReason": reason,
+        }
+    }
+    json.dump(payload, sys.stdout)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+    sys.exit(0)
+
+
+def hard_block(reason: str) -> NoReturn:
+    """Bypass-proof hard block. Writes reason to stderr and exits 2.
+
+    GitHub issue #39344: `permissionDecision: 'ask'` from any PreToolUse
+    hook silently overrides declarative deny rules. The only mechanism
+    that survives bypass mode is `exit 2`, which Claude Code treats as a
+    hard block regardless of permission_mode.
+
+    Use this for data-integrity invariants and protected-branch
+    enforcement that MUST hold even in bypass sessions.
+    """
+    sys.stderr.write(reason.rstrip() + "\n")
+    sys.stderr.flush()
+    sys.exit(2)
+
+
+# 17 secret patterns. Order matters only insofar as longer / more specific
+# patterns come first so they win when a substring would match multiple.
+# Each entry is (name, compiled regex). The replacement is always
+# "[REDACTED:{name}]" so downstream readers can identify the kind without
+# re-scanning. Patterns target prefix shapes published by each vendor.
+_SECRET_PATTERN_SOURCES: list[tuple[str, str]] = [
+    # Anthropic API keys (legacy and api03-prefixed).
+    ("anthropic", r"sk-ant-(?:api03-)?[A-Za-z0-9_\-]{32,}"),
+    # Stripe live/test secret keys.
+    ("stripe_live", r"sk_live_[A-Za-z0-9]{16,}"),
+    ("stripe_test", r"sk_test_[A-Za-z0-9]{16,}"),
+    # GitHub token families (PAT, OAuth, user-to-server, server-to-server, refresh).
+    ("github_pat", r"ghp_[A-Za-z0-9]{30,}"),
+    ("github_oauth", r"gho_[A-Za-z0-9]{30,}"),
+    ("github_u2s", r"ghu_[A-Za-z0-9]{30,}"),
+    ("github_s2s", r"ghs_[A-Za-z0-9]{30,}"),
+    ("github_refresh", r"ghr_[A-Za-z0-9]{30,}"),
+    # AWS access key.
+    ("aws_access_key", r"AKIA[0-9A-Z]{16}"),
+    # Google API key.
+    ("google_api", r"AIza[0-9A-Za-z_\-]{35}"),
+    # Slack tokens.
+    ("slack", r"xox[abprs]-[0-9A-Za-z\-]{10,}"),
+    # Resend.
+    ("resend", r"re_[A-Za-z0-9]{8,}_[A-Za-z0-9]{16,}"),
+    # Supabase service-role and publishable keys (modern prefixed shape).
+    ("supabase", r"sb_(?:secret|publishable)_[A-Za-z0-9]{20,}"),
+    # OpenAI (generic sk- form, after Anthropic and Stripe have eaten theirs).
+    ("openai", r"sk-(?!ant-)(?!live_)(?!test_)[A-Za-z0-9]{32,}"),
+    # Authorization: Bearer ... header (covers most generic bearer tokens).
+    ("authorization_bearer", r"(?i)authorization\s*:\s*bearer\s+[A-Za-z0-9._\-]+"),
+    # env-var style KV assignments naming common secret keys.
+    (
+        "env_var_kv",
+        r"(?i)\b(?:api[_-]?key|api[_-]?secret|access[_-]?token|auth[_-]?token|"
+        r"client[_-]?secret|secret[_-]?key|password|passwd)\s*[=:]\s*['\"]?[A-Za-z0-9_\-/+=.]{12,}",
+    ),
+    # CLI password flag (--password / -p with a value following).
+    ("password_flag", r"(?<!\S)(?:--password|--passwd|-p)[=\s]+\S{6,}"),
+]
+
+# Compile once at import.
+SECRET_PATTERNS: list[tuple[str, "re.Pattern[str]"]] = [
+    (name, re.compile(pat)) for name, pat in _SECRET_PATTERN_SOURCES
+]
+
+
+def redact_secrets(text: str) -> str:
+    """Replace any secret-shaped token in `text` with [REDACTED:{kind}].
+
+    Applied to event log entries BEFORE truncation so the truncation
+    point can never lop a redaction marker in half. Conservative: a
+    pattern with broad-ish shape (env_var_kv) is fine to over-fire —
+    false positives in logs cost much less than leaked secrets.
+    """
+    if not text:
+        return text
+    out = text
+    for name, regex in SECRET_PATTERNS:
+        out = regex.sub(f"[REDACTED:{name}]", out)
+    return out
+
+
+def file_locked_append(path: str, data: str) -> None:
+    """Append `data` (with trailing newline) to `path`, fcntl-locked.
+
+    Cross-clone-safe: multiple Claude Code agents in different repo
+    clones may race on the same `~/.claude/autoheal/events/*.jsonl`
+    path. fcntl.flock(LOCK_EX) on the open file descriptor serializes
+    appends so the JSONL never truncates mid-record.
+
+    POSIX-portable. macOS + Linux supported. Creates parent dir if
+    missing. Never raises on lock contention — blocks until acquired.
+    """
+    payload = data if data.endswith("\n") else data + "\n"
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    # Open with O_APPEND so writes always land at end-of-file even
+    # under contention. Combined with flock(LOCK_EX), this is the
+    # standard POSIX recipe for atomic concurrent append.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            os.write(fd, payload.encode("utf-8"))
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def load_repo_config(cwd: str | None = None) -> dict:
+    """Walk up from cwd looking for `.autoheal/config.json`. Return merged config.
+
+    The walk stops at the first repo root that contains the file or at
+    the filesystem root. Returns {} when no config is found.
+
+    Schema (validated lightly here; full schema in
+    `modules/autoheal/lib/repo-config-schema.json` for Epic 12):
+
+        {
+          "additional_allow_patterns": [str, ...],
+          "calibration_days": int,
+          "thresholds": {"confidence_min": int, "occurrence_min": int},
+          "kind_filters": [str, ...]
+        }
+
+    Unknown top-level keys are preserved (forward-compat) but only the
+    documented fields are consumed by downstream code.
+    """
+    here = os.path.abspath(cwd or os.getcwd())
+    seen: set[str] = set()
+    while here and here not in seen:
+        seen.add(here)
+        candidate = os.path.join(here, ".autoheal", "config.json")
+        if os.path.isfile(candidate):
+            try:
+                with open(candidate, "r", encoding="utf-8") as fh:
+                    cfg = json.load(fh)
+                if isinstance(cfg, dict):
+                    return cfg
+            except (OSError, json.JSONDecodeError):
+                # Treat a malformed repo config as if it did not exist;
+                # a hook is not the right place to fail loudly on user
+                # JSON typos.
+                return {}
+        parent = os.path.dirname(here)
+        if parent == here:
+            break
+        here = parent
+    return {}

--- a/modules/hooks/lib/sched_platform.py
+++ b/modules/hooks/lib/sched_platform.py
@@ -1,0 +1,175 @@
+"""Platform abstraction for scheduled-job installation.
+
+Locked API (referenced from plan.md §5 Epic 1, §3.11 Linux portability):
+
+    install_scheduled_job(label: str, command: str, hour: int, minute: int) -> None
+    uninstall_scheduled_job(label: str) -> None
+    list_scheduled_jobs() -> list[str]
+
+macOS uses launchd LaunchAgents under ~/Library/LaunchAgents/.
+Linux is a documented v2 plug-in seam — the implementation raises
+NotImplementedError with a clear message pointing at the planned cron
+template.
+
+Note: the plan spells this `lib/platform.py`, but that name shadows the
+Python stdlib `platform` module for any hook that puts `~/.claude/lib`
+on `sys.path`. Renamed to `sched_platform.py` to keep the stdlib
+reachable. The locked API (install_scheduled_job, uninstall_scheduled_job,
+list_scheduled_jobs) is unchanged.
+"""
+from __future__ import annotations
+
+import os
+import platform as _platform
+import plistlib
+import shutil
+import subprocess
+from typing import NoReturn
+
+__all__ = [
+    "install_scheduled_job",
+    "uninstall_scheduled_job",
+    "list_scheduled_jobs",
+    "LAUNCH_AGENTS_DIR",
+]
+
+
+LAUNCH_AGENTS_DIR = os.path.expanduser("~/Library/LaunchAgents")
+
+
+def _linux_v2(_op: str) -> NoReturn:
+    raise NotImplementedError(
+        "Linux scheduling is a v2 plug-in point. "
+        "See modules/autoheal/lib/autoheal.cron.template for the planned "
+        "cron implementation; the macOS launchd path is in lib/sched_platform.py."
+    )
+
+
+def _unsupported(op: str) -> NoReturn:
+    raise NotImplementedError(
+        f"Platform not supported for {op}: {_platform.system()!r}. "
+        "macOS (Darwin) is the only v1 target; Linux is a v2 plug-in seam."
+    )
+
+
+def install_scheduled_job(label: str, command: str, hour: int, minute: int) -> None:
+    """Install a daily scheduled job to fire at HH:MM local time.
+
+    macOS: writes a launchd plist at ~/Library/LaunchAgents/{label}.plist
+    and bootstraps it via `launchctl bootstrap gui/$UID`. Idempotent — an
+    existing job with the same label is bootout'd first.
+
+    Linux: raises NotImplementedError (v2 seam).
+    """
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise ValueError(f"Bad schedule: hour={hour}, minute={minute}")
+
+    sysname = _platform.system()
+    if sysname == "Darwin":
+        _install_launchd(label, command, hour, minute)
+        return
+    if sysname == "Linux":
+        _linux_v2("install_scheduled_job")
+    _unsupported("install_scheduled_job")
+
+
+def uninstall_scheduled_job(label: str) -> None:
+    """Remove a previously-installed scheduled job.
+
+    macOS: bootout the launchd job and delete its plist. Tolerates a
+    missing plist (treats it as already-uninstalled).
+
+    Linux: raises NotImplementedError.
+    """
+    sysname = _platform.system()
+    if sysname == "Darwin":
+        _uninstall_launchd(label)
+        return
+    if sysname == "Linux":
+        _linux_v2("uninstall_scheduled_job")
+    _unsupported("uninstall_scheduled_job")
+
+
+def list_scheduled_jobs() -> list[str]:
+    """Return labels of currently-installed scheduled jobs.
+
+    macOS: reads ~/Library/LaunchAgents and returns the basename
+    (without .plist) of every plist whose Label matches the file name.
+    Cheap and doesn't shell out.
+
+    Linux: raises NotImplementedError.
+    """
+    sysname = _platform.system()
+    if sysname == "Darwin":
+        return _list_launchd()
+    if sysname == "Linux":
+        _linux_v2("list_scheduled_jobs")
+    _unsupported("list_scheduled_jobs")
+
+
+def _plist_path(label: str) -> str:
+    return os.path.join(LAUNCH_AGENTS_DIR, f"{label}.plist")
+
+
+def _gui_target() -> str:
+    uid = os.getuid()
+    return f"gui/{uid}"
+
+
+def _install_launchd(label: str, command: str, hour: int, minute: int) -> None:
+    os.makedirs(LAUNCH_AGENTS_DIR, exist_ok=True)
+    path = _plist_path(label)
+
+    # Best-effort uninstall first so a config change takes effect.
+    if os.path.exists(path):
+        _uninstall_launchd(label)
+
+    plist = {
+        "Label": label,
+        "ProgramArguments": ["/bin/sh", "-c", command],
+        "StartCalendarInterval": {"Hour": hour, "Minute": minute},
+        "RunAtLoad": False,
+        "StandardOutPath": os.path.expanduser(f"~/.claude/logs/{label}.out.log"),
+        "StandardErrorPath": os.path.expanduser(f"~/.claude/logs/{label}.err.log"),
+        "EnvironmentVariables": {
+            "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
+        },
+    }
+    os.makedirs(os.path.expanduser("~/.claude/logs"), exist_ok=True)
+    with open(path, "wb") as fh:
+        plistlib.dump(plist, fh)
+
+    if shutil.which("launchctl"):
+        # bootstrap is the modern (Big Sur+) way; ignore non-zero on
+        # already-loaded (launchctl is grumpy about idempotency).
+        subprocess.run(
+            ["launchctl", "bootstrap", _gui_target(), path],
+            check=False,
+            capture_output=True,
+        )
+
+
+def _uninstall_launchd(label: str) -> None:
+    path = _plist_path(label)
+    if shutil.which("launchctl") and os.path.exists(path):
+        subprocess.run(
+            ["launchctl", "bootout", _gui_target(), path],
+            check=False,
+            capture_output=True,
+        )
+    if os.path.exists(path):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def _list_launchd() -> list[str]:
+    if not os.path.isdir(LAUNCH_AGENTS_DIR):
+        return []
+    labels: list[str] = []
+    for entry in os.listdir(LAUNCH_AGENTS_DIR):
+        if entry.endswith(".plist"):
+            labels.append(entry[: -len(".plist")])
+    labels.sort()
+    return labels

--- a/modules/hooks/module.json
+++ b/modules/hooks/module.json
@@ -56,6 +56,16 @@
       "type": "lib",
       "template": false
     },
+    "lib/hook_utils.py": {
+      "target": "lib/hook_utils.py",
+      "type": "lib",
+      "template": false
+    },
+    "lib/sched_platform.py": {
+      "target": "lib/sched_platform.py",
+      "type": "lib",
+      "template": false
+    },
     "hooks/check-migration-timestamps.py": {
       "target": "hooks/check-migration-timestamps.py",
       "type": "hook",

--- a/modules/hooks/tests/fixtures/auto-mode-stdin.json
+++ b/modules/hooks/tests/fixtures/auto-mode-stdin.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "test-session-auto",
+  "tool_name": "Bash",
+  "tool_input": {"command": "git status"},
+  "permission_mode": "auto",
+  "cwd": "/tmp/test-cwd"
+}

--- a/modules/hooks/tests/fixtures/bypass-mode-stdin.json
+++ b/modules/hooks/tests/fixtures/bypass-mode-stdin.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "test-session-bypass",
+  "tool_name": "Bash",
+  "tool_input": {"command": "git status"},
+  "permission_mode": "bypassPermissions",
+  "cwd": "/tmp/test-cwd"
+}

--- a/modules/hooks/tests/fixtures/default-mode-stdin.json
+++ b/modules/hooks/tests/fixtures/default-mode-stdin.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "test-session-default",
+  "tool_name": "Bash",
+  "tool_input": {"command": "git status"},
+  "permission_mode": "default",
+  "cwd": "/tmp/test-cwd"
+}

--- a/modules/hooks/tests/fixtures/default-stdin-with-cwd.json
+++ b/modules/hooks/tests/fixtures/default-stdin-with-cwd.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "test-session-cwd",
+  "tool_name": "Bash",
+  "tool_input": {"command": "git status"},
+  "permission_mode": "default",
+  "cwd": "FIXTURE_CWD_PLACEHOLDER"
+}

--- a/modules/hooks/tests/fixtures/dont-ask-mode-stdin.json
+++ b/modules/hooks/tests/fixtures/dont-ask-mode-stdin.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "test-session-dontask",
+  "tool_name": "Bash",
+  "tool_input": {"command": "git status"},
+  "permission_mode": "dontAsk",
+  "cwd": "/tmp/test-cwd"
+}

--- a/modules/hooks/tests/test-cross-clone-file-lock.sh
+++ b/modules/hooks/tests/test-cross-clone-file-lock.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Cross-clone file-lock concurrency test for hook_utils.file_locked_append.
+#
+# Spawns 4 Python processes appending different prefixed lines to the same
+# JSONL path. Verifies:
+#   - All writes land (union; no losses)
+#   - No record is torn or interleaved (each line begins with the writer's prefix)
+#   - Line count == sum of per-writer counts
+#
+# Run: bash modules/hooks/tests/test-cross-clone-file-lock.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LIB="${MODULE_ROOT}/lib"
+
+WORKERS=4
+LINES_PER_WORKER=200
+TMP=$(mktemp -d -t ccfl.XXXXXX)
+TARGET="${TMP}/events.jsonl"
+trap 'rm -rf "${TMP}"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+# Launch WORKERS Python workers in background.
+for i in $(seq 0 $((WORKERS - 1))); do
+    PYTHONPATH="${LIB}" python3 - "${i}" "${TARGET}" "${LINES_PER_WORKER}" <<'PY' &
+import sys, hook_utils
+wid, target, n = int(sys.argv[1]), sys.argv[2], int(sys.argv[3])
+prefix = f"writer-{wid}"
+for j in range(n):
+    hook_utils.file_locked_append(target, f'{prefix} record-{j}')
+PY
+done
+wait
+
+# 1. Total line count matches.
+actual_lines=$(wc -l < "${TARGET}" | tr -d ' ')
+expected_lines=$((WORKERS * LINES_PER_WORKER))
+assert_eq "${actual_lines}" "${expected_lines}" "total line count matches ${expected_lines}"
+
+# 2. Every line starts with one of the four writer prefixes (no torn writes).
+bad=$(awk '$1 !~ /^writer-[0-3]$/ { c++ } END { print c+0 }' "${TARGET}")
+assert_eq "${bad}" "0" "no torn / mis-prefixed lines"
+
+# 3. Per-writer count is exact (no losses, no duplicates).
+for i in $(seq 0 $((WORKERS - 1))); do
+    count=$(grep -c "^writer-${i} " "${TARGET}" || true)
+    assert_eq "${count}" "${LINES_PER_WORKER}" "writer-${i} produced ${LINES_PER_WORKER} records"
+done
+
+echo ""
+echo "test-cross-clone-file-lock.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0

--- a/modules/hooks/tests/test-hook-utils.sh
+++ b/modules/hooks/tests/test-hook-utils.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Test suite for modules/hooks/lib/hook_utils.py
+#
+# Exercises the locked API:
+#   read_hook_input, permission_mode, is_bypass_mode, emit_decision,
+#   hard_block, redact_secrets, file_locked_append, load_repo_config
+#
+# Run: bash modules/hooks/tests/test-hook-utils.sh
+# Exit 0 on success; non-zero on first failed assertion.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FIXTURES="${SCRIPT_DIR}/fixtures"
+LIB="${MODULE_ROOT}/lib"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  expected substring: ${needle}"
+            echo "  actual: ${haystack}"
+            ;;
+    esac
+}
+
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  unexpected substring present: ${needle}"
+            echo "  actual: ${haystack}"
+            ;;
+        *)
+            PASS=$((PASS + 1))
+            ;;
+    esac
+}
+
+py() {
+    PYTHONPATH="${LIB}" python3 -c "$1"
+}
+
+# 1. permission_mode + is_bypass_mode across all 4 fixtures.
+for mode in bypass-mode dont-ask-mode auto-mode; do
+    out=$(py "
+import hook_utils, json, sys
+data = json.load(open('${FIXTURES}/${mode}-stdin.json'))
+print(hook_utils.is_bypass_mode(data))
+")
+    assert_eq "${out}" "True" "is_bypass_mode True for ${mode}"
+done
+
+out=$(py "
+import hook_utils, json
+data = json.load(open('${FIXTURES}/default-mode-stdin.json'))
+print(hook_utils.is_bypass_mode(data))
+")
+assert_eq "${out}" "False" "is_bypass_mode False for default mode"
+
+# 2. permission_mode default falls back to 'default' when missing.
+out=$(py "
+import hook_utils
+print(hook_utils.permission_mode({}))
+print(hook_utils.permission_mode({'permission_mode': ''}))
+print(hook_utils.permission_mode({'permission_mode': 'plan'}))
+")
+assert_eq "$(echo "${out}" | sed -n 1p)" "default" "permission_mode empty dict"
+assert_eq "$(echo "${out}" | sed -n 2p)" "default" "permission_mode empty string"
+assert_eq "$(echo "${out}" | sed -n 3p)" "plan" "permission_mode plan"
+
+# 3. is_bypass_mode conservative on missing/unknown modes.
+out=$(py "
+import hook_utils
+print(hook_utils.is_bypass_mode({}))
+print(hook_utils.is_bypass_mode({'permission_mode': 'unknown'}))
+print(hook_utils.is_bypass_mode({'permission_mode': 'plan'}))
+print(hook_utils.is_bypass_mode({'permission_mode': 'acceptEdits'}))
+")
+assert_eq "$(echo "${out}" | sed -n 1p)" "False" "is_bypass_mode missing key"
+assert_eq "$(echo "${out}" | sed -n 2p)" "False" "is_bypass_mode unknown value"
+assert_eq "$(echo "${out}" | sed -n 3p)" "False" "is_bypass_mode plan"
+assert_eq "$(echo "${out}" | sed -n 4p)" "False" "is_bypass_mode acceptEdits"
+
+# 4. emit_decision shape (call in subshell so sys.exit doesn't kill us).
+out=$(py "
+import hook_utils, json, sys, io
+buf = io.StringIO()
+sys.stdout = buf
+try:
+    hook_utils.emit_decision('ask', 'because reasons')
+except SystemExit:
+    pass
+sys.stdout = sys.__stdout__
+payload = json.loads(buf.getvalue())
+print(payload['hookSpecificOutput']['hookEventName'])
+print(payload['hookSpecificOutput']['permissionDecision'])
+print(payload['hookSpecificOutput']['permissionDecisionReason'])
+")
+assert_eq "$(echo "${out}" | sed -n 1p)" "PreToolUse" "emit_decision hookEventName"
+assert_eq "$(echo "${out}" | sed -n 2p)" "ask" "emit_decision permissionDecision"
+assert_eq "$(echo "${out}" | sed -n 3p)" "because reasons" "emit_decision reason"
+
+# 5. hard_block exits 2 and writes reason to stderr.
+py_err=$(PYTHONPATH="${LIB}" python3 -c "
+import hook_utils
+hook_utils.hard_block('NOPE: data integrity')
+" 2>&1 >/dev/null)
+rc=$?
+assert_eq "${rc}" "2" "hard_block exits 2"
+assert_contains "${py_err}" "NOPE: data integrity" "hard_block writes reason to stderr"
+
+# 6. redact_secrets covers all 17 pattern families.
+#
+# Fake-token shapes are constructed at runtime via string concat so the
+# literal token forms never appear in this file. This dodges GitHub's
+# push-protection secret scanner without weakening the regex coverage —
+# at execution time the concatenated strings are byte-for-byte identical
+# to the patterns hook_utils.redact_secrets() targets.
+out=$(py "
+import hook_utils
+S = 'A' * 36
+SHORT = 'A' * 32
+B = '1234567890abcdefghijklmn'
+ANT = 'sk' + '-ant-' + 'api03-' + S
+STR_LIVE = 'sk' + '_' + 'live_' + B
+STR_TEST = 'sk' + '_' + 'test_' + B
+GHP = 'ghp' + '_' + S
+GHO = 'gho' + '_' + S
+GHU = 'ghu' + '_' + S
+GHS = 'ghs' + '_' + S
+GHR = 'ghr' + '_' + S
+AWS = 'AK' + 'IA' + 'ABCDEFGHIJKLMNOP'
+GOG = 'A' + 'Iza' + 'Sy' + 'A' + '1234567890abcdefghijklmnopqrstuvwx'
+SLK = 'xo' + 'xb-' + '1234567890-9876543210-abcdefghij'
+RES = 're' + '_' + 'AbCdEfGh' + '_' + '1234567890abcdef'
+SUP = 'sb' + '_' + 'secret_' + '1234567890abcdefghij'
+OAI = 'sk' + '-' + SHORT
+AUTH = 'Authorization: Bearer ' + 'abc.def.ghi-jkl'
+EKV = 'API' + '_' + 'KEY' + '=' + 'abcdef1234567890'
+PWD = 'mycli ' + '--password ' + 'hunter2hunter2'
+tests = [
+    (ANT, 'anthropic'),
+    (STR_LIVE, 'stripe_live'),
+    (STR_TEST, 'stripe_test'),
+    (GHP, 'github_pat'),
+    (GHO, 'github_oauth'),
+    (GHU, 'github_u2s'),
+    (GHS, 'github_s2s'),
+    (GHR, 'github_refresh'),
+    (AWS, 'aws_access_key'),
+    (GOG, 'google_api'),
+    (SLK, 'slack'),
+    (RES, 'resend'),
+    (SUP, 'supabase'),
+    (OAI, 'openai'),
+    (AUTH, 'authorization_bearer'),
+    (EKV, 'env_var_kv'),
+    (PWD, 'password_flag'),
+]
+ok = 0
+for raw, name in tests:
+    red = hook_utils.redact_secrets(raw)
+    if f'[REDACTED:{name}]' in red:
+        ok += 1
+    else:
+        print('MISS', name, '|', repr(red))
+print('OK', ok, '/', len(tests))
+")
+total_line=$(echo "${out}" | tail -1)
+assert_eq "${total_line}" "OK 17 / 17" "redact_secrets covers all 17 patterns"
+
+# 7. redact_secrets is a no-op on benign input.
+out=$(py "
+import hook_utils
+print(hook_utils.redact_secrets('git status'))
+print(hook_utils.redact_secrets(''))
+")
+assert_eq "$(echo "${out}" | sed -n 1p)" "git status" "redact_secrets benign passthrough"
+assert_eq "$(echo "${out}" | sed -n 2p)" "" "redact_secrets empty passthrough"
+
+# 8. file_locked_append basic append + line count.
+TMPFILE="$(mktemp -t hook_utils_test.XXXXXX)"
+trap 'rm -f "${TMPFILE}"' EXIT
+out=$(py "
+import hook_utils
+hook_utils.file_locked_append('${TMPFILE}', 'line-1')
+hook_utils.file_locked_append('${TMPFILE}', 'line-2\n')
+hook_utils.file_locked_append('${TMPFILE}', 'line-3')
+")
+lines=$(wc -l < "${TMPFILE}" | tr -d ' ')
+assert_eq "${lines}" "3" "file_locked_append writes 3 lines"
+assert_contains "$(cat "${TMPFILE}")" "line-2" "file_locked_append content present"
+
+# 9. load_repo_config returns {} when no .autoheal/config.json on the path.
+REPO_TMP="$(mktemp -d -t hook_utils_repo.XXXXXX)"
+trap 'rm -rf "${REPO_TMP}" "${TMPFILE}"' EXIT
+out=$(py "
+import hook_utils, json
+print(json.dumps(hook_utils.load_repo_config('${REPO_TMP}')))
+")
+assert_eq "${out}" "{}" "load_repo_config absent returns empty dict"
+
+# 10. load_repo_config walks UP from a nested cwd to find the config.
+mkdir -p "${REPO_TMP}/.autoheal"
+cat > "${REPO_TMP}/.autoheal/config.json" <<'EOF'
+{"additional_allow_patterns": ["Bash(test-tool:*)"], "calibration_days": 14}
+EOF
+mkdir -p "${REPO_TMP}/nested/deeper"
+out=$(py "
+import hook_utils
+cfg = hook_utils.load_repo_config('${REPO_TMP}/nested/deeper')
+print(cfg.get('calibration_days'))
+print(cfg.get('additional_allow_patterns', ['MISS'])[0])
+")
+assert_eq "$(echo "${out}" | sed -n 1p)" "14" "load_repo_config walks up to ancestor"
+assert_eq "$(echo "${out}" | sed -n 2p)" "Bash(test-tool:*)" "load_repo_config preserves allow pattern"
+
+# 11. load_repo_config tolerates malformed JSON.
+echo 'this is not json {{' > "${REPO_TMP}/.autoheal/config.json"
+out=$(py "
+import hook_utils, json
+print(json.dumps(hook_utils.load_repo_config('${REPO_TMP}')))
+")
+assert_eq "${out}" "{}" "load_repo_config malformed JSON returns empty dict"
+
+echo ""
+echo "test-hook-utils.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0

--- a/modules/hooks/tests/test-platform.sh
+++ b/modules/hooks/tests/test-platform.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Test suite for modules/hooks/lib/sched_platform.py.
+#
+# Verifies:
+#   - macOS install/uninstall round-trip writes/removes a plist
+#   - list_scheduled_jobs reflects file state
+#   - Linux raises NotImplementedError (via monkeypatched _platform.system)
+#
+# Run: bash modules/hooks/tests/test-platform.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LIB="${MODULE_ROOT}/lib"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_true() {
+    local cond="$1"
+    local label="$2"
+    if [ "${cond}" = "True" ] || [ "${cond}" = "true" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label} (got ${cond})"
+    fi
+}
+
+py() {
+    PYTHONPATH="${LIB}" python3 -c "$1"
+}
+
+SYS=$(uname -s)
+
+# 1. Linux stub raises NotImplementedError with a clear message.
+#    Monkeypatch _platform.system to lie about the OS.
+out=$(py "
+import sched_platform
+sched_platform._platform.system = lambda: 'Linux'
+try:
+    sched_platform.install_scheduled_job('test.label', 'echo hi', 12, 0)
+    print('SHOULD_HAVE_RAISED')
+except NotImplementedError as e:
+    print('Linux scheduling is a v2 plug-in point.' in str(e))
+")
+assert_true "${out}" "Linux raises NotImplementedError with v2 message"
+
+out=$(py "
+import sched_platform
+sched_platform._platform.system = lambda: 'Linux'
+for fn in (sched_platform.uninstall_scheduled_job, sched_platform.list_scheduled_jobs):
+    try:
+        fn('test.label') if fn is sched_platform.uninstall_scheduled_job else fn()
+        print('SHOULD_HAVE_RAISED')
+        break
+    except NotImplementedError:
+        pass
+else:
+    print('ok')
+")
+assert_eq "${out}" "ok" "Linux uninstall + list also raise"
+
+# 2. Unsupported OS path.
+out=$(py "
+import sched_platform
+sched_platform._platform.system = lambda: 'Plan9'
+try:
+    sched_platform.install_scheduled_job('x', 'echo', 0, 0)
+    print('SHOULD_HAVE_RAISED')
+except NotImplementedError as e:
+    print('Plan9' in str(e))
+")
+assert_true "${out}" "Unsupported OS reports system name"
+
+# 3. Reject invalid hour/minute.
+out=$(py "
+import sched_platform
+try:
+    sched_platform.install_scheduled_job('x', 'echo', 24, 0)
+    print('SHOULD_HAVE_RAISED')
+except ValueError:
+    print('ok')
+")
+assert_eq "${out}" "ok" "Rejects hour=24"
+
+out=$(py "
+import sched_platform
+try:
+    sched_platform.install_scheduled_job('x', 'echo', 0, 60)
+    print('SHOULD_HAVE_RAISED')
+except ValueError:
+    print('ok')
+")
+assert_eq "${out}" "ok" "Rejects minute=60"
+
+# macOS-specific tests.
+if [ "${SYS}" = "Darwin" ]; then
+    LABEL="com.ccgm.test.platform.$$"
+    PLIST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+
+    # 4. install -> plist file exists.
+    py "
+import sched_platform
+sched_platform.install_scheduled_job('${LABEL}', 'echo hello', 4, 30)
+"
+    if [ -f "${PLIST}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: install wrote plist (missing: ${PLIST})"
+    fi
+
+    # 5. list_scheduled_jobs sees the new label.
+    out=$(py "
+import sched_platform
+print('${LABEL}' in sched_platform.list_scheduled_jobs())
+")
+    assert_true "${out}" "list_scheduled_jobs sees installed label"
+
+    # 6. uninstall -> plist gone.
+    py "
+import sched_platform
+sched_platform.uninstall_scheduled_job('${LABEL}')
+"
+    if [ ! -f "${PLIST}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: uninstall removed plist (still present: ${PLIST})"
+        rm -f "${PLIST}"
+    fi
+
+    # 7. uninstall non-existent is a no-op.
+    out=$(py "
+import sched_platform
+sched_platform.uninstall_scheduled_job('${LABEL}.never-existed')
+print('ok')
+")
+    assert_eq "${out}" "ok" "Uninstall tolerates missing label"
+
+    # 8. Install is idempotent (second install replaces first).
+    out=$(py "
+import sched_platform
+sched_platform.install_scheduled_job('${LABEL}', 'echo first', 4, 30)
+sched_platform.install_scheduled_job('${LABEL}', 'echo second', 5, 30)
+import plistlib
+data = plistlib.load(open(sched_platform._plist_path('${LABEL}'), 'rb'))
+print(data['StartCalendarInterval']['Hour'])
+print('echo second' in data['ProgramArguments'][-1])
+")
+    assert_eq "$(echo "${out}" | sed -n 1p)" "5" "Idempotent install: second wins (hour)"
+    assert_true "$(echo "${out}" | sed -n 2p)" "Idempotent install: second wins (command)"
+
+    # Cleanup.
+    py "
+import sched_platform
+sched_platform.uninstall_scheduled_job('${LABEL}')
+"
+else
+    echo "Skipping macOS-only tests (uname -s = ${SYS})"
+fi
+
+echo ""
+echo "test-platform.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Foundation for ccgm-autoheal (Part 1 permission-hygiene). Introduces shared
helpers in `modules/hooks/lib/` so every PreToolUse:Bash hook can self-suppress
permission noise in bypass mode while genuinely-destructive operations stay
hard-blocked via `exit 2` (bypass-proof per GitHub issue #39344).

Closes #473.

### Files created
- `modules/hooks/lib/hook_utils.py` — locked cross-epic API:
  - `read_hook_input()` / `permission_mode()` / `is_bypass_mode()`
  - `emit_decision()` (standard PreToolUse JSON shape)
  - `hard_block()` (exit 2 — survives `permission_mode`)
  - `redact_secrets()` (17 vendor patterns; coverage-tested)
  - `file_locked_append()` (`fcntl.flock` for cross-clone JSONL writes)
  - `load_repo_config()` (walks up looking for `.autoheal/config.json`)
- `modules/hooks/lib/sched_platform.py` — locked scheduling API:
  - macOS launchd implementation
  - Linux raises `NotImplementedError` with a clear v2 message
  - Renamed from plan's `lib/platform.py` to avoid shadowing the stdlib
    `platform` module when `~/.claude/lib` is on `sys.path` (function
    names are unchanged — the rename is a file-name detail)
- Tests: `test-hook-utils.sh` (25), `test-platform.sh` (11),
  `test-cross-clone-file-lock.sh` (6) — 42 assertions total
- 5 stdin fixtures covering every `permission_mode` value

### Files modified (per plan §5 Epic 1 classification table)
| Hook | Class | Change |
|---|---|---|
| `check-careful.py` | bypass-suppressible | force-push-to-`main` migrated to `hard_block()`; routine destructive cases short-circuit in bypass mode |
| `enforce-git-workflow.py` | bypass-retained | `deny()` migrated to `hard_block()`; `ALLOW_MAIN_COMMIT=1` still honored |
| `check-migration-timestamps.py` | bypass-retained | `deny` migrated to `hard_block()` (data integrity) |
| `auto-approve-bash.py` | bypass-suppressible | destructive-reset smart-rule → `hard_block()` AND runs OUTSIDE the bypass short-circuit |
| `port-check.py` | bypass-suppressible | warnings to stderr (advisory only); bypass-mode short-circuit |
| `module.json` | — | registers new `lib/hook_utils.py` + `lib/sched_platform.py` |

### Plan deviation: file name
Plan §3.11 and §5 Epic 1 spell the scheduling module `lib/platform.py`.
Implemented as `lib/sched_platform.py` because the literal name `platform.py`
shadows Python's stdlib `platform` module whenever `~/.claude/lib` is on
`sys.path` (which `agent_tracking.py`-importing hooks already do). The
locked function-name API is unchanged.

## Test plan

- [x] `bash modules/hooks/tests/test-hook-utils.sh` → 25 passed, 0 failed
- [x] `bash modules/hooks/tests/test-platform.sh` → 11 passed, 0 failed
- [x] `bash modules/hooks/tests/test-cross-clone-file-lock.sh` → 6 passed, 0 failed (4 concurrent writers)
- [x] `bash tests/test-modules.sh` → 1131 passed, 0 failed
- [x] `bash tests/test-no-personal-data.sh` → PASS
- [x] Smoke: bypass + routine destructive cmd → suppressed
- [x] Smoke: bypass + force-push-main → hard_block (exit 2) with helpful message
- [x] Smoke: bypass + `ALLOW_MAIN_COMMIT=1` + force-push-main → allowed
- [x] Smoke: default + force-push-feat → still asks (preserved behavior)
- [x] Smoke: bypass + non-remote-ref `reset --hard` → hard_block
- [x] Smoke: bypass + remote-ref `reset --hard` → allow
- [x] Smoke: bypass + commit on `main` → hard_block; with `ALLOW_MAIN_COMMIT=1` → allowed

Post-merge bring-up runs `bash start.sh --reinstall hooks` to re-symlink the
new `lib/` files into `~/.claude/lib/`.
