### PR TITLE
#475: autoheal module scaffold + Epic 3 event capture + suppression

### DIFF
--- a/modules/autoheal/README.md
+++ b/modules/autoheal/README.md
@@ -1,0 +1,49 @@
+# autoheal
+
+Self-healing observability loop for Claude Code. Captures permission events, tool failures, and user-correction signals; runs a daily analyzer via direct Anthropic API call; surfaces a digest with proposed configuration changes. Optional real-time security alerts and confidence-gated auto-apply, both default off.
+
+## What this module installs
+
+- **5 event-capture hooks** on `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `UserPromptSubmit`, and `Stop`.
+- **2 response hooks**: `permission-request-suppress.py` (contextual auto-allow) and `realtime-security-scanner.py` (opt-in mid-session alerts).
+- **7 slash commands**: `/permission-fix`, `/permission-audit`, `/autoheal`, `/autoheal-digest`, `/autoheal-toggle`, `/autoheal-snooze`, `/autoheal-apply`.
+- **Daily LaunchAgent** (macOS) calling `bin/autoheal-daily.sh` at 08:00 local. Linux scheduling is an architectural seam, not built in v1.
+
+## Default posture
+
+- **Real-time security alerts: OFF.** Enable with `/autoheal-toggle realtime on` (or `realtime_alerts_enabled: true` in config).
+- **Auto-apply: OFF.** Enable with `/autoheal-toggle autoapply on` (or `auto_apply_enabled: true` in config).
+- **Email digest: OFF.** Local digest is always-on; opt into Resend with `digest_email` and `email_enabled: true` + `RESEND_API_KEY` in your shell env.
+- **Webhook publisher: OFF.** Set `webhook_url` in config to enable.
+
+## Config
+
+User-global config lives at `~/.claude/autoheal/config.json`. Per-repo overrides live in `.autoheal/config.json` at the repo root.
+
+See `rules/autoheal.md` for the full config-key table and merge rules.
+
+## Cross-references
+
+- Rule file: `rules/autoheal.md` (the contract autoheal expects Claude Code to follow).
+- Plan: `~/code/plans/ccgm-autoheal/plan.md`.
+- Bring-up runbook: `plan.md §9.1`.
+
+## Manual installation (development clone)
+
+```bash
+# From a CCGM development clone (not the canonical):
+bash start.sh --add autoheal
+```
+
+This installs the hooks, commands, rules, and shell scripts. Run `autoheal-install.sh` (Epic 6) afterwards to register the LaunchAgent.
+
+## Tests
+
+```bash
+bash modules/autoheal/tests/test-event-logging.sh
+bash modules/autoheal/tests/test-permission-suppress.sh
+bash modules/autoheal/tests/test-correction-detection.sh
+bash modules/autoheal/tests/test-redaction-coverage.sh
+```
+
+Each test sets `CCGM_AUTOHEAL_DIR` to a temp directory; nothing pollutes the real `~/.claude/autoheal/`.

--- a/modules/autoheal/bin/autoheal-analyze.sh
+++ b/modules/autoheal/bin/autoheal-analyze.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Epic 6: content TBD — daily analyzer (direct Anthropic API curl). See
+# plan.md §5 Epic 6 and §3.13.
+exit 0

--- a/modules/autoheal/bin/autoheal-auto-apply.sh
+++ b/modules/autoheal/bin/autoheal-auto-apply.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Epic 11: content TBD — opt-in confidence-gated auto-apply. Default off.
+# See plan.md §3.7 and §5 Epic 11.
+exit 0

--- a/modules/autoheal/bin/autoheal-daily.sh
+++ b/modules/autoheal/bin/autoheal-daily.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Epic 7: content TBD — daily wrapper that runs analyze -> auto-apply ->
+# digest -> email -> publish -> retention. See plan.md §5 Epic 7 and §5
+# Epic 12 for the final ordering.
+exit 0

--- a/modules/autoheal/bin/autoheal-digest.sh
+++ b/modules/autoheal/bin/autoheal-digest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Epic 7: content TBD — render local digest markdown from today's
+# proposals. See plan.md §5 Epic 7.
+exit 0

--- a/modules/autoheal/bin/autoheal-email.sh
+++ b/modules/autoheal/bin/autoheal-email.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Epic 7: content TBD — optional Resend delivery with multi-recipient
+# iteration and per-recipient idempotency key. See plan.md §5 Epic 7 and
+# §5 Epic 12.
+exit 0

--- a/modules/autoheal/bin/autoheal-install.sh
+++ b/modules/autoheal/bin/autoheal-install.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Epic 6: content TBD — interactive installer; calls
+# platform.install_scheduled_job() for the macOS launchd plist or the
+# Linux cron stub (raises). See plan.md §5 Epic 6.
+exit 0

--- a/modules/autoheal/bin/autoheal-publish.sh
+++ b/modules/autoheal/bin/autoheal-publish.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Epic 12: content TBD — webhook publisher seam. No-op when webhook_url
+# is null (default). See plan.md §3.10 and §5 Epic 12.
+exit 0

--- a/modules/autoheal/bin/autoheal-retention.sh
+++ b/modules/autoheal/bin/autoheal-retention.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Epic 12: content TBD — gzip events >30 days; delete gzipped >60 days.
+# Same policy for proposals and digests. See plan.md §5 Epic 12.
+exit 0

--- a/modules/autoheal/bin/autoheal-uninstall.sh
+++ b/modules/autoheal/bin/autoheal-uninstall.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Epic 6: content TBD — uninstall the LaunchAgent + clean up. See plan.md
+# §5 Epic 6.
+exit 0

--- a/modules/autoheal/bin/permission-audit.sh
+++ b/modules/autoheal/bin/permission-audit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Epic 5: content TBD — static audit of current hooks + settings.json
+# against the explicit classification table. See plan.md §5 Epic 5.
+exit 0

--- a/modules/autoheal/bin/post-install.sh
+++ b/modules/autoheal/bin/post-install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Epic 6: content TBD — called by start.sh on --reinstall to symlink
+# scripts + run autoheal-install.sh. See plan.md §5 Epic 6.
+exit 0

--- a/modules/autoheal/commands/autoheal-apply.md
+++ b/modules/autoheal/commands/autoheal-apply.md
@@ -1,0 +1,3 @@
+<!-- Epic 11: content TBD — /autoheal-apply [id|list]. Shared apply path
+with /permission-fix apply via lib/apply-proposal.py. See plan.md §5 Epic
+11. -->

--- a/modules/autoheal/commands/autoheal-digest.md
+++ b/modules/autoheal/commands/autoheal-digest.md
@@ -1,0 +1,2 @@
+<!-- Epic 7: content TBD — /autoheal-digest [date]. Renders the local
+digest for a given date (defaults to today). See plan.md §5 Epic 7. -->

--- a/modules/autoheal/commands/autoheal-snooze.md
+++ b/modules/autoheal/commands/autoheal-snooze.md
@@ -1,0 +1,3 @@
+<!-- Epic 7: content TBD — /autoheal-snooze <id> [days]. Snoozes a
+proposal for N days (default 7). Adds an entry to snoozed.json. See
+plan.md §5 Epic 7. -->

--- a/modules/autoheal/commands/autoheal-toggle.md
+++ b/modules/autoheal/commands/autoheal-toggle.md
@@ -1,0 +1,3 @@
+<!-- Epic 7: content TBD — /autoheal-toggle [pause|resume|status|realtime|autoapply|webhook].
+Toggles autoheal-wide pause, real-time alerts (Epic 10), auto-apply (Epic 11),
+and webhook publisher (Epic 12). See plan.md §5 Epic 7. -->

--- a/modules/autoheal/commands/autoheal.md
+++ b/modules/autoheal/commands/autoheal.md
@@ -1,0 +1,2 @@
+<!-- Epic 7: content TBD — /autoheal. Help / status command. See plan.md
+§5 Epic 7. -->

--- a/modules/autoheal/commands/permission-audit.md
+++ b/modules/autoheal/commands/permission-audit.md
@@ -1,0 +1,3 @@
+<!-- Epic 5: content TBD — /permission-audit. Runs bin/permission-audit.sh
+to produce a static audit of the current hooks + settings against the
+explicit classification table. See plan.md §5 Epic 5. -->

--- a/modules/autoheal/commands/permission-fix.md
+++ b/modules/autoheal/commands/permission-fix.md
@@ -1,0 +1,3 @@
+<!-- Epic 4: content TBD — /permission-fix [event-id|latest]. Dispatches the
+in-session root-cause sub-agent to propose a fix for a captured permission
+event; offers an apply path via lib/apply-proposal.py. See plan.md §5 Epic 4. -->

--- a/modules/autoheal/hooks/failure-logger.py
+++ b/modules/autoheal/hooks/failure-logger.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Failure-specialized event logger for autoheal.
+
+Registers on PostToolUseFailure (and runs alongside permission-event-logger.py
+on PostToolUse so that successful + failed runs both end up in the events
+JSONL with their respective kinds).
+
+This hook writes a tool_failure record with stderr and exit_code populated,
+in addition to the standard fields. permission-event-logger.py also writes a
+tool_failure record on the failure surface — that double-write is intentional:
+the analyzer dedupes on (session_id, timestamp, kind) and the redundancy
+guards against a single hook's bugs taking the whole signal down.
+
+Like permission-event-logger.py, this hook NEVER blocks the host tool call.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
+
+_MAX_COMMAND_LEN = 500
+_MAX_STDERR_LEN = 200
+
+
+def _autoheal_dir() -> str:
+    override = os.environ.get("CCGM_AUTOHEAL_DIR")
+    if override:
+        return override
+    return os.path.expanduser("~/.claude/autoheal")
+
+
+def _today_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).date().isoformat()
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+
+def _truncate(text: str, limit: int) -> str:
+    if not text:
+        return text
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 5)] + "[...]"
+
+
+def _is_failure(data: dict) -> bool:
+    """A PostToolUseFailure event is the obvious failure case. Also treat
+    any event with exit_code != 0 as a failure for compatibility with
+    older clients that omit hook_event_name.
+    """
+    name = (data.get("hook_event_name") or "").strip()
+    if name == "PostToolUseFailure":
+        return True
+    exit_code = data.get("exit_code")
+    if isinstance(exit_code, int) and exit_code != 0:
+        return True
+    return False
+
+
+def _build_failure_record(data: dict) -> dict:
+    tool_input = data.get("tool_input") or {}
+    command = tool_input.get("command") if isinstance(tool_input, dict) else None
+    if isinstance(command, str) and command:
+        redacted_command = _truncate(
+            hook_utils.redact_secrets(command), _MAX_COMMAND_LEN
+        )
+    else:
+        redacted_command = None
+
+    stderr_text = data.get("stderr") or ""
+    if isinstance(stderr_text, str) and stderr_text:
+        stderr_excerpt = _truncate(
+            hook_utils.redact_secrets(stderr_text), _MAX_STDERR_LEN
+        )
+    else:
+        stderr_excerpt = None
+
+    exit_code = data.get("exit_code")
+    if not isinstance(exit_code, int):
+        exit_code = None
+
+    return {
+        "kind": "tool_failure",
+        "timestamp": _now_iso(),
+        "session_id": str(data.get("session_id", "")),
+        "tool_name": str(data.get("tool_name", "")),
+        "redacted_command": redacted_command,
+        "exit_code": exit_code,
+        "stderr_excerpt": stderr_excerpt,
+        "permission_decision": None,
+        "cwd": data.get("cwd"),
+        "clone_path": data.get("cwd"),
+    }
+
+
+def main() -> None:
+    try:
+        data = hook_utils.read_hook_input()
+        if not _is_failure(data):
+            # Failure logger fires on both PostToolUse and PostToolUseFailure
+            # (registered on both surfaces). On PostToolUse with no failure
+            # signal, do nothing — permission-event-logger handles the
+            # tool_use record.
+            sys.exit(0)
+        record = _build_failure_record(data)
+        target = os.path.join(_autoheal_dir(), "events", _today_iso() + ".jsonl")
+        hook_utils.file_locked_append(target, json.dumps(record))
+    except Exception:
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/autoheal/hooks/permission-event-logger.py
+++ b/modules/autoheal/hooks/permission-event-logger.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Event logger for autoheal observability loop.
+
+Registers on PostToolUse, PostToolUseFailure, and PermissionRequest with no
+matcher. Captures one append-only JSONL record per tool call / failure /
+permission prompt to ~/.claude/autoheal/events/{YYYY-MM-DD}.jsonl.
+
+Design constraints (plan.md §3 and Epic 3 spec):
+  - Never blocks the host tool call: always exit 0.
+  - Always applies hook_utils.redact_secrets() BEFORE truncation so the
+    truncation boundary can never lop a redaction marker in half.
+  - Uses hook_utils.file_locked_append() so 4 concurrent agents writing to
+    the same file cannot interleave records.
+  - Event dir is overridable via $CCGM_AUTOHEAL_DIR for tests.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
+
+# Hard cap on the stored command excerpt. 500 chars is long enough to
+# diagnose most permission patterns while keeping the JSONL row small.
+_MAX_COMMAND_LEN = 500
+_MAX_STDERR_LEN = 200
+
+
+def _autoheal_dir() -> str:
+    """Resolve the autoheal data directory. Tests can override via env."""
+    override = os.environ.get("CCGM_AUTOHEAL_DIR")
+    if override:
+        return override
+    return os.path.expanduser("~/.claude/autoheal")
+
+
+def _today_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).date().isoformat()
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+
+def _truncate(text: str, limit: int) -> str:
+    """Truncate text to `limit` chars, marking the cut with [...]."""
+    if not text:
+        return text
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 5)] + "[...]"
+
+
+def _classify(data: dict) -> str:
+    """Map hook event type to autoheal event kind.
+
+    Claude Code passes the event name in `hook_event_name` (preferred) or
+    falls back to inference from other fields. We honor either.
+    """
+    name = (data.get("hook_event_name") or "").strip()
+    if name == "PostToolUseFailure":
+        return "tool_failure"
+    if name == "PermissionRequest":
+        return "permission_request"
+    if name == "PostToolUse":
+        return "tool_use"
+
+    # Fallback inference: presence of `permission_request` payload, exit
+    # code, or stderr.
+    if data.get("permission_request") is not None:
+        return "permission_request"
+    if data.get("exit_code") is not None and data.get("exit_code") != 0:
+        return "tool_failure"
+    return "tool_use"
+
+
+def _build_record(data: dict, kind: str) -> dict:
+    """Build a redacted event record. Schema: lib/event-schema.json."""
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input") or {}
+
+    # Bash commands are the most common security/leak surface. Redact
+    # BEFORE truncating so a partial redaction marker never escapes.
+    command = tool_input.get("command") if isinstance(tool_input, dict) else None
+    if isinstance(command, str) and command:
+        redacted = hook_utils.redact_secrets(command)
+        redacted_command = _truncate(redacted, _MAX_COMMAND_LEN)
+    else:
+        redacted_command = None
+
+    stderr_text = data.get("stderr") or ""
+    if isinstance(stderr_text, str) and stderr_text:
+        stderr_excerpt = _truncate(
+            hook_utils.redact_secrets(stderr_text), _MAX_STDERR_LEN
+        )
+    else:
+        stderr_excerpt = None
+
+    exit_code = data.get("exit_code")
+    if not isinstance(exit_code, int):
+        exit_code = None
+
+    permission_decision = None
+    pr = data.get("permission_request")
+    if isinstance(pr, dict):
+        decision = pr.get("decision")
+        if isinstance(decision, str):
+            permission_decision = decision
+
+    return {
+        "kind": kind,
+        "timestamp": _now_iso(),
+        "session_id": str(data.get("session_id", "")),
+        "tool_name": str(tool_name),
+        "redacted_command": redacted_command,
+        "exit_code": exit_code,
+        "stderr_excerpt": stderr_excerpt,
+        "permission_decision": permission_decision,
+        "cwd": data.get("cwd"),
+        "clone_path": data.get("cwd"),
+    }
+
+
+def main() -> None:
+    try:
+        data = hook_utils.read_hook_input()
+        kind = _classify(data)
+        record = _build_record(data, kind)
+        target = os.path.join(_autoheal_dir(), "events", _today_iso() + ".jsonl")
+        hook_utils.file_locked_append(target, json.dumps(record))
+    except Exception:
+        # NEVER block the host tool call. Swallow logger errors silently.
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/autoheal/hooks/permission-request-suppress.py
+++ b/modules/autoheal/hooks/permission-request-suppress.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Contextual auto-allow for PermissionRequest events.
+
+Registers on PermissionRequest with no matcher. The hook decides whether to
+auto-allow the prompt based on the historical event log. The gate is
+deliberately conservative: ALL of the following must hold for auto-allow:
+
+  1. The session is in bypass mode (bypassPermissions / dontAsk / auto).
+     If the user is in default mode they explicitly opted in to seeing
+     prompts, so we never suppress.
+  2. The (tool_name, command-or-path-signature) has been approved >= 3
+     times across >= 2 distinct session_ids in the events log. This
+     prevents one rogue session from establishing a precedent.
+  3. The signature is NOT currently snoozed (no entry in snoozed.json
+     with snoozed_until > now).
+
+If all conditions hold we emit a PermissionRequest 'allow' decision via
+hook_utils.emit_decision('allow', ...). Otherwise we exit 0 and let the
+normal permission flow continue (user sees the prompt).
+
+The hook NEVER blocks the host call; the worst case is the user sees a
+prompt they could have skipped.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
+
+
+_MIN_APPROVALS = 3
+_MIN_DISTINCT_SESSIONS = 2
+
+
+def _autoheal_dir() -> str:
+    override = os.environ.get("CCGM_AUTOHEAL_DIR")
+    if override:
+        return override
+    return os.path.expanduser("~/.claude/autoheal")
+
+
+def _events_dir() -> str:
+    return os.path.join(_autoheal_dir(), "events")
+
+
+def _snoozed_path() -> str:
+    return os.path.join(_autoheal_dir(), "snoozed.json")
+
+
+def _signature(tool_name: str, tool_input: dict) -> str:
+    """Build a stable signature string for the (tool, target) pair.
+
+    For Bash, the command's first token is the signature; for other tools
+    we use the file_path field if present, else a sentinel. This
+    deliberately ignores arguments after the verb so 'git diff foo' and
+    'git diff bar' are the same signature.
+    """
+    if tool_name == "Bash":
+        command = (tool_input or {}).get("command") or ""
+        # First two tokens of the command. Conservative: 'git diff foo'
+        # and 'git diff bar' share a signature, but 'git diff' and 'git
+        # log' do not.
+        tokens = command.strip().split()
+        head = " ".join(tokens[:2]) if tokens else ""
+        return f"Bash::{head}"
+    path = (tool_input or {}).get("file_path") or ""
+    return f"{tool_name}::{path}"
+
+
+def _scan_history(signature: str) -> tuple[int, set[str]]:
+    """Walk all events JSONL files; count prior 'allow' approvals for
+    this signature. Returns (approval_count, distinct_session_ids).
+
+    A prior approval is any event record with:
+      - kind == 'permission_request'
+      - permission_decision == 'allow'
+      - signature matching `signature`
+    """
+    events_dir = _events_dir()
+    approvals = 0
+    sessions: set[str] = set()
+
+    if not os.path.isdir(events_dir):
+        return (0, sessions)
+
+    try:
+        files = sorted(os.listdir(events_dir))
+    except OSError:
+        return (0, sessions)
+
+    for name in files:
+        # Only consider current .jsonl files; ignore gzipped archives.
+        if not name.endswith(".jsonl"):
+            continue
+        path = os.path.join(events_dir, name)
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if rec.get("kind") != "permission_request":
+                        continue
+                    if rec.get("permission_decision") != "allow":
+                        continue
+                    # Compute signature for this stored event from its
+                    # tool_name + redacted_command. This is approximate:
+                    # the redaction is already applied so the prefix
+                    # match still works for command verbs.
+                    stored_sig = _signature(
+                        rec.get("tool_name", ""),
+                        {"command": rec.get("redacted_command") or ""},
+                    )
+                    if stored_sig == signature:
+                        approvals += 1
+                        sid = rec.get("session_id")
+                        if isinstance(sid, str) and sid:
+                            sessions.add(sid)
+        except OSError:
+            continue
+
+    return (approvals, sessions)
+
+
+def _is_snoozed(signature: str) -> bool:
+    """Read snoozed.json; return True iff `signature` is snoozed and the
+    snooze hasn't expired.
+
+    Schema:
+        {
+          "<signature>": {"snoozed_until": "<ISO 8601>"},
+          ...
+        }
+    """
+    path = _snoozed_path()
+    if not os.path.isfile(path):
+        return False
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    entry = data.get(signature)
+    if not isinstance(entry, dict):
+        return False
+    until_str = entry.get("snoozed_until")
+    if not isinstance(until_str, str):
+        return False
+    try:
+        until = _dt.datetime.fromisoformat(until_str.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    now = _dt.datetime.now(_dt.timezone.utc)
+    if until.tzinfo is None:
+        until = until.replace(tzinfo=_dt.timezone.utc)
+    return until > now
+
+
+def main() -> None:
+    try:
+        data = hook_utils.read_hook_input()
+        if not hook_utils.is_bypass_mode(data):
+            sys.exit(0)
+
+        tool_name = str(data.get("tool_name", ""))
+        tool_input = data.get("tool_input") or {}
+        if not tool_name:
+            sys.exit(0)
+        signature = _signature(tool_name, tool_input if isinstance(tool_input, dict) else {})
+
+        if _is_snoozed(signature):
+            sys.exit(0)
+
+        approvals, sessions = _scan_history(signature)
+        if approvals < _MIN_APPROVALS:
+            sys.exit(0)
+        if len(sessions) < _MIN_DISTINCT_SESSIONS:
+            sys.exit(0)
+
+        # All gates passed: auto-allow.
+        hook_utils.emit_decision(
+            "allow",
+            f"autoheal: auto-allowed via pattern match "
+            f"({approvals} prior approvals across {len(sessions)} sessions).",
+        )
+    except SystemExit:
+        raise
+    except Exception:
+        # Never break the user flow if the suppression hook errors.
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/autoheal/hooks/post-prompt-introspect.py
+++ b/modules/autoheal/hooks/post-prompt-introspect.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+# Epic 4: content TBD — Stop hook that surfaces in-session root-cause
+# suggestions with session-level dedup. See plan.md §5 Epic 4.
+import sys
+
+sys.exit(0)

--- a/modules/autoheal/hooks/realtime-security-scanner.py
+++ b/modules/autoheal/hooks/realtime-security-scanner.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# Epic 10: content TBD — PostToolUse scanner with async:true,
+# asyncRewake:true. Reads realtime_alerts_enabled from
+# ~/.claude/autoheal/config.json and exits 0 if disabled (default).
+# See plan.md §3.6 and §5 Epic 10.
+#
+# The hook is registered unconditionally in settings.partial.json because
+# JSON cannot express config-flag-conditional registration. The runtime
+# gate on realtime_alerts_enabled lives here instead.
+import sys
+
+sys.exit(0)

--- a/modules/autoheal/hooks/user-correction-detector.py
+++ b/modules/autoheal/hooks/user-correction-detector.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Detect user-correction patterns in UserPromptSubmit input and log them.
+
+Registers on UserPromptSubmit (no matcher). When the user's prompt matches a
+correction pattern (e.g. "no, not like that", "stop doing X", "I told you"),
+log a user_correction event linking to the most recent tool_use events from
+today's JSONL. The analyzer uses these as supervised signals that the agent's
+recent actions were wrong.
+
+This hook NEVER blocks the prompt, NEVER modifies the prompt, and never asks
+for clarification. exit 0 always.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
+
+
+# Each tuple: (pattern_name, compiled_regex). Order matters only for
+# disambiguation when two patterns could match the same string; the first
+# match wins. Patterns are case-insensitive and word-bounded where it
+# makes sense. False positives are acceptable — the analyzer's threshold
+# logic is the second line of defense.
+_CORRECTION_PATTERNS: list[tuple[str, "re.Pattern[str]"]] = [
+    (
+        "no_not_like_that",
+        re.compile(r"\bno,?\s+not\s+like\s+that\b", re.IGNORECASE),
+    ),
+    (
+        "stop_doing",
+        re.compile(r"\bstop\s+doing\b", re.IGNORECASE),
+    ),
+    (
+        "dont_do_that",
+        re.compile(r"\b(?:don'?t|do\s+not)\s+(?:do\s+that|do\s+this)\b", re.IGNORECASE),
+    ),
+    (
+        "i_told_you",
+        re.compile(r"\bI\s+told\s+you\b", re.IGNORECASE),
+    ),
+    (
+        "wait_no",
+        re.compile(r"\bwait,?\s+no\b", re.IGNORECASE),
+    ),
+    (
+        "actually_correction",
+        re.compile(r"\bactually,?\s+(?:no|that's\s+wrong|that\s+is\s+wrong|do)\b", re.IGNORECASE),
+    ),
+    (
+        "instead",
+        re.compile(r"\b(?:do\s+\w+\s+)?instead\b", re.IGNORECASE),
+    ),
+    (
+        "thats_wrong",
+        re.compile(r"\bthat'?s\s+(?:wrong|not\s+right|incorrect)\b", re.IGNORECASE),
+    ),
+    (
+        "undo",
+        re.compile(r"\b(?:undo|revert)\s+(?:that|this|what\s+you\s+did)\b", re.IGNORECASE),
+    ),
+]
+
+_MAX_RECENT_CONTEXT = 3  # how many recent tool_use events to attach as context
+
+
+def _autoheal_dir() -> str:
+    override = os.environ.get("CCGM_AUTOHEAL_DIR")
+    if override:
+        return override
+    return os.path.expanduser("~/.claude/autoheal")
+
+
+def _today_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).date().isoformat()
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+
+def _match_pattern(text: str) -> str | None:
+    """Return the first matching pattern name, or None."""
+    if not text:
+        return None
+    for name, regex in _CORRECTION_PATTERNS:
+        if regex.search(text):
+            return name
+    return None
+
+
+def _recent_tool_use_ids(events_path: str) -> list[str]:
+    """Read up to _MAX_RECENT_CONTEXT trailing tool_use timestamps from
+    today's events JSONL. Returns the timestamps (used as light-weight
+    event ids — the event-schema allows but doesn't require an explicit
+    id field).
+    """
+    if not os.path.isfile(events_path):
+        return []
+    try:
+        with open(events_path, "r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except OSError:
+        return []
+
+    out: list[str] = []
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if rec.get("kind") == "tool_use":
+            ts = rec.get("timestamp") or rec.get("id")
+            if isinstance(ts, str):
+                out.append(ts)
+                if len(out) >= _MAX_RECENT_CONTEXT:
+                    break
+    return out
+
+
+def _extract_prompt(data: dict) -> str:
+    """Pull the user prompt text out of the hook input. The exact key
+    name varies by client version; try the documented ones in order.
+    """
+    for key in ("prompt", "user_prompt", "user_message", "text", "input"):
+        val = data.get(key)
+        if isinstance(val, str) and val:
+            return val
+        if isinstance(val, dict):
+            inner = val.get("text") or val.get("content")
+            if isinstance(inner, str) and inner:
+                return inner
+    # Last-resort fallback for UserPromptSubmit shape variants.
+    submit = data.get("user_prompt_submit") or data.get("prompt_submit")
+    if isinstance(submit, dict):
+        text = submit.get("text") or submit.get("prompt")
+        if isinstance(text, str):
+            return text
+    return ""
+
+
+def main() -> None:
+    try:
+        data = hook_utils.read_hook_input()
+        prompt_text = _extract_prompt(data)
+        pattern = _match_pattern(prompt_text)
+        if pattern is None:
+            sys.exit(0)
+
+        events_path = os.path.join(
+            _autoheal_dir(), "events", _today_iso() + ".jsonl"
+        )
+        context_ids = _recent_tool_use_ids(events_path)
+
+        record = {
+            "kind": "user_correction",
+            "timestamp": _now_iso(),
+            "session_id": str(data.get("session_id", "")),
+            "tool_name": "UserPrompt",
+            "redacted_command": None,
+            "exit_code": None,
+            "stderr_excerpt": None,
+            "permission_decision": None,
+            "cwd": data.get("cwd"),
+            "clone_path": data.get("cwd"),
+            "correction_pattern_matched": pattern,
+            "context_event_ids": context_ids,
+        }
+        hook_utils.file_locked_append(events_path, json.dumps(record))
+    except Exception:
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/autoheal/lib/analyzer-prompt.md
+++ b/modules/autoheal/lib/analyzer-prompt.md
@@ -1,0 +1,4 @@
+<!-- Epic 6: content TBD — system prompt for the daily analyzer API call.
+Includes untrusted-data framing, paraphrase-only rule, breadth_score
+guidance, and structured JSON output schema reference. See plan.md §5
+Epic 6 and §3.13. -->

--- a/modules/autoheal/lib/analyzer-sandbox.sb
+++ b/modules/autoheal/lib/analyzer-sandbox.sb
@@ -1,0 +1,3 @@
+;; Epic 6: content TBD — macOS Seatbelt (sandbox-exec) profile for the
+;; analyzer; restricts outbound network to api.anthropic.com:443 and
+;; file reads to a tempfile. See plan.md §3.13 and §5 Epic 6.

--- a/modules/autoheal/lib/apply-proposal.py
+++ b/modules/autoheal/lib/apply-proposal.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+# Epic 4 + Epic 11: content TBD — shared apply implementation used by
+# /permission-fix apply and /autoheal-apply. Creates feature branch,
+# applies diff, runs tests, commits, prints diff, writes applied audit.
+# See plan.md §3.9 and §5 Epics 4 + 11.

--- a/modules/autoheal/lib/autoheal.cron.template
+++ b/modules/autoheal/lib/autoheal.cron.template
@@ -1,0 +1,3 @@
+# Epic 6 (Linux v2): content TBD — crontab entry for the daily wrapper.
+# Present as architectural seam; Linux scheduling is not built in v1
+# (lib/platform.py raises NotImplementedError on Linux). See plan.md §3.11.

--- a/modules/autoheal/lib/com.__USERNAME__.ccgm.autoheal.daily.plist.template
+++ b/modules/autoheal/lib/com.__USERNAME__.ccgm.autoheal.daily.plist.template
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Epic 6: content TBD — launchd LaunchAgent plist template. Fires
+     bin/autoheal-daily.sh at 08:00 local; next-wake firing. NEVER
+     include RESEND_API_KEY or ANTHROPIC_API_KEY in EnvironmentVariables
+     (they are read from the shell env at runtime). See plan.md §5 Epic
+     6. -->

--- a/modules/autoheal/lib/event-schema.json
+++ b/modules/autoheal/lib/event-schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Autoheal Event Record",
+  "description": "Append-only event record written to ~/.claude/autoheal/events/{YYYY-MM-DD}.jsonl. Each line is one event captured by an autoheal hook. All free-text fields pass through hook_utils.redact_secrets() before being written so credentials cannot leak into the log.",
+  "type": "object",
+  "required": ["kind", "timestamp", "session_id", "tool_name"],
+  "additionalProperties": false,
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": [
+        "tool_use",
+        "tool_failure",
+        "permission_request",
+        "user_correction",
+        "realtime_security_alert"
+      ],
+      "description": "Event family. Determines which other fields are populated."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp of the event."
+    },
+    "session_id": {
+      "type": "string",
+      "description": "Claude Code session id; used for cross-event correlation."
+    },
+    "tool_name": {
+      "type": "string",
+      "description": "Tool that triggered the event (Bash, Edit, Write, Read, etc.)."
+    },
+    "redacted_command": {
+      "type": ["string", "null"],
+      "description": "For Bash events only: the command string after redact_secrets() and truncation to <= 500 chars."
+    },
+    "exit_code": {
+      "type": ["integer", "null"],
+      "description": "Exit code from PostToolUseFailure events; null for non-failure events."
+    },
+    "stderr_excerpt": {
+      "type": ["string", "null"],
+      "maxLength": 200,
+      "description": "Up to 200 redacted chars of stderr for tool_failure events."
+    },
+    "permission_decision": {
+      "type": ["string", "null"],
+      "description": "For permission_request events: 'allow' | 'deny' | 'ask' as decided by the user (or null when the request was auto-handled by a hook)."
+    },
+    "cwd": {
+      "type": ["string", "null"],
+      "description": "Working directory of the originating tool call. Used for per-repo config lookup."
+    },
+    "clone_path": {
+      "type": ["string", "null"],
+      "description": "Originating clone path (e.g. ~/code/ccgm-workspaces/ccgm-w1/ccgm-w1-c0). Enables cross-clone proposal correlation."
+    },
+    "approval_count": {
+      "type": ["integer", "null"],
+      "description": "For permission_request events: how many prior approvals of this (tool, command) signature exist across the event log. Used by permission-request-suppress.py."
+    },
+    "correction_pattern_matched": {
+      "type": ["string", "null"],
+      "description": "For user_correction events: the regex pattern name that matched."
+    },
+    "context_event_ids": {
+      "type": ["array", "null"],
+      "items": {"type": "string"},
+      "description": "For user_correction events: the prior tool_use event ids (recent) that the correction is about."
+    },
+    "security_pattern_matched": {
+      "type": ["string", "null"],
+      "description": "For realtime_security_alert events: the realtime-security-patterns.json pattern name that fired."
+    },
+    "id": {
+      "type": "string",
+      "description": "Optional event id (uuid4 short). Set when downstream code needs to reference this event by id."
+    }
+  }
+}

--- a/modules/autoheal/lib/permission-fix-prompt.md
+++ b/modules/autoheal/lib/permission-fix-prompt.md
@@ -1,0 +1,2 @@
+<!-- Epic 4: content TBD — sub-agent prompt for /permission-fix. Explicit
+Edit/Write/Bash prohibition. See plan.md §5 Epic 4. -->

--- a/modules/autoheal/lib/proposal-schema.json
+++ b/modules/autoheal/lib/proposal-schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Autoheal Proposal Record",
+  "description": "Append-only proposal record written by the daily analyzer to ~/.claude/autoheal/proposals/{YYYY-MM-DD}.jsonl. Each proposal describes a settings/hook/command change suggested by analysis of recent event traffic. See plan.md §3.4 and §3.7 for the data model and auto-apply confidence gate.",
+  "type": "object",
+  "required": [
+    "id",
+    "kind",
+    "title",
+    "rationale",
+    "confidence",
+    "breadth_score",
+    "occurrence_count",
+    "session_ids",
+    "proposed_diff_target",
+    "proposed_diff",
+    "fingerprint",
+    "originating_clone",
+    "generated_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "uuid4 short (e.g. 'prop_01HW...'). Stable for the lifetime of the proposal."
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "settings_allow_add",
+        "settings_deny_remove",
+        "hook_narrow",
+        "new_command",
+        "rule_update",
+        "command_doc_tweak"
+      ],
+      "description": "Kind of change being proposed. Auto-apply (Epic 11) targets only 'settings_allow_add'."
+    },
+    "title": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Human-readable one-line title; passed through redact_secrets() before persistence."
+    },
+    "rationale": {
+      "type": "string",
+      "maxLength": 2000,
+      "description": "Multi-line rationale; passed through redact_secrets() before persistence."
+    },
+    "confidence": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10,
+      "description": "Analyzer confidence. Auto-apply gate requires >= 9."
+    },
+    "breadth_score": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10,
+      "description": "How sweeping the change is. 1 = highly specific (single command); 10 = sweeping (entire tool family). Auto-apply gate requires <= 1."
+    },
+    "occurrence_count": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "How many events in the analyzed window support this proposal."
+    },
+    "session_ids": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1,
+      "description": "Distinct session ids that contributed evidence. High-confidence proposals must have >= 2."
+    },
+    "proposed_diff_target": {
+      "type": "string",
+      "description": "Path of the file the diff applies to, repo-relative (e.g. 'modules/settings/settings.partial.json'). Auto-apply gate requires startswith('modules/settings/')."
+    },
+    "proposed_diff": {
+      "type": "string",
+      "description": "Unified diff or before/after JSON description. Applied verbatim by apply-proposal.py."
+    },
+    "fingerprint": {
+      "type": "string",
+      "description": "sha256 over the normalized (kind, target, sorted-diff-content) form. Used by cross-clone dedup so two clones cannot file the same proposal twice."
+    },
+    "originating_clone": {
+      "type": "string",
+      "description": "Clone path or identifier where the proposal was first emitted (e.g. 'ccgm-w1-c0'). For cross-clone audit."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp when the analyzer emitted the proposal."
+    },
+    "snoozed_until": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "If set, /autoheal-snooze suppresses this proposal until the given timestamp."
+    },
+    "auto_apply_blocked": {
+      "type": "boolean",
+      "default": false,
+      "description": "If true, auto-apply skips this proposal even if it passes the gate. Set when a previous auto-apply attempt rolled back or when the user explicitly blocked it."
+    },
+    "source_events": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Event ids that triggered the proposal. Optional but useful for digest rendering."
+    }
+  }
+}

--- a/modules/autoheal/lib/realtime-security-patterns.json
+++ b/modules/autoheal/lib/realtime-security-patterns.json
@@ -1,0 +1,4 @@
+{
+  "_description": "Epic 10: content TBD — high-confidence security patterns for the realtime scanner. See plan.md §3.6. Patterns are: github_pat_in_commit_or_echo, aws_key_in_command, anthropic_key_in_command, force_push_main_without_bypass, rm_rf_absolute_root, sudo_destructive, drop_production_db.",
+  "patterns": []
+}

--- a/modules/autoheal/lib/repo-config-schema.json
+++ b/modules/autoheal/lib/repo-config-schema.json
@@ -1,0 +1,3 @@
+{
+  "_description": "Epic 12: content TBD — JSON schema for per-repo .autoheal/config.json. See plan.md §3.4 (per-repo overrides) and §5 Epic 12."
+}

--- a/modules/autoheal/lib/secret-patterns.json
+++ b/modules/autoheal/lib/secret-patterns.json
@@ -1,0 +1,107 @@
+{
+  "_description": "Documents the 17 secret-pattern families covered by hook_utils.redact_secrets(). This file is a parallel reference for the daily analyzer and tests; the canonical source of truth is modules/hooks/lib/hook_utils.py (the SECRET_PATTERNS list). Updating regexes here without also updating hook_utils.py will silently desync the contract.",
+  "patterns": [
+    {
+      "name": "anthropic",
+      "regex": "sk-ant-(?:api03-)?[A-Za-z0-9_\\-]{32,}",
+      "vendor": "Anthropic",
+      "notes": "Covers legacy and api03-prefixed forms."
+    },
+    {
+      "name": "stripe_live",
+      "regex": "sk_live_[A-Za-z0-9]{16,}",
+      "vendor": "Stripe",
+      "notes": "Live secret key."
+    },
+    {
+      "name": "stripe_test",
+      "regex": "sk_test_[A-Za-z0-9]{16,}",
+      "vendor": "Stripe",
+      "notes": "Test secret key."
+    },
+    {
+      "name": "github_pat",
+      "regex": "ghp_[A-Za-z0-9]{30,}",
+      "vendor": "GitHub",
+      "notes": "Personal access token."
+    },
+    {
+      "name": "github_oauth",
+      "regex": "gho_[A-Za-z0-9]{30,}",
+      "vendor": "GitHub",
+      "notes": "OAuth access token."
+    },
+    {
+      "name": "github_u2s",
+      "regex": "ghu_[A-Za-z0-9]{30,}",
+      "vendor": "GitHub",
+      "notes": "User-to-server token."
+    },
+    {
+      "name": "github_s2s",
+      "regex": "ghs_[A-Za-z0-9]{30,}",
+      "vendor": "GitHub",
+      "notes": "Server-to-server token."
+    },
+    {
+      "name": "github_refresh",
+      "regex": "ghr_[A-Za-z0-9]{30,}",
+      "vendor": "GitHub",
+      "notes": "Refresh token."
+    },
+    {
+      "name": "aws_access_key",
+      "regex": "AKIA[0-9A-Z]{16}",
+      "vendor": "AWS",
+      "notes": "Access key id; pairs with a 40-char secret access key (not pattern-matched here)."
+    },
+    {
+      "name": "google_api",
+      "regex": "AIza[0-9A-Za-z_\\-]{35}",
+      "vendor": "Google",
+      "notes": "API key."
+    },
+    {
+      "name": "slack",
+      "regex": "xox[abprs]-[0-9A-Za-z\\-]{10,}",
+      "vendor": "Slack",
+      "notes": "Covers xoxa, xoxb, xoxp, xoxr, xoxs variants."
+    },
+    {
+      "name": "resend",
+      "regex": "re_[A-Za-z0-9]{8,}_[A-Za-z0-9]{16,}",
+      "vendor": "Resend",
+      "notes": "API key."
+    },
+    {
+      "name": "supabase",
+      "regex": "sb_(?:secret|publishable)_[A-Za-z0-9]{20,}",
+      "vendor": "Supabase",
+      "notes": "Modern prefixed shape (replaces legacy anon/service_role keys)."
+    },
+    {
+      "name": "openai",
+      "regex": "sk-(?!ant-)(?!live_)(?!test_)[A-Za-z0-9]{32,}",
+      "vendor": "OpenAI",
+      "notes": "Generic sk- shape; explicitly excludes Anthropic and Stripe prefixes via negative lookaheads."
+    },
+    {
+      "name": "authorization_bearer",
+      "regex": "(?i)authorization\\s*:\\s*bearer\\s+[A-Za-z0-9._\\-]+",
+      "vendor": "Generic",
+      "notes": "Authorization header. Catches most generic bearer tokens."
+    },
+    {
+      "name": "env_var_kv",
+      "regex": "(?i)\\b(?:api[_-]?key|api[_-]?secret|access[_-]?token|auth[_-]?token|client[_-]?secret|secret[_-]?key|password|passwd)\\s*[=:]\\s*['\"]?[A-Za-z0-9_\\-/+=.]{12,}",
+      "vendor": "Generic",
+      "notes": "env-var-style KV assignments naming common secret keys. Conservative; over-fires acceptably."
+    },
+    {
+      "name": "password_flag",
+      "regex": "(?<!\\S)(?:--password|--passwd|-p)[=\\s]+\\S{6,}",
+      "vendor": "Generic",
+      "notes": "CLI --password/-p flag with a value following."
+    }
+  ]
+}

--- a/modules/autoheal/module.json
+++ b/modules/autoheal/module.json
@@ -1,0 +1,198 @@
+{
+  "name": "autoheal",
+  "displayName": "Autoheal: Self-Healing Observability Loop",
+  "description": "Captures permission events, tool failures, and user-correction signals; runs a daily analyzer via direct Anthropic API call; produces a local digest + opt-in Resend email; opt-in real-time security alerts and opt-in confidence-gated auto-apply. Cross-clone-safe via fcntl file locks. Webhook publisher seam is dormant by default.",
+  "category": "workflow",
+  "scope": ["global"],
+  "dependencies": ["hooks"],
+  "files": {
+    "hooks/permission-event-logger.py": {
+      "target": "hooks/permission-event-logger.py",
+      "type": "hook",
+      "template": false
+    },
+    "hooks/failure-logger.py": {
+      "target": "hooks/failure-logger.py",
+      "type": "hook",
+      "template": false
+    },
+    "hooks/user-correction-detector.py": {
+      "target": "hooks/user-correction-detector.py",
+      "type": "hook",
+      "template": false
+    },
+    "hooks/permission-request-suppress.py": {
+      "target": "hooks/permission-request-suppress.py",
+      "type": "hook",
+      "template": false
+    },
+    "hooks/post-prompt-introspect.py": {
+      "target": "hooks/post-prompt-introspect.py",
+      "type": "hook",
+      "template": false
+    },
+    "hooks/realtime-security-scanner.py": {
+      "target": "hooks/realtime-security-scanner.py",
+      "type": "hook",
+      "template": false
+    },
+    "commands/permission-fix.md": {
+      "target": "commands/permission-fix.md",
+      "type": "command",
+      "template": false
+    },
+    "commands/permission-audit.md": {
+      "target": "commands/permission-audit.md",
+      "type": "command",
+      "template": false
+    },
+    "commands/autoheal.md": {
+      "target": "commands/autoheal.md",
+      "type": "command",
+      "template": false
+    },
+    "commands/autoheal-digest.md": {
+      "target": "commands/autoheal-digest.md",
+      "type": "command",
+      "template": false
+    },
+    "commands/autoheal-toggle.md": {
+      "target": "commands/autoheal-toggle.md",
+      "type": "command",
+      "template": false
+    },
+    "commands/autoheal-snooze.md": {
+      "target": "commands/autoheal-snooze.md",
+      "type": "command",
+      "template": false
+    },
+    "commands/autoheal-apply.md": {
+      "target": "commands/autoheal-apply.md",
+      "type": "command",
+      "template": false
+    },
+    "bin/permission-audit.sh": {
+      "target": "bin/permission-audit.sh",
+      "type": "script",
+      "template": false
+    },
+    "bin/autoheal-analyze.sh": {
+      "target": "bin/autoheal-analyze.sh",
+      "type": "script",
+      "template": false
+    },
+    "bin/autoheal-install.sh": {
+      "target": "bin/autoheal-install.sh",
+      "type": "script",
+      "template": false
+    },
+    "bin/autoheal-uninstall.sh": {
+      "target": "bin/autoheal-uninstall.sh",
+      "type": "script",
+      "template": false
+    },
+    "bin/post-install.sh": {
+      "target": "bin/post-install.sh",
+      "type": "script",
+      "template": false
+    },
+    "bin/autoheal-digest.sh": {
+      "target": "bin/autoheal-digest.sh",
+      "type": "script",
+      "template": false
+    },
+    "bin/autoheal-email.sh": {
+      "target": "bin/autoheal-email.sh",
+      "type": "script",
+      "template": false
+    },
+    "bin/autoheal-daily.sh": {
+      "target": "bin/autoheal-daily.sh",
+      "type": "script",
+      "template": false
+    },
+    "bin/autoheal-auto-apply.sh": {
+      "target": "bin/autoheal-auto-apply.sh",
+      "type": "script",
+      "template": false
+    },
+    "bin/autoheal-publish.sh": {
+      "target": "bin/autoheal-publish.sh",
+      "type": "script",
+      "template": false
+    },
+    "bin/autoheal-retention.sh": {
+      "target": "bin/autoheal-retention.sh",
+      "type": "script",
+      "template": false
+    },
+    "lib/event-schema.json": {
+      "target": "lib/event-schema.json",
+      "type": "lib",
+      "template": false
+    },
+    "lib/proposal-schema.json": {
+      "target": "lib/proposal-schema.json",
+      "type": "lib",
+      "template": false
+    },
+    "lib/secret-patterns.json": {
+      "target": "lib/secret-patterns.json",
+      "type": "lib",
+      "template": false
+    },
+    "lib/permission-fix-prompt.md": {
+      "target": "lib/permission-fix-prompt.md",
+      "type": "lib",
+      "template": false
+    },
+    "lib/apply-proposal.py": {
+      "target": "lib/apply-proposal.py",
+      "type": "lib",
+      "template": false
+    },
+    "lib/analyzer-prompt.md": {
+      "target": "lib/analyzer-prompt.md",
+      "type": "lib",
+      "template": false
+    },
+    "lib/analyzer-sandbox.sb": {
+      "target": "lib/analyzer-sandbox.sb",
+      "type": "lib",
+      "template": false
+    },
+    "lib/com.__USERNAME__.ccgm.autoheal.daily.plist.template": {
+      "target": "lib/com.__USERNAME__.ccgm.autoheal.daily.plist",
+      "type": "lib",
+      "template": true
+    },
+    "lib/autoheal.cron.template": {
+      "target": "lib/autoheal.cron",
+      "type": "lib",
+      "template": true
+    },
+    "lib/realtime-security-patterns.json": {
+      "target": "lib/realtime-security-patterns.json",
+      "type": "lib",
+      "template": false
+    },
+    "lib/repo-config-schema.json": {
+      "target": "lib/repo-config-schema.json",
+      "type": "lib",
+      "template": false
+    },
+    "rules/autoheal.md": {
+      "target": "rules/autoheal.md",
+      "type": "rule",
+      "template": false
+    },
+    "settings.partial.json": {
+      "target": "settings.json",
+      "type": "config",
+      "merge": true,
+      "template": false
+    }
+  },
+  "tags": ["autoheal", "observability", "self-healing", "permissions", "telemetry", "jsonl", "hooks"],
+  "configPrompts": []
+}

--- a/modules/autoheal/rules/autoheal.md
+++ b/modules/autoheal/rules/autoheal.md
@@ -1,0 +1,71 @@
+# Autoheal: Self-Healing Observability Loop
+
+Autoheal is a CCGM module that observes how you and your agents interact with Claude Code, then proposes concrete configuration improvements once a day. It captures permission events, tool failures, and user-correction signals as a local JSONL log, runs a daily analyzer against the log via a direct Anthropic API call, and surfaces a digest of proposed changes. Real-time security alerts and confidence-gated auto-apply are opt-in.
+
+## What autoheal does
+
+1. **Event capture** (hooks). Five hooks register on `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `UserPromptSubmit`, and `Stop` to write append-only JSONL records to `~/.claude/autoheal/events/{YYYY-MM-DD}.jsonl`. Every record is redacted via `hook_utils.redact_secrets()` before truncation and every append goes through `hook_utils.file_locked_append()` so multiple clones cannot tear writes.
+2. **Contextual auto-allow** (`permission-request-suppress.py`). In bypass mode, a `PermissionRequest` for a (tool, command-verb) signature that has been approved at least 3 times across at least 2 sessions is auto-allowed. This is conservative on purpose — one rogue session cannot establish a precedent.
+3. **Daily analyzer** (Epic 6). A launchd job runs `bin/autoheal-daily.sh` at 08:00 local. The analyzer reads unanalyzed events, extracts ±3-turn transcript excerpts, and calls the Anthropic API directly (no agent runtime — eliminates exec-escape attack surface). It writes proposals to `~/.claude/autoheal/proposals/{YYYY-MM-DD}.jsonl`.
+4. **Digest** (Epic 7). `bin/autoheal-digest.sh` renders today's proposals as Markdown to `~/.claude/autoheal/digests/{YYYY-MM-DD}.md`. The local digest is always-on; optional Resend email is multi-recipient with per-recipient idempotency keys.
+5. **Apply path** (Epic 4 + 11). `/permission-fix` and `/autoheal-apply` share `lib/apply-proposal.py`: detect canonical clone, create feature branch, apply diff, run validation tests, commit, print `git diff`, write audit. Never auto-pushes; user reviews PR.
+6. **Real-time security alerts** (Epic 10, OPT-IN). When `realtime_alerts_enabled: true`, `realtime-security-scanner.py` runs on `PostToolUse` with `asyncRewake: true`. A match on a high-confidence pattern (`ghp_` in a commit, `rm -rf /`, force-push to main without `ALLOW_MAIN_COMMIT`, etc.) wakes Claude mid-session with `<autoheal-security-alert>`. Default off.
+7. **Confidence-gated auto-apply** (Epic 11, OPT-IN). When `auto_apply_enabled: true` AND a proposal has confidence ≥ 9, breadth ≤ 1, kind `settings_allow_add`, and target under `modules/settings/`, the daily run creates a feature branch and commits — but never pushes. Default off.
+8. **Webhook publisher** (Epic 12, OPT-IN). When `webhook_url` is set, `bin/autoheal-publish.sh` POSTs daily proposals/events/digests to the configured endpoint with a Bearer token. Default null → no-op.
+
+## Config keys (`~/.claude/autoheal/config.json`)
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `realtime_alerts_enabled` | bool | `false` | Opt-in to mid-session `<autoheal-security-alert>` blocks |
+| `auto_apply_enabled` | bool | `false` | Opt-in to confidence-gated auto-apply (feature branches only; never pushes) |
+| `email_enabled` | bool | `false` | Opt-in to Resend digest delivery |
+| `digest_email` | string OR string list | `null` | Recipient(s) for the optional email digest |
+| `webhook_url` | string | `null` | When set, daily run POSTs to `${webhook_url}/v1/ingest` |
+| `webhook_token` | string | generated at install time | 32-char Bearer token for the webhook |
+| `retention_gzip_days` | int | `30` | Gzip events/proposals/digests older than N days |
+| `retention_delete_days` | int | `60` | Delete gzipped artifacts older than N days |
+| `calibration_days` | int | `7` | Relaxed thresholds during the first N days after install |
+
+Per-repo overrides live in `.autoheal/config.json` at the repo root. The merge rule is "missing keys fall through to global"; see `hook_utils.load_repo_config()`.
+
+## Slash commands
+
+- `/permission-fix [event-id|latest]` — in-session root-cause sub-agent. Proposes a fix; can apply via `lib/apply-proposal.py`.
+- `/permission-audit` — static audit of installed hooks + settings against the explicit classification table.
+- `/autoheal` — help + status.
+- `/autoheal-digest [date]` — render today's (or a specific date's) digest.
+- `/autoheal-toggle [pause|resume|status|realtime|autoapply|webhook]` — flip config flags.
+- `/autoheal-snooze <id> [days]` — snooze a proposal for N days (default 7).
+- `/autoheal-apply [id|list]` — formal apply path; same shape as `/permission-fix apply`.
+
+## When NOT to invoke
+
+- **Do not edit `~/.claude/autoheal/events/*.jsonl` by hand.** The file is append-only by contract; the analyzer assumes monotonic ordering and idempotent reads. Use `/autoheal-snooze` to suppress proposals; never delete events to "clean up" the log.
+- **Do not bypass the apply path.** Auto-apply gates exist to keep the agent honest. Manually committing an autoheal proposal without running `apply-proposal.py` skips the validation tests and audit log.
+- **Do not enable `realtime_alerts_enabled` in a session that runs against production data without `ALLOW_MAIN_COMMIT=1` already set.** Real-time alerts will fire on legitimate production operations and may interrupt time-sensitive work. Use the opt-in only when you want mid-session friction for security signals.
+- **Do not point `webhook_url` at an untrusted endpoint.** The webhook publisher streams redacted events, but redaction is best-effort. Treat the webhook receiver as a trusted system.
+
+## Quick checks
+
+```bash
+# Verify the hooks are installed and the log is being written.
+ls ~/.claude/hooks/permission-event-logger.py
+ls ~/.claude/autoheal/events/
+
+# Verify the schemas are valid JSON.
+python3 -c "import json; json.load(open('modules/autoheal/lib/event-schema.json'))"
+python3 -c "import json; json.load(open('modules/autoheal/lib/proposal-schema.json'))"
+
+# Run the Epic-3 test suite.
+bash modules/autoheal/tests/test-event-logging.sh
+bash modules/autoheal/tests/test-permission-suppress.sh
+bash modules/autoheal/tests/test-correction-detection.sh
+bash modules/autoheal/tests/test-redaction-coverage.sh
+```
+
+## Cross-references
+
+- Plan: `~/code/plans/ccgm-autoheal/plan.md` (Section 1 vision; Section 3 architecture; Section 5 Epic 3 spec).
+- Hook helper: `modules/hooks/lib/hook_utils.py` — `read_hook_input`, `redact_secrets`, `file_locked_append`, `is_bypass_mode`, `emit_decision`, `hard_block`, `load_repo_config`.
+- Bring-up runbook: `plan.md §9.1`.

--- a/modules/autoheal/settings.partial.json
+++ b/modules/autoheal/settings.partial.json
@@ -1,0 +1,79 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/permission-event-logger.py",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/failure-logger.py",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/realtime-security-scanner.py",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/permission-event-logger.py",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/failure-logger.py",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/permission-event-logger.py",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/permission-request-suppress.py",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/user-correction-detector.py",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/post-prompt-introspect.py",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/modules/autoheal/tests/run-all.sh
+++ b/modules/autoheal/tests/run-all.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-analyzer-api-call.sh
+++ b/modules/autoheal/tests/test-analyzer-api-call.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-auto-apply-gate.sh
+++ b/modules/autoheal/tests/test-auto-apply-gate.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-correction-detection.sh
+++ b/modules/autoheal/tests/test-correction-detection.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Test suite for modules/autoheal/hooks/user-correction-detector.py
+#
+# Covers:
+#   - Prompts matching each correction pattern produce a user_correction
+#     event with the right correction_pattern_matched value.
+#   - Benign prompts do NOT produce an event.
+#   - The context_event_ids field captures up to 3 recent tool_use
+#     timestamps from today's events JSONL.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOK="${MODULE_ROOT}/hooks/user-correction-detector.py"
+HOOKS_MODULE="$(cd "${MODULE_ROOT}/../hooks" && pwd)"
+HOOK_LIB="${HOOKS_MODULE}/lib"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+TMP_HOME=$(mktemp -d -t autoheal_correction.XXXXXX)
+trap 'rm -rf "${TMP_HOME}"' EXIT
+mkdir -p "${TMP_HOME}/.claude/lib"
+cp "${HOOK_LIB}/hook_utils.py" "${TMP_HOME}/.claude/lib/hook_utils.py"
+
+export HOME="${TMP_HOME}"
+export CCGM_AUTOHEAL_DIR="${TMP_HOME}/autoheal"
+
+today() {
+    python3 -c "import datetime; print(datetime.datetime.now(datetime.timezone.utc).date().isoformat())"
+}
+
+events_file() {
+    echo "${CCGM_AUTOHEAL_DIR}/events/$(today).jsonl"
+}
+
+last_record() {
+    # Print the last record matching the given filter using jq-free
+    # Python — keeps the test portable on machines without jq.
+    python3 -c "
+import json
+recs = [json.loads(line) for line in open('$(events_file)') if line.strip()]
+recs = [r for r in recs if r.get('kind') == 'user_correction']
+print(json.dumps(recs[-1]) if recs else '{}')
+"
+}
+
+run_correction() {
+    local prompt="$1"
+    # Build the JSON in Python to avoid bash-side quoting hell.
+    PROMPT_TEXT="${prompt}" python3 -c "
+import json, os, subprocess, sys
+payload = {
+    'hook_event_name': 'UserPromptSubmit',
+    'session_id': 'corr-session',
+    'tool_name': 'UserPrompt',
+    'prompt': os.environ['PROMPT_TEXT'],
+    'cwd': '/tmp/repo',
+}
+p = subprocess.run(['python3', '${HOOK}'], input=json.dumps(payload), capture_output=True, text=True)
+sys.exit(p.returncode)
+"
+    return $?
+}
+
+# Helper: count user_correction events in today's file.
+correction_count() {
+    if [ ! -f "$(events_file)" ]; then
+        echo 0
+        return
+    fi
+    python3 -c "
+import json
+n = 0
+for line in open('$(events_file)'):
+    line = line.strip()
+    if not line: continue
+    try:
+        if json.loads(line).get('kind') == 'user_correction':
+            n += 1
+    except Exception:
+        pass
+print(n)
+"
+}
+
+# 1. Each correction pattern fires.
+declare -a PATTERNS=(
+    "no, not like that"
+    "stop doing that"
+    "don't do that"
+    "I told you we use Tailwind"
+    "wait, no"
+    "actually, that's wrong"
+    "do A instead"
+    "that's wrong"
+    "undo that"
+)
+
+declare -a EXPECTED_NAMES=(
+    "no_not_like_that"
+    "stop_doing"
+    "dont_do_that"
+    "i_told_you"
+    "wait_no"
+    "actually_correction"
+    "instead"
+    "thats_wrong"
+    "undo"
+)
+
+# Pre-seed two tool_use events so context_event_ids gets populated.
+mkdir -p "${CCGM_AUTOHEAL_DIR}/events"
+python3 <<'PY'
+import json, os, datetime
+path = os.path.join(os.environ['CCGM_AUTOHEAL_DIR'], 'events', datetime.datetime.now(datetime.timezone.utc).date().isoformat() + '.jsonl')
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(path, 'a') as fh:
+    for cmd in ['git diff', 'git status']:
+        rec = {
+            'kind': 'tool_use',
+            'timestamp': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            'session_id': 'corr-session',
+            'tool_name': 'Bash',
+            'redacted_command': cmd,
+            'exit_code': None,
+            'stderr_excerpt': None,
+            'permission_decision': None,
+            'cwd': '/tmp/repo',
+            'clone_path': '/tmp/repo',
+        }
+        fh.write(json.dumps(rec) + '\n')
+PY
+
+for i in "${!PATTERNS[@]}"; do
+    run_correction "${PATTERNS[$i]}"
+    rc=$?
+    assert_eq "${rc}" "0" "correction hook exits 0 for '${PATTERNS[$i]}'"
+done
+
+# 2. Each emitted event carries the expected pattern name.
+python3 <<'PY' > /tmp/correction_names.txt
+import json, os, datetime
+path = os.path.join(os.environ['CCGM_AUTOHEAL_DIR'], 'events', datetime.datetime.now(datetime.timezone.utc).date().isoformat() + '.jsonl')
+for line in open(path):
+    line = line.strip()
+    if not line: continue
+    try:
+        rec = json.loads(line)
+    except Exception:
+        continue
+    if rec.get('kind') == 'user_correction':
+        print(rec.get('correction_pattern_matched', ''))
+PY
+
+# The 9 expected pattern names should appear in the same order in the
+# emitted log.
+declare -a got
+mapfile -t got < /tmp/correction_names.txt
+for i in "${!EXPECTED_NAMES[@]}"; do
+    assert_eq "${got[$i]}" "${EXPECTED_NAMES[$i]}" "pattern $i matches ${EXPECTED_NAMES[$i]}"
+done
+
+# 3. Benign prompts produce NO new user_correction event.
+before=$(correction_count)
+run_correction "let me check the docs and report back"
+run_correction "looks good to me"
+run_correction "running tests now"
+after=$(correction_count)
+assert_eq "${before}" "${after}" "benign prompts add 0 events"
+
+# 4. context_event_ids captures up to 3 recent tool_use entries.
+ctx=$(python3 -c "
+import json, os, datetime
+path = os.path.join(os.environ['CCGM_AUTOHEAL_DIR'], 'events', datetime.datetime.now(datetime.timezone.utc).date().isoformat() + '.jsonl')
+recs = [json.loads(line) for line in open(path) if line.strip()]
+last = [r for r in recs if r.get('kind') == 'user_correction'][-1]
+print(len(last.get('context_event_ids', [])))
+")
+# We seeded 2 tool_use records, so we expect <= 2 context ids.
+case "${ctx}" in
+    0|1|2)
+        PASS=$((PASS + 1))
+        ;;
+    *)
+        FAIL=$((FAIL + 1))
+        echo "FAIL: context_event_ids count <= 2"
+        echo "  actual: ${ctx}"
+        ;;
+esac
+
+# 5. Malformed stdin exits 0.
+echo 'not json {{{' | python3 "${HOOK}"
+rc=$?
+assert_eq "${rc}" "0" "malformed stdin exits 0"
+
+echo ""
+echo "test-correction-detection.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0

--- a/modules/autoheal/tests/test-cross-clone-lock-concurrent.sh
+++ b/modules/autoheal/tests/test-cross-clone-lock-concurrent.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-digest-rendering.sh
+++ b/modules/autoheal/tests/test-digest-rendering.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-e2e-bypass-suppression.sh
+++ b/modules/autoheal/tests/test-e2e-bypass-suppression.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-e2e-resend-failure.sh
+++ b/modules/autoheal/tests/test-e2e-resend-failure.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-event-logging.sh
+++ b/modules/autoheal/tests/test-event-logging.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Test suite for modules/autoheal/hooks/permission-event-logger.py
+#
+# Covers:
+#   - A synthetic PostToolUse stdin produces one row with kind=tool_use,
+#     the correct redacted command, and a timestamp.
+#   - 3 successive tool calls produce 3 rows.
+#   - A command with embedded secrets has REDACTED markers in the
+#     stored event (not the raw token).
+#
+# Each test points CCGM_AUTOHEAL_DIR at a fresh temp dir so the real
+# ~/.claude/autoheal is never touched.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOK="${MODULE_ROOT}/hooks/permission-event-logger.py"
+HOOKS_MODULE="$(cd "${MODULE_ROOT}/../hooks" && pwd)"
+HOOK_LIB="${HOOKS_MODULE}/lib"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  expected substring: ${needle}"
+            echo "  actual: ${haystack}"
+            ;;
+    esac
+}
+
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  unexpected substring present: ${needle}"
+            echo "  actual: ${haystack}"
+            ;;
+        *)
+            PASS=$((PASS + 1))
+            ;;
+    esac
+}
+
+# Symlink ~/.claude/lib to the in-repo hook_utils so the hook can import
+# it without requiring a CCGM install on the test machine. We do this in
+# a private $HOME so we never touch the user's real ~/.claude.
+TMP_HOME=$(mktemp -d -t autoheal_test.XXXXXX)
+trap 'rm -rf "${TMP_HOME}"' EXIT
+mkdir -p "${TMP_HOME}/.claude/lib"
+cp "${HOOK_LIB}/hook_utils.py" "${TMP_HOME}/.claude/lib/hook_utils.py"
+
+export HOME="${TMP_HOME}"
+export CCGM_AUTOHEAL_DIR="${TMP_HOME}/autoheal"
+
+run_hook() {
+    # $1 = JSON stdin; emits nothing on stdout, must exit 0.
+    local payload="$1"
+    echo "${payload}" | python3 "${HOOK}"
+    return $?
+}
+
+today() {
+    python3 -c "import datetime; print(datetime.datetime.now(datetime.timezone.utc).date().isoformat())"
+}
+
+events_file() {
+    echo "${CCGM_AUTOHEAL_DIR}/events/$(today).jsonl"
+}
+
+# 1. Single tool_use append produces 1 line with kind=tool_use.
+rm -f "$(events_file)"
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","tool_name":"Bash","tool_input":{"command":"git diff"},"cwd":"/tmp/repo","permission_mode":"default"}'
+rc=$?
+assert_eq "${rc}" "0" "logger exits 0 on PostToolUse"
+[ -f "$(events_file)" ] && PASS=$((PASS + 1)) || { FAIL=$((FAIL + 1)); echo "FAIL: events file created"; }
+
+line_count=$(wc -l < "$(events_file)" | tr -d ' ')
+assert_eq "${line_count}" "1" "logger writes 1 line"
+
+line=$(head -1 "$(events_file)")
+kind=$(python3 -c "import json,sys; print(json.loads('''${line}''')['kind'])")
+assert_eq "${kind}" "tool_use" "kind=tool_use"
+
+cmd=$(python3 -c "import json; print(json.loads(open('$(events_file)').readline())['redacted_command'])")
+assert_eq "${cmd}" "git diff" "redacted_command preserved benign value"
+
+# Timestamp must parse as ISO 8601.
+ts_ok=$(python3 -c "
+import json, datetime
+rec = json.loads(open('$(events_file)').readline())
+ts = rec['timestamp']
+datetime.datetime.fromisoformat(ts.replace('Z', '+00:00'))
+print('ok')
+" 2>&1)
+assert_eq "${ts_ok}" "ok" "timestamp parses as ISO 8601"
+
+# 2. Three calls produce three lines.
+rm -f "$(events_file)"
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","tool_name":"Bash","tool_input":{"command":"git status"},"cwd":"/tmp/repo"}'
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","tool_name":"Bash","tool_input":{"command":"git log -1"},"cwd":"/tmp/repo"}'
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","tool_name":"Bash","tool_input":{"command":"git diff --staged"},"cwd":"/tmp/repo"}'
+line_count=$(wc -l < "$(events_file)" | tr -d ' ')
+assert_eq "${line_count}" "3" "3 tool calls produce 3 rows"
+
+# 3. Secret-bearing command is redacted in the stored event.
+#
+# Build the fake token at runtime so no literal token form ever appears
+# in this file. We assemble the JSON in Python (not bash) to avoid
+# double-escaping the embedded quote chars.
+rm -f "$(events_file)"
+PAYLOAD=$(python3 <<'PY'
+import json
+S = 'A' * 40
+cmd = 'curl -H "Authorization: Bearer ' + S + '" https://api.example.com'
+print(json.dumps({
+    "hook_event_name": "PostToolUse",
+    "session_id": "s1",
+    "tool_name": "Bash",
+    "tool_input": {"command": cmd},
+    "cwd": "/tmp/repo",
+}))
+PY
+)
+echo "${PAYLOAD}" | python3 "${HOOK}"
+stored=$(python3 -c "
+import json
+print(json.loads(open('$(events_file)').readline())['redacted_command'])
+")
+assert_contains "${stored}" "[REDACTED:authorization_bearer]" "secret redacted in stored event"
+assert_not_contains "${stored}" "AAAAAAAA" "raw secret bytes not present"
+
+# 4. PermissionRequest event is classified correctly.
+rm -f "$(events_file)"
+run_hook '{"hook_event_name":"PermissionRequest","session_id":"s1","tool_name":"Bash","tool_input":{"command":"git push --force feat-x"},"cwd":"/tmp/repo"}'
+kind=$(python3 -c "
+import json
+print(json.loads(open('$(events_file)').readline())['kind'])
+")
+assert_eq "${kind}" "permission_request" "PermissionRequest event has kind permission_request"
+
+# 5. PostToolUseFailure event is classified correctly.
+rm -f "$(events_file)"
+run_hook '{"hook_event_name":"PostToolUseFailure","session_id":"s1","tool_name":"Bash","tool_input":{"command":"false"},"exit_code":1,"stderr":"something failed","cwd":"/tmp/repo"}'
+kind=$(python3 -c "
+import json
+print(json.loads(open('$(events_file)').readline())['kind'])
+")
+assert_eq "${kind}" "tool_failure" "PostToolUseFailure event has kind tool_failure"
+
+ec=$(python3 -c "
+import json
+print(json.loads(open('$(events_file)').readline())['exit_code'])
+")
+assert_eq "${ec}" "1" "exit_code captured"
+
+# 6. cwd and clone_path are populated.
+cwd=$(python3 -c "
+import json
+print(json.loads(open('$(events_file)').readline())['cwd'])
+")
+assert_eq "${cwd}" "/tmp/repo" "cwd captured"
+
+# 7. Malformed JSON stdin does not crash the hook (must still exit 0).
+echo 'not even valid json {{{' | python3 "${HOOK}"
+rc=$?
+assert_eq "${rc}" "0" "malformed stdin exits 0"
+
+echo ""
+echo "test-event-logging.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0

--- a/modules/autoheal/tests/test-idempotency.sh
+++ b/modules/autoheal/tests/test-idempotency.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-multi-recipient-email.sh
+++ b/modules/autoheal/tests/test-multi-recipient-email.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-permission-audit.sh
+++ b/modules/autoheal/tests/test-permission-audit.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-permission-suppress.sh
+++ b/modules/autoheal/tests/test-permission-suppress.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Test suite for modules/autoheal/hooks/permission-request-suppress.py
+#
+# Covers:
+#   - Default-mode PermissionRequest does NOT auto-allow (suppression
+#     only fires in bypass mode).
+#   - Bypass mode with 3 prior allow approvals across 2 sessions DOES
+#     auto-allow (emits an 'allow' decision and exits 0).
+#   - Bypass mode with only 2 prior approvals (below the threshold)
+#     does NOT auto-allow.
+#   - Bypass mode where the (tool, command) signature is snoozed does
+#     NOT auto-allow.
+#
+# All event history is written into a fresh CCGM_AUTOHEAL_DIR temp dir
+# so the user's real ~/.claude/autoheal is never touched.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOK="${MODULE_ROOT}/hooks/permission-request-suppress.py"
+HOOKS_MODULE="$(cd "${MODULE_ROOT}/../hooks" && pwd)"
+HOOK_LIB="${HOOKS_MODULE}/lib"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  expected substring: ${needle}"
+            echo "  actual: ${haystack}"
+            ;;
+    esac
+}
+
+TMP_HOME=$(mktemp -d -t autoheal_suppress.XXXXXX)
+trap 'rm -rf "${TMP_HOME}"' EXIT
+mkdir -p "${TMP_HOME}/.claude/lib"
+cp "${HOOK_LIB}/hook_utils.py" "${TMP_HOME}/.claude/lib/hook_utils.py"
+
+export HOME="${TMP_HOME}"
+export CCGM_AUTOHEAL_DIR="${TMP_HOME}/autoheal"
+mkdir -p "${CCGM_AUTOHEAL_DIR}/events"
+
+today() {
+    python3 -c "import datetime; print(datetime.datetime.now(datetime.timezone.utc).date().isoformat())"
+}
+
+events_file() {
+    echo "${CCGM_AUTOHEAL_DIR}/events/$(today).jsonl"
+}
+
+# Seed `n` approvals across `k` sessions for a given Bash command verb.
+seed_history() {
+    local cmd="$1"
+    local n="$2"
+    local k="$3"
+    python3 <<PY
+import json, os, datetime
+path = '$(events_file)'
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(path, 'a') as fh:
+    for i in range($n):
+        session = f'sess-{i % $k}'
+        rec = {
+            'kind': 'permission_request',
+            'timestamp': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            'session_id': session,
+            'tool_name': 'Bash',
+            'redacted_command': '$cmd',
+            'permission_decision': 'allow',
+            'exit_code': None,
+            'stderr_excerpt': None,
+            'cwd': '/tmp/repo',
+            'clone_path': '/tmp/repo',
+        }
+        fh.write(json.dumps(rec) + '\n')
+PY
+}
+
+# 1. Default-mode PermissionRequest: no auto-allow even with rich history.
+seed_history "git diff" 5 3
+out=$(echo '{"hook_event_name":"PermissionRequest","session_id":"s-default","tool_name":"Bash","tool_input":{"command":"git diff foo"},"permission_mode":"default","cwd":"/tmp/repo"}' | python3 "${HOOK}")
+rc=$?
+assert_eq "${rc}" "0" "default mode exits 0"
+assert_eq "${out}" "" "default mode emits no decision (empty stdout)"
+
+# 2. Bypass mode + 3 approvals across 2 sessions: auto-allow.
+rm -f "$(events_file)"
+seed_history "git diff" 3 2
+out=$(echo '{"hook_event_name":"PermissionRequest","session_id":"s-bypass","tool_name":"Bash","tool_input":{"command":"git diff bar"},"permission_mode":"bypassPermissions","cwd":"/tmp/repo"}' | python3 "${HOOK}")
+rc=$?
+assert_eq "${rc}" "0" "bypass with history exits 0"
+decision=$(echo "${out}" | python3 -c "import json, sys; print(json.load(sys.stdin)['hookSpecificOutput']['permissionDecision'])")
+assert_eq "${decision}" "allow" "auto-allow decision emitted"
+reason=$(echo "${out}" | python3 -c "import json, sys; print(json.load(sys.stdin)['hookSpecificOutput']['permissionDecisionReason'])")
+assert_contains "${reason}" "autoheal" "reason mentions autoheal"
+
+# 3. Bypass mode + only 2 prior approvals: no auto-allow.
+rm -f "$(events_file)"
+seed_history "git diff" 2 2
+out=$(echo '{"hook_event_name":"PermissionRequest","session_id":"s-bypass","tool_name":"Bash","tool_input":{"command":"git diff baz"},"permission_mode":"bypassPermissions","cwd":"/tmp/repo"}' | python3 "${HOOK}")
+rc=$?
+assert_eq "${rc}" "0" "bypass with <3 approvals exits 0"
+assert_eq "${out}" "" "bypass with <3 approvals emits no decision"
+
+# 4. Bypass + 3 approvals but all in ONE session: still no auto-allow.
+rm -f "$(events_file)"
+seed_history "git diff" 3 1
+out=$(echo '{"hook_event_name":"PermissionRequest","session_id":"s-bypass","tool_name":"Bash","tool_input":{"command":"git diff qux"},"permission_mode":"bypassPermissions","cwd":"/tmp/repo"}' | python3 "${HOOK}")
+rc=$?
+assert_eq "${rc}" "0" "bypass with single-session history exits 0"
+assert_eq "${out}" "" "bypass with single-session history emits no decision"
+
+# 5. Bypass + history + signature snoozed: no auto-allow.
+rm -f "$(events_file)"
+seed_history "git diff" 3 2
+# Snoozed until +1 hour from now.
+python3 <<'PY'
+import json, datetime, os
+sig = 'Bash::git diff'
+data = {sig: {'snoozed_until': (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)).isoformat()}}
+os.makedirs(os.environ['CCGM_AUTOHEAL_DIR'], exist_ok=True)
+with open(os.path.join(os.environ['CCGM_AUTOHEAL_DIR'], 'snoozed.json'), 'w') as fh:
+    json.dump(data, fh)
+PY
+out=$(echo '{"hook_event_name":"PermissionRequest","session_id":"s-bypass","tool_name":"Bash","tool_input":{"command":"git diff thing"},"permission_mode":"bypassPermissions","cwd":"/tmp/repo"}' | python3 "${HOOK}")
+rc=$?
+assert_eq "${rc}" "0" "snoozed bypass exits 0"
+assert_eq "${out}" "" "snoozed bypass emits no decision"
+
+# 6. Bypass + history + signature with EXPIRED snooze: auto-allow.
+rm -f "${CCGM_AUTOHEAL_DIR}/snoozed.json"
+python3 <<'PY'
+import json, datetime, os
+sig = 'Bash::git diff'
+data = {sig: {'snoozed_until': (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)).isoformat()}}
+with open(os.path.join(os.environ['CCGM_AUTOHEAL_DIR'], 'snoozed.json'), 'w') as fh:
+    json.dump(data, fh)
+PY
+out=$(echo '{"hook_event_name":"PermissionRequest","session_id":"s-bypass","tool_name":"Bash","tool_input":{"command":"git diff later"},"permission_mode":"bypassPermissions","cwd":"/tmp/repo"}' | python3 "${HOOK}")
+decision=$(echo "${out}" | python3 -c "import json, sys; print(json.load(sys.stdin)['hookSpecificOutput']['permissionDecision'])")
+assert_eq "${decision}" "allow" "expired snooze does not block auto-allow"
+
+# 7. Malformed stdin exits 0 cleanly.
+echo 'not json {{{' | python3 "${HOOK}"
+rc=$?
+assert_eq "${rc}" "0" "malformed stdin exits 0"
+
+echo ""
+echo "test-permission-suppress.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0

--- a/modules/autoheal/tests/test-post-prompt-introspect.sh
+++ b/modules/autoheal/tests/test-post-prompt-introspect.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-privilege-escalation-filter.sh
+++ b/modules/autoheal/tests/test-privilege-escalation-filter.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-redaction-coverage.sh
+++ b/modules/autoheal/tests/test-redaction-coverage.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Test suite verifying that all 17 secret-pattern families documented in
+# modules/autoheal/lib/secret-patterns.json are actually redacted when an
+# event flows through permission-event-logger.py.
+#
+# Fake-token shapes are constructed at runtime via string concat so the
+# literal token forms never appear in this file (GitHub push protection
+# scanner does not see them). At execution time the concatenated strings
+# are byte-for-byte identical to the patterns redact_secrets() targets.
+#
+# The redaction itself is unit-tested in modules/hooks/tests/test-hook-utils.sh.
+# This test verifies the contract end-to-end: a tool_input containing a
+# secret produces a stored event whose redacted_command bears the right
+# [REDACTED:<name>] marker.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOK="${MODULE_ROOT}/hooks/permission-event-logger.py"
+export HOOK
+HOOKS_MODULE="$(cd "${MODULE_ROOT}/../hooks" && pwd)"
+HOOK_LIB="${HOOKS_MODULE}/lib"
+PATTERNS_JSON="${MODULE_ROOT}/lib/secret-patterns.json"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+TMP_HOME=$(mktemp -d -t autoheal_redact.XXXXXX)
+trap 'rm -rf "${TMP_HOME}"' EXIT
+mkdir -p "${TMP_HOME}/.claude/lib"
+cp "${HOOK_LIB}/hook_utils.py" "${TMP_HOME}/.claude/lib/hook_utils.py"
+
+export HOME="${TMP_HOME}"
+export CCGM_AUTOHEAL_DIR="${TMP_HOME}/autoheal"
+
+today() {
+    python3 -c "import datetime; print(datetime.datetime.now(datetime.timezone.utc).date().isoformat())"
+}
+
+events_file() {
+    echo "${CCGM_AUTOHEAL_DIR}/events/$(today).jsonl"
+}
+
+# Sanity: secret-patterns.json lists exactly 17 patterns.
+count=$(python3 -c "
+import json
+print(len(json.load(open('${PATTERNS_JSON}'))['patterns']))
+")
+assert_eq "${count}" "17" "secret-patterns.json lists 17 patterns"
+
+# For each of the 17 pattern families, build a fake token, ship it
+# through the hook, and assert the stored event has the right marker.
+#
+# String concat dodges GitHub push protection. The Python here-doc emits
+# one assertion per pattern; we capture the totals and verify all-pass.
+result=$(python3 <<'PY'
+import json, os, subprocess, sys
+
+S40 = 'A' * 40
+S36 = 'A' * 36
+SHORT = 'A' * 32
+B = '1234567890abcdefghijklmn'
+
+# Each tuple: (pattern_name, fake_token_string). The fake token is
+# constructed via concat so no literal pattern appears in this file.
+fakes = [
+    ('anthropic',           'sk' + '-ant-' + 'api03-' + S36),
+    ('stripe_live',         'sk' + '_' + 'live_' + B),
+    ('stripe_test',         'sk' + '_' + 'test_' + B),
+    ('github_pat',          'ghp' + '_' + S36),
+    ('github_oauth',        'gho' + '_' + S36),
+    ('github_u2s',          'ghu' + '_' + S36),
+    ('github_s2s',          'ghs' + '_' + S36),
+    ('github_refresh',      'ghr' + '_' + S36),
+    ('aws_access_key',      'AK' + 'IA' + 'ABCDEFGHIJKLMNOP'),
+    ('google_api',          'A' + 'Iza' + 'Sy' + 'A' + '1234567890abcdefghijklmnopqrstuvwx'),
+    ('slack',               'xo' + 'xb-' + '1234567890-9876543210-abcdefghij'),
+    ('resend',              're' + '_' + 'AbCdEfGh' + '_' + '1234567890abcdef'),
+    ('supabase',            'sb' + '_' + 'secret_' + '1234567890abcdefghij'),
+    ('openai',              'sk' + '-' + SHORT),
+    ('authorization_bearer','Authorization: Bearer ' + 'abc.def.ghi-jkl'),
+    ('env_var_kv',          'API' + '_' + 'KEY' + '=' + 'abcdef1234567890'),
+    ('password_flag',       'mycli ' + '--password ' + 'hunter2hunter2'),
+]
+
+events_path = os.path.join(os.environ['CCGM_AUTOHEAL_DIR'], 'events', __import__('datetime').datetime.now(__import__('datetime').timezone.utc).date().isoformat() + '.jsonl')
+os.makedirs(os.path.dirname(events_path), exist_ok=True)
+# Clean slate.
+if os.path.exists(events_path):
+    os.remove(events_path)
+
+ok = 0
+missed = []
+for name, fake in fakes:
+    cmd = 'echo ' + fake
+    payload = {
+        'hook_event_name': 'PostToolUse',
+        'session_id': 's-' + name,
+        'tool_name': 'Bash',
+        'tool_input': {'command': cmd},
+        'cwd': '/tmp/repo',
+    }
+    subprocess.run(['python3', os.environ['HOOK']], input=json.dumps(payload), text=True, check=False)
+
+# Now read the events file and walk each line.
+with open(events_path) as fh:
+    lines = [json.loads(line) for line in fh if line.strip()]
+
+# Build a session -> redacted_command map.
+by_session = {r['session_id']: r['redacted_command'] for r in lines}
+
+for name, fake in fakes:
+    cmd_stored = by_session.get('s-' + name, '')
+    marker = f'[REDACTED:{name}]'
+    if marker in (cmd_stored or '') and fake not in (cmd_stored or ''):
+        ok += 1
+    else:
+        missed.append((name, cmd_stored))
+
+print(f'OK {ok} / {len(fakes)}')
+for name, val in missed:
+    print('MISS', name, '|', repr(val))
+PY
+)
+
+total_line=$(echo "${result}" | head -1)
+assert_eq "${total_line}" "OK 17 / 17" "all 17 patterns redacted via the event-logger path"
+
+# If there were misses, print them for debugging.
+if echo "${result}" | grep -q "MISS"; then
+    echo "${result}" | grep MISS
+fi
+
+echo ""
+echo "test-redaction-coverage.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0

--- a/modules/autoheal/tests/test-repo-config-merge.sh
+++ b/modules/autoheal/tests/test-repo-config-merge.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-retention-sweep.sh
+++ b/modules/autoheal/tests/test-retention-sweep.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-synthetic-e2e.sh
+++ b/modules/autoheal/tests/test-synthetic-e2e.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0

--- a/modules/autoheal/tests/test-webhook-publisher.sh
+++ b/modules/autoheal/tests/test-webhook-publisher.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Stub: this test belongs to a later epic; content TBD. See plan.md §5
+# for the owning epic and the assertion list.
+exit 0


### PR DESCRIPTION
## Summary

Wave 2 Epic 3 — `autoheal` module scaffold. Pre-lists ALL files across Epics 3–12 in `module.json` + `settings.partial.json` so later epics fill content without merge conflicts. Implements the 4 event-capture hooks, 1 suppression hook, schemas, and 17-pattern redaction reference.

Closes #475.

## Files

- 4 hooks with content: `permission-event-logger.py`, `failure-logger.py`, `user-correction-detector.py`, `permission-request-suppress.py`
- 3 schemas: `lib/event-schema.json`, `lib/proposal-schema.json` (with `originating_clone` + `auto_apply_blocked`), `lib/secret-patterns.json`
- `rules/autoheal.md` documenting the contract
- `module.json` + `settings.partial.json` pre-registering 37 file paths and 5 hook surfaces
- `README.md`
- Stubs for Epic 4–12 content (2 hooks, 7 commands, 11 bin scripts, 5 lib files, 16 test files — each with a 1-line "Epic N: content TBD" header)

## Hook event surfaces registered

| Surface | Hooks (no matcher) |
|---|---|
| `PostToolUse` | `permission-event-logger`, `failure-logger`, `realtime-security-scanner` (Epic 10; stub no-ops today) |
| `PostToolUseFailure` | `permission-event-logger`, `failure-logger` |
| `PermissionRequest` | `permission-event-logger`, `permission-request-suppress` |
| `UserPromptSubmit` | `user-correction-detector` |
| `Stop` | `post-prompt-introspect` (Epic 4 fills content) |

## Test plan

- [x] `bash modules/autoheal/tests/test-event-logging.sh` → 14 passed
- [x] `bash modules/autoheal/tests/test-permission-suppress.sh` → 13 passed
- [x] `bash modules/autoheal/tests/test-correction-detection.sh` → 21 passed
- [x] `bash modules/autoheal/tests/test-redaction-coverage.sh` → 2 passed (covers all 17 patterns end-to-end via the logger)
- [x] `bash tests/test-modules.sh` → 1180 passed
- [x] `bash tests/test-no-personal-data.sh` → PASS

50 assertions across the 4 Epic-3-owned tests.

## Implementer-flagged concerns (DONE_WITH_CONCERNS, accepted)

1. **Conditional hook registration not expressible in JSON.** `realtime-security-scanner.py` is registered unconditionally; its stub `exit 0`s by default. Epic 10 implements the actual scan + `realtime_alerts_enabled` runtime gate. The README documents the default-OFF posture.
2. **`secret-patterns.json` is documentation/reference, not source of truth.** Canonical patterns live in `modules/hooks/lib/hook_utils.py`. A `_description` field in the JSON points at the contract.
3. **`permission-request-suppress.py` signature uses first 2 Bash tokens.** Conservative on purpose; matches the plan §3 rationale. Richer signatures for non-Bash tools are a future refinement.
4. **Bash heredoc footgun in tests:** the redaction test switched to Python-built JSON shelled out. Future test authors should follow this pattern when stdin JSON has embedded quotes.

Post-merge bring-up runs `bash start.sh --add autoheal`.
