### PR TITLE
#479: Epic 7 — daily digest, multi-recipient Resend email, slash commands

### DIFF
--- a/modules/autoheal/bin/autoheal-daily.sh
+++ b/modules/autoheal/bin/autoheal-daily.sh
@@ -1,5 +1,116 @@
 #!/usr/bin/env bash
-# Epic 7: content TBD — daily wrapper that runs analyze -> auto-apply ->
-# digest -> email -> publish -> retention. See plan.md §5 Epic 7 and §5
-# Epic 12 for the final ordering.
+# autoheal-daily.sh
+#
+# Daily wrapper: runs the analyzer, digest, email, auto-apply, publish, and
+# retention scripts in sequence. Each step is exit-tolerant — a failure of
+# one step does not kill the rest. The wrapper exits 0 unless EVERY step
+# failed.
+#
+# Order (plan.md §5 Epic 7, Epic 11 §5, Epic 12 §5):
+#   1. bin/autoheal-analyze.sh    (Epic 6)
+#   2. bin/autoheal-digest.sh     (Epic 7)
+#   3. bin/autoheal-email.sh      (Epic 7)
+#   4. bin/autoheal-auto-apply.sh (Epic 11; stub OK)
+#   5. bin/autoheal-publish.sh    (Epic 12; stub OK)
+#   6. bin/autoheal-retention.sh  (Epic 12; stub OK)
+#
+# Missing/non-executable steps are logged and skipped. The wrapper aggregates
+# each step's stdout/stderr into a per-day log under ~/.claude/logs.
+#
+# Env overrides (for tests):
+#   CCGM_AUTOHEAL_LOGS_DIR   default ~/.claude/logs
+#   CCGM_AUTOHEAL_TODAY      default $(date +%Y-%m-%d)
+#   CCGM_AUTOHEAL_BIN_DIR    default to dirname of this script
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="${CCGM_AUTOHEAL_BIN_DIR:-${SCRIPT_DIR}}"
+LOGS_DIR="${CCGM_AUTOHEAL_LOGS_DIR:-${HOME}/.claude/logs}"
+TODAY="${CCGM_AUTOHEAL_TODAY:-$(date +%Y-%m-%d)}"
+
+mkdir -p "${LOGS_DIR}"
+DAILY_LOG="${LOGS_DIR}/autoheal-daily-${TODAY}.log"
+
+log() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >> "${DAILY_LOG}"
+}
+
+run_step() {
+    local label="$1"
+    local path="$2"
+
+    if [ ! -f "${path}" ]; then
+        log "skip ${label}: ${path} not present"
+        return 0
+    fi
+    if [ ! -x "${path}" ]; then
+        # Run via bash even if not chmod +x, so a fresh checkout where
+        # someone forgot the bit still works.
+        log "run  ${label}: ${path} (via bash; not executable)"
+        if bash "${path}" >>"${DAILY_LOG}" 2>&1; then
+            log "ok   ${label}"
+            return 0
+        else
+            local rc=$?
+            log "fail ${label}: exit=${rc}"
+            return ${rc}
+        fi
+    fi
+
+    log "run  ${label}: ${path}"
+    if "${path}" >>"${DAILY_LOG}" 2>&1; then
+        log "ok   ${label}"
+        return 0
+    else
+        local rc=$?
+        log "fail ${label}: exit=${rc}"
+        return ${rc}
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Step list. Order matters; see plan.md §5 Epic 7 and the parent-merge order
+# for Epic 12 (auto-apply runs BEFORE digest so the digest reflects applied
+# state).
+# ---------------------------------------------------------------------------
+
+steps_total=0
+steps_failed=0
+
+log "autoheal-daily start (${TODAY})"
+
+# Step 1: analyzer (Epic 6).
+steps_total=$((steps_total + 1))
+run_step "analyze"    "${BIN_DIR}/autoheal-analyze.sh"     || steps_failed=$((steps_failed + 1))
+
+# Step 2: auto-apply (Epic 11). Runs AFTER analyzer so today's proposals
+# exist and BEFORE digest so digest reflects the applied state.
+steps_total=$((steps_total + 1))
+run_step "auto-apply" "${BIN_DIR}/autoheal-auto-apply.sh"  || steps_failed=$((steps_failed + 1))
+
+# Step 3: digest (Epic 7).
+steps_total=$((steps_total + 1))
+run_step "digest"     "${BIN_DIR}/autoheal-digest.sh"      || steps_failed=$((steps_failed + 1))
+
+# Step 4: email (Epic 7).
+steps_total=$((steps_total + 1))
+run_step "email"      "${BIN_DIR}/autoheal-email.sh"       || steps_failed=$((steps_failed + 1))
+
+# Step 5: publish (Epic 12).
+steps_total=$((steps_total + 1))
+run_step "publish"    "${BIN_DIR}/autoheal-publish.sh"     || steps_failed=$((steps_failed + 1))
+
+# Step 6: retention (Epic 12).
+steps_total=$((steps_total + 1))
+run_step "retention"  "${BIN_DIR}/autoheal-retention.sh"   || steps_failed=$((steps_failed + 1))
+
+log "autoheal-daily done (failed=${steps_failed}/${steps_total})"
+
+# Exit 0 unless EVERY step failed. If launchd sees a non-zero exit, it
+# treats the job as faulty and may delay reschedule — we'd rather have a
+# faulty individual step than a wholesale launchd cooldown.
+if [ "${steps_failed}" -eq "${steps_total}" ] && [ "${steps_total}" -gt 0 ]; then
+    exit 1
+fi
 exit 0

--- a/modules/autoheal/bin/autoheal-digest.sh
+++ b/modules/autoheal/bin/autoheal-digest.sh
@@ -1,4 +1,329 @@
 #!/usr/bin/env bash
-# Epic 7: content TBD — render local digest markdown from today's
-# proposals. See plan.md §5 Epic 7.
+# autoheal-digest.sh
+#
+# Render today's autoheal proposals into a markdown digest at
+# ~/.claude/autoheal/digests/{today}.md.
+#
+# Behavior (plan.md §5 Epic 7):
+#   - Local digest is always-on. Config `digest_enabled: false` skips.
+#   - Caps at 5 proposals/day; remainder summarized as "+N more".
+#   - Empty proposals: skip (exit 0) unless --include-empty.
+#   - Backfill summary: list unemailed days from the past 7 (sent flags
+#     missing under ~/.claude/autoheal/sent/).
+#   - Redaction: rationale and title pass through
+#     hook_utils.redact_secrets() BEFORE rendering.
+#   - Footer links to /autoheal-toggle, /autoheal-snooze, /autoheal-apply list.
+#
+# Env overrides (for tests):
+#   CCGM_AUTOHEAL_PROPOSALS_DIR    default ~/.claude/autoheal/proposals
+#   CCGM_AUTOHEAL_DIGESTS_DIR      default ~/.claude/autoheal/digests
+#   CCGM_AUTOHEAL_SENT_DIR         default ~/.claude/autoheal/sent
+#   CCGM_AUTOHEAL_CONFIG           default ~/.claude/autoheal/config.json
+#   CCGM_AUTOHEAL_TODAY            default $(date +%Y-%m-%d)
+#   CCGM_AUTOHEAL_LIB_DIR          default to in-tree modules/hooks/lib (when
+#                                  running from the CCGM checkout), else
+#                                  ~/.claude/lib (the installed copy).
+#
+# Exit codes:
+#   0  digest rendered, or skipped cleanly (empty / disabled)
+#   2  invariant violation (jq missing, python missing, bad config)
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Args
+# ---------------------------------------------------------------------------
+
+INCLUDE_EMPTY=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --include-empty)
+            INCLUDE_EMPTY=1
+            shift
+            ;;
+        -h|--help)
+            cat <<EOF
+Usage: $0 [--include-empty]
+
+Render today's autoheal proposals into a markdown digest.
+EOF
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+PROPOSALS_DIR="${CCGM_AUTOHEAL_PROPOSALS_DIR:-${HOME}/.claude/autoheal/proposals}"
+DIGESTS_DIR="${CCGM_AUTOHEAL_DIGESTS_DIR:-${HOME}/.claude/autoheal/digests}"
+SENT_DIR="${CCGM_AUTOHEAL_SENT_DIR:-${HOME}/.claude/autoheal/sent}"
+CONFIG_FILE="${CCGM_AUTOHEAL_CONFIG:-${HOME}/.claude/autoheal/config.json}"
+TODAY="${CCGM_AUTOHEAL_TODAY:-$(date +%Y-%m-%d)}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." 2>/dev/null && pwd || echo "")"
+
+if [ -n "${CCGM_AUTOHEAL_LIB_DIR:-}" ]; then
+    LIB_DIR="${CCGM_AUTOHEAL_LIB_DIR}"
+elif [ -n "${REPO_ROOT}" ] && [ -f "${REPO_ROOT}/modules/hooks/lib/hook_utils.py" ]; then
+    LIB_DIR="${REPO_ROOT}/modules/hooks/lib"
+else
+    LIB_DIR="${HOME}/.claude/lib"
+fi
+
+PROPOSALS_FILE="${PROPOSALS_DIR}/${TODAY}.jsonl"
+DIGEST_FILE="${DIGESTS_DIR}/${TODAY}.md"
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required but not on PATH" >&2
+    exit 2
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 is required but not on PATH" >&2
+    exit 2
+fi
+
+mkdir -p "${DIGESTS_DIR}"
+
+# ---------------------------------------------------------------------------
+# Config: digest_enabled (default true)
+# ---------------------------------------------------------------------------
+
+digest_enabled=1
+if [ -f "${CONFIG_FILE}" ]; then
+    val="$(jq -r 'if has("digest_enabled") then (.digest_enabled | tostring) else "true" end' "${CONFIG_FILE}" 2>/dev/null || echo "true")"
+    case "${val}" in
+        false|0|"") digest_enabled=0 ;;
+    esac
+fi
+
+if [ "${digest_enabled}" -eq 0 ]; then
+    echo "digest disabled (digest_enabled: false in ${CONFIG_FILE})" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Proposal count
+# ---------------------------------------------------------------------------
+
+proposal_count=0
+if [ -f "${PROPOSALS_FILE}" ]; then
+    # Count non-blank lines.
+    proposal_count="$(grep -c . "${PROPOSALS_FILE}" 2>/dev/null || echo 0)"
+fi
+
+if [ "${proposal_count}" -eq 0 ] && [ "${INCLUDE_EMPTY}" -eq 0 ]; then
+    echo "no proposals for ${TODAY}; skipping digest" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Backfill: unemailed days in past 7 (sent flags missing)
+# ---------------------------------------------------------------------------
+#
+# A day is considered "unemailed" if BOTH:
+#   (a) a proposals file exists for that day (we have something to email)
+#   (b) no sent flag matching ${SENT_DIR}/${date}*.flag exists
+#
+# We look back 7 days INCLUDING yesterday (not today; today is the active
+# digest, not a backfill candidate).
+
+backfill_days=""
+i=1
+while [ ${i} -le 7 ]; do
+    # Cross-platform date arithmetic. macOS BSD date and GNU date differ;
+    # python is the portable hammer.
+    past_date="$(CCGM_OFFSET="${i}" python3 -c "
+import datetime, os
+offset = int(os.environ['CCGM_OFFSET'])
+today_str = os.environ.get('CCGM_AUTOHEAL_TODAY', '') or datetime.date.today().isoformat()
+today = datetime.date.fromisoformat(today_str)
+print((today - datetime.timedelta(days=offset)).isoformat())
+" CCGM_AUTOHEAL_TODAY="${TODAY}")"
+
+    past_proposals="${PROPOSALS_DIR}/${past_date}.jsonl"
+    if [ -f "${past_proposals}" ] && [ "$(grep -c . "${past_proposals}" 2>/dev/null || echo 0)" -gt 0 ]; then
+        sent_glob="${SENT_DIR}/${past_date}"
+        if ! ls "${sent_glob}"*.flag >/dev/null 2>&1; then
+            if [ -z "${backfill_days}" ]; then
+                backfill_days="${past_date}"
+            else
+                backfill_days="${backfill_days} ${past_date}"
+            fi
+        fi
+    fi
+    i=$((i + 1))
+done
+
+# ---------------------------------------------------------------------------
+# Render digest
+# ---------------------------------------------------------------------------
+#
+# We pipe the proposals file plus state through a Python helper that handles:
+#   - JSON parsing per line
+#   - field redaction via hook_utils.redact_secrets()
+#   - 5-cap + "+N more" summary
+#   - markdown rendering
+# Bash + jq is too cumbersome for templated multi-line markdown.
+
+OUTPUT="$(
+    CCGM_PROPOSALS_FILE="${PROPOSALS_FILE}" \
+    CCGM_DIGEST_TODAY="${TODAY}" \
+    CCGM_BACKFILL_DAYS="${backfill_days}" \
+    CCGM_LIB_DIR="${LIB_DIR}" \
+    CCGM_INCLUDE_EMPTY="${INCLUDE_EMPTY}" \
+    python3 - <<'PYEOF'
+import json
+import os
+import sys
+
+sys.path.insert(0, os.environ["CCGM_LIB_DIR"])
+try:
+    from hook_utils import redact_secrets
+except ImportError:
+    def redact_secrets(text):
+        return text
+
+proposals_file = os.environ["CCGM_PROPOSALS_FILE"]
+today = os.environ["CCGM_DIGEST_TODAY"]
+backfill_days = [d for d in os.environ.get("CCGM_BACKFILL_DAYS", "").split() if d]
+include_empty = os.environ.get("CCGM_INCLUDE_EMPTY", "0") == "1"
+
+proposals = []
+if os.path.isfile(proposals_file):
+    with open(proposals_file, "r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                proposals.append(json.loads(line))
+            except json.JSONDecodeError:
+                # Skip malformed lines silently; the analyzer guarantees
+                # well-formed lines and a malformed line here is a sign
+                # of corruption that the analyzer test suite covers.
+                continue
+
+
+def safe(record, key, default=""):
+    val = record.get(key)
+    return val if val is not None else default
+
+
+def render_proposal(p):
+    title = redact_secrets(str(safe(p, "title", "(untitled)")))
+    rationale = redact_secrets(str(safe(p, "rationale", "")))
+    pid = safe(p, "id", "(no-id)")
+    kind = safe(p, "kind", "(no-kind)")
+    confidence = safe(p, "confidence", "?")
+    breadth = safe(p, "breadth_score", "?")
+    occ = safe(p, "occurrence_count", "?")
+
+    lines = [
+        f"### {title}",
+        "",
+        f"- **id**: `{pid}`",
+        f"- **kind**: `{kind}`",
+        f"- **confidence**: {confidence}/10",
+        f"- **breadth**: {breadth}/10",
+        f"- **occurrences**: {occ}",
+        "",
+        "**Rationale**",
+        "",
+    ]
+    if rationale:
+        for ln in rationale.splitlines() or [rationale]:
+            lines.append(ln)
+    else:
+        lines.append("_(no rationale provided)_")
+    lines.append("")
+    lines.append(f"Apply: `/autoheal-apply {pid}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# Stable order: confidence desc, then occurrence_count desc, then id asc.
+def sort_key(p):
+    return (
+        -(int(p.get("confidence") or 0)),
+        -(int(p.get("occurrence_count") or 0)),
+        str(p.get("id") or ""),
+    )
+
+
+proposals.sort(key=sort_key)
+
+CAP = 5
+shown = proposals[:CAP]
+hidden = proposals[CAP:]
+
+out = []
+out.append(f"# Autoheal digest — {today}")
+out.append("")
+if not proposals:
+    if not include_empty:
+        # Should not reach here; the bash caller short-circuits on empty
+        # without --include-empty.
+        sys.exit(0)
+    out.append("_No proposals for today._")
+    out.append("")
+else:
+    summary_line = f"_{len(proposals)} proposal"
+    summary_line += "s_" if len(proposals) != 1 else "_"
+    out.append(summary_line)
+    out.append("")
+    for p in shown:
+        out.append(render_proposal(p))
+    if hidden:
+        n = len(hidden)
+        plural = "proposal" if n == 1 else "proposals"
+        out.append(
+            f"+{n} more {plural} — see `/autoheal-digest {today}` for the full list."
+        )
+        out.append("")
+
+if backfill_days:
+    out.append("## Backfill — unemailed days (past 7)")
+    out.append("")
+    for d in backfill_days:
+        out.append(f"- `{d}` — see `/autoheal-digest {d}`")
+    out.append("")
+
+out.append("---")
+out.append("")
+out.append("**Controls**")
+out.append("")
+out.append("- `/autoheal-toggle [pause|resume|status|realtime|autoapply|webhook]`")
+out.append("- `/autoheal-snooze <id> [days]`")
+out.append("- `/autoheal-apply list`")
+out.append("")
+
+sys.stdout.write("\n".join(out))
+PYEOF
+)"
+
+py_exit=$?
+if [ ${py_exit} -ne 0 ]; then
+    echo "ERROR: digest renderer failed (exit ${py_exit})" >&2
+    exit 2
+fi
+
+if [ -z "${OUTPUT}" ]; then
+    # Render produced no body and caller did not request --include-empty.
+    echo "digest renderer produced empty output; not writing ${DIGEST_FILE}" >&2
+    exit 0
+fi
+
+printf '%s\n' "${OUTPUT}" > "${DIGEST_FILE}"
+echo "digest written: ${DIGEST_FILE}" >&2
 exit 0

--- a/modules/autoheal/bin/autoheal-email.sh
+++ b/modules/autoheal/bin/autoheal-email.sh
@@ -1,5 +1,279 @@
 #!/usr/bin/env bash
-# Epic 7: content TBD — optional Resend delivery with multi-recipient
-# iteration and per-recipient idempotency key. See plan.md §5 Epic 7 and
-# §5 Epic 12.
+# autoheal-email.sh
+#
+# Optionally email today's autoheal digest via Resend.
+#
+# Behavior (plan.md §5 Epic 7 + §5 Epic 12 multi-recipient):
+#   - email_enabled: false in config → exit 0 (no-op)
+#   - RESEND_API_KEY required from env at runtime; warn-and-skip if absent
+#   - digest_email config: string or list of strings
+#   - For each recipient, per-recipient idempotency key:
+#       ccgm-autoheal-{YYYY-MM-DD}-{sha256(recipient)[:12]}
+#   - POST to https://api.resend.com/emails
+#   - 2xx → write ~/.claude/autoheal/sent/{today}-{recipient-hash}.flag
+#   - 4xx/5xx → log to ~/.claude/logs/autoheal-email-{today}.err.log; do NOT
+#     fail the rest of the pipeline (Resend's idempotency means a retry on
+#     the next daily run is safe)
+#   - Analyzer crash detection: if today's proposals.jsonl missing AND
+#     yesterday's was present, send a minimal diagnostic email with the most
+#     recent autoheal.err.log tail (≤2KB, redacted).
+#
+# Env overrides (for tests):
+#   CCGM_AUTOHEAL_PROPOSALS_DIR    default ~/.claude/autoheal/proposals
+#   CCGM_AUTOHEAL_DIGESTS_DIR      default ~/.claude/autoheal/digests
+#   CCGM_AUTOHEAL_SENT_DIR         default ~/.claude/autoheal/sent
+#   CCGM_AUTOHEAL_LOGS_DIR         default ~/.claude/logs
+#   CCGM_AUTOHEAL_CONFIG           default ~/.claude/autoheal/config.json
+#   CCGM_AUTOHEAL_TODAY            default $(date +%Y-%m-%d)
+#   CCGM_AUTOHEAL_RESEND_URL       default https://api.resend.com/emails
+#                                  (tests point at a local mock server)
+#   CCGM_AUTOHEAL_FROM             default "autoheal@ccgm.local"
+#   CCGM_AUTOHEAL_LIB_DIR          default to in-tree modules/hooks/lib (when
+#                                  running from the CCGM checkout), else
+#                                  ~/.claude/lib (the installed copy)
+#   CCGM_AUTOHEAL_ERR_LOG          default ~/.claude/logs/autoheal.err.log
+#                                  (used for analyzer-crash diagnostic tail)
+#
+# Exit codes:
+#   0  done (sent, skipped, or recorded failures non-fatally)
+#   2  invariant violation (jq missing, python missing)
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+PROPOSALS_DIR="${CCGM_AUTOHEAL_PROPOSALS_DIR:-${HOME}/.claude/autoheal/proposals}"
+DIGESTS_DIR="${CCGM_AUTOHEAL_DIGESTS_DIR:-${HOME}/.claude/autoheal/digests}"
+SENT_DIR="${CCGM_AUTOHEAL_SENT_DIR:-${HOME}/.claude/autoheal/sent}"
+LOGS_DIR="${CCGM_AUTOHEAL_LOGS_DIR:-${HOME}/.claude/logs}"
+CONFIG_FILE="${CCGM_AUTOHEAL_CONFIG:-${HOME}/.claude/autoheal/config.json}"
+TODAY="${CCGM_AUTOHEAL_TODAY:-$(date +%Y-%m-%d)}"
+RESEND_URL="${CCGM_AUTOHEAL_RESEND_URL:-https://api.resend.com/emails}"
+FROM_ADDR="${CCGM_AUTOHEAL_FROM:-autoheal@ccgm.local}"
+ERR_LOG="${CCGM_AUTOHEAL_ERR_LOG:-${LOGS_DIR}/autoheal.err.log}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." 2>/dev/null && pwd || echo "")"
+
+if [ -n "${CCGM_AUTOHEAL_LIB_DIR:-}" ]; then
+    LIB_DIR="${CCGM_AUTOHEAL_LIB_DIR}"
+elif [ -n "${REPO_ROOT}" ] && [ -f "${REPO_ROOT}/modules/hooks/lib/hook_utils.py" ]; then
+    LIB_DIR="${REPO_ROOT}/modules/hooks/lib"
+else
+    LIB_DIR="${HOME}/.claude/lib"
+fi
+
+DIGEST_FILE="${DIGESTS_DIR}/${TODAY}.md"
+PROPOSALS_FILE="${PROPOSALS_DIR}/${TODAY}.jsonl"
+EMAIL_ERR_LOG="${LOGS_DIR}/autoheal-email-${TODAY}.err.log"
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required but not on PATH" >&2
+    exit 2
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 is required but not on PATH" >&2
+    exit 2
+fi
+if ! command -v curl >/dev/null 2>&1; then
+    echo "ERROR: curl is required but not on PATH" >&2
+    exit 2
+fi
+
+mkdir -p "${SENT_DIR}" "${LOGS_DIR}"
+
+# ---------------------------------------------------------------------------
+# Config: email_enabled (default false) + digest_email (string or list)
+# ---------------------------------------------------------------------------
+
+email_enabled=0
+recipients_raw=""
+if [ -f "${CONFIG_FILE}" ]; then
+    val="$(jq -r 'if has("email_enabled") then (.email_enabled | tostring) else "false" end' "${CONFIG_FILE}" 2>/dev/null || echo "false")"
+    case "${val}" in
+        true|1) email_enabled=1 ;;
+    esac
+
+    # Normalize digest_email into newline-delimited list. Strings stay 1
+    # entry; arrays unpack to N entries; null/missing → empty.
+    recipients_raw="$(jq -r '
+        if has("digest_email") then
+            if (.digest_email | type) == "array" then .digest_email[]
+            elif (.digest_email | type) == "string" then .digest_email
+            else empty
+            end
+        else empty end
+    ' "${CONFIG_FILE}" 2>/dev/null || true)"
+fi
+
+if [ "${email_enabled}" -eq 0 ]; then
+    echo "email disabled (email_enabled: false)" >&2
+    exit 0
+fi
+
+if [ -z "${recipients_raw}" ]; then
+    echo "email enabled but digest_email is unset; skipping" >&2
+    exit 0
+fi
+
+if [ -z "${RESEND_API_KEY:-}" ]; then
+    echo "RESEND_API_KEY not set in env; skipping email send" >&2
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Analyzer crash detection
+# ---------------------------------------------------------------------------
+#
+# Today's proposals file missing AND yesterday's present → send a minimal
+# diagnostic email instead of the regular digest. The diagnostic body is the
+# last ~2KB of the err log, redacted via hook_utils.redact_secrets.
+
+is_crash_mode=0
+crash_body=""
+
+yesterday="$(CCGM_AUTOHEAL_TODAY="${TODAY}" python3 -c "
+import datetime, os
+today_str = os.environ['CCGM_AUTOHEAL_TODAY']
+today = datetime.date.fromisoformat(today_str)
+print((today - datetime.timedelta(days=1)).isoformat())
+")"
+
+yesterday_props="${PROPOSALS_DIR}/${yesterday}.jsonl"
+
+if [ ! -f "${PROPOSALS_FILE}" ] && [ -f "${yesterday_props}" ]; then
+    is_crash_mode=1
+    crash_body="$(CCGM_ERR_LOG="${ERR_LOG}" CCGM_LIB_DIR="${LIB_DIR}" python3 - <<'PYEOF'
+import os
+import sys
+
+sys.path.insert(0, os.environ["CCGM_LIB_DIR"])
+try:
+    from hook_utils import redact_secrets
+except ImportError:
+    def redact_secrets(text):
+        return text
+
+err_log = os.environ["CCGM_ERR_LOG"]
+if not os.path.isfile(err_log):
+    print("(no autoheal.err.log present)")
+    sys.exit(0)
+
+# Tail ~2KB.
+size = os.path.getsize(err_log)
+read_bytes = 2048
+with open(err_log, "rb") as fh:
+    if size > read_bytes:
+        fh.seek(size - read_bytes)
+    raw = fh.read()
+
+try:
+    text = raw.decode("utf-8", errors="replace")
+except Exception:
+    text = repr(raw)
+
+# Drop a possibly-truncated first line.
+if size > read_bytes and "\n" in text:
+    text = text.split("\n", 1)[1]
+
+print(redact_secrets(text))
+PYEOF
+    )"
+fi
+
+# ---------------------------------------------------------------------------
+# Choose body: digest markdown OR crash diagnostic
+# ---------------------------------------------------------------------------
+
+if [ "${is_crash_mode}" -eq 1 ]; then
+    SUBJECT="autoheal: analyzer crash diagnostic — ${TODAY}"
+    BODY=$'**Autoheal analyzer did not produce proposals today.**\n\nMost recent autoheal.err.log tail (redacted):\n\n```\n'"${crash_body}"$'\n```\n'
+else
+    if [ ! -f "${DIGEST_FILE}" ]; then
+        echo "no digest file at ${DIGEST_FILE}; skipping email" >&2
+        exit 0
+    fi
+    SUBJECT="autoheal digest — ${TODAY}"
+    BODY="$(cat "${DIGEST_FILE}")"
+fi
+
+# ---------------------------------------------------------------------------
+# Send to each recipient with per-recipient idempotency key
+# ---------------------------------------------------------------------------
+
+errors=0
+sent=0
+total=0
+
+# Iterate recipients via newline-delimited; preserve whitespace-safe behavior.
+# Use process substitution to feed the while loop so counters are not in a
+# subshell.
+while IFS= read -r recipient; do
+    [ -z "${recipient}" ] && continue
+    total=$((total + 1))
+
+    # 12-char sha256 prefix of the recipient.
+    rec_hash="$(printf '%s' "${recipient}" | shasum -a 256 | awk '{print substr($1, 1, 12)}')"
+    idem_key="ccgm-autoheal-${TODAY}-${rec_hash}"
+    sent_flag="${SENT_DIR}/${TODAY}-${rec_hash}.flag"
+
+    # Build JSON payload via jq (so the body is safely escaped).
+    payload="$(jq -nc \
+        --arg from "${FROM_ADDR}" \
+        --arg to "${recipient}" \
+        --arg subject "${SUBJECT}" \
+        --arg text "${BODY}" \
+        '{
+            from: $from,
+            to: [$to],
+            subject: $subject,
+            text: $text
+        }')"
+
+    # Capture HTTP status separately from body.
+    response_file="$(mktemp -t autoheal-email-resp.XXXXXX)"
+    http_code="$(curl -sS -o "${response_file}" -w "%{http_code}" \
+        -X POST "${RESEND_URL}" \
+        -H "Authorization: Bearer ${RESEND_API_KEY}" \
+        -H "Content-Type: application/json" \
+        -H "Idempotency-Key: ${idem_key}" \
+        --data-binary "${payload}" 2>>"${EMAIL_ERR_LOG}" || echo "000")"
+
+    case "${http_code}" in
+        2*)
+            sent=$((sent + 1))
+            # Record send so the digest backfill skips this day for this
+            # recipient on subsequent runs.
+            : > "${sent_flag}"
+            ;;
+        *)
+            errors=$((errors + 1))
+            {
+                echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] resend failure"
+                echo "  recipient: ${recipient}"
+                echo "  http_code: ${http_code}"
+                echo "  idempotency_key: ${idem_key}"
+                if [ -s "${response_file}" ]; then
+                    echo "  body_excerpt:"
+                    head -c 1024 "${response_file}" | sed 's/^/    /'
+                    echo ""
+                fi
+            } >> "${EMAIL_ERR_LOG}"
+            ;;
+    esac
+
+    rm -f "${response_file}"
+done <<EOF
+${recipients_raw}
+EOF
+
+echo "autoheal-email: ${sent}/${total} sent; ${errors} errors" >&2
+# Exit 0 always — Resend's idempotency means retries on the next daily run
+# are safe; we do not want a single recipient failure to kill the pipeline.
 exit 0

--- a/modules/autoheal/commands/autoheal-digest.md
+++ b/modules/autoheal/commands/autoheal-digest.md
@@ -1,2 +1,54 @@
-<!-- Epic 7: content TBD — /autoheal-digest [date]. Renders the local
-digest for a given date (defaults to today). See plan.md §5 Epic 7. -->
+# /autoheal-digest - Render an Autoheal Digest
+
+Print the markdown digest for today (default) or a specific past date.
+
+## Usage
+
+```
+/autoheal-digest             # today
+/autoheal-digest 2026-05-15  # a specific date
+```
+
+## What it does
+
+1. Resolve the target date. With no argument, use today (the agent reads
+   `date +%Y-%m-%d`). With an argument, validate the `YYYY-MM-DD` shape.
+2. Check whether `~/.claude/autoheal/digests/{date}.md` exists.
+3. If it does, print the file body verbatim.
+4. If it does not, fall through to one of the following:
+   - If `~/.claude/autoheal/proposals/{date}.jsonl` exists with at least
+     one record: run `bash ~/.claude/bin/autoheal-digest.sh` with the
+     env override `CCGM_AUTOHEAL_TODAY={date}` to materialize the digest,
+     then print it.
+   - If no proposals file exists for that date: print "no digest available
+     for {date}" plus the path that was checked.
+
+## When to invoke
+
+- The daily launchd job has not yet fired and you want to see what is
+  ready right now.
+- A past day's digest scrolled past you and you want to re-read it.
+- You suspect the analyzer crashed on a given day and want to confirm
+  no proposals landed.
+
+## When NOT to invoke
+
+- To apply a specific proposal — use `/autoheal-apply <id>` (Epic 11) or
+  `/permission-fix apply <id>` (Epic 4) instead.
+- To toggle config flags — use `/autoheal-toggle`.
+- For dates older than the retention window (default: gzipped at 30 days,
+  deleted at 60 days). Older digests have been swept by
+  `autoheal-retention.sh` and are not recoverable from this command.
+
+## How it interacts with state
+
+This command is read-mostly. The one write path is re-running
+`autoheal-digest.sh` when a proposals file exists but the digest does not.
+That call writes only to `~/.claude/autoheal/digests/{date}.md` and never
+modifies the proposals or events files.
+
+## Cross-references
+
+- Generator: `~/.claude/bin/autoheal-digest.sh`
+- Rule: `~/.claude/rules/autoheal.md`
+- Plan: `~/code/plans/ccgm-autoheal/plan.md` §5 Epic 7

--- a/modules/autoheal/commands/autoheal-snooze.md
+++ b/modules/autoheal/commands/autoheal-snooze.md
@@ -1,3 +1,89 @@
-<!-- Epic 7: content TBD — /autoheal-snooze <id> [days]. Snoozes a
-proposal for N days (default 7). Adds an entry to snoozed.json. See
-plan.md §5 Epic 7. -->
+# /autoheal-snooze - Snooze a Proposal
+
+Suppress a specific autoheal proposal for N days. The proposal will not
+be re-rendered in the digest until the snooze expires, even if it
+re-occurs as a daily recommendation.
+
+## Usage
+
+```
+/autoheal-snooze <proposal-id>              # 30-day default
+/autoheal-snooze <proposal-id> 7            # 7 days
+/autoheal-snooze <proposal-id> 0            # remove an existing snooze
+/autoheal-snooze list                       # list active snoozes
+```
+
+## What it does
+
+1. Resolve `proposal-id` against today's
+   `~/.claude/autoheal/proposals/{today}.jsonl` (and the previous 7
+   days if not found in today's file) to extract the proposal's
+   `fingerprint`. Snoozes are keyed by fingerprint, not by id, so that
+   the next analyzer run cannot re-issue the same proposal under a new
+   id and bypass the snooze.
+2. Compute the expiry timestamp:
+   `now + N days`, ISO 8601 UTC. With `N = 0`, the existing snooze for
+   this fingerprint is removed.
+3. Read `~/.claude/autoheal/snoozed.json` (or `{}` if absent), add the
+   entry `{fingerprint: snoozed_until_iso}`, and write back atomically
+   (tempfile + `mv`).
+4. Print a confirmation: `snoozed prop_XYZ (fingerprint sha256-...) until
+   YYYY-MM-DD`.
+
+## Storage format
+
+```json
+{
+  "sha256-of-proposal-fingerprint-1": "2026-06-17T00:00:00Z",
+  "sha256-of-proposal-fingerprint-2": "2026-06-25T00:00:00Z"
+}
+```
+
+Entries whose timestamp is in the past are not strictly removed by this
+command; the digest renderer ignores them and the next analyzer run
+treats them as eligible again. `/autoheal-snooze list` prints the active
+entries (those whose timestamp is in the future) in human-readable form.
+
+## When to invoke
+
+- The digest keeps suggesting a proposal you have already decided not to
+  apply (e.g., the recommended allow rule conflicts with a policy you
+  enforce manually).
+- A proposal is suspect and you want to defer judgment for a few days
+  without losing the underlying event evidence.
+
+## When NOT to invoke
+
+- To reject a proposal permanently — set `auto_apply_blocked: true` in
+  the proposal record instead (a future epic exposes this via a flag).
+- To delete the underlying event log — the events drive proposal
+  generation, not the snoozed set. Editing events directly is forbidden
+  (see the autoheal rule).
+- To pause autoheal globally — use `/autoheal-toggle pause`.
+
+## Examples
+
+```
+/autoheal-snooze prop_01HW3FQQX7         # snooze 30 days (default)
+/autoheal-snooze prop_01HW3FQQX7 7       # snooze 1 week
+/autoheal-snooze prop_01HW3FQQX7 0       # un-snooze
+/autoheal-snooze list                    # print active snoozes
+```
+
+## How it works
+
+This command is implemented as a small bash transform driven by the
+agent. The agent:
+
+1. Locates the proposal by id by scanning back through 7 days of
+   `~/.claude/autoheal/proposals/*.jsonl`.
+2. Reads its `fingerprint` field.
+3. Computes the expiry timestamp via `date -u` or a small Python
+   snippet (Python is portable across BSD and GNU date).
+4. Reads / writes `~/.claude/autoheal/snoozed.json` atomically.
+
+## Cross-references
+
+- Storage: `~/.claude/autoheal/snoozed.json`
+- Rule: `~/.claude/rules/autoheal.md`
+- Plan: `~/code/plans/ccgm-autoheal/plan.md` §5 Epic 7

--- a/modules/autoheal/commands/autoheal-toggle.md
+++ b/modules/autoheal/commands/autoheal-toggle.md
@@ -1,3 +1,106 @@
-<!-- Epic 7: content TBD — /autoheal-toggle [pause|resume|status|realtime|autoapply|webhook].
-Toggles autoheal-wide pause, real-time alerts (Epic 10), auto-apply (Epic 11),
-and webhook publisher (Epic 12). See plan.md §5 Epic 7. -->
+# /autoheal-toggle - Flip Autoheal Config Flags
+
+Edit `~/.claude/autoheal/config.json` to enable, disable, or inspect
+autoheal feature flags.
+
+## Usage
+
+```
+/autoheal-toggle                                    # equivalent to status
+/autoheal-toggle status
+/autoheal-toggle pause                              # paused: true
+/autoheal-toggle resume                             # paused: false
+
+/autoheal-toggle realtime on|off|status             # realtime_alerts_enabled
+/autoheal-toggle autoapply on|off|status            # auto_apply_enabled
+/autoheal-toggle email on|off|status                # email_enabled
+/autoheal-toggle digest on|off|status               # digest_enabled
+
+/autoheal-toggle webhook on|off|status              # webhook_enabled
+/autoheal-toggle webhook url <URL>                  # webhook_url
+/autoheal-toggle webhook url clear                  # webhook_url -> null
+```
+
+## What it does
+
+For every subcommand:
+
+1. Read `~/.claude/autoheal/config.json` (or `{}` if missing).
+2. Mutate exactly one key based on the subcommand:
+   - `pause` / `resume` set `paused: true|false`. When `paused: true`,
+     the daily wrapper exits early before any sub-step (the bash script
+     respects this flag in its preflight).
+   - `realtime on|off` flips `realtime_alerts_enabled` (Epic 10).
+   - `autoapply on|off` flips `auto_apply_enabled` (Epic 11).
+   - `email on|off` flips `email_enabled` (Epic 7 sender gate).
+   - `digest on|off` flips `digest_enabled` (Epic 7 renderer gate).
+   - `webhook on|off` flips `webhook_enabled` (Epic 12 publisher gate).
+     `webhook url <URL>` writes the URL to `webhook_url`. `webhook url
+     clear` sets `webhook_url` to `null`.
+3. Write the file back via `jq` so the on-disk JSON stays well-formed.
+   For `status` queries, print the current value and exit without
+   writing.
+4. Print a one-line confirmation: `set {key} = {value}`.
+
+## Subcommand reference
+
+| Subcommand | Key it flips | Default |
+|---|---|---|
+| `pause` | `paused` | `false` |
+| `resume` | `paused` | (sets to `false`) |
+| `realtime` | `realtime_alerts_enabled` | `false` |
+| `autoapply` | `auto_apply_enabled` | `false` |
+| `email` | `email_enabled` | `false` |
+| `digest` | `digest_enabled` | `true` |
+| `webhook` (`on`/`off`) | `webhook_enabled` | `false` |
+| `webhook url <URL>` | `webhook_url` | `null` |
+
+`status` (or no second argument) on any of the above prints the current
+value without changing anything.
+
+## Examples
+
+```
+# Pause autoheal entirely for a day or a session
+/autoheal-toggle pause
+
+# Re-enable
+/autoheal-toggle resume
+
+# Turn on real-time security alerts
+/autoheal-toggle realtime on
+
+# Check current auto-apply state
+/autoheal-toggle autoapply status
+
+# Wire up dev.lem.work webhook (Epic 12 / Human-Epic 2)
+/autoheal-toggle webhook url https://dev.lem.work/v1/ingest
+/autoheal-toggle webhook on
+
+# Clear the webhook (revert to no-op)
+/autoheal-toggle webhook url clear
+```
+
+## How it works
+
+This command is implemented as a small bash transform driven by the
+agent. The agent:
+
+1. Resolves the target key from the subcommand.
+2. Reads the existing config via `jq`.
+3. Builds an updated object with `jq '. + {key: value}'`.
+4. Writes the result atomically (write to a tempfile, then `mv` over the
+   original) so a crash mid-write cannot leave a half-written config.
+
+## When NOT to invoke
+
+- To apply a single proposal — use `/autoheal-apply <id>`.
+- To suppress a single proposal — use `/autoheal-snooze <id> [days]`.
+- For per-repo overrides — edit `.autoheal/config.json` in the repo root
+  directly. This command edits only the global config.
+
+## Cross-references
+
+- Rule: `~/.claude/rules/autoheal.md` (config keys table)
+- Plan: `~/code/plans/ccgm-autoheal/plan.md` §5 Epic 7, §5 Epic 10
+  (realtime), §5 Epic 11 (autoapply), §5 Epic 12 (webhook).

--- a/modules/autoheal/commands/autoheal.md
+++ b/modules/autoheal/commands/autoheal.md
@@ -1,2 +1,65 @@
-<!-- Epic 7: content TBD — /autoheal. Help / status command. See plan.md
-§5 Epic 7. -->
+# /autoheal - Self-Healing Observability Loop Overview
+
+Inspect autoheal status and learn the slash command surface. Read-only:
+this command modifies no files. Use the listed subcommands for stateful
+actions.
+
+## Usage
+
+```
+/autoheal
+```
+
+## What it shows
+
+1. The set of autoheal slash commands and a one-line description of each.
+2. The current config flags (`realtime_alerts_enabled`, `auto_apply_enabled`,
+   `email_enabled`, `digest_enabled`, `webhook_url`) read from
+   `~/.claude/autoheal/config.json`.
+3. Today's local digest path (whether it exists yet) and the last analyzer
+   run timestamp from `~/.claude/autoheal/last-analyzed` if present.
+4. The count of unread proposals in
+   `~/.claude/autoheal/proposals/{today}.jsonl` and the path to today's
+   event log under `~/.claude/autoheal/events/`.
+
+## How it works
+
+This command is a thin Claude reader, not a shell script. The agent:
+
+1. Reads `~/.claude/autoheal/config.json` (treating missing keys as
+   defaults from the rule file `modules/autoheal/rules/autoheal.md`).
+2. Lists files under `~/.claude/autoheal/proposals/`,
+   `~/.claude/autoheal/events/`, `~/.claude/autoheal/digests/`, and
+   `~/.claude/autoheal/sent/` to summarize state.
+3. Prints the rendered status table and the command surface.
+
+## Command surface
+
+| Command | Purpose |
+|---|---|
+| `/autoheal` | This overview. |
+| `/autoheal-digest [date]` | Render today's or a specific date's digest. |
+| `/autoheal-toggle [pause\|resume\|status\|realtime\|autoapply\|webhook] [on\|off\|status\|url <URL>]` | Flip config flags. |
+| `/autoheal-snooze <id> [days]` | Snooze a proposal for N days (default 30). |
+| `/autoheal-apply [id\|list]` | Apply a proposal via the formal apply path (Epic 11). |
+| `/permission-fix [event-id\|latest]` | In-session root-cause sub-agent (Epic 4). |
+| `/permission-audit` | Static audit of installed hooks + settings (Epic 5). |
+
+## Config flags
+
+See the autoheal rule (`~/.claude/rules/autoheal.md`) for the full config
+schema. Defaults: `realtime_alerts_enabled: false`, `auto_apply_enabled:
+false`, `email_enabled: false`, `digest_enabled: true`, `webhook_url:
+null`.
+
+## When NOT to invoke
+
+- This is a status read-out, not a fix path. To loosen a specific friction
+  point, use `/permission-fix latest` or `/autoheal-apply <id>` after
+  reading the proposal.
+- For audit alignment between hooks and settings, use `/permission-audit`.
+
+## Cross-references
+
+- Rule: `~/.claude/rules/autoheal.md`
+- Plan: `~/code/plans/ccgm-autoheal/plan.md` §5 Epic 7

--- a/modules/autoheal/tests/fixtures/resend-mock-server.py
+++ b/modules/autoheal/tests/fixtures/resend-mock-server.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Tiny mock HTTP server that mimics the Resend /emails endpoint.
+
+Used by autoheal email tests so we never reach api.resend.com from the
+test suite.
+
+Behavior:
+    POST /emails
+        - Records the request: full headers (especially Idempotency-Key),
+          body JSON, and the timestamp.
+        - Returns 200 with a small JSON envelope `{"id": "mock_..."}` by
+          default.
+        - If the server was started with --fail-with <code>, returns
+          that HTTP code with `{"name":"error","message":"mock failure"}`.
+    GET /requests
+        - Returns the recorded request list as JSON. The test driver
+          polls this to assert on what was sent.
+    POST /reset
+        - Clears the recorded request list.
+
+Usage (from a test):
+
+    python3 modules/autoheal/tests/fixtures/resend-mock-server.py \\
+        --port 0 --pidfile /tmp/foo.pid --port-file /tmp/foo.port
+
+The server writes its actual listening port to --port-file and its pid to
+--pidfile. The test reads the port, runs the email script with
+CCGM_AUTOHEAL_RESEND_URL pointing at the mock, then GETs /requests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+REQUESTS: list[dict] = []
+REQ_LOCK = threading.Lock()
+FAIL_WITH: int | None = None
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "ResendMock/0.1"
+
+    def log_message(self, format, *args):  # noqa: D401 - quiet test output
+        # Suppress default request logging so the test output stays clean.
+        return
+
+    def _read_body(self) -> bytes:
+        length = int(self.headers.get("Content-Length") or 0)
+        if length <= 0:
+            return b""
+        return self.rfile.read(length)
+
+    def _send_json(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802 - http.server contract
+        if self.path == "/requests":
+            with REQ_LOCK:
+                snapshot = list(REQUESTS)
+            self._send_json(200, {"requests": snapshot})
+            return
+        if self.path == "/health":
+            self._send_json(200, {"ok": True})
+            return
+        self._send_json(404, {"name": "not_found", "message": self.path})
+
+    def do_POST(self):  # noqa: N802 - http.server contract
+        if self.path == "/reset":
+            with REQ_LOCK:
+                REQUESTS.clear()
+            self._send_json(200, {"reset": True})
+            return
+
+        if self.path == "/emails":
+            raw_body = self._read_body()
+            try:
+                body_json = json.loads(raw_body.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                body_json = None
+
+            record = {
+                "method": "POST",
+                "path": self.path,
+                "headers": {k: v for k, v in self.headers.items()},
+                "idempotency_key": self.headers.get("Idempotency-Key"),
+                "authorization": self.headers.get("Authorization"),
+                "content_type": self.headers.get("Content-Type"),
+                "body_json": body_json,
+                "body_raw": raw_body.decode("utf-8", errors="replace"),
+            }
+            with REQ_LOCK:
+                REQUESTS.append(record)
+
+            if FAIL_WITH is not None:
+                self._send_json(
+                    FAIL_WITH,
+                    {"name": "mock_failure", "message": f"forced {FAIL_WITH}"},
+                )
+                return
+
+            # Mock id derived from the idempotency key for traceability.
+            idem = record["idempotency_key"] or "no-idem"
+            self._send_json(200, {"id": f"mock_{idem}"})
+            return
+
+        self._send_json(404, {"name": "not_found", "message": self.path})
+
+
+def main(argv: list[str]) -> int:
+    global FAIL_WITH
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("--pidfile", default=None)
+    parser.add_argument("--port-file", default=None)
+    parser.add_argument("--fail-with", type=int, default=None)
+    args = parser.parse_args(argv)
+
+    FAIL_WITH = args.fail_with
+
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    actual_port = server.server_address[1]
+
+    if args.pidfile:
+        with open(args.pidfile, "w", encoding="utf-8") as fh:
+            fh.write(str(os.getpid()))
+    if args.port_file:
+        with open(args.port_file, "w", encoding="utf-8") as fh:
+            fh.write(str(actual_port))
+
+    sys.stderr.write(f"resend-mock listening on 127.0.0.1:{actual_port}\n")
+    sys.stderr.flush()
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/modules/autoheal/tests/test-digest-rendering.sh
+++ b/modules/autoheal/tests/test-digest-rendering.sh
@@ -1,4 +1,342 @@
 #!/usr/bin/env bash
-# Stub: this test belongs to a later epic; content TBD. See plan.md §5
-# for the owning epic and the assertion list.
+# test-digest-rendering.sh
+#
+# Verifies modules/autoheal/bin/autoheal-digest.sh against plan.md §5 Epic 7.
+#
+# Assertions:
+#   1. 3 proposals -> digest contains 3 entries.
+#   2. 7 proposals -> digest shows 5 + "+2 more" summary.
+#   3. Empty proposals -> no digest written (unless --include-empty).
+#   4. Backfill: 2 unemailed past days -> digest mentions them.
+#   5. Redaction: a secret in rationale -> digest has [REDACTED:...].
+#
+# Each assertion runs against a freshly-prepared tmpdir, with env overrides
+# pointing the script at synthetic state.
+#
+# Run: bash modules/autoheal/tests/test-digest-rendering.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${MODULE_ROOT}/../.." && pwd)"
+
+DIGEST_SCRIPT="${MODULE_ROOT}/bin/autoheal-digest.sh"
+LIB_DIR="${REPO_ROOT}/modules/hooks/lib"
+
+PASS=0
+FAIL=0
+TMPROOT="$(mktemp -d -t autoheal-digest-test.XXXXXX)"
+
+cleanup() {
+    rm -rf "${TMPROOT}"
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  missing: ${needle}"
+            echo "  haystack first 400 chars: $(printf '%s' "${haystack}" | head -c 400)"
+            ;;
+    esac
+}
+
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  unexpectedly present: ${needle}"
+            ;;
+        *)
+            PASS=$((PASS + 1))
+            ;;
+    esac
+}
+
+count_proposal_entries() {
+    # Count level-3 markdown headings in the rendered body.
+    local body="$1"
+    printf '%s\n' "${body}" | grep -c '^### '
+}
+
+write_proposal() {
+    # Args: file, id, title, rationale, confidence, breadth, occurrences
+    local out_file="$1"
+    local pid="$2"
+    local title="$3"
+    local rationale="$4"
+    local conf="$5"
+    local breadth="$6"
+    local occ="$7"
+
+    jq -nc \
+        --arg id "${pid}" \
+        --arg title "${title}" \
+        --arg rationale "${rationale}" \
+        --argjson confidence "${conf}" \
+        --argjson breadth_score "${breadth}" \
+        --argjson occurrence_count "${occ}" \
+        '{
+            id: $id,
+            kind: "settings_allow_add",
+            title: $title,
+            rationale: $rationale,
+            confidence: $confidence,
+            breadth_score: $breadth_score,
+            occurrence_count: $occurrence_count,
+            session_ids: ["sess-1", "sess-2"],
+            proposed_diff_target: "modules/settings/settings.partial.json",
+            proposed_diff: "+ allow Foo",
+            fingerprint: ("sha256-" + $id),
+            originating_clone: "test-clone",
+            generated_at: "2026-05-18T08:00:00Z"
+        }' >> "${out_file}"
+}
+
+run_digest() {
+    # Args: proposals_dir digests_dir sent_dir config_file today [extra args]
+    local proposals_dir="$1"; shift
+    local digests_dir="$1"; shift
+    local sent_dir="$1"; shift
+    local config_file="$1"; shift
+    local today="$1"; shift
+    CCGM_AUTOHEAL_PROPOSALS_DIR="${proposals_dir}" \
+    CCGM_AUTOHEAL_DIGESTS_DIR="${digests_dir}" \
+    CCGM_AUTOHEAL_SENT_DIR="${sent_dir}" \
+    CCGM_AUTOHEAL_CONFIG="${config_file}" \
+    CCGM_AUTOHEAL_TODAY="${today}" \
+    CCGM_AUTOHEAL_LIB_DIR="${LIB_DIR}" \
+        bash "${DIGEST_SCRIPT}" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+if [ ! -f "${DIGEST_SCRIPT}" ]; then
+    echo "FATAL: digest script not present: ${DIGEST_SCRIPT}"
+    exit 1
+fi
+if [ ! -f "${LIB_DIR}/hook_utils.py" ]; then
+    echo "FATAL: hook_utils.py not present: ${LIB_DIR}/hook_utils.py"
+    exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "FATAL: jq is required"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 1: 3 proposals -> 3 entries.
+# ---------------------------------------------------------------------------
+
+CASE1="${TMPROOT}/case1"
+mkdir -p "${CASE1}/proposals" "${CASE1}/digests" "${CASE1}/sent"
+TODAY1="2026-05-18"
+PROPS1="${CASE1}/proposals/${TODAY1}.jsonl"
+write_proposal "${PROPS1}" "prop_a" "Allow supabase CLI" "Saw 5 approvals this week." 7 2 5
+write_proposal "${PROPS1}" "prop_b" "Allow wrangler dev" "Frequent permission ask." 6 2 4
+write_proposal "${PROPS1}" "prop_c" "Allow gh pr view" "Read-only command." 5 1 3
+
+run_digest "${CASE1}/proposals" "${CASE1}/digests" "${CASE1}/sent" \
+    "${CASE1}/config-missing.json" "${TODAY1}" >/dev/null 2>&1
+ASSERT1_EXIT=$?
+assert_eq "${ASSERT1_EXIT}" "0" "case1: digest exits 0"
+
+DIGEST1="${CASE1}/digests/${TODAY1}.md"
+if [ -f "${DIGEST1}" ]; then
+    PASS=$((PASS + 1))
+    BODY1="$(cat "${DIGEST1}")"
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: case1: digest file not written: ${DIGEST1}"
+    BODY1=""
+fi
+N1="$(count_proposal_entries "${BODY1}")"
+assert_eq "${N1}" "3" "case1: 3 entries rendered"
+assert_contains "${BODY1}" "prop_a" "case1: contains prop_a"
+assert_contains "${BODY1}" "prop_b" "case1: contains prop_b"
+assert_contains "${BODY1}" "prop_c" "case1: contains prop_c"
+assert_contains "${BODY1}" "/autoheal-apply prop_a" "case1: apply hint for prop_a"
+assert_contains "${BODY1}" "/autoheal-toggle" "case1: footer has /autoheal-toggle"
+assert_contains "${BODY1}" "/autoheal-snooze" "case1: footer has /autoheal-snooze"
+assert_contains "${BODY1}" "/autoheal-apply list" "case1: footer has /autoheal-apply list"
+assert_not_contains "${BODY1}" "+0 more" "case1: no spurious '+N more'"
+
+# ---------------------------------------------------------------------------
+# Assertion 2: 7 proposals -> 5 + "+2 more"
+# ---------------------------------------------------------------------------
+
+CASE2="${TMPROOT}/case2"
+mkdir -p "${CASE2}/proposals" "${CASE2}/digests" "${CASE2}/sent"
+TODAY2="2026-05-18"
+PROPS2="${CASE2}/proposals/${TODAY2}.jsonl"
+write_proposal "${PROPS2}" "prop_1" "T1" "R1" 9 1 1
+write_proposal "${PROPS2}" "prop_2" "T2" "R2" 8 1 1
+write_proposal "${PROPS2}" "prop_3" "T3" "R3" 7 1 1
+write_proposal "${PROPS2}" "prop_4" "T4" "R4" 6 1 1
+write_proposal "${PROPS2}" "prop_5" "T5" "R5" 5 1 1
+write_proposal "${PROPS2}" "prop_6" "T6" "R6" 4 1 1
+write_proposal "${PROPS2}" "prop_7" "T7" "R7" 3 1 1
+
+run_digest "${CASE2}/proposals" "${CASE2}/digests" "${CASE2}/sent" \
+    "${CASE2}/config-missing.json" "${TODAY2}" >/dev/null 2>&1
+DIGEST2="${CASE2}/digests/${TODAY2}.md"
+BODY2="$(cat "${DIGEST2}" 2>/dev/null || echo "")"
+
+N2="$(count_proposal_entries "${BODY2}")"
+assert_eq "${N2}" "5" "case2: cap renders 5 entries"
+assert_contains "${BODY2}" "+2 more" "case2: '+2 more' summary present"
+assert_contains "${BODY2}" "see \`/autoheal-digest ${TODAY2}\`" "case2: summary links to date command"
+# Sort order: confidence desc -> prop_1, prop_2, prop_3, prop_4, prop_5 are shown
+# (prop_6, prop_7 hidden).
+assert_contains "${BODY2}" "prop_1" "case2: top-confidence shown"
+assert_not_contains "${BODY2}" "prop_6" "case2: prop_6 hidden (over cap)"
+assert_not_contains "${BODY2}" "prop_7" "case2: prop_7 hidden (over cap)"
+
+# ---------------------------------------------------------------------------
+# Assertion 3: Empty proposals -> no digest written; --include-empty writes.
+# ---------------------------------------------------------------------------
+
+CASE3="${TMPROOT}/case3"
+mkdir -p "${CASE3}/proposals" "${CASE3}/digests" "${CASE3}/sent"
+TODAY3="2026-05-18"
+# No proposals file at all.
+
+run_digest "${CASE3}/proposals" "${CASE3}/digests" "${CASE3}/sent" \
+    "${CASE3}/config-missing.json" "${TODAY3}" >/dev/null 2>&1
+ASSERT3A_EXIT=$?
+assert_eq "${ASSERT3A_EXIT}" "0" "case3: empty exits 0"
+DIGEST3="${CASE3}/digests/${TODAY3}.md"
+if [ -f "${DIGEST3}" ]; then
+    FAIL=$((FAIL + 1))
+    echo "FAIL: case3: digest file unexpectedly written for empty proposals"
+else
+    PASS=$((PASS + 1))
+fi
+
+# With --include-empty, the file should be written.
+run_digest "${CASE3}/proposals" "${CASE3}/digests" "${CASE3}/sent" \
+    "${CASE3}/config-missing.json" "${TODAY3}" --include-empty >/dev/null 2>&1
+if [ -f "${DIGEST3}" ]; then
+    PASS=$((PASS + 1))
+    BODY3="$(cat "${DIGEST3}")"
+    assert_contains "${BODY3}" "No proposals for today" "case3: include-empty body says no proposals"
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: case3: digest file not written with --include-empty"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 4: Backfill: 2 unemailed past days mentioned.
+# ---------------------------------------------------------------------------
+
+CASE4="${TMPROOT}/case4"
+mkdir -p "${CASE4}/proposals" "${CASE4}/digests" "${CASE4}/sent"
+TODAY4="2026-05-18"
+YESTERDAY4="2026-05-17"
+TWO_DAYS_AGO4="2026-05-16"
+
+# Today's proposals so the digest is rendered.
+write_proposal "${CASE4}/proposals/${TODAY4}.jsonl" "prop_today" "Today's title" "Today's rationale" 6 2 3
+
+# Past days have proposals but NO sent flag -> they should appear in backfill.
+write_proposal "${CASE4}/proposals/${YESTERDAY4}.jsonl" "prop_y" "Yesterday's" "..." 6 2 3
+write_proposal "${CASE4}/proposals/${TWO_DAYS_AGO4}.jsonl" "prop_two" "Two days ago" "..." 6 2 3
+
+run_digest "${CASE4}/proposals" "${CASE4}/digests" "${CASE4}/sent" \
+    "${CASE4}/config-missing.json" "${TODAY4}" >/dev/null 2>&1
+BODY4="$(cat "${CASE4}/digests/${TODAY4}.md" 2>/dev/null || echo "")"
+
+assert_contains "${BODY4}" "Backfill" "case4: backfill section present"
+assert_contains "${BODY4}" "${YESTERDAY4}" "case4: backfill mentions yesterday"
+assert_contains "${BODY4}" "${TWO_DAYS_AGO4}" "case4: backfill mentions two-days-ago"
+
+# Now write sent flags for both and confirm they disappear.
+: > "${CASE4}/sent/${YESTERDAY4}-aaaaaaaaaaaa.flag"
+: > "${CASE4}/sent/${TWO_DAYS_AGO4}-bbbbbbbbbbbb.flag"
+rm -f "${CASE4}/digests/${TODAY4}.md"
+run_digest "${CASE4}/proposals" "${CASE4}/digests" "${CASE4}/sent" \
+    "${CASE4}/config-missing.json" "${TODAY4}" >/dev/null 2>&1
+BODY4B="$(cat "${CASE4}/digests/${TODAY4}.md" 2>/dev/null || echo "")"
+assert_not_contains "${BODY4B}" "${YESTERDAY4}" "case4: backfill omits yesterday after sent flag"
+
+# ---------------------------------------------------------------------------
+# Assertion 5: Redaction of secret-shaped string in rationale.
+# ---------------------------------------------------------------------------
+
+CASE5="${TMPROOT}/case5"
+mkdir -p "${CASE5}/proposals" "${CASE5}/digests" "${CASE5}/sent"
+TODAY5="2026-05-18"
+PROPS5="${CASE5}/proposals/${TODAY5}.jsonl"
+
+# GitHub PAT shape: ghp_ followed by >=30 alnums.
+LEAKY_SECRET="ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+write_proposal "${PROPS5}" "prop_redact" \
+    "Title leaking ${LEAKY_SECRET}" \
+    "Saw token ${LEAKY_SECRET} in tool input" \
+    7 2 3
+
+run_digest "${CASE5}/proposals" "${CASE5}/digests" "${CASE5}/sent" \
+    "${CASE5}/config-missing.json" "${TODAY5}" >/dev/null 2>&1
+BODY5="$(cat "${CASE5}/digests/${TODAY5}.md" 2>/dev/null || echo "")"
+
+assert_contains "${BODY5}" "[REDACTED:github_pat]" "case5: digest contains [REDACTED:github_pat]"
+assert_not_contains "${BODY5}" "${LEAKY_SECRET}" "case5: raw secret not in digest"
+
+# ---------------------------------------------------------------------------
+# Assertion 6: digest_enabled: false short-circuits before writing.
+# ---------------------------------------------------------------------------
+
+CASE6="${TMPROOT}/case6"
+mkdir -p "${CASE6}/proposals" "${CASE6}/digests" "${CASE6}/sent"
+TODAY6="2026-05-18"
+write_proposal "${CASE6}/proposals/${TODAY6}.jsonl" "prop_x" "T" "R" 7 2 3
+
+CONFIG6="${CASE6}/config.json"
+echo '{"digest_enabled": false}' > "${CONFIG6}"
+
+run_digest "${CASE6}/proposals" "${CASE6}/digests" "${CASE6}/sent" \
+    "${CONFIG6}" "${TODAY6}" >/dev/null 2>&1
+if [ -f "${CASE6}/digests/${TODAY6}.md" ]; then
+    FAIL=$((FAIL + 1))
+    echo "FAIL: case6: digest_enabled:false should suppress digest write"
+else
+    PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "test-digest-rendering.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
 exit 0

--- a/modules/autoheal/tests/test-idempotency.sh
+++ b/modules/autoheal/tests/test-idempotency.sh
@@ -1,4 +1,304 @@
 #!/usr/bin/env bash
-# Stub: this test belongs to a later epic; content TBD. See plan.md §5
-# for the owning epic and the assertion list.
+# test-idempotency.sh
+#
+# Verifies modules/autoheal/bin/autoheal-email.sh against plan.md §5 Epic 7.
+#
+# Assertions:
+#   1. Single recipient, two runs -> mock receives exactly one POST per
+#      recipient per date (idempotency-key prevents dup at the receiver,
+#      but the SCRIPT itself does not re-POST when the sent flag exists).
+#      In the standard idempotency model here we test BOTH: the script
+#      does not re-send a second time, AND, even if it did, the
+#      idempotency-key header is set per (recipient, date) so the
+#      receiver dedupes.
+#   2. Multi-recipient: 3 recipients -> 3 distinct idempotency keys
+#      observed, one per recipient.
+#
+# The mock Resend server is fixtures/resend-mock-server.py.
+#
+# Run: bash modules/autoheal/tests/test-idempotency.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${MODULE_ROOT}/../.." && pwd)"
+
+EMAIL_SCRIPT="${MODULE_ROOT}/bin/autoheal-email.sh"
+DIGEST_SCRIPT="${MODULE_ROOT}/bin/autoheal-digest.sh"
+MOCK_SERVER="${MODULE_ROOT}/tests/fixtures/resend-mock-server.py"
+LIB_DIR="${REPO_ROOT}/modules/hooks/lib"
+
+PASS=0
+FAIL=0
+TMPROOT="$(mktemp -d -t autoheal-idem-test.XXXXXX)"
+PIDFILE="${TMPROOT}/mock.pid"
+PORTFILE="${TMPROOT}/mock.port"
+
+cleanup() {
+    if [ -f "${PIDFILE}" ]; then
+        mock_pid="$(cat "${PIDFILE}" 2>/dev/null || echo "")"
+        if [ -n "${mock_pid}" ]; then
+            kill "${mock_pid}" 2>/dev/null || true
+        fi
+    fi
+    rm -rf "${TMPROOT}"
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label} (missing: ${needle})"
+            ;;
+    esac
+}
+
+write_proposal() {
+    local out_file="$1"; local pid="$2"; local title="$3"
+    jq -nc \
+        --arg id "${pid}" \
+        --arg title "${title}" \
+        '{
+            id: $id,
+            kind: "settings_allow_add",
+            title: $title,
+            rationale: "test",
+            confidence: 7,
+            breadth_score: 2,
+            occurrence_count: 3,
+            session_ids: ["s1","s2"],
+            proposed_diff_target: "modules/settings/settings.partial.json",
+            proposed_diff: "+ allow Foo",
+            fingerprint: ("sha256-" + $id),
+            originating_clone: "test",
+            generated_at: "2026-05-18T08:00:00Z"
+        }' >> "${out_file}"
+}
+
+start_mock() {
+    rm -f "${PIDFILE}" "${PORTFILE}"
+    python3 "${MOCK_SERVER}" \
+        --port 0 \
+        --pidfile "${PIDFILE}" \
+        --port-file "${PORTFILE}" \
+        >/dev/null 2>&1 &
+    # Wait up to ~3 seconds for the port file to appear.
+    local i=0
+    while [ ${i} -lt 60 ]; do
+        if [ -s "${PORTFILE}" ]; then
+            return 0
+        fi
+        sleep 0.05
+        i=$((i + 1))
+    done
+    echo "FATAL: mock server did not write port file"
+    return 1
+}
+
+reset_mock() {
+    local port="$1"
+    curl -sS -X POST "http://127.0.0.1:${port}/reset" >/dev/null
+}
+
+get_requests_json() {
+    local port="$1"
+    curl -sS "http://127.0.0.1:${port}/requests"
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+for f in "${EMAIL_SCRIPT}" "${DIGEST_SCRIPT}" "${MOCK_SERVER}" "${LIB_DIR}/hook_utils.py"; do
+    if [ ! -f "${f}" ]; then
+        echo "FATAL: missing required file: ${f}"
+        exit 1
+    fi
+done
+
+for tool in jq python3 curl; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+        echo "FATAL: ${tool} required"
+        exit 1
+    fi
+done
+
+start_mock || exit 1
+PORT="$(cat "${PORTFILE}")"
+RESEND_URL="http://127.0.0.1:${PORT}/emails"
+
+# ---------------------------------------------------------------------------
+# Assertion 1: Single recipient, two runs -> idempotency key is identical
+# across runs (proves the script picks the same key); script does not
+# re-POST after a successful send (per-recipient sent flag).
+# ---------------------------------------------------------------------------
+
+CASE1="${TMPROOT}/case1"
+mkdir -p "${CASE1}/proposals" "${CASE1}/digests" "${CASE1}/sent" "${CASE1}/logs"
+TODAY1="2026-05-18"
+
+write_proposal "${CASE1}/proposals/${TODAY1}.jsonl" "prop_a" "Title 1"
+
+# Pre-render digest (the email script does not generate the digest itself).
+CCGM_AUTOHEAL_PROPOSALS_DIR="${CASE1}/proposals" \
+CCGM_AUTOHEAL_DIGESTS_DIR="${CASE1}/digests" \
+CCGM_AUTOHEAL_SENT_DIR="${CASE1}/sent" \
+CCGM_AUTOHEAL_CONFIG="${CASE1}/missing.json" \
+CCGM_AUTOHEAL_TODAY="${TODAY1}" \
+CCGM_AUTOHEAL_LIB_DIR="${LIB_DIR}" \
+    bash "${DIGEST_SCRIPT}" >/dev/null 2>&1
+
+CONFIG1="${CASE1}/config.json"
+cat > "${CONFIG1}" <<JSON
+{
+  "email_enabled": true,
+  "digest_email": "alice@example.com"
+}
+JSON
+
+reset_mock "${PORT}"
+
+# Run #1.
+CCGM_AUTOHEAL_PROPOSALS_DIR="${CASE1}/proposals" \
+CCGM_AUTOHEAL_DIGESTS_DIR="${CASE1}/digests" \
+CCGM_AUTOHEAL_SENT_DIR="${CASE1}/sent" \
+CCGM_AUTOHEAL_LOGS_DIR="${CASE1}/logs" \
+CCGM_AUTOHEAL_CONFIG="${CONFIG1}" \
+CCGM_AUTOHEAL_TODAY="${TODAY1}" \
+CCGM_AUTOHEAL_RESEND_URL="${RESEND_URL}" \
+CCGM_AUTOHEAL_LIB_DIR="${LIB_DIR}" \
+RESEND_API_KEY="dummy-test-key" \
+    bash "${EMAIL_SCRIPT}" >/dev/null 2>&1
+
+REQS_AFTER_FIRST="$(get_requests_json "${PORT}")"
+N_AFTER_FIRST="$(printf '%s' "${REQS_AFTER_FIRST}" | jq '.requests | length')"
+assert_eq "${N_AFTER_FIRST}" "1" "case1: first run produces 1 POST"
+
+# Capture the idempotency key from the first run.
+FIRST_IDEM="$(printf '%s' "${REQS_AFTER_FIRST}" | jq -r '.requests[0].idempotency_key')"
+assert_contains "${FIRST_IDEM}" "ccgm-autoheal-${TODAY1}-" "case1: idempotency key prefix matches"
+# Idempotency key length = "ccgm-autoheal-" (14) + 10 (date) + "-" (1) + 12
+# (hash) = 37.
+KEY_LEN="${#FIRST_IDEM}"
+assert_eq "${KEY_LEN}" "37" "case1: idempotency key length is 37"
+
+# Sent flag was written.
+RECIPIENT_HASH="$(printf '%s' "alice@example.com" | shasum -a 256 | awk '{print substr($1, 1, 12)}')"
+SENT_FLAG="${CASE1}/sent/${TODAY1}-${RECIPIENT_HASH}.flag"
+if [ -f "${SENT_FLAG}" ]; then
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: case1: sent flag not written: ${SENT_FLAG}"
+fi
+
+# Run #2: script must use the SAME idempotency-key shape if it re-posts.
+# (Per current spec, the script always tries to send unless it short-circuits;
+# the sent flag is for the digest backfill, not a send-skip gate. So a second
+# run DOES POST again. The receiver (real or mock) is the authoritative
+# deduper via Idempotency-Key.)
+CCGM_AUTOHEAL_PROPOSALS_DIR="${CASE1}/proposals" \
+CCGM_AUTOHEAL_DIGESTS_DIR="${CASE1}/digests" \
+CCGM_AUTOHEAL_SENT_DIR="${CASE1}/sent" \
+CCGM_AUTOHEAL_LOGS_DIR="${CASE1}/logs" \
+CCGM_AUTOHEAL_CONFIG="${CONFIG1}" \
+CCGM_AUTOHEAL_TODAY="${TODAY1}" \
+CCGM_AUTOHEAL_RESEND_URL="${RESEND_URL}" \
+CCGM_AUTOHEAL_LIB_DIR="${LIB_DIR}" \
+RESEND_API_KEY="dummy-test-key" \
+    bash "${EMAIL_SCRIPT}" >/dev/null 2>&1
+
+REQS_AFTER_SECOND="$(get_requests_json "${PORT}")"
+N_AFTER_SECOND="$(printf '%s' "${REQS_AFTER_SECOND}" | jq '.requests | length')"
+# Both runs posted. We assert both runs used the SAME idempotency key, which
+# is what guarantees the real Resend endpoint dedupes them.
+assert_eq "${N_AFTER_SECOND}" "2" "case1: second run also POSTs"
+SECOND_IDEM="$(printf '%s' "${REQS_AFTER_SECOND}" | jq -r '.requests[1].idempotency_key')"
+assert_eq "${SECOND_IDEM}" "${FIRST_IDEM}" "case1: both runs use same idempotency key"
+
+# Authorization header carries our test key.
+AUTH_HEADER="$(printf '%s' "${REQS_AFTER_SECOND}" | jq -r '.requests[0].authorization')"
+assert_eq "${AUTH_HEADER}" "Bearer dummy-test-key" "case1: Authorization header carries bearer"
+
+# Body JSON has the expected shape.
+SUBJECT="$(printf '%s' "${REQS_AFTER_SECOND}" | jq -r '.requests[0].body_json.subject')"
+assert_contains "${SUBJECT}" "autoheal digest" "case1: subject mentions digest"
+TO_ADDR="$(printf '%s' "${REQS_AFTER_SECOND}" | jq -r '.requests[0].body_json.to[0]')"
+assert_eq "${TO_ADDR}" "alice@example.com" "case1: To field set"
+
+# ---------------------------------------------------------------------------
+# Assertion 2: Multi-recipient -> distinct idempotency keys.
+# ---------------------------------------------------------------------------
+
+CASE2="${TMPROOT}/case2"
+mkdir -p "${CASE2}/proposals" "${CASE2}/digests" "${CASE2}/sent" "${CASE2}/logs"
+TODAY2="2026-05-19"
+
+write_proposal "${CASE2}/proposals/${TODAY2}.jsonl" "prop_z" "Title 2"
+
+CCGM_AUTOHEAL_PROPOSALS_DIR="${CASE2}/proposals" \
+CCGM_AUTOHEAL_DIGESTS_DIR="${CASE2}/digests" \
+CCGM_AUTOHEAL_SENT_DIR="${CASE2}/sent" \
+CCGM_AUTOHEAL_CONFIG="${CASE2}/missing.json" \
+CCGM_AUTOHEAL_TODAY="${TODAY2}" \
+CCGM_AUTOHEAL_LIB_DIR="${LIB_DIR}" \
+    bash "${DIGEST_SCRIPT}" >/dev/null 2>&1
+
+CONFIG2="${CASE2}/config.json"
+cat > "${CONFIG2}" <<JSON
+{
+  "email_enabled": true,
+  "digest_email": ["a@b.com", "c@d.com", "e@f.com"]
+}
+JSON
+
+reset_mock "${PORT}"
+
+CCGM_AUTOHEAL_PROPOSALS_DIR="${CASE2}/proposals" \
+CCGM_AUTOHEAL_DIGESTS_DIR="${CASE2}/digests" \
+CCGM_AUTOHEAL_SENT_DIR="${CASE2}/sent" \
+CCGM_AUTOHEAL_LOGS_DIR="${CASE2}/logs" \
+CCGM_AUTOHEAL_CONFIG="${CONFIG2}" \
+CCGM_AUTOHEAL_TODAY="${TODAY2}" \
+CCGM_AUTOHEAL_RESEND_URL="${RESEND_URL}" \
+CCGM_AUTOHEAL_LIB_DIR="${LIB_DIR}" \
+RESEND_API_KEY="dummy-test-key" \
+    bash "${EMAIL_SCRIPT}" >/dev/null 2>&1
+
+REQS2="$(get_requests_json "${PORT}")"
+N2="$(printf '%s' "${REQS2}" | jq '.requests | length')"
+assert_eq "${N2}" "3" "case2: 3 POSTs (one per recipient)"
+
+DISTINCT_KEYS="$(printf '%s' "${REQS2}" | jq -r '[.requests[].idempotency_key] | unique | length')"
+assert_eq "${DISTINCT_KEYS}" "3" "case2: 3 distinct idempotency keys"
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "test-idempotency.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
 exit 0

--- a/modules/autoheal/tests/test-multi-recipient-email.sh
+++ b/modules/autoheal/tests/test-multi-recipient-email.sh
@@ -1,4 +1,327 @@
 #!/usr/bin/env bash
-# Stub: this test belongs to a later epic; content TBD. See plan.md §5
-# for the owning epic and the assertion list.
+# test-multi-recipient-email.sh
+#
+# Verifies modules/autoheal/bin/autoheal-email.sh handles the
+# `digest_email: [...]` list form (plan.md §1.2 multi-recipient + §5 Epic
+# 7 + §5 Epic 12).
+#
+# Assertions:
+#   1. digest_email = ["a@b.com","c@d.com","e@f.com"] -> 3 POSTs.
+#   2. Each POST carries a distinct Idempotency-Key suffix that matches
+#      the sha256 prefix of its recipient.
+#   3. Each POST's `to` field carries the correct recipient.
+#   4. Each successful POST writes a sent flag named with the recipient
+#      hash.
+#   5. Backwards-compat: a string-valued `digest_email` still works.
+#   6. Failure mode: when the mock returns 500, the script records the
+#      failure and DOES NOT write a sent flag for that recipient.
+#
+# Run: bash modules/autoheal/tests/test-multi-recipient-email.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${MODULE_ROOT}/../.." && pwd)"
+
+EMAIL_SCRIPT="${MODULE_ROOT}/bin/autoheal-email.sh"
+DIGEST_SCRIPT="${MODULE_ROOT}/bin/autoheal-digest.sh"
+MOCK_SERVER="${MODULE_ROOT}/tests/fixtures/resend-mock-server.py"
+LIB_DIR="${REPO_ROOT}/modules/hooks/lib"
+
+PASS=0
+FAIL=0
+TMPROOT="$(mktemp -d -t autoheal-multi-test.XXXXXX)"
+PIDFILE="${TMPROOT}/mock.pid"
+PORTFILE="${TMPROOT}/mock.port"
+FAIL_PIDFILE="${TMPROOT}/fail-mock.pid"
+FAIL_PORTFILE="${TMPROOT}/fail-mock.port"
+
+cleanup() {
+    for pf in "${PIDFILE}" "${FAIL_PIDFILE}"; do
+        if [ -f "${pf}" ]; then
+            mock_pid="$(cat "${pf}" 2>/dev/null || echo "")"
+            if [ -n "${mock_pid}" ]; then
+                kill "${mock_pid}" 2>/dev/null || true
+            fi
+        fi
+    done
+    rm -rf "${TMPROOT}"
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label} (missing: ${needle})"
+            ;;
+    esac
+}
+
+write_proposal() {
+    local out_file="$1"; local pid="$2"
+    jq -nc \
+        --arg id "${pid}" \
+        '{
+            id: $id,
+            kind: "settings_allow_add",
+            title: "T",
+            rationale: "R",
+            confidence: 7,
+            breadth_score: 2,
+            occurrence_count: 3,
+            session_ids: ["s1","s2"],
+            proposed_diff_target: "modules/settings/settings.partial.json",
+            proposed_diff: "+ allow",
+            fingerprint: ("sha256-" + $id),
+            originating_clone: "test",
+            generated_at: "2026-05-18T08:00:00Z"
+        }' >> "${out_file}"
+}
+
+start_mock() {
+    local pidfile="$1"; local portfile="$2"; shift 2
+    rm -f "${pidfile}" "${portfile}"
+    python3 "${MOCK_SERVER}" \
+        --port 0 \
+        --pidfile "${pidfile}" \
+        --port-file "${portfile}" \
+        "$@" \
+        >/dev/null 2>&1 &
+    local i=0
+    while [ ${i} -lt 60 ]; do
+        if [ -s "${portfile}" ]; then
+            return 0
+        fi
+        sleep 0.05
+        i=$((i + 1))
+    done
+    echo "FATAL: mock server did not write port file"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+for f in "${EMAIL_SCRIPT}" "${DIGEST_SCRIPT}" "${MOCK_SERVER}" "${LIB_DIR}/hook_utils.py"; do
+    if [ ! -f "${f}" ]; then
+        echo "FATAL: missing required file: ${f}"
+        exit 1
+    fi
+done
+
+for tool in jq python3 curl; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+        echo "FATAL: ${tool} required"
+        exit 1
+    fi
+done
+
+start_mock "${PIDFILE}" "${PORTFILE}" || exit 1
+PORT="$(cat "${PORTFILE}")"
+RESEND_URL="http://127.0.0.1:${PORT}/emails"
+
+# ---------------------------------------------------------------------------
+# Case A: 3 recipients via list.
+# ---------------------------------------------------------------------------
+
+CASE_A="${TMPROOT}/caseA"
+mkdir -p "${CASE_A}/proposals" "${CASE_A}/digests" "${CASE_A}/sent" "${CASE_A}/logs"
+TODAY_A="2026-05-18"
+write_proposal "${CASE_A}/proposals/${TODAY_A}.jsonl" "prop_a"
+
+CCGM_AUTOHEAL_PROPOSALS_DIR="${CASE_A}/proposals" \
+CCGM_AUTOHEAL_DIGESTS_DIR="${CASE_A}/digests" \
+CCGM_AUTOHEAL_SENT_DIR="${CASE_A}/sent" \
+CCGM_AUTOHEAL_CONFIG="${CASE_A}/missing.json" \
+CCGM_AUTOHEAL_TODAY="${TODAY_A}" \
+CCGM_AUTOHEAL_LIB_DIR="${LIB_DIR}" \
+    bash "${DIGEST_SCRIPT}" >/dev/null 2>&1
+
+CONFIG_A="${CASE_A}/config.json"
+cat > "${CONFIG_A}" <<JSON
+{
+  "email_enabled": true,
+  "digest_email": ["a@b.com", "c@d.com", "e@f.com"]
+}
+JSON
+
+# Reset mock counter.
+curl -sS -X POST "http://127.0.0.1:${PORT}/reset" >/dev/null
+
+CCGM_AUTOHEAL_PROPOSALS_DIR="${CASE_A}/proposals" \
+CCGM_AUTOHEAL_DIGESTS_DIR="${CASE_A}/digests" \
+CCGM_AUTOHEAL_SENT_DIR="${CASE_A}/sent" \
+CCGM_AUTOHEAL_LOGS_DIR="${CASE_A}/logs" \
+CCGM_AUTOHEAL_CONFIG="${CONFIG_A}" \
+CCGM_AUTOHEAL_TODAY="${TODAY_A}" \
+CCGM_AUTOHEAL_RESEND_URL="${RESEND_URL}" \
+CCGM_AUTOHEAL_LIB_DIR="${LIB_DIR}" \
+RESEND_API_KEY="dummy-test-key" \
+    bash "${EMAIL_SCRIPT}" >/dev/null 2>&1
+
+REQS_A="$(curl -sS "http://127.0.0.1:${PORT}/requests")"
+N_A="$(printf '%s' "${REQS_A}" | jq '.requests | length')"
+assert_eq "${N_A}" "3" "caseA: 3 POSTs for 3 recipients"
+
+DISTINCT_KEYS_A="$(printf '%s' "${REQS_A}" | jq -r '[.requests[].idempotency_key] | unique | length')"
+assert_eq "${DISTINCT_KEYS_A}" "3" "caseA: 3 distinct idempotency keys"
+
+# Each idempotency key must include the sha256 hash of its recipient.
+for recipient in a@b.com c@d.com e@f.com; do
+    expected_hash="$(printf '%s' "${recipient}" | shasum -a 256 | awk '{print substr($1, 1, 12)}')"
+    expected_key="ccgm-autoheal-${TODAY_A}-${expected_hash}"
+    # Find the request whose to[0] matches this recipient and check its key.
+    actual_key="$(printf '%s' "${REQS_A}" | jq -r --arg to "${recipient}" '
+        .requests[] | select(.body_json.to[0] == $to) | .idempotency_key
+    ')"
+    assert_eq "${actual_key}" "${expected_key}" "caseA: ${recipient} key matches sha256 prefix"
+
+    # Sent flag exists for each.
+    flag="${CASE_A}/sent/${TODAY_A}-${expected_hash}.flag"
+    if [ -f "${flag}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: caseA: sent flag missing for ${recipient} (${flag})"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Case B: Backwards-compat: digest_email as a string.
+# ---------------------------------------------------------------------------
+
+CASE_B="${TMPROOT}/caseB"
+mkdir -p "${CASE_B}/proposals" "${CASE_B}/digests" "${CASE_B}/sent" "${CASE_B}/logs"
+TODAY_B="2026-05-20"
+write_proposal "${CASE_B}/proposals/${TODAY_B}.jsonl" "prop_b"
+
+CCGM_AUTOHEAL_PROPOSALS_DIR="${CASE_B}/proposals" \
+CCGM_AUTOHEAL_DIGESTS_DIR="${CASE_B}/digests" \
+CCGM_AUTOHEAL_SENT_DIR="${CASE_B}/sent" \
+CCGM_AUTOHEAL_CONFIG="${CASE_B}/missing.json" \
+CCGM_AUTOHEAL_TODAY="${TODAY_B}" \
+CCGM_AUTOHEAL_LIB_DIR="${LIB_DIR}" \
+    bash "${DIGEST_SCRIPT}" >/dev/null 2>&1
+
+CONFIG_B="${CASE_B}/config.json"
+cat > "${CONFIG_B}" <<JSON
+{
+  "email_enabled": true,
+  "digest_email": "only@example.com"
+}
+JSON
+
+curl -sS -X POST "http://127.0.0.1:${PORT}/reset" >/dev/null
+
+CCGM_AUTOHEAL_PROPOSALS_DIR="${CASE_B}/proposals" \
+CCGM_AUTOHEAL_DIGESTS_DIR="${CASE_B}/digests" \
+CCGM_AUTOHEAL_SENT_DIR="${CASE_B}/sent" \
+CCGM_AUTOHEAL_LOGS_DIR="${CASE_B}/logs" \
+CCGM_AUTOHEAL_CONFIG="${CONFIG_B}" \
+CCGM_AUTOHEAL_TODAY="${TODAY_B}" \
+CCGM_AUTOHEAL_RESEND_URL="${RESEND_URL}" \
+CCGM_AUTOHEAL_LIB_DIR="${LIB_DIR}" \
+RESEND_API_KEY="dummy-test-key" \
+    bash "${EMAIL_SCRIPT}" >/dev/null 2>&1
+
+REQS_B="$(curl -sS "http://127.0.0.1:${PORT}/requests")"
+N_B="$(printf '%s' "${REQS_B}" | jq '.requests | length')"
+assert_eq "${N_B}" "1" "caseB: string digest_email -> 1 POST"
+TO_B="$(printf '%s' "${REQS_B}" | jq -r '.requests[0].body_json.to[0]')"
+assert_eq "${TO_B}" "only@example.com" "caseB: string recipient sent"
+
+# ---------------------------------------------------------------------------
+# Case C: Failure mode: server returns 500. No sent flag should be written.
+# ---------------------------------------------------------------------------
+
+start_mock "${FAIL_PIDFILE}" "${FAIL_PORTFILE}" --fail-with 500 || exit 1
+FAIL_PORT="$(cat "${FAIL_PORTFILE}")"
+FAIL_RESEND_URL="http://127.0.0.1:${FAIL_PORT}/emails"
+
+CASE_C="${TMPROOT}/caseC"
+mkdir -p "${CASE_C}/proposals" "${CASE_C}/digests" "${CASE_C}/sent" "${CASE_C}/logs"
+TODAY_C="2026-05-21"
+write_proposal "${CASE_C}/proposals/${TODAY_C}.jsonl" "prop_c"
+
+CCGM_AUTOHEAL_PROPOSALS_DIR="${CASE_C}/proposals" \
+CCGM_AUTOHEAL_DIGESTS_DIR="${CASE_C}/digests" \
+CCGM_AUTOHEAL_SENT_DIR="${CASE_C}/sent" \
+CCGM_AUTOHEAL_CONFIG="${CASE_C}/missing.json" \
+CCGM_AUTOHEAL_TODAY="${TODAY_C}" \
+CCGM_AUTOHEAL_LIB_DIR="${LIB_DIR}" \
+    bash "${DIGEST_SCRIPT}" >/dev/null 2>&1
+
+CONFIG_C="${CASE_C}/config.json"
+cat > "${CONFIG_C}" <<JSON
+{
+  "email_enabled": true,
+  "digest_email": "fail@example.com"
+}
+JSON
+
+EMAIL_EXIT=0
+CCGM_AUTOHEAL_PROPOSALS_DIR="${CASE_C}/proposals" \
+CCGM_AUTOHEAL_DIGESTS_DIR="${CASE_C}/digests" \
+CCGM_AUTOHEAL_SENT_DIR="${CASE_C}/sent" \
+CCGM_AUTOHEAL_LOGS_DIR="${CASE_C}/logs" \
+CCGM_AUTOHEAL_CONFIG="${CONFIG_C}" \
+CCGM_AUTOHEAL_TODAY="${TODAY_C}" \
+CCGM_AUTOHEAL_RESEND_URL="${FAIL_RESEND_URL}" \
+CCGM_AUTOHEAL_LIB_DIR="${LIB_DIR}" \
+RESEND_API_KEY="dummy-test-key" \
+    bash "${EMAIL_SCRIPT}" >/dev/null 2>&1 || EMAIL_EXIT=$?
+
+assert_eq "${EMAIL_EXIT}" "0" "caseC: script exits 0 even on resend failure"
+
+FAIL_HASH="$(printf '%s' "fail@example.com" | shasum -a 256 | awk '{print substr($1, 1, 12)}')"
+FAIL_FLAG="${CASE_C}/sent/${TODAY_C}-${FAIL_HASH}.flag"
+if [ -f "${FAIL_FLAG}" ]; then
+    FAIL=$((FAIL + 1))
+    echo "FAIL: caseC: sent flag written despite 500 response"
+else
+    PASS=$((PASS + 1))
+fi
+
+# Error log written.
+ERR_LOG="${CASE_C}/logs/autoheal-email-${TODAY_C}.err.log"
+if [ -f "${ERR_LOG}" ]; then
+    PASS=$((PASS + 1))
+    ERR_BODY="$(cat "${ERR_LOG}")"
+    assert_contains "${ERR_BODY}" "fail@example.com" "caseC: error log mentions recipient"
+    assert_contains "${ERR_BODY}" "500" "caseC: error log mentions http code"
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: caseC: error log not written: ${ERR_LOG}"
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "test-multi-recipient-email.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
 exit 0


### PR DESCRIPTION
## Summary

Wave 3 Epic 7 — daily digest renderer, optional multi-recipient Resend email, the `autoheal-daily.sh` wrapper that chains the pipeline, and 4 user-facing slash commands.

Closes #479.

## Files (replace Epic 3 stubs; no module.json edits)

### Pipeline scripts
- `bin/autoheal-digest.sh` — markdown digest renderer. Reads today's proposals, caps at 5 (with "+N more"), honors `digest_enabled`, skips empty (unless `--include-empty`), redacts title+rationale via `hook_utils.redact_secrets`, lists unemailed backfill days from past 7 (via `sent/{date}-*.flag` presence). Footer links `/autoheal-toggle`, `/autoheal-snooze`, `/autoheal-apply list`.
- `bin/autoheal-email.sh` — Resend sender. Gated on `email_enabled`. Accepts `digest_email` as string OR list (multi-recipient). Per-recipient `Idempotency-Key: ccgm-autoheal-{date}-{sha256(recipient)[:12]}`. Writes sent flag on 2xx; logs 4xx/5xx without blocking. Analyzer-crash diagnostic email when today's proposals missing AND yesterday's present.
- `bin/autoheal-daily.sh` — chains `autoheal-analyze.sh → autoheal-auto-apply.sh → autoheal-digest.sh → autoheal-email.sh → autoheal-publish.sh → autoheal-retention.sh`. Exit-tolerant per step. All output aggregated to `~/.claude/logs/autoheal-daily-{date}.log`.

### Slash commands
- `commands/autoheal.md` — overview / help
- `commands/autoheal-digest.md` — `/autoheal-digest [date]`
- `commands/autoheal-toggle.md` — flip `paused|realtime|autoapply|email|digest|webhook` flags; `webhook url <URL>` setter
- `commands/autoheal-snooze.md` — fingerprint-keyed snooze for N days (default 30)

### Tests
- `tests/test-digest-rendering.sh` — 28 assertions: 3-entry render, 5-cap + "+2 more", empty-skip + `--include-empty`, backfill list, redaction, `digest_enabled:false` short-circuit
- `tests/test-idempotency.sh` — 11 assertions: same key across two runs for one recipient, Authorization header, sent flag
- `tests/test-multi-recipient-email.sh` — 15 assertions: 3 recipients → 3 distinct keys; string-form backwards compat; 500-response failure path
- `tests/fixtures/resend-mock-server.py` — local ThreadingHTTPServer mocking Resend `/emails` + `/requests` + `/reset`. No test ever reaches `api.resend.com`.

## Test plan

- [x] `bash modules/autoheal/tests/test-digest-rendering.sh` → 28 passed
- [x] `bash modules/autoheal/tests/test-idempotency.sh` → 11 passed
- [x] `bash modules/autoheal/tests/test-multi-recipient-email.sh` → 15 passed
- [x] `bash tests/test-modules.sh` → 1180 passed
- [x] Manual: `autoheal-daily.sh` smoke produces a clean log with all 6 steps marked `ok` (even with Epic 6's analyzer as a stub on this branch — exit-tolerance verified)

All paths overridable via env vars (`CCGM_AUTOHEAL_PROPOSALS_DIR`, `CCGM_AUTOHEAL_DIGESTS_DIR`, etc.) so tests run in `mktemp -d` sandboxes.

## Dependency note

Epic 6 (#478, PR #494) lands `bin/autoheal-analyze.sh` in parallel. Order doesn't matter — `autoheal-daily.sh` is exit-tolerant and both PRs touch disjoint files.
