### PR TITLE
#483: Epic 11 — confidence-gated auto-apply + /autoheal-apply command

### DIFF
--- a/modules/autoheal/bin/autoheal-auto-apply.sh
+++ b/modules/autoheal/bin/autoheal-auto-apply.sh
@@ -1,4 +1,322 @@
 #!/usr/bin/env bash
-# Epic 11: content TBD — opt-in confidence-gated auto-apply. Default off.
-# See plan.md §3.7 and §5 Epic 11.
+# autoheal-auto-apply.sh
+#
+# Epic 11: opt-in confidence-gated auto-apply.
+#
+# Reads today's proposals from ~/.claude/autoheal/proposals/{today}.jsonl,
+# evaluates each against the strict auto-apply gate (plan.md §3.7), and
+# routes qualifying proposals through lib/apply-proposal.py. The apply
+# logic is shared with /permission-fix apply and /autoheal-apply <id>
+# so the branch shape, commit format, and audit record stay identical
+# across the three invocation paths.
+#
+# This script is chained at the end of autoheal-daily.sh (after the
+# analyzer has written today's proposals, before the digest). It NEVER
+# pushes to remote: it only commits to a feature branch named
+# `autoheal/auto/{proposal-id}`. The user reviews the resulting diff and
+# opens the PR by hand.
+#
+# Gate predicate (plan.md §3.7):
+#   confidence            >= 9
+#   breadth_score         <= 1
+#   kind                  == "settings_allow_add"
+#   proposed_diff_target  startswith("modules/settings/")
+#   snoozed_until         is null
+#   auto_apply_blocked    is false
+#
+# Every apply attempt — success OR failure — appends a record to
+# ~/.claude/autoheal/applied/{today}.jsonl. Failures additionally write
+# a stderr-tagged line to ~/.claude/logs/autoheal-auto-apply-{today}.log
+# so the daily-wrapper log captures the reason without polluting the
+# audit trail.
+#
+# Env overrides (tests):
+#   CCGM_AUTOHEAL_CONFIG         default ~/.claude/autoheal/config.json
+#   CCGM_AUTOHEAL_PROPOSALS_DIR  default ~/.claude/autoheal/proposals
+#   CCGM_AUTOHEAL_APPLIED_DIR    default ~/.claude/autoheal/applied
+#   CCGM_AUTOHEAL_LOGS_DIR       default ~/.claude/logs
+#   CCGM_AUTOHEAL_TODAY          default $(date -u +%Y-%m-%d)
+#   CCGM_AUTOHEAL_CLONE_ROOT     forwarded as CCGM_CLONE_ROOT to
+#                                apply-proposal.py
+#
+# Exit codes:
+#   0  always (per autoheal-daily.sh contract: a single failed proposal
+#      should not crash the daily wrapper). Per-proposal failures are
+#      logged but do not propagate.
+
+set -u
+
+# ---------------------------------------------------------------------
+# Resolve module + path defaults.
+# ---------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+APPLY_LIB="${MODULE_ROOT}/lib/apply-proposal.py"
+
+CONFIG_FILE="${CCGM_AUTOHEAL_CONFIG:-${HOME}/.claude/autoheal/config.json}"
+PROPOSALS_DIR="${CCGM_AUTOHEAL_PROPOSALS_DIR:-${HOME}/.claude/autoheal/proposals}"
+APPLIED_DIR="${CCGM_AUTOHEAL_APPLIED_DIR:-${HOME}/.claude/autoheal/applied}"
+LOGS_DIR="${CCGM_AUTOHEAL_LOGS_DIR:-${HOME}/.claude/logs}"
+
+if [ -n "${CCGM_AUTOHEAL_TODAY:-}" ]; then
+    TODAY="${CCGM_AUTOHEAL_TODAY}"
+else
+    TODAY="$(python3 -c "import datetime; print(datetime.datetime.now(datetime.timezone.utc).date().isoformat())")"
+fi
+
+PROPOSALS_FILE="${PROPOSALS_DIR}/${TODAY}.jsonl"
+APPLIED_FILE="${APPLIED_DIR}/${TODAY}.jsonl"
+LOG_FILE="${LOGS_DIR}/autoheal-auto-apply-${TODAY}.log"
+
+mkdir -p "${APPLIED_DIR}" "${LOGS_DIR}"
+
+# Forward the autoheal-flavored clone-root override to apply-proposal.py,
+# which reads CCGM_CLONE_ROOT. We never overwrite an explicit caller-set
+# CCGM_CLONE_ROOT so manual invocations still work.
+if [ -n "${CCGM_AUTOHEAL_CLONE_ROOT:-}" ] && [ -z "${CCGM_CLONE_ROOT:-}" ]; then
+    export CCGM_CLONE_ROOT="${CCGM_AUTOHEAL_CLONE_ROOT}"
+fi
+
+# Pass through the env knobs apply-proposal.py honors. These are already
+# exported in the daily-wrapper case, but re-exporting in tests keeps the
+# script self-contained.
+export CCGM_AUTOHEAL_PROPOSALS_DIR="${PROPOSALS_DIR}"
+export CCGM_AUTOHEAL_APPLIED_DIR="${APPLIED_DIR}"
+export CCGM_AUTOHEAL_TODAY="${TODAY}"
+
+log() {
+    # Append a tagged line to the per-day log AND echo to stderr so the
+    # daily wrapper's aggregated log captures it too.
+    local msg="$1"
+    local ts
+    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '[%s] %s\n' "${ts}" "${msg}" >>"${LOG_FILE}"
+    printf '[%s] %s\n' "${ts}" "${msg}" >&2
+}
+
+# ---------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------
+
+if ! command -v python3 >/dev/null 2>&1; then
+    log "python3 not on PATH; auto-apply disabled this run"
+    exit 0
+fi
+
+if [ ! -f "${APPLY_LIB}" ]; then
+    log "apply-proposal.py missing at ${APPLY_LIB}; auto-apply disabled this run"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------
+# Config gate: auto_apply_enabled must be true.
+# ---------------------------------------------------------------------
+
+auto_apply_enabled() {
+    # Default false. We read with python so we do not depend on jq in the
+    # daily-wrapper environment (jq IS present for digest, but the gate
+    # script is the safer place to stay python-only).
+    if [ ! -f "${CONFIG_FILE}" ]; then
+        echo "false"
+        return 0
+    fi
+    python3 - "${CONFIG_FILE}" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        cfg = json.load(fh)
+except (OSError, json.JSONDecodeError):
+    print("false")
+    sys.exit(0)
+
+if not isinstance(cfg, dict):
+    print("false")
+    sys.exit(0)
+
+print("true" if bool(cfg.get("auto_apply_enabled", False)) else "false")
+PY
+}
+
+ENABLED="$(auto_apply_enabled)"
+if [ "${ENABLED}" != "true" ]; then
+    log "auto_apply_enabled=false (default off); skipping ${TODAY}"
+    exit 0
+fi
+
+if [ ! -f "${PROPOSALS_FILE}" ]; then
+    log "no proposals file for ${TODAY}; nothing to apply"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------
+# Build the list of proposal ids that pass the gate.
+#
+# We do the gate evaluation in a single python pass so the predicate
+# matches plan.md §3.7 exactly, with no shell-quoting ambiguity. The
+# python prints one line per proposal: `<status>\t<id>\t<reason>`, where
+# status is one of:
+#   QUALIFY   passed the gate; auto-apply will run
+#   SKIP      failed the gate; reason names the rejected field
+#   BAD_ROW   malformed JSON or missing required field; skipped
+# ---------------------------------------------------------------------
+
+evaluate_gate() {
+    python3 - "${PROPOSALS_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+
+
+def gate(p):
+    # Predicate from plan.md §3.7. Return (ok, reason).
+    if not isinstance(p, dict):
+        return False, "not-a-dict"
+    pid = p.get("id")
+    if not isinstance(pid, str) or not pid:
+        return False, "missing-id"
+    try:
+        c = int(p.get("confidence"))
+    except (TypeError, ValueError):
+        return False, "confidence-not-int"
+    if c < 9:
+        return False, f"confidence<{9} (got {c})"
+    try:
+        b = int(p.get("breadth_score"))
+    except (TypeError, ValueError):
+        return False, "breadth_score-not-int"
+    if b > 1:
+        return False, f"breadth_score>{1} (got {b})"
+    kind = p.get("kind")
+    if kind != "settings_allow_add":
+        return False, f"kind!=settings_allow_add (got {kind!r})"
+    target = p.get("proposed_diff_target") or ""
+    if not isinstance(target, str) or not target.startswith("modules/settings/"):
+        return False, f"target not under modules/settings/ (got {target!r})"
+    if p.get("snoozed_until"):
+        return False, "snoozed"
+    if p.get("auto_apply_blocked"):
+        return False, "auto_apply_blocked"
+    return True, ""
+
+
+total = 0
+qualified = 0
+with open(path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        total += 1
+        try:
+            rec = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            sys.stdout.write("BAD_ROW\t-\tinvalid-json\n")
+            continue
+        ok, reason = gate(rec)
+        if ok:
+            qualified += 1
+            sys.stdout.write(f"QUALIFY\t{rec['id']}\t-\n")
+        else:
+            pid = rec.get("id") if isinstance(rec, dict) else "-"
+            sys.stdout.write(f"SKIP\t{pid or '-'}\t{reason}\n")
+
+sys.stderr.write(f"evaluated={total} qualified={qualified}\n")
+PY
+}
+
+GATE_OUTPUT="$(evaluate_gate 2>&1)"
+# Separate the per-row tab-delimited rows from the trailing stderr counter.
+ROWS="$(printf '%s\n' "${GATE_OUTPUT}" | grep -E '^(QUALIFY|SKIP|BAD_ROW)\t' || true)"
+
+EVALUATED=0
+QUALIFIED=0
+APPLIED=0
+FAILED=0
+
+while IFS= read -r row; do
+    [ -z "${row}" ] && continue
+    EVALUATED=$((EVALUATED + 1))
+    status="${row%%	*}"
+    rest="${row#*	}"
+    pid="${rest%%	*}"
+    reason="${rest#*	}"
+    case "${status}" in
+        SKIP|BAD_ROW)
+            log "skip ${pid}: ${reason}"
+            ;;
+        QUALIFY)
+            QUALIFIED=$((QUALIFIED + 1))
+            log "qualify ${pid}: routing to apply-proposal.py"
+
+            # Run apply-proposal.py with source=auto-apply. The library
+            # creates branch autoheal/auto/{pid}, applies the diff, runs
+            # tests/test-modules.sh + tests/test-no-personal-data.sh, and
+            # — on pass — commits with `#auto: apply autoheal proposal {pid}`
+            # and appends to applied/{today}.jsonl. We capture stdout +
+            # stderr into the per-day log so a tester sees both the diff
+            # and the failure reason in one place.
+            apply_out="$(python3 "${APPLY_LIB}" "${pid}" auto-apply 2>&1)"
+            apply_rc=$?
+            printf '%s\n' "${apply_out}" >>"${LOG_FILE}"
+
+            if [ "${apply_rc}" -eq 0 ]; then
+                APPLIED=$((APPLIED + 1))
+                log "applied ${pid}: branch + commit created (review the PR)"
+            else
+                FAILED=$((FAILED + 1))
+                # The library wrote NO applied record on failure (its
+                # contract is "audit on success"). We add a failure-tagged
+                # record so the audit log captures the attempt either way.
+                python3 - "${APPLIED_FILE}" "${pid}" "${apply_out}" <<'PY'
+import datetime
+import json
+import os
+import sys
+
+path = sys.argv[1]
+pid = sys.argv[2]
+err = sys.argv[3]
+
+# Truncate the err blob so a 4MB test-output dump doesn't bloat the audit.
+err_short = err[-2000:] if len(err) > 2000 else err
+
+rec = {
+    "id": f"app_{pid}_failed_{int(datetime.datetime.now(datetime.timezone.utc).timestamp())}",
+    "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    "proposal_id": pid,
+    "method": "auto_apply",
+    "branch": None,
+    "commit_sha": None,
+    "tests_passed": False,
+    "rolled_back": True,
+    "error": err_short,
+}
+
+parent = os.path.dirname(path)
+if parent:
+    os.makedirs(parent, exist_ok=True)
+with open(path, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(rec, separators=(",", ":")) + "\n")
+PY
+                log "failed ${pid}: apply-proposal.py exit=${apply_rc} (see log for details)"
+            fi
+            ;;
+        *)
+            log "unknown gate row: ${row}"
+            ;;
+    esac
+done <<< "${ROWS}"
+
+# ---------------------------------------------------------------------
+# Summary line. The daily wrapper aggregates stderr into its log so this
+# is visible without parsing the per-day file.
+# ---------------------------------------------------------------------
+
+printf 'autoheal-auto-apply: evaluated=%d qualified=%d applied=%d failed=%d (today=%s)\n' \
+    "${EVALUATED}" "${QUALIFIED}" "${APPLIED}" "${FAILED}" "${TODAY}" >&2
+
 exit 0

--- a/modules/autoheal/commands/autoheal-apply.md
+++ b/modules/autoheal/commands/autoheal-apply.md
@@ -1,3 +1,136 @@
-<!-- Epic 11: content TBD — /autoheal-apply [id|list]. Shared apply path
-with /permission-fix apply via lib/apply-proposal.py. See plan.md §5 Epic
-11. -->
+# /autoheal-apply - List or Apply Autoheal Proposals
+
+Inspect the queue of pending autoheal proposals from the last 7 days,
+or apply a single proposal by id through the shared `lib/apply-proposal.py`
+path. Same workflow as `/permission-fix apply`: feature branch + diff +
+test gate + reversible commit. Never auto-pushes or auto-merges.
+
+## Usage
+
+```
+/autoheal-apply                          # list pending proposals
+/autoheal-apply list                     # same as above
+/autoheal-apply <proposal-id>            # apply a single proposal
+```
+
+## When to invoke
+
+- The daily digest landed and you want to review the proposal queue
+  before applying anything.
+- You want to apply a specific proposal that was not picked up by
+  opt-in auto-apply (most proposals are NOT auto-apply-eligible: the
+  gate is intentionally strict).
+- A previous `/permission-fix apply <id>` attempt failed and you want
+  to retry after fixing the underlying issue.
+
+## When NOT to invoke
+
+- To configure flags (auto-apply, realtime, webhook) — use
+  `/autoheal-toggle`.
+- To suppress a proposal — use `/autoheal-snooze <id> [days]`.
+- To trigger the daily analyzer — it runs on its LaunchAgent
+  schedule; manual invocation is `bash modules/autoheal/bin/autoheal-analyze.sh`.
+
+## How it works
+
+### `/autoheal-apply` (no args) and `/autoheal-apply list`
+
+Read-only enumeration of pending proposals. List mode does not modify
+any files.
+
+1. Walk back over the last 8 days of
+   `~/.claude/autoheal/proposals/{date}.jsonl` (today + 7 prior).
+2. Read each proposal record. Skip those whose `snoozed_until` is in
+   the future or whose `id` already appears in
+   `~/.claude/autoheal/applied/*.jsonl` (already applied).
+3. Print one table row per remaining proposal:
+
+   ```
+   ID                  KIND                  CONFIDENCE  BREADTH  TITLE
+   prop_01HW3FQQX7     settings_allow_add    9/10        1        add wrangler dev to safe-list
+   prop_01HW8KLLM4     hook_narrow           7/10        3        narrow git-workflow allow-list
+   ...
+   ```
+
+4. Sort by `(confidence desc, breadth_score asc, generated_at desc)`
+   so the proposals most likely to be worth applying surface first.
+5. After the table, print: `Found N pending proposal(s). Run
+   /autoheal-apply <id> to apply one.` If `N == 0`, print: `No
+   pending proposals.`
+
+### `/autoheal-apply <proposal-id>`
+
+The single write path. Routes through `lib/apply-proposal.py` so the
+branch shape, commit message, test gate, and audit record are
+identical to `/permission-fix apply <id>` and the opt-in
+`autoheal-auto-apply.sh`.
+
+1. Look up the proposal by id in
+   `~/.claude/autoheal/proposals/{today}.jsonl`. The library scans
+   today's file only; to apply an older proposal, copy it into today's
+   file or set `CCGM_AUTOHEAL_TODAY=<date>` for the agent's environment.
+2. Resolve the canonical CCGM clone path by walking up from `cwd`
+   until `start.sh` is found; fall back to `~/code/ccgm/`.
+3. Verify the working tree is clean on `main`. If dirty, commit any
+   WIP per the CCGM no-stash rule (commit message
+   `#auto: WIP before autoheal apply`).
+4. Create the feature branch `autoheal/{proposal-id}` (the `source`
+   argument is `"permission-fix"`; the auto-apply daemon uses
+   `"auto-apply"` which produces `autoheal/auto/{proposal-id}` —
+   different prefix on purpose, so the audit log can distinguish
+   manual from automatic applies).
+5. Apply the proposal's `proposed_diff` to its `proposed_diff_target`
+   via `git apply`.
+6. Run `tests/test-modules.sh` and `tests/test-no-personal-data.sh`.
+   If either fails: revert the branch (`git checkout main`,
+   `git branch -D autoheal/{id}`), surface the failure, exit non-zero.
+7. If tests pass: commit with message
+   `#auto: apply autoheal proposal {proposal-id}`. The `#auto:`
+   prefix is recognized by `enforce-git-workflow.py` as a non-issue
+   commit type.
+8. Append a record to `~/.claude/autoheal/applied/{today}.jsonl`
+   with `method: permission_fix` and the resulting branch + commit
+   sha.
+9. Print `git diff HEAD~1` to stdout.
+10. Print the line `To undo: git revert HEAD`.
+11. Print a suggested `gh pr create` command. Never auto-merge.
+
+The agent invoking this command should execute the apply through:
+
+```bash
+python3 modules/autoheal/lib/apply-proposal.py <proposal-id> permission-fix
+```
+
+The CLI exits 0 on success, 1 on apply failure, 2 on usage error.
+
+## Output
+
+- `list` / no args: a one-row-per-proposal table (description above).
+- `<id>` apply: the unified diff + revert hint + PR-create suggestion,
+  plus a JSON status line that the caller can parse for a structured
+  result.
+
+## Constraints
+
+- Apply NEVER auto-merges. The user opens the PR via the printed
+  `gh pr create` command.
+- Apply NEVER writes to `~/.claude/settings.json` directly. It always
+  writes to the canonical CCGM clone under `modules/`. The next
+  `start.sh --reinstall` propagates the change.
+- Apply runs both `test-modules.sh` and `test-no-personal-data.sh`
+  before commit. A failing test is a hard stop, not a warning.
+- The list mode is read-only. It MUST NOT create branches, write to
+  the applied audit log, or modify any state.
+
+## Cross-references
+
+- `/permission-fix apply <id>` — same shared apply path; preferred
+  entry point when you're acting on the proposal surfaced in
+  `<autoheal-suggestion>` in the current session.
+- `/autoheal-toggle autoapply on|off|status` — flip the opt-in
+  daemon (gated apply, never pushes).
+- `/autoheal-snooze <id> [days]` — suppress a proposal without
+  applying it.
+- Rule: `~/.claude/rules/autoheal.md` (apply path summary)
+- Plan: `~/code/plans/ccgm-autoheal/plan.md` §3.7 (gate predicate),
+  §3.9 (apply path), §5 Epic 11.

--- a/modules/autoheal/tests/test-auto-apply-gate.sh
+++ b/modules/autoheal/tests/test-auto-apply-gate.sh
@@ -1,4 +1,426 @@
 #!/usr/bin/env bash
-# Stub: this test belongs to a later epic; content TBD. See plan.md §5
-# for the owning epic and the assertion list.
+# Test suite for modules/autoheal/bin/autoheal-auto-apply.sh
+#
+# Covers the auto-apply confidence gate (plan.md §3.7) end-to-end. The
+# test builds a temp CCGM clone (a freshly init'd git repo with the same
+# layout the real apply path expects: start.sh at the root, tests/
+# directory with test-modules.sh + test-no-personal-data.sh, and a
+# modules/settings/settings.partial.json that the fixture diff modifies).
+#
+# Then it stages 6 proposals into proposals/{today}.jsonl, runs the
+# script with auto_apply_enabled: true, and asserts:
+#
+#   - The 1 qualifying proposal (confidence 9, breadth 1, kind
+#     settings_allow_add, target modules/settings/) gets a feature branch
+#     autoheal/auto/{id} + commit + applied/{today}.jsonl record.
+#   - The 5 rejecting proposals get NO branch and NO applied-success
+#     record. The rejection reasons are:
+#       a. confidence 8 (below the >=9 cutoff)
+#       b. breadth 2 (above the <=1 cutoff)
+#       c. kind hook_narrow (wrong kind)
+#       d. target outside modules/settings/ (wrong dir)
+#       e. snoozed_until in the future
+#       f. auto_apply_blocked: true
+#     (Six rejection axes give us six separate misses; combined with the
+#     one accept, that is seven fixtures total. The plan says 5 reject +
+#     1 accept; we widen to 6 reject to cover snooze AND blocked
+#     explicitly. Both belong to the gate.)
+#
+# Plus the "switch is off" axis:
+#   - auto_apply_enabled: false → no proposals applied even if all qualify.
+#
+# Run: bash modules/autoheal/tests/test-auto-apply-gate.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${MODULE_ROOT}/../.." && pwd)"
+AUTO_APPLY_SH="${MODULE_ROOT}/bin/autoheal-auto-apply.sh"
+APPLY_LIB="${MODULE_ROOT}/lib/apply-proposal.py"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  expected substring: ${needle}"
+            echo "  actual: ${haystack}"
+            ;;
+    esac
+}
+
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  unexpected substring: ${needle}"
+            echo "  actual: ${haystack}"
+            ;;
+        *)
+            PASS=$((PASS + 1))
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------
+# Build the sandbox.
+#
+# A fake CCGM clone needs:
+#   - start.sh (used by _resolve_clone_root to anchor)
+#   - tests/test-modules.sh        (apply path runs these)
+#   - tests/test-no-personal-data.sh
+#   - modules/settings/settings.partial.json (target of fixture diff)
+#   - .git initialized with a main branch + initial commit so
+#     `git apply` and `git checkout -b` work.
+# ---------------------------------------------------------------------
+
+CLONE_ROOT="$(mktemp -d -t autoapply_clone.XXXXXX)"
+PROPOSALS_DIR="$(mktemp -d -t autoapply_proposals.XXXXXX)"
+APPLIED_DIR="$(mktemp -d -t autoapply_applied.XXXXXX)"
+LOGS_DIR="$(mktemp -d -t autoapply_logs.XXXXXX)"
+CONFIG_DIR="$(mktemp -d -t autoapply_config.XXXXXX)"
+trap 'rm -rf "${CLONE_ROOT}" "${PROPOSALS_DIR}" "${APPLIED_DIR}" "${LOGS_DIR}" "${CONFIG_DIR}"' EXIT
+
+CONFIG_FILE="${CONFIG_DIR}/config.json"
+TODAY="2026-05-18"
+PROPOSALS_FILE="${PROPOSALS_DIR}/${TODAY}.jsonl"
+APPLIED_FILE="${APPLIED_DIR}/${TODAY}.jsonl"
+
+# Seed the fake clone.
+touch "${CLONE_ROOT}/start.sh"
+mkdir -p "${CLONE_ROOT}/tests"
+mkdir -p "${CLONE_ROOT}/modules/settings"
+
+cat > "${CLONE_ROOT}/tests/test-modules.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${CLONE_ROOT}/tests/test-modules.sh"
+
+cat > "${CLONE_ROOT}/tests/test-no-personal-data.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${CLONE_ROOT}/tests/test-no-personal-data.sh"
+
+# Initial settings file the fixture diff edits.
+cat > "${CLONE_ROOT}/modules/settings/settings.partial.json" <<'EOF'
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status)"
+    ]
+  }
+}
+EOF
+
+(
+    cd "${CLONE_ROOT}"
+    git init -q -b main
+    git config user.email "test@example.invalid"
+    git config user.name "test"
+    git config commit.gpgsign false
+    # Defeat global core.hooksPath so the user's pre-commit / pre-push
+    # hooks do not run inside the sandbox. The apply-path commits must
+    # succeed in CI as well.
+    git config core.hooksPath "${CLONE_ROOT}/.git/empty-hooks"
+    mkdir -p "${CLONE_ROOT}/.git/empty-hooks"
+    git add -A
+    git commit -q -m "init"
+)
+
+# ---------------------------------------------------------------------
+# Build the fixture proposals.
+#
+# The QUALIFY proposal carries a real unified diff that appends one new
+# allow entry to settings.partial.json. We construct the diff with python
+# and inline it into the JSONL so the test does not depend on a separate
+# fixture file (and so the literal `--- a/...` markers are not chopped
+# by shell quoting).
+# ---------------------------------------------------------------------
+
+build_proposals() {
+    python3 - "${PROPOSALS_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+
+# Unified diff: add a new line to the allow array. The diff is anchored
+# on the existing content (3 lines of context) so `git apply` accepts it
+# against the seeded settings.partial.json.
+diff_qualify = (
+    "--- a/modules/settings/settings.partial.json\n"
+    "+++ b/modules/settings/settings.partial.json\n"
+    "@@ -1,7 +1,8 @@\n"
+    " {\n"
+    "   \"permissions\": {\n"
+    "     \"allow\": [\n"
+    "-      \"Bash(git status)\"\n"
+    "+      \"Bash(git status)\",\n"
+    "+      \"Bash(git diff)\"\n"
+    "     ]\n"
+    "   }\n"
+    " }\n"
+)
+
+base = {
+    "kind": "settings_allow_add",
+    "title": "stub",
+    "rationale": "stub",
+    "confidence": 9,
+    "breadth_score": 1,
+    "occurrence_count": 3,
+    "session_ids": ["s1", "s2"],
+    "proposed_diff_target": "modules/settings/settings.partial.json",
+    "proposed_diff": diff_qualify,
+    "fingerprint": "stub",
+    "originating_clone": "test-clone",
+    "generated_at": "2026-05-18T00:00:00Z",
+}
+
+
+def with_id(**overrides):
+    rec = dict(base)
+    rec.update(overrides)
+    return rec
+
+
+records = [
+    with_id(id="prop_qualify_01"),
+    with_id(id="prop_lowconf_02", confidence=8),
+    with_id(id="prop_breadth_03", breadth_score=2),
+    with_id(id="prop_kind_04", kind="hook_narrow"),
+    with_id(
+        id="prop_target_05",
+        proposed_diff_target="modules/hooks/hooks/enforce-git-workflow.py",
+    ),
+    with_id(id="prop_snooze_06", snoozed_until="2099-01-01T00:00:00Z"),
+    with_id(id="prop_blocked_07", auto_apply_blocked=True),
+]
+
+with open(path, "w", encoding="utf-8") as fh:
+    for r in records:
+        fh.write(json.dumps(r) + "\n")
+
+print(len(records))
+PY
+}
+
+PROP_COUNT="$(build_proposals)"
+assert_eq "${PROP_COUNT}" "7" "fixture proposal count"
+
+# ---------------------------------------------------------------------
+# Test 1: auto_apply_enabled: false → no applies at all.
+# ---------------------------------------------------------------------
+
+cat > "${CONFIG_FILE}" <<'EOF'
+{ "auto_apply_enabled": false }
+EOF
+
+# Wipe the applied file before each run so we measure THIS run only.
+rm -f "${APPLIED_FILE}"
+
+out=$(
+    CCGM_AUTOHEAL_CONFIG="${CONFIG_FILE}" \
+    CCGM_AUTOHEAL_PROPOSALS_DIR="${PROPOSALS_DIR}" \
+    CCGM_AUTOHEAL_APPLIED_DIR="${APPLIED_DIR}" \
+    CCGM_AUTOHEAL_LOGS_DIR="${LOGS_DIR}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    CCGM_AUTOHEAL_CLONE_ROOT="${CLONE_ROOT}" \
+    bash "${AUTO_APPLY_SH}" 2>&1
+)
+rc=$?
+assert_eq "${rc}" "0" "test 1: script exits 0 with autoapply off"
+assert_contains "${out}" "auto_apply_enabled=false" \
+    "test 1: stderr notes the disabled flag"
+
+# No applied file should be created (or it should be empty).
+if [ -s "${APPLIED_FILE}" ]; then
+    FAIL=$((FAIL + 1))
+    echo "FAIL: test 1: applied file should be empty when autoapply is off"
+    echo "  contents:"
+    cat "${APPLIED_FILE}"
+else
+    PASS=$((PASS + 1))
+fi
+
+# Branch with the auto-apply prefix must NOT exist.
+branches=$(cd "${CLONE_ROOT}" && git branch --list 'autoheal/auto/*')
+assert_eq "${branches}" "" "test 1: no autoheal/auto/* branches when autoapply is off"
+
+# ---------------------------------------------------------------------
+# Test 2: auto_apply_enabled: true → only the qualifying proposal applies.
+# ---------------------------------------------------------------------
+
+cat > "${CONFIG_FILE}" <<'EOF'
+{ "auto_apply_enabled": true }
+EOF
+
+# Reset clone working tree to clean main before the gated run. The first
+# test did not modify state, so this is precautionary.
+(
+    cd "${CLONE_ROOT}"
+    git checkout -q main
+    git clean -fdq
+)
+rm -f "${APPLIED_FILE}"
+
+out=$(
+    CCGM_AUTOHEAL_CONFIG="${CONFIG_FILE}" \
+    CCGM_AUTOHEAL_PROPOSALS_DIR="${PROPOSALS_DIR}" \
+    CCGM_AUTOHEAL_APPLIED_DIR="${APPLIED_DIR}" \
+    CCGM_AUTOHEAL_LOGS_DIR="${LOGS_DIR}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    CCGM_AUTOHEAL_CLONE_ROOT="${CLONE_ROOT}" \
+    bash "${AUTO_APPLY_SH}" 2>&1
+)
+rc=$?
+assert_eq "${rc}" "0" "test 2: script exits 0 with autoapply on"
+
+# Summary line must show 7 evaluated, 1 qualified, 1 applied, 0 failed.
+assert_contains "${out}" "evaluated=7 qualified=1" \
+    "test 2: summary reports 7 evaluated, 1 qualified"
+assert_contains "${out}" "applied=1 failed=0" \
+    "test 2: summary reports 1 applied, 0 failed"
+
+# Each rejected proposal should be tagged in the log with its reason.
+LOG_FILE="${LOGS_DIR}/autoheal-auto-apply-${TODAY}.log"
+log_content=$(cat "${LOG_FILE}" 2>/dev/null || echo "")
+assert_contains "${log_content}" "prop_lowconf_02" "test 2: low-confidence skip logged"
+assert_contains "${log_content}" "prop_breadth_03" "test 2: high-breadth skip logged"
+assert_contains "${log_content}" "prop_kind_04"    "test 2: wrong-kind skip logged"
+assert_contains "${log_content}" "prop_target_05"  "test 2: wrong-target skip logged"
+assert_contains "${log_content}" "prop_snooze_06"  "test 2: snoozed skip logged"
+assert_contains "${log_content}" "prop_blocked_07" "test 2: blocked skip logged"
+
+# The qualifying proposal must have a feature branch + a commit.
+branches=$(cd "${CLONE_ROOT}" && git branch --list 'autoheal/auto/prop_qualify_01')
+assert_contains "${branches}" "autoheal/auto/prop_qualify_01" \
+    "test 2: qualifying proposal got its autoheal/auto/* branch"
+
+# The branch's commit message must match the apply-path format.
+commit_msg=$(
+    cd "${CLONE_ROOT}"
+    git log -1 --format=%s autoheal/auto/prop_qualify_01 2>/dev/null || echo ""
+)
+expected_msg="#auto: apply autoheal proposal prop_qualify_01"
+assert_eq "${commit_msg}" "${expected_msg}" \
+    "test 2: commit message uses the #auto: prefix"
+
+# The applied audit log must contain exactly one success record for the
+# qualifying proposal and no records for the rejected ones.
+if [ ! -f "${APPLIED_FILE}" ]; then
+    FAIL=$((FAIL + 1))
+    echo "FAIL: test 2: applied file was not created"
+else
+    success_count=$(grep -c '"proposal_id":"prop_qualify_01"' "${APPLIED_FILE}" || true)
+    assert_eq "${success_count}" "1" \
+        "test 2: applied/{today}.jsonl contains 1 record for prop_qualify_01"
+
+    for rejected in prop_lowconf_02 prop_breadth_03 prop_kind_04 prop_target_05 prop_snooze_06 prop_blocked_07; do
+        miss=$(grep -c "\"proposal_id\":\"${rejected}\"" "${APPLIED_FILE}" || true)
+        assert_eq "${miss}" "0" \
+            "test 2: applied/{today}.jsonl has NO record for ${rejected}"
+    done
+
+    # Method must be auto_apply for the success row.
+    method=$(python3 -c "
+import json
+for line in open('${APPLIED_FILE}'):
+    rec = json.loads(line)
+    if rec.get('proposal_id') == 'prop_qualify_01':
+        print(rec.get('method'))
+        break
+")
+    assert_eq "${method}" "auto_apply" "test 2: applied record method=auto_apply"
+
+    # tests_passed must be true; rolled_back false.
+    tp=$(python3 -c "
+import json
+for line in open('${APPLIED_FILE}'):
+    rec = json.loads(line)
+    if rec.get('proposal_id') == 'prop_qualify_01':
+        print(rec.get('tests_passed'))
+        break
+")
+    assert_eq "${tp}" "True" "test 2: applied record tests_passed=true"
+
+    rb=$(python3 -c "
+import json
+for line in open('${APPLIED_FILE}'):
+    rec = json.loads(line)
+    if rec.get('proposal_id') == 'prop_qualify_01':
+        print(rec.get('rolled_back'))
+        break
+")
+    assert_eq "${rb}" "False" "test 2: applied record rolled_back=false"
+fi
+
+# The settings.partial.json on the new branch must contain the new
+# allow entry (proves the diff actually landed).
+content=$(cd "${CLONE_ROOT}" && git show autoheal/auto/prop_qualify_01:modules/settings/settings.partial.json 2>/dev/null)
+assert_contains "${content}" "Bash(git diff)" \
+    "test 2: feature branch contains the applied diff"
+
+# main must still be clean (no work leaked onto the trunk).
+(
+    cd "${CLONE_ROOT}"
+    git checkout -q main
+)
+main_content=$(cat "${CLONE_ROOT}/modules/settings/settings.partial.json")
+assert_not_contains "${main_content}" "Bash(git diff)" \
+    "test 2: main branch is NOT modified by auto-apply"
+
+# ---------------------------------------------------------------------
+# Test 3: re-running auto-apply against the same proposals should not
+# crash. The qualifying branch already exists, so apply-proposal.py
+# refuses to recreate it. The failure is logged but the script exits 0.
+# ---------------------------------------------------------------------
+
+out=$(
+    CCGM_AUTOHEAL_CONFIG="${CONFIG_FILE}" \
+    CCGM_AUTOHEAL_PROPOSALS_DIR="${PROPOSALS_DIR}" \
+    CCGM_AUTOHEAL_APPLIED_DIR="${APPLIED_DIR}" \
+    CCGM_AUTOHEAL_LOGS_DIR="${LOGS_DIR}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    CCGM_AUTOHEAL_CLONE_ROOT="${CLONE_ROOT}" \
+    bash "${AUTO_APPLY_SH}" 2>&1
+)
+rc=$?
+assert_eq "${rc}" "0" "test 3: re-run exits 0 even when branch already exists"
+assert_contains "${out}" "applied=0 failed=1" \
+    "test 3: re-run reports 1 failure (branch already exists)"
+
+echo ""
+echo "test-auto-apply-gate.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
 exit 0

--- a/modules/autoheal/tests/test-autoheal-apply-command.sh
+++ b/modules/autoheal/tests/test-autoheal-apply-command.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Test suite for the /autoheal-apply slash command spec.
+#
+# The command itself is documented in modules/autoheal/commands/autoheal-apply.md
+# and is implemented in two halves:
+#
+#   - LIST mode: agent-driven read of past-7-days proposals files, skipping
+#     applied + snoozed. There is no executable for list mode; the agent
+#     follows the documented procedure. This test exercises the SAME read
+#     logic the agent should use, so a future implementation in code (e.g.
+#     a small `autoheal-apply-list.py`) can be wired without changing the
+#     contract.
+#
+#   - APPLY mode: routes through lib/apply-proposal.py — the gate test
+#     (test-auto-apply-gate.sh) covers that path end-to-end. This test
+#     only spot-checks that the CLI exposes the documented usage.
+#
+# Run: bash modules/autoheal/tests/test-autoheal-apply-command.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+APPLY_LIB="${MODULE_ROOT}/lib/apply-proposal.py"
+COMMAND_DOC="${MODULE_ROOT}/commands/autoheal-apply.md"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  expected substring: ${needle}"
+            echo "  actual: ${haystack}"
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------
+# Test 1: the command doc names the expected subcommands. A regression
+# in the command surface would silently break the agent that follows the
+# spec, so we pin the wording.
+# ---------------------------------------------------------------------
+
+[ -f "${COMMAND_DOC}" ] && PASS=$((PASS + 1)) || {
+    FAIL=$((FAIL + 1))
+    echo "FAIL: command doc exists at ${COMMAND_DOC}"
+}
+
+doc_content=$(cat "${COMMAND_DOC}" 2>/dev/null || echo "")
+assert_contains "${doc_content}" "/autoheal-apply" \
+    "doc: top-level command name present"
+assert_contains "${doc_content}" "/autoheal-apply list" \
+    "doc: list subcommand documented"
+assert_contains "${doc_content}" "/autoheal-apply <proposal-id>" \
+    "doc: apply-by-id subcommand documented"
+assert_contains "${doc_content}" "lib/apply-proposal.py" \
+    "doc: routes through the shared apply library"
+assert_contains "${doc_content}" "autoheal/{proposal-id}" \
+    "doc: names the manual-apply branch shape"
+assert_contains "${doc_content}" "tests/test-modules.sh" \
+    "doc: test-gate references test-modules.sh"
+assert_contains "${doc_content}" "tests/test-no-personal-data.sh" \
+    "doc: test-gate references test-no-personal-data.sh"
+
+# ---------------------------------------------------------------------
+# Test 2: the CLI exposes the documented usage string and rejects bad
+# source labels. We do not run the apply itself here (the gate test
+# covers that); we only confirm the CLI surface matches the doc.
+# ---------------------------------------------------------------------
+
+usage=$(python3 "${APPLY_LIB}" 2>&1 || true)
+assert_contains "${usage}" "apply-proposal.py" "cli: usage names the script"
+assert_contains "${usage}" "permission-fix|auto-apply" \
+    "cli: usage names the two source labels"
+
+bad_source=$(python3 "${APPLY_LIB}" prop_x notarealsource 2>&1 || true)
+assert_contains "${bad_source}" "source must be" \
+    "cli: rejects unknown source labels"
+
+# ---------------------------------------------------------------------
+# Test 3: LIST mode logic — read the last N days, skip applied, skip
+# future-snoozed. We do not run a list executable (the command is
+# agent-driven); we exercise the procedure the agent should follow.
+# ---------------------------------------------------------------------
+
+PROPOSALS_DIR="$(mktemp -d -t autoheal_list_proposals.XXXXXX)"
+APPLIED_DIR="$(mktemp -d -t autoheal_list_applied.XXXXXX)"
+trap 'rm -rf "${PROPOSALS_DIR}" "${APPLIED_DIR}"' EXIT
+
+TODAY="2026-05-18"
+YDAY="2026-05-17"
+
+# Today: 3 proposals (1 normal, 1 future-snoozed, 1 already-applied).
+cat > "${PROPOSALS_DIR}/${TODAY}.jsonl" <<EOF
+{"id":"prop_today_a","kind":"settings_allow_add","title":"add A","confidence":9,"breadth_score":1,"occurrence_count":2,"session_ids":["s1"],"proposed_diff_target":"modules/settings/x","proposed_diff":"","fingerprint":"fa","originating_clone":"c","generated_at":"${TODAY}T00:00:00Z"}
+{"id":"prop_today_b","kind":"settings_allow_add","title":"add B","confidence":9,"breadth_score":1,"occurrence_count":2,"session_ids":["s1"],"proposed_diff_target":"modules/settings/x","proposed_diff":"","fingerprint":"fb","originating_clone":"c","generated_at":"${TODAY}T00:00:00Z","snoozed_until":"2099-01-01T00:00:00Z"}
+{"id":"prop_today_c","kind":"settings_allow_add","title":"add C","confidence":9,"breadth_score":1,"occurrence_count":2,"session_ids":["s1"],"proposed_diff_target":"modules/settings/x","proposed_diff":"","fingerprint":"fc","originating_clone":"c","generated_at":"${TODAY}T00:00:00Z"}
+EOF
+
+# Yesterday: 1 proposal (still pending).
+cat > "${PROPOSALS_DIR}/${YDAY}.jsonl" <<EOF
+{"id":"prop_yday_a","kind":"hook_narrow","title":"narrow X","confidence":7,"breadth_score":3,"occurrence_count":2,"session_ids":["s1"],"proposed_diff_target":"modules/hooks/x","proposed_diff":"","fingerprint":"fy","originating_clone":"c","generated_at":"${YDAY}T00:00:00Z"}
+EOF
+
+# Mark prop_today_c as already applied.
+cat > "${APPLIED_DIR}/${TODAY}.jsonl" <<EOF
+{"id":"app_prop_today_c","ts":"${TODAY}T01:00:00Z","proposal_id":"prop_today_c","method":"permission_fix","branch":"autoheal/prop_today_c","commit_sha":"abc","tests_passed":true,"rolled_back":false}
+EOF
+
+# The agent's list procedure:
+#   1. Walk proposals_dir for the last 8 days.
+#   2. Skip any whose snoozed_until is in the future (vs TODAY).
+#   3. Skip any whose id is present in applied_dir/*.jsonl.
+#   4. Emit a sorted table.
+list_output=$(
+    CCGM_AUTOHEAL_PROPOSALS_DIR="${PROPOSALS_DIR}" \
+    CCGM_AUTOHEAL_APPLIED_DIR="${APPLIED_DIR}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    python3 - <<'PY'
+import datetime as dt
+import glob
+import json
+import os
+
+prop_dir = os.environ["CCGM_AUTOHEAL_PROPOSALS_DIR"]
+appl_dir = os.environ["CCGM_AUTOHEAL_APPLIED_DIR"]
+today_iso = os.environ["CCGM_AUTOHEAL_TODAY"]
+today = dt.date.fromisoformat(today_iso)
+
+# Applied id set.
+applied = set()
+for path in glob.glob(os.path.join(appl_dir, "*.jsonl")):
+    with open(path) as fh:
+        for line in fh:
+            try:
+                rec = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            pid = rec.get("proposal_id") or rec.get("id")
+            if pid:
+                applied.add(pid)
+
+now_iso = today_iso + "T23:59:59Z"
+
+pending = []
+for offset in range(0, 8):
+    day = (today - dt.timedelta(days=offset)).isoformat()
+    path = os.path.join(prop_dir, f"{day}.jsonl")
+    if not os.path.isfile(path):
+        continue
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            pid = rec.get("id")
+            if not pid or pid in applied:
+                continue
+            snz = rec.get("snoozed_until")
+            if snz and snz > now_iso:
+                continue
+            pending.append(rec)
+
+pending.sort(
+    key=lambda r: (
+        -int(r.get("confidence") or 0),
+        int(r.get("breadth_score") or 99),
+        r.get("generated_at") or "",
+    )
+)
+
+for rec in pending:
+    print(
+        f"{rec['id']}\t{rec['kind']}\t{rec.get('confidence', '-')}/10\t"
+        f"{rec.get('breadth_score', '-')}\t{rec.get('title', '')}"
+    )
+
+print(f"--PENDING={len(pending)}")
+PY
+)
+
+assert_contains "${list_output}" "prop_today_a" \
+    "list: pending today proposal appears"
+assert_contains "${list_output}" "prop_yday_a"  \
+    "list: pending yesterday proposal appears"
+# prop_today_b is snoozed — must be skipped.
+case "${list_output}" in
+    *prop_today_b*)
+        FAIL=$((FAIL + 1))
+        echo "FAIL: list: snoozed proposal must be skipped"
+        ;;
+    *)
+        PASS=$((PASS + 1))
+        ;;
+esac
+# prop_today_c is already applied — must be skipped.
+case "${list_output}" in
+    *prop_today_c*)
+        FAIL=$((FAIL + 1))
+        echo "FAIL: list: already-applied proposal must be skipped"
+        ;;
+    *)
+        PASS=$((PASS + 1))
+        ;;
+esac
+assert_contains "${list_output}" "--PENDING=2" \
+    "list: pending count = 2"
+
+echo ""
+echo "test-autoheal-apply-command.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Wave 5 Epic 11 — opt-in confidence-gated auto-apply (`bin/autoheal-auto-apply.sh`) plus the user-facing `/autoheal-apply` slash command. Default OFF. Strict gate per plan §3.7. Always creates a feature branch — NEVER pushes to main.

Closes #483.

## Apply gate (ALL must hold)

- `confidence >= 9`
- `breadth_score <= 1`
- `kind == "settings_allow_add"`
- `proposed_diff_target` starts with `modules/settings/`
- not snoozed
- not `auto_apply_blocked`

## Files

- `bin/autoheal-auto-apply.sh` — gates on `auto_apply_enabled` (default false); evaluates gate in a single python pass; routes qualifying proposals through `python3 lib/apply-proposal.py <id> auto-apply`. Each attempt (success or failure) writes to `~/.claude/autoheal/applied/{today}.jsonl`. Failures log to `~/.claude/logs/autoheal-auto-apply-{today}.log`. NEVER pushes; only commits to `autoheal/auto/{id}`. Honors env overrides `CCGM_AUTOHEAL_{CONFIG,PROPOSALS_DIR,APPLIED_DIR,LOGS_DIR,TODAY,CLONE_ROOT}`.
- `commands/autoheal-apply.md` — slash command spec. LIST mode walks the last 8 days of proposals files, skips snoozed + already-applied, emits sorted table. APPLY mode routes through `apply-proposal.py` with the same `#auto:` commit prefix and undo hint as `/permission-fix apply`.
- `tests/test-auto-apply-gate.sh` — 30 assertions. 7 fixtures (1 accept + 6 reject axes). Uses a temp git repo as the fake CCGM clone target so apply-proposal.py has a place to land branches.
- `tests/test-autoheal-apply-command.sh` — bonus test. 16 assertions. Pins documented command surface + LIST-mode read procedure end-to-end (4 proposals across 2 days, 1 snoozed, 1 already-applied → exactly 2 pending).

## Dependency

#491 (`#auto:` commit prefix allow-list) is required for `apply-proposal.py`'s commit to succeed. Already merged.

## Test plan

- [x] `bash modules/autoheal/tests/test-auto-apply-gate.sh` → 30 passed
- [x] `bash modules/autoheal/tests/test-autoheal-apply-command.sh` → 16 passed
- [x] `bash modules/autoheal/tests/run-all.sh` → all autoheal scripts pass
- [x] `bash tests/test-modules.sh` → 1182 passed
- [x] `bash tests/test-no-personal-data.sh` → PASS

## Implementer-flagged concerns (DONE_WITH_CONCERNS, accepted)

1. **Env var name divergence** (`CCGM_AUTOHEAL_CLONE_ROOT` vs Epic 4's `CCGM_CLONE_ROOT`) — handled via forwarding shim in `autoheal-auto-apply.sh`. Both names work. Worth a small follow-up to normalize.
2. **Positional CLI vs `--source` flag** — used positional. 5-line follow-up to add a `--source` flag to apply-proposal.py if preferred.
3. **Worktree base mismatch** — agent properly switched to `483-auto-apply-and-command` from `origin/main`.
4. **Re-running idempotency** — once a branch exists, the next daemon run reports per-proposal failure (Epic 4's `_create_branch` refuses to recreate). Documented behavior.
