### PR TITLE
#477: /permission-audit read-only static audit command

### DIFF
--- a/modules/autoheal/bin/permission-audit.sh
+++ b/modules/autoheal/bin/permission-audit.sh
@@ -1,4 +1,451 @@
 #!/usr/bin/env bash
-# Epic 5: content TBD — static audit of current hooks + settings.json
-# against the explicit classification table. See plan.md §5 Epic 5.
+# permission-audit.sh
+#
+# Read-only static audit of CCGM hook classification vs settings.json deny list.
+#
+# For each hook .py file in the hooks directory:
+#   - has-hook_utils: does the file contain `import hook_utils`?
+#   - bypass-aware:   does the file reference `is_bypass_mode`?
+#   - has-hard-block: does the file reference `hard_block`?
+# Classification:
+#   - bypass-suppressible: bypass-aware=YES (with or without hard_block)
+#   - bypass-retained:     bypass-aware=NO and has-hard-block=YES
+#   - legacy:              bypass-aware=NO and has-hard-block=NO
+#
+# For the settings file, count `.permissions.deny | length` and flag entries
+# that appear redundant with a hook's hard_block rule.
+#
+# Modifies no files. bash 3.2 compatible (no associative arrays, no mapfile).
+#
+# Usage:
+#   permission-audit.sh [--hooks-dir <path>] [--settings-file <path>] [--format text|json]
+#
+# Plan §5 Epic 5 / Section 1.3 (Part 1 — permission hygiene).
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+# Default hooks dir / settings file. If we appear to be running from a CCGM
+# checkout (modules/hooks/hooks exists relative to the script), prefer the
+# in-tree paths. Otherwise default to the installed paths.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd 2>/dev/null || echo "")"
+
+if [ -n "${REPO_ROOT}" ] && [ -d "${REPO_ROOT}/modules/hooks/hooks" ]; then
+    DEFAULT_HOOKS_DIR="${REPO_ROOT}/modules/hooks/hooks"
+else
+    DEFAULT_HOOKS_DIR="${HOME}/.claude/hooks"
+fi
+
+if [ -n "${REPO_ROOT}" ] && [ -f "${REPO_ROOT}/modules/settings/settings.base.json" ]; then
+    DEFAULT_SETTINGS_FILE="${REPO_ROOT}/modules/settings/settings.base.json"
+else
+    DEFAULT_SETTINGS_FILE="${HOME}/.claude/settings.json"
+fi
+
+HOOKS_DIR="${DEFAULT_HOOKS_DIR}"
+SETTINGS_FILE="${DEFAULT_SETTINGS_FILE}"
+FORMAT="text"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+usage() {
+    cat <<EOF
+Usage: $0 [--hooks-dir <path>] [--settings-file <path>] [--format text|json]
+
+Defaults:
+  --hooks-dir     ${DEFAULT_HOOKS_DIR}
+  --settings-file ${DEFAULT_SETTINGS_FILE}
+  --format        text
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --hooks-dir)
+            HOOKS_DIR="$2"
+            shift 2
+            ;;
+        --settings-file)
+            SETTINGS_FILE="$2"
+            shift 2
+            ;;
+        --format)
+            FORMAT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+case "${FORMAT}" in
+    text|json) ;;
+    *)
+        echo "ERROR: --format must be 'text' or 'json' (got: ${FORMAT})" >&2
+        exit 2
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+if [ ! -d "${HOOKS_DIR}" ]; then
+    echo "ERROR: hooks dir does not exist: ${HOOKS_DIR}" >&2
+    exit 2
+fi
+
+if [ ! -f "${SETTINGS_FILE}" ]; then
+    echo "ERROR: settings file does not exist: ${SETTINGS_FILE}" >&2
+    exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required but not on PATH" >&2
+    exit 2
+fi
+
+# Normalize to absolute paths for the report.
+HOOKS_DIR="$(cd "${HOOKS_DIR}" && pwd)"
+SETTINGS_FILE_DIR="$(cd "$(dirname "${SETTINGS_FILE}")" && pwd)"
+SETTINGS_FILE="${SETTINGS_FILE_DIR}/$(basename "${SETTINGS_FILE}")"
+
+# ---------------------------------------------------------------------------
+# Hook classification
+# ---------------------------------------------------------------------------
+#
+# bash 3.2: no associative arrays, no mapfile. We use parallel indexed arrays.
+# Each hook contributes one row in each array, indexed by HOOK_COUNT-1.
+
+HOOK_NAMES=()
+HOOK_CLASS=()
+HOOK_NOTES=()
+HOOK_HAS_UTILS=()
+HOOK_BYPASS=()
+HOOK_HARDBLOCK=()
+
+count_suppressible=0
+count_retained=0
+count_legacy=0
+
+# Iterate hook files in alphabetical order for stable output.
+# Use a find | sort pipe + while-read to stay bash 3.2 compatible.
+while IFS= read -r hook_path; do
+    [ -z "${hook_path}" ] && continue
+    hook_name="$(basename "${hook_path}")"
+
+    if grep -q "import hook_utils" "${hook_path}" 2>/dev/null; then
+        has_utils="YES"
+    else
+        has_utils="NO"
+    fi
+
+    if grep -q "is_bypass_mode" "${hook_path}" 2>/dev/null; then
+        bypass_aware="YES"
+    else
+        bypass_aware="NO"
+    fi
+
+    if grep -q "hard_block" "${hook_path}" 2>/dev/null; then
+        has_hard_block="YES"
+    else
+        has_hard_block="NO"
+    fi
+
+    classification=""
+    notes=""
+
+    if [ "${bypass_aware}" = "YES" ]; then
+        classification="bypass-suppressible"
+        if [ "${has_hard_block}" = "YES" ]; then
+            notes="uses both helpers"
+        else
+            notes="hook_utils-aware, no hard_block"
+        fi
+        count_suppressible=$((count_suppressible + 1))
+    elif [ "${has_hard_block}" = "YES" ]; then
+        classification="bypass-retained"
+        notes="hard_block, no is_bypass_mode"
+        count_retained=$((count_retained + 1))
+    else
+        classification="legacy"
+        if [ "${has_utils}" = "YES" ]; then
+            notes="imports hook_utils but uses neither helper"
+        else
+            notes="not yet migrated to hook_utils"
+        fi
+        count_legacy=$((count_legacy + 1))
+    fi
+
+    HOOK_NAMES+=("${hook_name}")
+    HOOK_CLASS+=("${classification}")
+    HOOK_NOTES+=("${notes}")
+    HOOK_HAS_UTILS+=("${has_utils}")
+    HOOK_BYPASS+=("${bypass_aware}")
+    HOOK_HARDBLOCK+=("${has_hard_block}")
+done < <(find "${HOOKS_DIR}" -maxdepth 1 -name "*.py" -type f 2>/dev/null | sort)
+
+HOOK_COUNT=${#HOOK_NAMES[@]}
+
+# ---------------------------------------------------------------------------
+# Deny list inspection
+# ---------------------------------------------------------------------------
+
+if ! jq -e . "${SETTINGS_FILE}" >/dev/null 2>&1; then
+    echo "ERROR: settings file is not valid JSON: ${SETTINGS_FILE}" >&2
+    exit 2
+fi
+
+DENY_COUNT="$(jq '(.permissions.deny // []) | length' "${SETTINGS_FILE}")"
+
+# Pull entries one per line into a file (bash 3.2 has no mapfile).
+DENY_TMP="$(mktemp -t permission-audit-deny.XXXXXX)"
+jq -r '.permissions.deny // [] | .[]' "${SETTINGS_FILE}" > "${DENY_TMP}"
+
+# ---------------------------------------------------------------------------
+# Misalignment detection
+# ---------------------------------------------------------------------------
+#
+# Known overlap rules:
+#   - Bash(rm -rf:*) / Bash(rm -r:*)              overlaps check-careful.py destructive-rm
+#   - Bash(git reset --hard:*)                    overlaps auto-approve-bash.py destructive-reset hard_block
+#   - Bash(git push --force origin main:*)        overlaps check-careful.py force-push-to-main hard_block
+#   - Bash(git push --force main:*)               same family
+#   - Bash(git push -f main:*)                    same family
+#   - Bash(git push -f origin main:*)             same family
+#   - Bash(git push --force-with-lease origin main:*)  same family
+#
+# We only flag overlaps that are actionable signals — i.e., the corresponding
+# hook is present in the hooks dir AND classified bypass-suppressible (so the
+# hard_block survives bypass mode and the deny entry is redundant defense-in-
+# depth that we may want to retain or prune).
+
+MISALIGN_DENY=()       # the deny string
+MISALIGN_HOOK=()       # the related hook file
+MISALIGN_NOTE=()       # human-readable note
+
+hook_present_with_class() {
+    # Args: hook_name expected_classification
+    local hook_name="$1"
+    local expected="$2"
+    local i=0
+    while [ ${i} -lt ${HOOK_COUNT} ]; do
+        if [ "${HOOK_NAMES[$i]}" = "${hook_name}" ]; then
+            if [ "${HOOK_CLASS[$i]}" = "${expected}" ]; then
+                return 0
+            fi
+            return 1
+        fi
+        i=$((i + 1))
+    done
+    return 1
+}
+
+hook_present_with_hard_block() {
+    # Args: hook_name
+    local hook_name="$1"
+    local i=0
+    while [ ${i} -lt ${HOOK_COUNT} ]; do
+        if [ "${HOOK_NAMES[$i]}" = "${hook_name}" ]; then
+            if [ "${HOOK_HARDBLOCK[$i]}" = "YES" ]; then
+                return 0
+            fi
+            return 1
+        fi
+        i=$((i + 1))
+    done
+    return 1
+}
+
+flag_misalignment() {
+    local entry="$1"
+    local hook="$2"
+    local note="$3"
+    MISALIGN_DENY+=("${entry}")
+    MISALIGN_HOOK+=("${hook}")
+    MISALIGN_NOTE+=("${note}")
+}
+
+while IFS= read -r entry; do
+    [ -z "${entry}" ] && continue
+    case "${entry}" in
+        "Bash(rm -rf:*)"|"Bash(rm -r:*)")
+            if hook_present_with_hard_block "check-careful.py"; then
+                flag_misalignment "${entry}" "check-careful.py" "destructive-rm rule"
+            fi
+            ;;
+        "Bash(git reset --hard:*)")
+            if hook_present_with_hard_block "auto-approve-bash.py"; then
+                flag_misalignment "${entry}" "auto-approve-bash.py" "destructive-reset hard_block"
+            fi
+            ;;
+        "Bash(git push --force origin main:*)"|"Bash(git push --force main:*)"|"Bash(git push -f main:*)"|"Bash(git push -f origin main:*)"|"Bash(git push --force-with-lease origin main:*)")
+            if hook_present_with_hard_block "check-careful.py"; then
+                flag_misalignment "${entry}" "check-careful.py" "force-push-to-main hard_block"
+            fi
+            ;;
+    esac
+done < "${DENY_TMP}"
+
+MISALIGN_COUNT=${#MISALIGN_DENY[@]}
+
+# Also flag hooks that import hook_utils but use neither helper — they're
+# orphaned migrations. (Counted as "legacy" above but called out explicitly
+# in the misalignment list because the orphan import is a real signal.)
+i=0
+while [ ${i} -lt ${HOOK_COUNT} ]; do
+    if [ "${HOOK_CLASS[$i]}" = "legacy" ] && [ "${HOOK_HAS_UTILS[$i]}" = "YES" ]; then
+        flag_misalignment "" "${HOOK_NAMES[$i]}" "hook imports hook_utils but uses neither is_bypass_mode nor hard_block"
+    fi
+    i=$((i + 1))
+done
+MISALIGN_COUNT=${#MISALIGN_DENY[@]}
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+if [ "${FORMAT}" = "json" ]; then
+    # Build JSON via jq to avoid hand-rolling escaping.
+    HOOKS_JSON="$(mktemp -t permission-audit-hooks.XXXXXX)"
+    printf '[' > "${HOOKS_JSON}"
+    i=0
+    while [ ${i} -lt ${HOOK_COUNT} ]; do
+        [ ${i} -gt 0 ] && printf ',' >> "${HOOKS_JSON}"
+        jq -nc \
+            --arg name "${HOOK_NAMES[$i]}" \
+            --arg classification "${HOOK_CLASS[$i]}" \
+            --arg has_hook_utils "${HOOK_HAS_UTILS[$i]}" \
+            --arg bypass_aware "${HOOK_BYPASS[$i]}" \
+            --arg has_hard_block "${HOOK_HARDBLOCK[$i]}" \
+            --arg notes "${HOOK_NOTES[$i]}" \
+            '{
+              name: $name,
+              classification: $classification,
+              has_hook_utils: ($has_hook_utils == "YES"),
+              bypass_aware: ($bypass_aware == "YES"),
+              has_hard_block: ($has_hard_block == "YES"),
+              notes: $notes
+            }' >> "${HOOKS_JSON}"
+        i=$((i + 1))
+    done
+    printf ']' >> "${HOOKS_JSON}"
+
+    MISALIGN_JSON="$(mktemp -t permission-audit-misalign.XXXXXX)"
+    printf '[' > "${MISALIGN_JSON}"
+    i=0
+    while [ ${i} -lt ${MISALIGN_COUNT} ]; do
+        [ ${i} -gt 0 ] && printf ',' >> "${MISALIGN_JSON}"
+        if [ -n "${MISALIGN_DENY[$i]}" ]; then
+            jq -nc \
+                --arg deny_entry "${MISALIGN_DENY[$i]}" \
+                --arg hook "${MISALIGN_HOOK[$i]}" \
+                --arg note "${MISALIGN_NOTE[$i]}" \
+                '{
+                  kind: "deny_overlaps_hard_block",
+                  deny_entry: $deny_entry,
+                  hook: $hook,
+                  note: $note
+                }' >> "${MISALIGN_JSON}"
+        else
+            jq -nc \
+                --arg hook "${MISALIGN_HOOK[$i]}" \
+                --arg note "${MISALIGN_NOTE[$i]}" \
+                '{
+                  kind: "orphan_hook_utils_import",
+                  hook: $hook,
+                  note: $note
+                }' >> "${MISALIGN_JSON}"
+        fi
+        i=$((i + 1))
+    done
+    printf ']' >> "${MISALIGN_JSON}"
+
+    jq -n \
+        --arg hooks_dir "${HOOKS_DIR}" \
+        --arg settings_file "${SETTINGS_FILE}" \
+        --slurpfile hooks "${HOOKS_JSON}" \
+        --argjson deny_count "${DENY_COUNT}" \
+        --slurpfile misalignments "${MISALIGN_JSON}" \
+        --argjson bypass_suppressible "${count_suppressible}" \
+        --argjson bypass_retained "${count_retained}" \
+        --argjson legacy "${count_legacy}" \
+        --argjson misalignment_count "${MISALIGN_COUNT}" \
+        '{
+          hooks_dir: $hooks_dir,
+          settings_file: $settings_file,
+          hooks: $hooks[0],
+          deny_count: $deny_count,
+          misalignments: $misalignments[0],
+          summary: {
+            bypass_suppressible: $bypass_suppressible,
+            bypass_retained: $bypass_retained,
+            legacy: $legacy,
+            deny_entries: $deny_count,
+            misalignments: $misalignment_count
+          }
+        }'
+
+    rm -f "${HOOKS_JSON}" "${MISALIGN_JSON}" "${DENY_TMP}"
+    exit 0
+fi
+
+# Text mode.
+echo "=== CCGM permission-audit ==="
+echo "hooks-dir:     ${HOOKS_DIR}"
+echo "settings-file: ${SETTINGS_FILE}"
+echo ""
+echo "--- Hook classification ---"
+printf "%-34s %-22s %s\n" "HOOK_NAME" "CLASSIFICATION" "NOTES"
+i=0
+while [ ${i} -lt ${HOOK_COUNT} ]; do
+    printf "%-34s %-22s %s\n" \
+        "${HOOK_NAMES[$i]}" \
+        "${HOOK_CLASS[$i]}" \
+        "${HOOK_NOTES[$i]}"
+    i=$((i + 1))
+done
+
+echo ""
+echo "--- Deny list ---"
+echo "count: ${DENY_COUNT}"
+
+echo ""
+echo "--- Misalignments ---"
+if [ ${MISALIGN_COUNT} -eq 0 ]; then
+    echo "(none)"
+else
+    i=0
+    while [ ${i} -lt ${MISALIGN_COUNT} ]; do
+        if [ -n "${MISALIGN_DENY[$i]}" ]; then
+            echo "- deny entry \`${MISALIGN_DENY[$i]}\` overlaps with ${MISALIGN_HOOK[$i]} ${MISALIGN_NOTE[$i]}"
+        else
+            echo "- ${MISALIGN_HOOK[$i]}: ${MISALIGN_NOTE[$i]}"
+        fi
+        i=$((i + 1))
+    done
+fi
+
+echo ""
+echo "--- Summary ---"
+echo "bypass-suppressible: ${count_suppressible}"
+echo "bypass-retained:     ${count_retained}"
+echo "legacy:              ${count_legacy}"
+echo "deny entries:        ${DENY_COUNT}"
+echo "misalignments:       ${MISALIGN_COUNT}"
+
+rm -f "${DENY_TMP}"
 exit 0

--- a/modules/autoheal/commands/permission-audit.md
+++ b/modules/autoheal/commands/permission-audit.md
@@ -1,3 +1,147 @@
-<!-- Epic 5: content TBD — /permission-audit. Runs bin/permission-audit.sh
-to produce a static audit of the current hooks + settings against the
-explicit classification table. See plan.md §5 Epic 5. -->
+---
+description: Audit CCGM hooks + settings.json deny list for permission-mode alignment.
+---
+
+# /permission-audit
+
+Read-only audit that reports the alignment between:
+
+- Each `~/.claude/hooks/*.py` hook's classification (bypass-suppressible vs.
+  bypass-retained vs. legacy), derived from static inspection of the source —
+  does it `import hook_utils`? does it call `is_bypass_mode()`? does it call
+  `hard_block()`?
+- `~/.claude/settings.json` deny list entries — are any redundant with a
+  hook-level `hard_block()` smart rule? are any obvious force-push variants
+  duplicated?
+- Misalignments — e.g., a hook documented as "bypass-suppressible" that does
+  not actually short-circuit; a deny entry that overlaps a hook hard-block;
+  a hook that imports `hook_utils` but uses neither helper.
+
+The command shells out to `bin/permission-audit.sh`, which performs the
+classification and rendering. It modifies no files.
+
+## What it does
+
+1. Resolves the hooks directory and settings file (with overrides — see below).
+2. For each `*.py` file in the hooks directory, statically inspects the file
+   to set three flags:
+   - `has-hook_utils` — does the source contain `import hook_utils`?
+   - `bypass-aware` — does the source reference `is_bypass_mode`?
+   - `has-hard-block` — does the source reference `hard_block`?
+3. Classifies each hook:
+   - **bypass-suppressible** — `bypass-aware=YES` (with or without `hard_block`).
+     The hook respects bypass mode and may also have always-on safety rails.
+   - **bypass-retained** — `bypass-aware=NO`, `has-hard-block=YES`. The hook is
+     always-on safety, intentionally bypass-proof.
+   - **legacy** — `bypass-aware=NO`, `has-hard-block=NO`. Pre-Epic-1 hook that
+     has not been migrated yet (informational; not necessarily wrong).
+4. Counts `.permissions.deny` entries in the settings file.
+5. For each deny entry, flags whether it appears redundant with a hook
+   `hard_block` (e.g., `Bash(rm -rf:*)` overlaps with `check-careful.py`'s
+   destructive-rm hard_block).
+6. Renders a text report (default) or a JSON envelope (`--format json`).
+
+## Output sections (text mode)
+
+```
+=== CCGM permission-audit ===
+hooks-dir:     <path>
+settings-file: <path>
+
+--- Hook classification ---
+HOOK_NAME                       CLASSIFICATION       NOTES
+check-careful.py                bypass-suppressible  uses both helpers
+port-check.py                   bypass-suppressible  hook_utils-aware, no hard_block
+enforce-git-workflow.py         bypass-retained      hard_block, no is_bypass_mode
+check-migration-timestamps.py   bypass-retained      hard_block, no is_bypass_mode
+agent-tracking-pre.py           legacy               not yet migrated to hook_utils
+
+--- Deny list ---
+count: 13
+
+--- Misalignments ---
+- deny entry `Bash(rm -rf:*)` overlaps with check-careful.py destructive-rm rule
+- deny entry `Bash(git reset --hard:*)` overlaps with auto-approve-bash.py destructive-reset hard_block
+- deny entry `Bash(git push --force origin main:*)` overlaps with check-careful.py force-push-to-main hard_block
+
+--- Summary ---
+bypass-suppressible: 3
+bypass-retained:     2
+legacy:              9
+deny entries:        13
+misalignments:       3
+```
+
+## How to invoke
+
+Default invocation (operates on the installed CCGM state):
+
+```bash
+/permission-audit
+```
+
+This calls `bin/permission-audit.sh` with the defaults:
+
+- `--hooks-dir ~/.claude/hooks`
+- `--settings-file ~/.claude/settings.json`
+
+When run from a CCGM checkout (development context), defaults shift to the
+in-tree paths:
+
+- `--hooks-dir modules/hooks/hooks`
+- `--settings-file modules/settings/settings.base.json`
+
+### Overrides (for testing on fixture trees)
+
+```bash
+bash modules/autoheal/bin/permission-audit.sh \
+  --hooks-dir modules/autoheal/tests/fixtures/audit-hooks \
+  --settings-file modules/autoheal/tests/fixtures/audit-settings.json
+```
+
+### JSON output
+
+```bash
+bash modules/autoheal/bin/permission-audit.sh --format json | jq .
+```
+
+The JSON envelope has the shape:
+
+```json
+{
+  "hooks_dir": "<absolute path>",
+  "settings_file": "<absolute path>",
+  "hooks": [
+    {
+      "name": "check-careful.py",
+      "classification": "bypass-suppressible",
+      "has_hook_utils": true,
+      "bypass_aware": true,
+      "has_hard_block": true,
+      "notes": "uses both helpers"
+    }
+  ],
+  "deny_count": 13,
+  "misalignments": [
+    {
+      "kind": "deny_overlaps_hard_block",
+      "deny_entry": "Bash(rm -rf:*)",
+      "hook": "check-careful.py",
+      "note": "destructive-rm rule"
+    }
+  ],
+  "summary": {
+    "bypass_suppressible": 3,
+    "bypass_retained": 2,
+    "legacy": 9,
+    "deny_entries": 13,
+    "misalignments": 3
+  }
+}
+```
+
+## Read-only contract
+
+`permission-audit.sh` never modifies any file. It is safe to run repeatedly
+and concurrently with other CCGM operations. Use `/permission-fix` (Epic 4)
+when a remediation proposal is wanted.

--- a/modules/autoheal/tests/fixtures/audit-hooks/fixture-legacy.py
+++ b/modules/autoheal/tests/fixtures/audit-hooks/fixture-legacy.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+Fixture hook: pre-migration baseline.
+
+Does not import the shared helper module. Does not use the bypass-aware
+short-circuit. Does not use the bypass-proof block helper. Represents an
+unmigrated hook.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    try:
+        json.load(sys.stdin)
+    except Exception:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/autoheal/tests/fixtures/audit-hooks/fixture-retained.py
+++ b/modules/autoheal/tests/fixtures/audit-hooks/fixture-retained.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+Fixture hook: always-on safety.
+
+Imports the shared helper module and uses a bypass-proof block helper as
+always-on safety. Does NOT call the bypass-aware short-circuit helper
+(intentionally — this hook is data-integrity enforcement that must run even
+when the user is in bypass mode).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
+
+
+def main() -> int:
+    data = hook_utils.read_hook_input()
+    cmd = data.get("tool_input", {}).get("command", "")
+
+    if cmd.startswith("rm -rf /"):
+        hook_utils.hard_block("Refusing rm -rf against root path.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/autoheal/tests/fixtures/audit-hooks/fixture-suppressible.py
+++ b/modules/autoheal/tests/fixtures/audit-hooks/fixture-suppressible.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+Fixture hook: bypass-suppressible.
+
+Imports hook_utils, uses is_bypass_mode for short-circuit, AND uses hard_block
+for always-on safety on a narrow destructive case. Used by
+test-permission-audit.sh to validate classifier behavior on a known shape.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
+
+
+def main() -> int:
+    data = hook_utils.read_hook_input()
+    cmd = data.get("tool_input", {}).get("command", "")
+
+    if "DROP TABLE" in cmd:
+        hook_utils.hard_block("Refusing DROP TABLE: bypass-proof safety.")
+
+    if hook_utils.is_bypass_mode(data):
+        return 0
+
+    hook_utils.emit_decision("ask", "Confirm before running.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/autoheal/tests/fixtures/audit-settings.json
+++ b/modules/autoheal/tests/fixtures/audit-settings.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status)",
+      "Bash(git log:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf:*)",
+      "Bash(git push --force origin main:*)"
+    ],
+    "defaultMode": "ask"
+  }
+}

--- a/modules/autoheal/tests/test-permission-audit.sh
+++ b/modules/autoheal/tests/test-permission-audit.sh
@@ -1,4 +1,201 @@
 #!/usr/bin/env bash
-# Stub: this test belongs to a later epic; content TBD. See plan.md §5
-# for the owning epic and the assertion list.
+# Test modules/autoheal/bin/permission-audit.sh.
+#
+# Verifies (per plan.md §5 Epic 5):
+#   - Default run against the in-tree CCGM state mentions every hook by name
+#   - Each hook gets a classification (one of bypass-suppressible /
+#     bypass-retained / legacy)
+#   - Deny count is reported
+#   - --format json produces valid JSON (pipe through `jq -e .`)
+#   - Fixture run with --hooks-dir + --settings-file overrides correctly
+#     classifies the 3 fixture hooks
+#
+# Run: bash modules/autoheal/tests/test-permission-audit.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${MODULE_ROOT}/../.." && pwd)"
+AUDIT="${MODULE_ROOT}/bin/permission-audit.sh"
+
+HOOKS_DIR="${REPO_ROOT}/modules/hooks/hooks"
+SETTINGS_FILE="${REPO_ROOT}/modules/settings/settings.base.json"
+
+FIXTURE_HOOKS_DIR="${MODULE_ROOT}/tests/fixtures/audit-hooks"
+FIXTURE_SETTINGS="${MODULE_ROOT}/tests/fixtures/audit-settings.json"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label} (missing: ${needle})"
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+if [ ! -x "${AUDIT}" ]; then
+    echo "FATAL: audit script not executable: ${AUDIT}"
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "FATAL: jq is required for this test"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Default text run against in-tree paths.
+# ---------------------------------------------------------------------------
+
+TEXT_OUTPUT="$(bash "${AUDIT}" --hooks-dir "${HOOKS_DIR}" --settings-file "${SETTINGS_FILE}" --format text 2>&1)"
+TEXT_EXIT=$?
+assert_eq "${TEXT_EXIT}" "0" "text run exits 0"
+
+# Mentions the headers.
+assert_contains "${TEXT_OUTPUT}" "Hook classification" "text run has Hook classification section"
+assert_contains "${TEXT_OUTPUT}" "Deny list"           "text run has Deny list section"
+assert_contains "${TEXT_OUTPUT}" "Misalignments"       "text run has Misalignments section"
+assert_contains "${TEXT_OUTPUT}" "Summary"             "text run has Summary section"
+
+# Mentions every .py hook in the hooks dir by name.
+while IFS= read -r hook_path; do
+    hook_name="$(basename "${hook_path}")"
+    assert_contains "${TEXT_OUTPUT}" "${hook_name}" "text run mentions ${hook_name}"
+done < <(find "${HOOKS_DIR}" -maxdepth 1 -name "*.py" -type f | sort)
+
+# Reports deny count (non-zero in current state).
+assert_contains "${TEXT_OUTPUT}" "count: " "text run reports deny count"
+
+# Specific classifications we know are stable post-Epic-1.
+assert_contains "${TEXT_OUTPUT}" "check-careful.py" "mentions check-careful.py"
+# Each line containing check-careful should also carry bypass-suppressible.
+careful_line="$(printf '%s\n' "${TEXT_OUTPUT}" | grep '^check-careful.py' || true)"
+assert_contains "${careful_line}" "bypass-suppressible" "check-careful.py is bypass-suppressible"
+
+mig_line="$(printf '%s\n' "${TEXT_OUTPUT}" | grep '^check-migration-timestamps.py' || true)"
+assert_contains "${mig_line}" "bypass-retained" "check-migration-timestamps.py is bypass-retained"
+
+# ---------------------------------------------------------------------------
+# 2. JSON mode produces valid JSON.
+# ---------------------------------------------------------------------------
+
+JSON_OUTPUT="$(bash "${AUDIT}" --hooks-dir "${HOOKS_DIR}" --settings-file "${SETTINGS_FILE}" --format json 2>&1)"
+JSON_EXIT=$?
+assert_eq "${JSON_EXIT}" "0" "json run exits 0"
+
+if printf '%s' "${JSON_OUTPUT}" | jq -e . >/dev/null 2>&1; then
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: json run output is not valid JSON"
+fi
+
+# Top-level fields.
+for field in hooks_dir settings_file hooks deny_count misalignments summary; do
+    if printf '%s' "${JSON_OUTPUT}" | jq -e ".${field}" >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: json missing top-level field: ${field}"
+    fi
+done
+
+# Every hook is in the hooks[] array.
+JSON_HOOK_COUNT="$(printf '%s' "${JSON_OUTPUT}" | jq '.hooks | length')"
+FS_HOOK_COUNT="$(find "${HOOKS_DIR}" -maxdepth 1 -name "*.py" -type f | wc -l | tr -d ' ')"
+assert_eq "${JSON_HOOK_COUNT}" "${FS_HOOK_COUNT}" "json hooks[] length matches filesystem"
+
+# summary.deny_entries matches the file's actual deny length.
+ACTUAL_DENY="$(jq '.permissions.deny | length' "${SETTINGS_FILE}")"
+JSON_DENY="$(printf '%s' "${JSON_OUTPUT}" | jq '.summary.deny_entries')"
+assert_eq "${JSON_DENY}" "${ACTUAL_DENY}" "json summary.deny_entries matches settings"
+
+# ---------------------------------------------------------------------------
+# 3. Fixture run via override flags.
+# ---------------------------------------------------------------------------
+
+FIXTURE_TEXT="$(bash "${AUDIT}" --hooks-dir "${FIXTURE_HOOKS_DIR}" --settings-file "${FIXTURE_SETTINGS}" --format text 2>&1)"
+FIXTURE_EXIT=$?
+assert_eq "${FIXTURE_EXIT}" "0" "fixture run exits 0"
+
+# All 3 fixture hooks present.
+assert_contains "${FIXTURE_TEXT}" "fixture-suppressible.py" "fixture run mentions fixture-suppressible.py"
+assert_contains "${FIXTURE_TEXT}" "fixture-retained.py"     "fixture run mentions fixture-retained.py"
+assert_contains "${FIXTURE_TEXT}" "fixture-legacy.py"       "fixture run mentions fixture-legacy.py"
+
+# Correct classifications.
+supp_line="$(printf '%s\n' "${FIXTURE_TEXT}" | grep '^fixture-suppressible.py' || true)"
+assert_contains "${supp_line}" "bypass-suppressible" "fixture-suppressible.py classified bypass-suppressible"
+
+ret_line="$(printf '%s\n' "${FIXTURE_TEXT}" | grep '^fixture-retained.py' || true)"
+assert_contains "${ret_line}" "bypass-retained" "fixture-retained.py classified bypass-retained"
+
+leg_line="$(printf '%s\n' "${FIXTURE_TEXT}" | grep '^fixture-legacy.py' || true)"
+assert_contains "${leg_line}" "legacy" "fixture-legacy.py classified legacy"
+
+# Fixture JSON: summary counts match the 3-hook fixture set.
+FIXTURE_JSON="$(bash "${AUDIT}" --hooks-dir "${FIXTURE_HOOKS_DIR}" --settings-file "${FIXTURE_SETTINGS}" --format json 2>&1)"
+assert_eq "$(printf '%s' "${FIXTURE_JSON}" | jq '.summary.bypass_suppressible')" "1" "fixture summary bypass_suppressible=1"
+assert_eq "$(printf '%s' "${FIXTURE_JSON}" | jq '.summary.bypass_retained')"     "1" "fixture summary bypass_retained=1"
+assert_eq "$(printf '%s' "${FIXTURE_JSON}" | jq '.summary.legacy')"              "1" "fixture summary legacy=1"
+assert_eq "$(printf '%s' "${FIXTURE_JSON}" | jq '.summary.deny_entries')"        "2" "fixture summary deny_entries=2"
+
+# ---------------------------------------------------------------------------
+# 4. Bad input handling.
+# ---------------------------------------------------------------------------
+
+BAD_HOOKS_OUTPUT="$(bash "${AUDIT}" --hooks-dir "/nonexistent-${RANDOM}" --settings-file "${SETTINGS_FILE}" 2>&1)"
+BAD_HOOKS_EXIT=$?
+if [ "${BAD_HOOKS_EXIT}" -ne 0 ]; then
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: missing hooks dir should exit non-zero"
+fi
+assert_contains "${BAD_HOOKS_OUTPUT}" "hooks dir does not exist" "missing hooks dir prints clear error"
+
+BAD_FMT_OUTPUT="$(bash "${AUDIT}" --hooks-dir "${HOOKS_DIR}" --settings-file "${SETTINGS_FILE}" --format yaml 2>&1)"
+BAD_FMT_EXIT=$?
+if [ "${BAD_FMT_EXIT}" -ne 0 ]; then
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: invalid --format should exit non-zero"
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "test-permission-audit.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
 exit 0


### PR DESCRIPTION
## Summary

Wave 2 Epic 5 — read-only `/permission-audit` command. Static analyzer that classifies each `modules/hooks/hooks/*.py` (bypass-suppressible / bypass-retained / legacy) and flags overlaps with the `settings.base.json` deny list.

Closes #477. Rebased onto #475 (Epic 3 scaffold).

### Files

- `commands/permission-audit.md` — slash-command spec; behaviour, output, JSON envelope shape, overrides.
- `bin/permission-audit.sh` — bash 3.2 compatible. Args: `--hooks-dir`, `--settings-file`, `--format text|json`. Auto-detects in-tree vs installed defaults via REPO_ROOT probe. Classifies hooks by inspection: imports `hook_utils` + uses `is_bypass_mode` → bypass-suppressible; uses `hard_block` only → bypass-retained; neither → legacy. Counts deny entries and flags overlaps with hook hard_blocks. JSON output validates through `jq -e .`.
- `tests/test-permission-audit.sh` — 47 assertions: text run, JSON validity, every hook mentioned, classification for sentinel hooks, fixture counts, error handling.
- `tests/fixtures/audit-hooks/{fixture-suppressible,fixture-retained,fixture-legacy}.py` — 3 minimal mock hooks for each classification (docstrings avoid the helper-name substrings the classifier matches against, so the classification stays accurate).
- `tests/fixtures/audit-settings.json` — minimal 2-entry settings fixture.

### Real-state audit output (post-Wave-1)

```
3 bypass-suppressible: auto-approve-bash, check-careful, port-check
2 bypass-retained:    check-migration-timestamps, enforce-git-workflow
9 legacy:             (the other hooks predating Epic 1)
13 deny entries
4 misalignments flagged: rm -rf overlap x2; git reset --hard; force-push-main
```

The misalignments are EXPECTED (defense-in-depth, see #474's README rationale).

## Test plan

- [x] `bash modules/autoheal/tests/test-permission-audit.sh` → 47 passed
- [x] `bash tests/test-modules.sh` → 1180 passed
- [x] `bash tests/test-no-personal-data.sh` → PASS
- [x] Manual: `/permission-audit` produces coherent report on the real repo

Post-merge bring-up: `bash start.sh --reinstall autoheal`.
