### PR TITLE
#484: Epic 12 — robustness pack (locks, repo overrides, retention, webhook, platform)

### DIFF
--- a/modules/autoheal/bin/autoheal-publish.sh
+++ b/modules/autoheal/bin/autoheal-publish.sh
@@ -1,4 +1,356 @@
 #!/usr/bin/env bash
-# Epic 12: content TBD — webhook publisher seam. No-op when webhook_url
-# is null (default). See plan.md §3.10 and §5 Epic 12.
+# autoheal-publish.sh
+#
+# Webhook publisher seam (plan.md §3.10, §5 Epic 12).
+#
+# Default state: webhook_url is null → script writes "webhook disabled
+# (set webhook_url to enable)" to stderr and exits 0. No-op until a
+# future dev.lem.work agent (a) deploys a /v1/ingest receiver and (b)
+# tells the user the URL + token. The user adds them to config.json and
+# the next daily run starts publishing.
+#
+# When webhook_url is set:
+#   1. Diff today's proposals/events/digests against
+#      ~/.claude/autoheal/published/{today}.last (cursor file). Cursor
+#      records the count of records ALREADY PUBLISHED per kind.
+#   2. For each new record (up to webhook_max_per_run), POST an envelope
+#      to ${webhook_url}/v1/ingest with
+#          Authorization: Bearer ${webhook_token}
+#          Content-Type:  application/json
+#      Envelope shape (plan.md §3.4):
+#          {kind, ts, session_id, machine_id, data}
+#      Idempotency: receiving endpoint expects (kind, machine_id, data.id)
+#      to be unique; safe to re-POST.
+#   3. On 2xx: advance cursor.
+#   4. On 4xx/5xx: log to ~/.claude/logs/autoheal-publish-{today}.log;
+#      DO NOT advance cursor (next daily run retries). NEVER fail the
+#      pipeline; we always exit 0 so the daily wrapper continues.
+#
+# Env overrides (for tests):
+#   CCGM_AUTOHEAL_DIR              default ~/.claude/autoheal
+#   CCGM_AUTOHEAL_CONFIG           default $CCGM_AUTOHEAL_DIR/config.json
+#   CCGM_AUTOHEAL_PROPOSALS_DIR    default $CCGM_AUTOHEAL_DIR/proposals
+#   CCGM_AUTOHEAL_EVENTS_DIR       default $CCGM_AUTOHEAL_DIR/events
+#   CCGM_AUTOHEAL_DIGESTS_DIR      default $CCGM_AUTOHEAL_DIR/digests
+#   CCGM_AUTOHEAL_PUBLISHED_DIR    default $CCGM_AUTOHEAL_DIR/published
+#   CCGM_AUTOHEAL_LOGS_DIR         default ~/.claude/logs
+#   CCGM_AUTOHEAL_TODAY            default $(date +%Y-%m-%d)
+#   CCGM_AUTOHEAL_MACHINE_ID       default `hostname`
+#
+# Exit codes:
+#   0  always (failures are recorded in the log; never propagate)
+#   2  invariant violation (jq/python3/curl missing)
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+AUTOHEAL_DIR="${CCGM_AUTOHEAL_DIR:-${HOME}/.claude/autoheal}"
+CONFIG_FILE="${CCGM_AUTOHEAL_CONFIG:-${AUTOHEAL_DIR}/config.json}"
+PROPOSALS_DIR="${CCGM_AUTOHEAL_PROPOSALS_DIR:-${AUTOHEAL_DIR}/proposals}"
+EVENTS_DIR="${CCGM_AUTOHEAL_EVENTS_DIR:-${AUTOHEAL_DIR}/events}"
+DIGESTS_DIR="${CCGM_AUTOHEAL_DIGESTS_DIR:-${AUTOHEAL_DIR}/digests}"
+PUBLISHED_DIR="${CCGM_AUTOHEAL_PUBLISHED_DIR:-${AUTOHEAL_DIR}/published}"
+LOGS_DIR="${CCGM_AUTOHEAL_LOGS_DIR:-${HOME}/.claude/logs}"
+TODAY="${CCGM_AUTOHEAL_TODAY:-$(date +%Y-%m-%d)}"
+
+PUBLISH_LOG="${LOGS_DIR}/autoheal-publish-${TODAY}.log"
+CURSOR_FILE="${PUBLISHED_DIR}/${TODAY}.last"
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required but not on PATH" >&2
+    exit 2
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 is required but not on PATH" >&2
+    exit 2
+fi
+if ! command -v curl >/dev/null 2>&1; then
+    echo "ERROR: curl is required but not on PATH" >&2
+    exit 2
+fi
+
+mkdir -p "${PUBLISHED_DIR}" "${LOGS_DIR}"
+
+# ---------------------------------------------------------------------------
+# Config: webhook_url, webhook_token, webhook_kinds, webhook_max_per_run
+# ---------------------------------------------------------------------------
+
+WEBHOOK_URL=""
+WEBHOOK_TOKEN=""
+WEBHOOK_KINDS_RAW=""
+WEBHOOK_MAX=100
+
+if [ -f "${CONFIG_FILE}" ]; then
+    WEBHOOK_URL="$(jq -r '.webhook_url // empty' "${CONFIG_FILE}" 2>/dev/null || echo "")"
+    WEBHOOK_TOKEN="$(jq -r '.webhook_token // empty' "${CONFIG_FILE}" 2>/dev/null || echo "")"
+    WEBHOOK_KINDS_RAW="$(jq -r '(.webhook_kinds // ["proposal","event","digest"]) | .[]' "${CONFIG_FILE}" 2>/dev/null || echo "")"
+    cfg_max="$(jq -r '.webhook_max_per_run // 100' "${CONFIG_FILE}" 2>/dev/null || echo "100")"
+    case "${cfg_max}" in
+        ''|*[!0-9]*) WEBHOOK_MAX=100 ;;
+        *)           WEBHOOK_MAX="${cfg_max}" ;;
+    esac
+fi
+
+if [ -z "${WEBHOOK_URL}" ]; then
+    echo "webhook disabled (set webhook_url to enable)" >&2
+    exit 0
+fi
+
+# Strip trailing slash so we can append /v1/ingest without doubling it.
+WEBHOOK_URL="${WEBHOOK_URL%/}"
+INGEST_URL="${WEBHOOK_URL}/v1/ingest"
+
+# Default kind list if jq returned empty.
+if [ -z "${WEBHOOK_KINDS_RAW}" ]; then
+    WEBHOOK_KINDS_RAW=$'proposal\nevent\ndigest'
+fi
+
+# Build a lookup function so we can check kind membership cheaply.
+kind_enabled() {
+    local k="$1"
+    printf '%s\n' "${WEBHOOK_KINDS_RAW}" | grep -qx "${k}"
+}
+
+MACHINE_ID="${CCGM_AUTOHEAL_MACHINE_ID:-$(hostname 2>/dev/null || python3 -c 'import socket; print(socket.gethostname())')}"
+
+# ---------------------------------------------------------------------------
+# Cursor: how many of each kind have already been published today.
+# Format: simple TSV `kind\tcount` (so the file is editable + greppable
+# and we don't need jq to read it).
+# ---------------------------------------------------------------------------
+
+read_cursor() {
+    local kind="$1"
+    if [ ! -f "${CURSOR_FILE}" ]; then
+        echo "0"
+        return
+    fi
+    local n
+    n="$(awk -v k="${kind}" 'BEGIN{n=0} $1==k{n=$2} END{print n+0}' "${CURSOR_FILE}")"
+    echo "${n:-0}"
+}
+
+write_cursor() {
+    local kind="$1"
+    local n="$2"
+    local tmp="${CURSOR_FILE}.tmp.$$"
+    if [ -f "${CURSOR_FILE}" ]; then
+        awk -v k="${kind}" '$1!=k' "${CURSOR_FILE}" > "${tmp}"
+    else
+        : > "${tmp}"
+    fi
+    printf '%s\t%s\n' "${kind}" "${n}" >> "${tmp}"
+    mv "${tmp}" "${CURSOR_FILE}"
+}
+
+log_line() {
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >> "${PUBLISH_LOG}"
+}
+
+# ---------------------------------------------------------------------------
+# POST a single envelope. Echo HTTP status code to stdout. Echo nothing
+# else (so callers can capture status cleanly). Body excerpt and status
+# go to the publish log on non-2xx.
+# ---------------------------------------------------------------------------
+
+post_envelope() {
+    local envelope="$1"
+    local kind="$2"
+    local rec_id="$3"
+
+    local resp
+    resp="$(mktemp -t autoheal-publish-resp.XXXXXX)"
+    local http_code
+    http_code="$(curl -sS -o "${resp}" -w "%{http_code}" \
+        -X POST "${INGEST_URL}" \
+        -H "Authorization: Bearer ${WEBHOOK_TOKEN}" \
+        -H "Content-Type: application/json" \
+        --data-binary "${envelope}" 2>>"${PUBLISH_LOG}" || echo "000")"
+
+    case "${http_code}" in
+        2*) : ;;
+        *)
+            {
+                echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] webhook failure"
+                echo "  kind: ${kind}"
+                echo "  record_id: ${rec_id}"
+                echo "  url: ${INGEST_URL}"
+                echo "  http_code: ${http_code}"
+                if [ -s "${resp}" ]; then
+                    echo "  body_excerpt:"
+                    head -c 512 "${resp}" | sed 's/^/    /'
+                    echo ""
+                fi
+            } >> "${PUBLISH_LOG}"
+            ;;
+    esac
+
+    rm -f "${resp}"
+    echo "${http_code}"
+}
+
+# ---------------------------------------------------------------------------
+# Iterate a JSONL source file from a starting offset; build envelope per
+# record; POST; advance cursor on 2xx. Returns the new cursor value.
+# Bounded by REMAINING_BUDGET (which decreases across kinds within one run).
+# ---------------------------------------------------------------------------
+
+REMAINING_BUDGET="${WEBHOOK_MAX}"
+TOTAL_SENT=0
+TOTAL_FAILED=0
+
+publish_jsonl_kind() {
+    local kind="$1"
+    local src="$2"
+
+    if ! kind_enabled "${kind}"; then
+        return 0
+    fi
+    if [ ! -f "${src}" ]; then
+        return 0
+    fi
+
+    local cursor; cursor="$(read_cursor "${kind}")"
+    # Use awk to extract lines [cursor+1 .. cursor+REMAINING_BUDGET]. We
+    # pipe each record into post_envelope; if it returns 2xx we advance
+    # the cursor and continue, otherwise we STOP this kind (so the same
+    # record retries next run; everything after it stays unpublished).
+    local total_lines; total_lines="$(wc -l < "${src}" | tr -d ' ')"
+
+    local idx="${cursor}"
+    while [ "${idx}" -lt "${total_lines}" ] && [ "${REMAINING_BUDGET}" -gt 0 ]; do
+        idx=$((idx + 1))
+        local record
+        record="$(sed -n "${idx}p" "${src}")"
+        [ -z "${record}" ] && continue
+
+        # Extract id, ts, session_id from the record. Defaults if absent.
+        local rec_id rec_ts rec_session
+        rec_id="$(printf '%s' "${record}" | jq -r '.id // empty' 2>/dev/null)"
+        rec_ts="$(printf '%s' "${record}" | jq -r '.timestamp // .generated_at // empty' 2>/dev/null)"
+        rec_session="$(printf '%s' "${record}" | jq -r '.session_id // empty' 2>/dev/null)"
+
+        # If no id, synthesize one from a content hash so the envelope
+        # still satisfies the receiving endpoint's idempotency contract.
+        if [ -z "${rec_id}" ]; then
+            rec_id="$(printf '%s' "${record}" | shasum -a 256 | awk '{print "auto_"substr($1,1,16)}')"
+        fi
+
+        # Build the envelope. The `data` field is the verbatim record
+        # (parsed back into JSON so it's nested as an object, not a
+        # double-encoded string).
+        local envelope
+        envelope="$(jq -nc \
+            --arg kind "${kind}" \
+            --arg ts "${rec_ts}" \
+            --arg sid "${rec_session}" \
+            --arg mid "${MACHINE_ID}" \
+            --argjson data "${record}" \
+            '{kind: $kind, ts: $ts, session_id: $sid, machine_id: $mid, data: $data}' 2>/dev/null)"
+
+        if [ -z "${envelope}" ]; then
+            # Malformed JSONL line — log + skip (do NOT advance the
+            # cursor so a future fix lets us retry; but DO let the loop
+            # progress past it by writing the skip to the log).
+            log_line "skip kind=${kind} idx=${idx}: malformed record"
+            # Advance cursor anyway — otherwise a single malformed line
+            # blocks the rest of the kind forever. The downside is we
+            # don't retry; the upside is the pipeline keeps moving.
+            cursor="${idx}"
+            write_cursor "${kind}" "${cursor}"
+            continue
+        fi
+
+        local code
+        code="$(post_envelope "${envelope}" "${kind}" "${rec_id}")"
+
+        case "${code}" in
+            2*)
+                cursor="${idx}"
+                write_cursor "${kind}" "${cursor}"
+                REMAINING_BUDGET=$((REMAINING_BUDGET - 1))
+                TOTAL_SENT=$((TOTAL_SENT + 1))
+                ;;
+            *)
+                # Stop this kind on the first failure. Cursor is NOT
+                # advanced, so the same record retries on the next run.
+                TOTAL_FAILED=$((TOTAL_FAILED + 1))
+                log_line "stop kind=${kind} at idx=${idx}: http=${code}"
+                return 0
+                ;;
+        esac
+    done
+
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Digest is a single Markdown file, not JSONL. Treat it as a one-record
+# stream: cursor=0 means "not yet published", cursor=1 means "published".
+# ---------------------------------------------------------------------------
+
+publish_digest() {
+    if ! kind_enabled "digest"; then
+        return 0
+    fi
+    local digest_file="${DIGESTS_DIR}/${TODAY}.md"
+    if [ ! -f "${digest_file}" ]; then
+        return 0
+    fi
+    if [ "${REMAINING_BUDGET}" -le 0 ]; then
+        return 0
+    fi
+
+    local cursor; cursor="$(read_cursor "digest")"
+    if [ "${cursor}" -ge 1 ]; then
+        return 0  # Already published today.
+    fi
+
+    local body
+    body="$(cat "${digest_file}")"
+    local rec_id="digest_${TODAY}"
+    local envelope
+    envelope="$(jq -nc \
+        --arg kind "digest" \
+        --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --arg mid "${MACHINE_ID}" \
+        --arg date "${TODAY}" \
+        --arg id "${rec_id}" \
+        --arg body "${body}" \
+        '{kind: $kind, ts: $ts, session_id: "", machine_id: $mid,
+          data: {id: $id, date: $date, body: $body}}')"
+
+    local code
+    code="$(post_envelope "${envelope}" "digest" "${rec_id}")"
+    case "${code}" in
+        2*)
+            write_cursor "digest" "1"
+            REMAINING_BUDGET=$((REMAINING_BUDGET - 1))
+            TOTAL_SENT=$((TOTAL_SENT + 1))
+            ;;
+        *)
+            TOTAL_FAILED=$((TOTAL_FAILED + 1))
+            log_line "stop kind=digest http=${code}"
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Run the three streams in priority order: proposals first (most signal),
+# then events, then digest.
+# ---------------------------------------------------------------------------
+
+publish_jsonl_kind "proposal" "${PROPOSALS_DIR}/${TODAY}.jsonl"
+publish_jsonl_kind "event"    "${EVENTS_DIR}/${TODAY}.jsonl"
+publish_digest
+
+echo "autoheal-publish: ${TOTAL_SENT} sent; ${TOTAL_FAILED} failed; budget remaining=${REMAINING_BUDGET}" >&2
+# Always exit 0 — failures are logged but never block the pipeline.
 exit 0

--- a/modules/autoheal/bin/autoheal-retention.sh
+++ b/modules/autoheal/bin/autoheal-retention.sh
@@ -1,4 +1,122 @@
 #!/usr/bin/env bash
-# Epic 12: content TBD — gzip events >30 days; delete gzipped >60 days.
-# Same policy for proposals and digests. See plan.md §5 Epic 12.
+# autoheal-retention.sh
+#
+# Retention sweep (plan.md §1.3, §5 Epic 12).
+#
+# For each autoheal subdirectory that holds date-named records
+# (events/, proposals/, digests/, applied/, sent/):
+#   - Files older than retention_gzip_days that are NOT yet gzipped →
+#     gzip in place (file.jsonl → file.jsonl.gz).
+#   - Files older than retention_delete_days that ARE gzipped (or that
+#     otherwise pass the deletion age threshold) → delete.
+#
+# Idempotent: a second run on the same state produces no further changes
+# and emits no errors. Achieved via:
+#   - `gzip -f` only on files we have already confirmed are NOT .gz
+#   - delete predicate scoped to *.gz so already-gzipped files are the
+#     only deletion candidates (we never delete uncompressed records)
+#   - find -mtime +N is monotone: a file that was below the threshold
+#     yesterday cannot drop below today; once moved to .gz we don't
+#     touch the new mtime since we delete based on the .gz file's age
+#     too (gzip preserves mtime via -n + system default behavior)
+#
+# Env overrides (for tests):
+#   CCGM_AUTOHEAL_DIR              default ~/.claude/autoheal
+#   CCGM_AUTOHEAL_CONFIG           default $CCGM_AUTOHEAL_DIR/config.json
+#   CCGM_AUTOHEAL_RETENTION_GZIP   default from config (30)
+#   CCGM_AUTOHEAL_RETENTION_DELETE default from config (60)
+#
+# Exit codes:
+#   0  always (failures on individual files are logged to stderr but the
+#      sweep continues; we never block the pipeline)
+
+set -u
+
+AUTOHEAL_DIR="${CCGM_AUTOHEAL_DIR:-${HOME}/.claude/autoheal}"
+CONFIG_FILE="${CCGM_AUTOHEAL_CONFIG:-${AUTOHEAL_DIR}/config.json}"
+
+# Read thresholds from config (defaults 30/60). Env overrides win.
+GZIP_DAYS="${CCGM_AUTOHEAL_RETENTION_GZIP:-}"
+DELETE_DAYS="${CCGM_AUTOHEAL_RETENTION_DELETE:-}"
+
+if [ -z "${GZIP_DAYS}" ] || [ -z "${DELETE_DAYS}" ]; then
+    if [ -f "${CONFIG_FILE}" ] && command -v jq >/dev/null 2>&1; then
+        if [ -z "${GZIP_DAYS}" ]; then
+            GZIP_DAYS="$(jq -r '.retention_gzip_days // 30' "${CONFIG_FILE}" 2>/dev/null || echo 30)"
+        fi
+        if [ -z "${DELETE_DAYS}" ]; then
+            DELETE_DAYS="$(jq -r '.retention_delete_days // 60' "${CONFIG_FILE}" 2>/dev/null || echo 60)"
+        fi
+    fi
+fi
+
+# Numeric guard.
+case "${GZIP_DAYS}" in
+    ''|*[!0-9]*) GZIP_DAYS=30 ;;
+esac
+case "${DELETE_DAYS}" in
+    ''|*[!0-9]*) DELETE_DAYS=60 ;;
+esac
+
+if [ ! -d "${AUTOHEAL_DIR}" ]; then
+    # Nothing to do. Fresh install or test run with no autoheal yet.
+    echo "autoheal-retention: ${AUTOHEAL_DIR} not present; nothing to do" >&2
+    exit 0
+fi
+
+# Directories with date-named records that participate in retention.
+SUBDIRS=(events proposals digests applied sent)
+
+gzipped=0
+deleted=0
+errors=0
+
+# Phase 1: gzip files older than GZIP_DAYS that are not yet compressed.
+#
+# We restrict to known suffixes (.jsonl, .md, .log, .flag) so we don't
+# accidentally compress lock sidecars or partial files. The .flag files
+# are size-0 sentinel files; gzipping them is wasteful but harmless and
+# keeps the policy uniform.
+for sub in "${SUBDIRS[@]}"; do
+    dir="${AUTOHEAL_DIR}/${sub}"
+    [ -d "${dir}" ] || continue
+
+    # find -mtime +N: strictly older than N*24h.
+    while IFS= read -r path; do
+        [ -z "${path}" ] && continue
+        # Skip if already gzipped (defensive; the -name filters above
+        # already exclude .gz, but a future caller passing CCGM_AUTOHEAL_*
+        # could change the policy).
+        case "${path}" in
+            *.gz) continue ;;
+        esac
+        if gzip -f -- "${path}" 2>/dev/null; then
+            gzipped=$((gzipped + 1))
+        else
+            errors=$((errors + 1))
+            echo "autoheal-retention: gzip failed for ${path}" >&2
+        fi
+    done < <(find "${dir}" -maxdepth 1 -type f \
+        \( -name '*.jsonl' -o -name '*.md' -o -name '*.log' -o -name '*.flag' \) \
+        -mtime "+${GZIP_DAYS}" 2>/dev/null)
+done
+
+# Phase 2: delete gzipped files older than DELETE_DAYS.
+for sub in "${SUBDIRS[@]}"; do
+    dir="${AUTOHEAL_DIR}/${sub}"
+    [ -d "${dir}" ] || continue
+
+    while IFS= read -r path; do
+        [ -z "${path}" ] && continue
+        if rm -f -- "${path}" 2>/dev/null; then
+            deleted=$((deleted + 1))
+        else
+            errors=$((errors + 1))
+            echo "autoheal-retention: rm failed for ${path}" >&2
+        fi
+    done < <(find "${dir}" -maxdepth 1 -type f -name '*.gz' \
+        -mtime "+${DELETE_DAYS}" 2>/dev/null)
+done
+
+echo "autoheal-retention: gzipped=${gzipped} deleted=${deleted} errors=${errors} (gzip>${GZIP_DAYS}d, delete>${DELETE_DAYS}d)" >&2
 exit 0

--- a/modules/autoheal/lib/repo-config-schema.json
+++ b/modules/autoheal/lib/repo-config-schema.json
@@ -1,3 +1,66 @@
 {
-  "_description": "Epic 12: content TBD — JSON schema for per-repo .autoheal/config.json. See plan.md §3.4 (per-repo overrides) and §5 Epic 12."
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Autoheal Per-Repo Config",
+  "description": "Optional per-repository override file at <repo-root>/.autoheal/config.json. Loaded by hook_utils.load_repo_config() during analyzer/digest runs. The merge rule (plan.md §3.4): repo config overrides global for keys it sets; missing keys fall through to global. Security constraint (plan.md §R21 — risk table): `additional_allow_patterns` is the only ADDITIVE mutating field. Per-repo config CANNOT remove deny entries — that would let an attacker who lands a .autoheal/config.json into a repo widen permissions. Deny lists live only in the canonical ~/.claude/settings.json layer.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "additional_allow_patterns": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Claude Code permission pattern (e.g. 'Bash(supabase:*)', 'Bash(wrangler:*)'). Format follows the same shape as settings.json `permissions.allow` entries."
+      },
+      "default": [],
+      "description": "Extra allow patterns appended (NOT subtracted) to the global allow list when working inside this repo. The only ADDITIVE field — cannot remove from the global deny list."
+    },
+    "calibration_days": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Per-repo override of the analyzer calibration window (in days). 0 disables calibration; analyzer treats all events as production-quality."
+    },
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "confidence_min": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10,
+          "description": "Minimum analyzer confidence required for a proposal sourced from this repo to be retained. Higher = stricter."
+        },
+        "occurrence_min": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Minimum occurrence count required for a proposal from this repo. Higher = stricter."
+        }
+      },
+      "description": "Per-repo overrides for the global proposal thresholds. Either field may be set independently; unset fields fall through to global."
+    },
+    "kind_filters": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "settings_allow_add",
+          "settings_deny_remove",
+          "hook_narrow",
+          "new_command",
+          "rule_update",
+          "command_doc_tweak"
+        ]
+      },
+      "uniqueItems": true,
+      "description": "Whitelist of proposal kinds to retain for this repo. Empty array means 'no proposals from this repo'. Missing field means 'all kinds permitted'. Enum mirrors proposal-schema.json `kind`."
+    },
+    "realtime_alerts_enabled": {
+      "type": "boolean",
+      "description": "Per-repo override of the global realtime_alerts_enabled flag."
+    },
+    "auto_apply_enabled": {
+      "type": "boolean",
+      "description": "Per-repo override of the global auto_apply_enabled flag."
+    }
+  }
 }

--- a/modules/autoheal/tests/fixtures/repo-config-supabase.json
+++ b/modules/autoheal/tests/fixtures/repo-config-supabase.json
@@ -1,0 +1,17 @@
+{
+  "_description": "Reference fixture for per-repo .autoheal/config.json. Used by test-repo-config-merge.sh and as an example for users authoring their own repo-level overrides. Schema in lib/repo-config-schema.json.",
+  "additional_allow_patterns": [
+    "Bash(supabase:*)",
+    "Bash(supabase db:*)",
+    "Bash(supabase migration:*)"
+  ],
+  "calibration_days": 14,
+  "thresholds": {
+    "confidence_min": 8,
+    "occurrence_min": 2
+  },
+  "kind_filters": [
+    "settings_allow_add",
+    "command_doc_tweak"
+  ]
+}

--- a/modules/autoheal/tests/fixtures/retention-fixture-dates/README.md
+++ b/modules/autoheal/tests/fixtures/retention-fixture-dates/README.md
@@ -1,0 +1,24 @@
+# retention-fixture-dates
+
+Reference fixture documenting how `test-retention-sweep.sh` constructs date-bounded files.
+
+The actual test creates fixture files in `mktemp -d` and uses `touch -t` to set
+mtimes at three age boundaries:
+
+- **15-day-old** file → `retention_gzip_days` is 30 → should remain untouched
+- **45-day-old** file → between gzip (30) and delete (60) → should be gzipped
+- **75-day-old** file → past delete (60) → should be deleted
+
+This README exists because plan.md §3.3 lists `fixtures/retention-fixture-dates/`
+as a fixture directory. The inline `touch -t` approach in the test is
+preferred over checked-in dated files because: (a) committed mtimes don't
+preserve across clones/checkouts, (b) age boundaries shift relative to "today"
+and would need re-creation periodically. The test owns its data deterministically.
+
+Example commands used by the test:
+
+```bash
+touch -t "$(date -v -15d +%Y%m%d0000)" "${EVENTS_DIR}/2026-05-03.jsonl"
+touch -t "$(date -v -45d +%Y%m%d0000)" "${EVENTS_DIR}/2026-04-03.jsonl"
+touch -t "$(date -v -75d +%Y%m%d0000)" "${EVENTS_DIR}/2026-03-04.jsonl"
+```

--- a/modules/autoheal/tests/fixtures/webhook-server-mock.py
+++ b/modules/autoheal/tests/fixtures/webhook-server-mock.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Tiny mock HTTP server for the autoheal webhook publisher.
+
+Used by `test-webhook-publisher.sh` so we never reach a real
+`dev.lem.work`-style endpoint from the test suite.
+
+Behavior:
+    POST /v1/ingest
+        - Records the envelope: full headers (especially Authorization),
+          body JSON, timestamp.
+        - Returns 200 with `{"ok": true}` by default.
+        - If the server was started with --fail-with <code>, returns
+          that HTTP code with `{"error": "mock failure"}`.
+        - If started with --fail-once <code>, returns that code for the
+          FIRST request, then 200 for all subsequent requests. Used to
+          simulate the retry path: first attempt fails, cursor stays put,
+          second daily run succeeds and cursor advances.
+    GET /requests
+        - Returns the recorded envelope list as JSON. The test driver
+          polls this to assert on what was sent.
+    POST /reset
+        - Clears the recorded envelope list AND resets the fail-once
+          counter so a fresh fail-once flow can be exercised after the
+          first one completes.
+
+Usage (from a test):
+
+    python3 modules/autoheal/tests/fixtures/webhook-server-mock.py \\
+        --port 0 --pidfile /tmp/foo.pid --port-file /tmp/foo.port
+
+The server writes its actual listening port to --port-file and its pid
+to --pidfile. The test reads the port, runs autoheal-publish.sh with
+CCGM webhook env pointing at the mock, then GETs /requests.
+
+Modeled on tests/fixtures/resend-mock-server.py to keep the two test
+fixtures consistent in shape.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+REQUESTS: list[dict] = []
+REQ_LOCK = threading.Lock()
+FAIL_WITH: int | None = None
+FAIL_ONCE: int | None = None
+FAIL_ONCE_FIRED = False
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "WebhookMock/0.1"
+
+    def log_message(self, format, *args):  # noqa: D401 - quiet test output
+        # Suppress default request logging so the test output stays clean.
+        return
+
+    def _read_body(self) -> bytes:
+        length = int(self.headers.get("Content-Length") or 0)
+        if length <= 0:
+            return b""
+        return self.rfile.read(length)
+
+    def _send_json(self, code: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802 - http.server contract
+        if self.path == "/requests":
+            with REQ_LOCK:
+                snapshot = list(REQUESTS)
+            self._send_json(200, {"requests": snapshot})
+            return
+        if self.path == "/health":
+            self._send_json(200, {"ok": True})
+            return
+        self._send_json(404, {"error": "not_found", "path": self.path})
+
+    def do_POST(self):  # noqa: N802 - http.server contract
+        global FAIL_ONCE_FIRED
+
+        if self.path == "/reset":
+            with REQ_LOCK:
+                REQUESTS.clear()
+            FAIL_ONCE_FIRED = False
+            self._send_json(200, {"reset": True})
+            return
+
+        if self.path == "/v1/ingest":
+            raw_body = self._read_body()
+            try:
+                body_json = json.loads(raw_body.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                body_json = None
+
+            record = {
+                "method": "POST",
+                "path": self.path,
+                "headers": {k: v for k, v in self.headers.items()},
+                "authorization": self.headers.get("Authorization"),
+                "content_type": self.headers.get("Content-Type"),
+                "body_json": body_json,
+                "body_raw": raw_body.decode("utf-8", errors="replace"),
+            }
+            with REQ_LOCK:
+                REQUESTS.append(record)
+
+            if FAIL_WITH is not None:
+                self._send_json(
+                    FAIL_WITH,
+                    {"error": "mock_failure", "code": FAIL_WITH},
+                )
+                return
+
+            if FAIL_ONCE is not None and not FAIL_ONCE_FIRED:
+                FAIL_ONCE_FIRED = True
+                self._send_json(
+                    FAIL_ONCE,
+                    {"error": "mock_fail_once", "code": FAIL_ONCE},
+                )
+                return
+
+            self._send_json(200, {"ok": True})
+            return
+
+        self._send_json(404, {"error": "not_found", "path": self.path})
+
+
+def main(argv: list[str]) -> int:
+    global FAIL_WITH, FAIL_ONCE
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("--pidfile", default=None)
+    parser.add_argument("--port-file", default=None)
+    parser.add_argument("--fail-with", type=int, default=None,
+                        help="Return this HTTP code for EVERY POST /v1/ingest.")
+    parser.add_argument("--fail-once", type=int, default=None,
+                        help="Return this HTTP code for the FIRST POST, then 200 for all subsequent POSTs (resets on /reset).")
+    args = parser.parse_args(argv)
+
+    FAIL_WITH = args.fail_with
+    FAIL_ONCE = args.fail_once
+
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    actual_port = server.server_address[1]
+
+    if args.pidfile:
+        with open(args.pidfile, "w", encoding="utf-8") as fh:
+            fh.write(str(os.getpid()))
+    if args.port_file:
+        with open(args.port_file, "w", encoding="utf-8") as fh:
+            fh.write(str(actual_port))
+
+    sys.stderr.write(f"webhook-mock listening on 127.0.0.1:{actual_port}\n")
+    sys.stderr.flush()
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/modules/autoheal/tests/test-cross-clone-lock-concurrent.sh
+++ b/modules/autoheal/tests/test-cross-clone-lock-concurrent.sh
@@ -1,4 +1,40 @@
 #!/usr/bin/env bash
-# Stub: this test belongs to a later epic; content TBD. See plan.md §5
-# for the owning epic and the assertion list.
-exit 0
+# test-cross-clone-lock-concurrent.sh
+#
+# Epic 12 cross-clone concurrency check.
+#
+# The substantive 4-writer concurrent fcntl.flock test for
+# hook_utils.file_locked_append is owned by Epic 1 and lives at:
+#
+#     modules/hooks/tests/test-cross-clone-file-lock.sh
+#
+# That test verifies the union/no-loss/no-tear properties at the
+# function level — and every autoheal hook that appends JSONL
+# (permission-event-logger.py, failure-logger.py, user-correction-detector.py)
+# and every analyzer-side append (bin/autoheal-analyze.sh's
+# append_jsonl helper) routes through the SAME shape (or directly
+# calls hook_utils.file_locked_append). Duplicating that test in
+# autoheal/ would be redundant: the contract is enforced at the
+# helper level, not at each call site.
+#
+# This script therefore delegates to the canonical test. It exists
+# as a stub so the autoheal/run-all.sh aggregator and the Epic 12
+# acceptance criteria still find a `test-cross-clone-lock-concurrent.sh`
+# in the autoheal tests directory, and so that anyone scanning the
+# autoheal test list sees the cross-clone concurrency check is
+# accounted for.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+CANONICAL_TEST="${REPO_ROOT}/modules/hooks/tests/test-cross-clone-file-lock.sh"
+
+if [ ! -f "${CANONICAL_TEST}" ]; then
+    echo "FAIL: canonical cross-clone file-lock test missing at ${CANONICAL_TEST}"
+    echo "      Epic 12 relies on Epic 1's file_locked_append being tested."
+    exit 1
+fi
+
+echo "Delegating to canonical test: ${CANONICAL_TEST}"
+exec bash "${CANONICAL_TEST}"

--- a/modules/autoheal/tests/test-platform-seam.sh
+++ b/modules/autoheal/tests/test-platform-seam.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Platform-seam test from autoheal's perspective.
+#
+# Most of the platform-abstraction work landed in Epic 1
+# (`modules/hooks/lib/sched_platform.py`), and the authoritative test is
+# `modules/hooks/tests/test-platform.sh` which already covers:
+#   - macOS install/uninstall round-trip
+#   - list_scheduled_jobs reflects file state
+#   - Linux raises NotImplementedError with the "v2 plug-in" message
+#   - Unsupported OSes raise
+#   - hour/minute validation
+#
+# Per plan.md §3.11 (Linux portability seams), the contract is "Linux is a v2
+# plug-in point." This autoheal-side test confirms that autoheal-install.sh
+# refuses to proceed on Linux with a clean error (it depends on sched_platform).
+# When v2 lands and the Linux path is implemented, this test will need updating.
+#
+# Run: bash modules/autoheal/tests/test-platform-seam.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${MODULE_ROOT}/../.." && pwd)"
+HOOKS_LIB="${REPO_ROOT}/modules/hooks/lib"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_true() {
+    if [ "$1" = "True" ] || [ "$1" = "true" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: $2 (got $1)"
+    fi
+}
+
+# 1. sched_platform module loads successfully via the install path.
+out=$(PYTHONPATH="${HOOKS_LIB}" python3 -c "
+import sched_platform
+print(hasattr(sched_platform, 'install_scheduled_job'))
+print(hasattr(sched_platform, 'uninstall_scheduled_job'))
+print(hasattr(sched_platform, 'list_scheduled_jobs'))
+")
+assert_true "$(echo "${out}" | sed -n 1p)" "install_scheduled_job is exported"
+assert_true "$(echo "${out}" | sed -n 2p)" "uninstall_scheduled_job is exported"
+assert_true "$(echo "${out}" | sed -n 3p)" "list_scheduled_jobs is exported"
+
+# 2. Linux path raises NotImplementedError with the documented "v2" message.
+out=$(PYTHONPATH="${HOOKS_LIB}" python3 -c "
+import sched_platform
+sched_platform._platform.system = lambda: 'Linux'
+try:
+    sched_platform.install_scheduled_job('test.label', 'echo hi', 12, 0)
+    print('SHOULD_HAVE_RAISED')
+except NotImplementedError as e:
+    msg = str(e)
+    print('v2 plug-in point' in msg)
+    print('sched_platform.py' in msg)
+")
+assert_true "$(echo "${out}" | sed -n 1p)" "Linux raises with 'v2 plug-in point' message"
+assert_true "$(echo "${out}" | sed -n 2p)" "Linux message references the actual file name (sched_platform)"
+
+# 3. autoheal-install.sh detects the platform via sched_platform and refuses
+#    on Linux with a clean exit (does NOT crash with a traceback).
+INSTALLER="${MODULE_ROOT}/bin/autoheal-install.sh"
+if [ -x "${INSTALLER}" ]; then
+    # We cannot actually invoke the installer end-to-end here — it has side
+    # effects (writes to ~/.claude/autoheal/, modifies launchd). What we CAN
+    # verify is that it imports sched_platform (not the stdlib platform).
+    if grep -q "sched_platform" "${INSTALLER}"; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: autoheal-install.sh does not reference sched_platform"
+    fi
+else
+    echo "SKIP: autoheal-install.sh missing or not executable"
+fi
+
+# 4. The Linux cron stub template exists (per §3.11 — file present but unused).
+CRON_TEMPLATE="${MODULE_ROOT}/lib/autoheal.cron.template"
+if [ -f "${CRON_TEMPLATE}" ]; then
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: lib/autoheal.cron.template missing"
+fi
+
+echo ""
+echo "test-platform-seam.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0

--- a/modules/autoheal/tests/test-repo-config-merge.sh
+++ b/modules/autoheal/tests/test-repo-config-merge.sh
@@ -1,4 +1,178 @@
 #!/usr/bin/env bash
-# Stub: this test belongs to a later epic; content TBD. See plan.md §5
-# for the owning epic and the assertion list.
+# test-repo-config-merge.sh
+#
+# Verifies hook_utils.load_repo_config() (Epic 1) when invoked from the
+# autoheal side (Epic 12).
+#
+# Properties exercised:
+#   - Walks upward from a nested subdir to the first .autoheal/config.json
+#   - Returns the parsed dict verbatim (additional_allow_patterns kept)
+#   - Missing config → returns {}
+#   - Malformed config → returns {} (analyzer must not crash on user
+#     JSON typos in a per-repo override)
+#   - The repo-config-schema.json declares additionalProperties:false,
+#     so an attempt to inject a top-level field that COULD widen security
+#     (e.g. a phantom "allow_remove_deny_patterns") is documented as
+#     out-of-schema. The runtime helper preserves unknown keys
+#     (forward-compat) — but downstream consumers only read documented
+#     fields, which is the actual security boundary.
+#
+# Run: bash modules/autoheal/tests/test-repo-config-merge.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${MODULE_ROOT}/../.." && pwd)"
+HOOK_LIB="${REPO_ROOT}/modules/hooks/lib"
+SCHEMA_PATH="${MODULE_ROOT}/lib/repo-config-schema.json"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+if [ ! -f "${HOOK_LIB}/hook_utils.py" ]; then
+    echo "FATAL: hook_utils.py missing at ${HOOK_LIB}"
+    exit 1
+fi
+if [ ! -f "${SCHEMA_PATH}" ]; then
+    echo "FATAL: repo-config-schema.json missing at ${SCHEMA_PATH}"
+    exit 1
+fi
+
+TMP=$(mktemp -d -t repo_cfg_test.XXXXXX)
+trap 'rm -rf "${TMP}"' EXIT
+
+# Build a fake repo tree with a nested cwd far below the .autoheal dir.
+REPO="${TMP}/fake-repo"
+NESTED="${REPO}/src/server/api"
+mkdir -p "${NESTED}"
+mkdir -p "${REPO}/.autoheal"
+
+# A typical per-repo override: additional_allow_patterns + a kind filter
+# + a thresholds bump. This matches the Supabase fixture intent
+# documented in plan.md §3.4.
+cat > "${REPO}/.autoheal/config.json" <<'JSON'
+{
+  "additional_allow_patterns": ["Bash(supabase:*)", "Bash(wrangler:*)"],
+  "calibration_days": 7,
+  "thresholds": {"confidence_min": 6, "occurrence_min": 3},
+  "kind_filters": ["settings_allow_add"]
+}
+JSON
+
+# ---------------------------------------------------------------------------
+# 1. Walk from nested cwd → returns the dict verbatim.
+# ---------------------------------------------------------------------------
+
+result_json="$(CCGM_TEST_CWD="${NESTED}" PYTHONPATH="${HOOK_LIB}" python3 - <<'PY'
+import json, os
+import hook_utils
+cfg = hook_utils.load_repo_config(os.environ["CCGM_TEST_CWD"])
+print(json.dumps(cfg, sort_keys=True))
+PY
+)"
+
+# Field-by-field assertions on the result.
+n_allow="$(printf '%s' "${result_json}" | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("additional_allow_patterns", [])))')"
+assert_eq "${n_allow}" "2" "additional_allow_patterns list length"
+
+first_pat="$(printf '%s' "${result_json}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["additional_allow_patterns"][0])')"
+assert_eq "${first_pat}" "Bash(supabase:*)" "additional_allow_patterns[0] preserved"
+
+second_pat="$(printf '%s' "${result_json}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["additional_allow_patterns"][1])')"
+assert_eq "${second_pat}" "Bash(wrangler:*)" "additional_allow_patterns[1] preserved"
+
+cal_days="$(printf '%s' "${result_json}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["calibration_days"])')"
+assert_eq "${cal_days}" "7" "calibration_days passed through"
+
+conf_min="$(printf '%s' "${result_json}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["thresholds"]["confidence_min"])')"
+assert_eq "${conf_min}" "6" "thresholds.confidence_min passed through"
+
+occ_min="$(printf '%s' "${result_json}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["thresholds"]["occurrence_min"])')"
+assert_eq "${occ_min}" "3" "thresholds.occurrence_min passed through"
+
+n_kinds="$(printf '%s' "${result_json}" | python3 -c 'import sys,json; print(len(json.load(sys.stdin)["kind_filters"]))')"
+assert_eq "${n_kinds}" "1" "kind_filters list length"
+
+first_kind="$(printf '%s' "${result_json}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["kind_filters"][0])')"
+assert_eq "${first_kind}" "settings_allow_add" "kind_filters[0] preserved"
+
+# ---------------------------------------------------------------------------
+# 2. Missing config → {} . Use a sibling subtree with no .autoheal.
+# ---------------------------------------------------------------------------
+
+OTHER="${TMP}/other-repo/src"
+mkdir -p "${OTHER}"
+result_empty="$(CCGM_TEST_CWD="${OTHER}" PYTHONPATH="${HOOK_LIB}" python3 - <<'PY'
+import json, os
+import hook_utils
+print(json.dumps(hook_utils.load_repo_config(os.environ["CCGM_TEST_CWD"])))
+PY
+)"
+assert_eq "${result_empty}" "{}" "missing config returns {}"
+
+# ---------------------------------------------------------------------------
+# 3. Malformed JSON → {} (must not raise).
+# ---------------------------------------------------------------------------
+
+BAD="${TMP}/bad-repo"
+mkdir -p "${BAD}/.autoheal" "${BAD}/src"
+echo '{ "additional_allow_patterns": [ "Bash(broken' > "${BAD}/.autoheal/config.json"
+
+result_bad="$(CCGM_TEST_CWD="${BAD}/src" PYTHONPATH="${HOOK_LIB}" python3 - <<'PY'
+import json, os
+import hook_utils
+print(json.dumps(hook_utils.load_repo_config(os.environ["CCGM_TEST_CWD"])))
+PY
+)"
+assert_eq "${result_bad}" "{}" "malformed config returns {}"
+
+# ---------------------------------------------------------------------------
+# 4. Schema sanity check (Epic 12): the schema is valid JSON and exposes
+# the documented top-level fields. We don't fail if jsonschema isn't
+# installed; that's a soft check.
+# ---------------------------------------------------------------------------
+
+schema_ok="$(SCHEMA_PATH="${SCHEMA_PATH}" python3 - <<'PY'
+import json, os, sys
+with open(os.environ["SCHEMA_PATH"]) as fh:
+    s = json.load(fh)
+required_props = {
+    "additional_allow_patterns",
+    "calibration_days",
+    "thresholds",
+    "kind_filters",
+}
+props = set((s.get("properties") or {}).keys())
+missing = required_props - props
+if missing:
+    print(f"missing-props:{sorted(missing)}")
+    sys.exit(1)
+# additionalProperties must be False so an attacker can't sneak in a
+# deny-removal field. plan.md §R21.
+if s.get("additionalProperties") is not False:
+    print("additionalProperties-not-false")
+    sys.exit(1)
+print("ok")
+PY
+)"
+assert_eq "${schema_ok}" "ok" "repo-config-schema.json sanity"
+
+echo ""
+echo "test-repo-config-merge.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
 exit 0

--- a/modules/autoheal/tests/test-retention-sweep.sh
+++ b/modules/autoheal/tests/test-retention-sweep.sh
@@ -1,4 +1,195 @@
 #!/usr/bin/env bash
-# Stub: this test belongs to a later epic; content TBD. See plan.md §5
-# for the owning epic and the assertion list.
+# test-retention-sweep.sh
+#
+# Verifies bin/autoheal-retention.sh (plan.md §1.3, §5 Epic 12 +
+# acceptance criterion "Retention sweep is idempotent").
+#
+# Fixture: three files at three age boundaries.
+#   - 15 days old  → must remain untouched (younger than gzip_days=30)
+#   - 45 days old  → must be gzipped (between gzip_days and delete_days)
+#   - 75 days old  → must be deleted (older than delete_days=60)
+#
+# Idempotency: running the sweep a second time must produce no errors
+# and no further changes to the on-disk state.
+#
+# Run: bash modules/autoheal/tests/test-retention-sweep.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RETENTION_SCRIPT="${MODULE_ROOT}/bin/autoheal-retention.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_exists() {
+    if [ -e "$1" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: $2"
+        echo "  missing path: $1"
+    fi
+}
+
+assert_absent() {
+    if [ ! -e "$1" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: $2"
+        echo "  unexpected path: $1"
+    fi
+}
+
+if [ ! -f "${RETENTION_SCRIPT}" ]; then
+    echo "FATAL: retention script missing at ${RETENTION_SCRIPT}"
+    exit 1
+fi
+
+TMP=$(mktemp -d -t retention_test.XXXXXX)
+trap 'rm -rf "${TMP}"' EXIT
+
+AUTOHEAL_DIR="${TMP}/autoheal"
+mkdir -p "${AUTOHEAL_DIR}/events" \
+         "${AUTOHEAL_DIR}/proposals" \
+         "${AUTOHEAL_DIR}/digests" \
+         "${AUTOHEAL_DIR}/applied" \
+         "${AUTOHEAL_DIR}/sent"
+
+# touch -t expects [[CC]YY]MMDDhhmm[.ss]. We compute three dates relative
+# to today via python so the test is calendar-correct (handles month
+# rollovers etc.).
+dates_json="$(python3 - <<'PY'
+import datetime, json
+today = datetime.date.today()
+out = {
+    "d15": (today - datetime.timedelta(days=15)).strftime("%Y%m%d0000"),
+    "d45": (today - datetime.timedelta(days=45)).strftime("%Y%m%d0000"),
+    "d75": (today - datetime.timedelta(days=75)).strftime("%Y%m%d0000"),
+    "iso15": (today - datetime.timedelta(days=15)).isoformat(),
+    "iso45": (today - datetime.timedelta(days=45)).isoformat(),
+    "iso75": (today - datetime.timedelta(days=75)).isoformat(),
+}
+print(json.dumps(out))
+PY
+)"
+
+D15="$(printf '%s' "${dates_json}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["d15"])')"
+D45="$(printf '%s' "${dates_json}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["d45"])')"
+D75="$(printf '%s' "${dates_json}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["d75"])')"
+ISO15="$(printf '%s' "${dates_json}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["iso15"])')"
+ISO45="$(printf '%s' "${dates_json}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["iso45"])')"
+ISO75="$(printf '%s' "${dates_json}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["iso75"])')"
+
+# Create fixture files across multiple subdirs so we exercise each one.
+F_KEEP="${AUTOHEAL_DIR}/events/${ISO15}.jsonl"
+F_GZIP_EVENTS="${AUTOHEAL_DIR}/events/${ISO45}.jsonl"
+F_GZIP_PROPS="${AUTOHEAL_DIR}/proposals/${ISO45}.jsonl"
+F_DELETE_DIGEST="${AUTOHEAL_DIR}/digests/${ISO75}.md"
+F_DELETE_APPLIED="${AUTOHEAL_DIR}/applied/${ISO75}.jsonl"
+
+echo '{"id":"e1","ts":"x"}' > "${F_KEEP}"
+echo '{"id":"e2","ts":"x"}' > "${F_GZIP_EVENTS}"
+echo '{"id":"p1","ts":"x"}' > "${F_GZIP_PROPS}"
+echo '# digest' > "${F_DELETE_DIGEST}"
+echo '{"id":"a1","ts":"x"}' > "${F_DELETE_APPLIED}"
+
+# Backdate the file mtimes to the fixture ages.
+touch -t "${D15}" "${F_KEEP}"
+touch -t "${D45}" "${F_GZIP_EVENTS}" "${F_GZIP_PROPS}"
+touch -t "${D75}" "${F_DELETE_DIGEST}" "${F_DELETE_APPLIED}"
+
+# The deletion-phase files must START as .gz to exercise the delete
+# branch (the sweep only deletes *.gz, not raw .jsonl). Gzip them
+# without changing the mtime (gzip -n keeps the original-name field
+# blank; -f overrides any existing .gz; touching after gzip preserves
+# the fixture's age).
+gzip -nf "${F_DELETE_DIGEST}" "${F_DELETE_APPLIED}"
+touch -t "${D75}" "${F_DELETE_DIGEST}.gz" "${F_DELETE_APPLIED}.gz"
+
+# Verify the fixture is in the expected starting shape.
+assert_exists "${F_KEEP}"                "fixture: keep file exists"
+assert_exists "${F_GZIP_EVENTS}"         "fixture: events gzip candidate exists"
+assert_exists "${F_GZIP_PROPS}"          "fixture: proposals gzip candidate exists"
+assert_exists "${F_DELETE_DIGEST}.gz"    "fixture: digest delete candidate exists (.gz)"
+assert_exists "${F_DELETE_APPLIED}.gz"   "fixture: applied delete candidate exists (.gz)"
+
+# ---------------------------------------------------------------------------
+# Run 1: should gzip the 45-day files and delete the 75-day .gz files.
+# ---------------------------------------------------------------------------
+
+CCGM_AUTOHEAL_DIR="${AUTOHEAL_DIR}" \
+CCGM_AUTOHEAL_RETENTION_GZIP="30" \
+CCGM_AUTOHEAL_RETENTION_DELETE="60" \
+    bash "${RETENTION_SCRIPT}" >"${TMP}/run1.out" 2>"${TMP}/run1.err"
+rc=$?
+assert_eq "${rc}" "0" "run1: exit code 0"
+
+# 15-day file untouched (still raw).
+assert_exists "${F_KEEP}"                "run1: 15-day file untouched"
+assert_absent "${F_KEEP}.gz"             "run1: 15-day file NOT gzipped"
+
+# 45-day files now gzipped.
+assert_absent "${F_GZIP_EVENTS}"         "run1: 45-day events raw gone"
+assert_exists "${F_GZIP_EVENTS}.gz"      "run1: 45-day events now .gz"
+assert_absent "${F_GZIP_PROPS}"          "run1: 45-day proposals raw gone"
+assert_exists "${F_GZIP_PROPS}.gz"       "run1: 45-day proposals now .gz"
+
+# 75-day .gz files deleted.
+assert_absent "${F_DELETE_DIGEST}.gz"    "run1: 75-day digest deleted"
+assert_absent "${F_DELETE_APPLIED}.gz"   "run1: 75-day applied deleted"
+
+# ---------------------------------------------------------------------------
+# Run 2: idempotency. Same state in → same state out, no errors.
+# ---------------------------------------------------------------------------
+
+# Snapshot the file tree before run 2.
+SNAP_BEFORE="$(find "${AUTOHEAL_DIR}" -type f | sort)"
+
+CCGM_AUTOHEAL_DIR="${AUTOHEAL_DIR}" \
+CCGM_AUTOHEAL_RETENTION_GZIP="30" \
+CCGM_AUTOHEAL_RETENTION_DELETE="60" \
+    bash "${RETENTION_SCRIPT}" >"${TMP}/run2.out" 2>"${TMP}/run2.err"
+rc=$?
+assert_eq "${rc}" "0" "run2: exit code 0 (idempotent)"
+
+SNAP_AFTER="$(find "${AUTOHEAL_DIR}" -type f | sort)"
+
+if [ "${SNAP_BEFORE}" = "${SNAP_AFTER}" ]; then
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: run2: idempotent (file tree changed on second run)"
+    diff <(printf '%s\n' "${SNAP_BEFORE}") <(printf '%s\n' "${SNAP_AFTER}") | sed 's/^/    /' || true
+fi
+
+# stderr from run 2 must not contain any "failed" tokens (we're checking
+# that idempotency does not generate noise).
+if grep -qi 'failed' "${TMP}/run2.err"; then
+    FAIL=$((FAIL + 1))
+    echo "FAIL: run2: stderr contains 'failed' tokens"
+    sed 's/^/    /' "${TMP}/run2.err"
+else
+    PASS=$((PASS + 1))
+fi
+
+echo ""
+echo "test-retention-sweep.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
 exit 0

--- a/modules/autoheal/tests/test-webhook-publisher.sh
+++ b/modules/autoheal/tests/test-webhook-publisher.sh
@@ -1,4 +1,427 @@
 #!/usr/bin/env bash
-# Stub: this test belongs to a later epic; content TBD. See plan.md §5
-# for the owning epic and the assertion list.
+# test-webhook-publisher.sh
+#
+# Verifies bin/autoheal-publish.sh (plan.md §3.10, §5 Epic 12).
+#
+# Properties exercised:
+#   1. webhook_url null → no HTTP requests; stderr says "webhook disabled"
+#   2. webhook_url set → POSTs proposals/events to ${url}/v1/ingest with
+#      Authorization: Bearer ${webhook_token}; envelope shape correct
+#      (kind, ts, session_id, machine_id, data)
+#   3. 500 response → cursor NOT advanced; publish log written; exit 0
+#   4. 2xx after retry → cursor advances; idempotent re-run produces no
+#      additional POSTs
+#
+# Local mock server only (modules/autoheal/tests/fixtures/webhook-server-mock.py).
+# No real network.
+#
+# Run: bash modules/autoheal/tests/test-webhook-publisher.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PUBLISH_SCRIPT="${MODULE_ROOT}/bin/autoheal-publish.sh"
+MOCK_SERVER="${MODULE_ROOT}/tests/fixtures/webhook-server-mock.py"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  expected substring: ${needle}"
+            echo "  actual (first 400): $(printf '%s' "${haystack}" | head -c 400)"
+            ;;
+    esac
+}
+
+assert_file_exists() {
+    if [ -f "$1" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: $2"
+        echo "  expected file: $1"
+    fi
+}
+
+assert_file_absent() {
+    if [ ! -e "$1" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: $2"
+        echo "  unexpected path: $1"
+    fi
+}
+
+if [ ! -f "${PUBLISH_SCRIPT}" ]; then
+    echo "FATAL: publish script missing at ${PUBLISH_SCRIPT}"
+    exit 1
+fi
+if [ ! -f "${MOCK_SERVER}" ]; then
+    echo "FATAL: mock server missing at ${MOCK_SERVER}"
+    exit 1
+fi
+for tool in jq python3 curl; do
+    if ! command -v "${tool}" >/dev/null 2>&1; then
+        echo "FATAL: ${tool} required on PATH"
+        exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Mock server lifecycle
+# ---------------------------------------------------------------------------
+
+TMPROOT="$(mktemp -d -t autoheal-publish.XXXXXX)"
+MOCK_PIDFILE="${TMPROOT}/mock.pid"
+MOCK_PORTFILE="${TMPROOT}/mock.port"
+
+cleanup() {
+    for pf in "${MOCK_PIDFILE}"; do
+        if [ -f "${pf}" ]; then
+            mock_pid="$(cat "${pf}" 2>/dev/null || echo "")"
+            if [ -n "${mock_pid}" ]; then
+                kill "${mock_pid}" 2>/dev/null || true
+            fi
+        fi
+    done
+    rm -rf "${TMPROOT}"
+}
+trap cleanup EXIT
+
+start_mock() {
+    rm -f "${MOCK_PIDFILE}" "${MOCK_PORTFILE}"
+    python3 "${MOCK_SERVER}" \
+        --port 0 \
+        --pidfile "${MOCK_PIDFILE}" \
+        --port-file "${MOCK_PORTFILE}" \
+        "$@" \
+        >/dev/null 2>&1 &
+    local i=0
+    while [ ${i} -lt 60 ]; do
+        if [ -s "${MOCK_PORTFILE}" ]; then
+            return 0
+        fi
+        sleep 0.05
+        i=$((i + 1))
+    done
+    echo "FATAL: mock server did not write port file"
+    return 1
+}
+
+stop_mock() {
+    if [ -f "${MOCK_PIDFILE}" ]; then
+        kill "$(cat "${MOCK_PIDFILE}")" 2>/dev/null || true
+        rm -f "${MOCK_PIDFILE}" "${MOCK_PORTFILE}"
+    fi
+}
+
+reset_mock() {
+    curl -sS -X POST "http://127.0.0.1:${MOCK_PORT}/reset" >/dev/null
+}
+
+mock_requests() {
+    curl -sS "http://127.0.0.1:${MOCK_PORT}/requests"
+}
+
+# ---------------------------------------------------------------------------
+# Fixture: today's proposals + events. Two of each.
+# ---------------------------------------------------------------------------
+
+TODAY="2026-05-18"
+AUTOHEAL_DIR="${TMPROOT}/autoheal"
+mkdir -p "${AUTOHEAL_DIR}/proposals" \
+         "${AUTOHEAL_DIR}/events" \
+         "${AUTOHEAL_DIR}/digests" \
+         "${AUTOHEAL_DIR}/published" \
+         "${TMPROOT}/logs"
+
+PROPOSAL_FILE="${AUTOHEAL_DIR}/proposals/${TODAY}.jsonl"
+EVENT_FILE="${AUTOHEAL_DIR}/events/${TODAY}.jsonl"
+
+jq -nc \
+    '{id:"prop_001",kind:"settings_allow_add",title:"Allow t1",rationale:"r1",
+      confidence:7,breadth_score:2,occurrence_count:3,session_ids:["s1","s2"],
+      proposed_diff_target:"modules/settings/settings.partial.json",
+      proposed_diff:"+ allow",fingerprint:"sha256-a",originating_clone:"test",
+      generated_at:"2026-05-18T07:00:00Z"}' > "${PROPOSAL_FILE}"
+jq -nc \
+    '{id:"prop_002",kind:"settings_allow_add",title:"Allow t2",rationale:"r2",
+      confidence:8,breadth_score:1,occurrence_count:4,session_ids:["s3"],
+      proposed_diff_target:"modules/settings/settings.partial.json",
+      proposed_diff:"+ allow2",fingerprint:"sha256-b",originating_clone:"test",
+      generated_at:"2026-05-18T07:30:00Z"}' >> "${PROPOSAL_FILE}"
+
+jq -nc \
+    '{id:"evt_001",kind:"tool_use",timestamp:"2026-05-18T08:00:00Z",
+      session_id:"s1",tool_name:"Bash",redacted_command:"git status",cwd:"/tmp"}' > "${EVENT_FILE}"
+jq -nc \
+    '{id:"evt_002",kind:"tool_failure",timestamp:"2026-05-18T08:05:00Z",
+      session_id:"s1",tool_name:"Bash",redacted_command:"git push",cwd:"/tmp"}' >> "${EVENT_FILE}"
+
+# Config with a fixed token so we can assert the Authorization header.
+TOKEN="test-token-deadbeef"
+CONFIG_FILE="${AUTOHEAL_DIR}/config.json"
+make_config() {
+    local url="$1"
+    if [ -z "${url}" ] || [ "${url}" = "null" ]; then
+        jq -n --arg token "${TOKEN}" \
+            '{webhook_url:null, webhook_token:$token,
+              webhook_kinds:["proposal","event","digest"], webhook_max_per_run:100}' \
+            > "${CONFIG_FILE}"
+    else
+        jq -n --arg token "${TOKEN}" --arg url "${url}" \
+            '{webhook_url:$url, webhook_token:$token,
+              webhook_kinds:["proposal","event","digest"], webhook_max_per_run:100}' \
+            > "${CONFIG_FILE}"
+    fi
+}
+
+run_publish() {
+    set +e
+    CCGM_AUTOHEAL_DIR="${AUTOHEAL_DIR}" \
+    CCGM_AUTOHEAL_CONFIG="${CONFIG_FILE}" \
+    CCGM_AUTOHEAL_LOGS_DIR="${TMPROOT}/logs" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    CCGM_AUTOHEAL_MACHINE_ID="test-host-001" \
+        bash "${PUBLISH_SCRIPT}" >"${TMPROOT}/out" 2>"${TMPROOT}/err"
+    local rc=$?
+    set -e
+    echo "${rc}"
+}
+
+# ===========================================================================
+# Test 1: webhook_url null → no requests, stderr message, exit 0.
+# ===========================================================================
+
+make_config ""
+rc=$(run_publish)
+assert_eq "${rc}" "0" "test1: rc=0 when webhook_url is null"
+
+stderr1="$(cat "${TMPROOT}/err")"
+assert_contains "${stderr1}" "webhook disabled" "test1: stderr says 'webhook disabled'"
+
+# Cursor must not exist.
+assert_file_absent "${AUTOHEAL_DIR}/published/${TODAY}.last" "test1: no cursor created"
+
+# Publish log must not exist (we never tried to POST).
+assert_file_absent "${TMPROOT}/logs/autoheal-publish-${TODAY}.log" "test1: no publish log when disabled"
+
+# ===========================================================================
+# Test 2: webhook_url set → POSTs all records; cursor advances.
+# ===========================================================================
+
+start_mock || exit 1
+MOCK_PORT="$(cat "${MOCK_PORTFILE}")"
+MOCK_BASE_URL="http://127.0.0.1:${MOCK_PORT}"
+reset_mock
+
+make_config "${MOCK_BASE_URL}"
+rc=$(run_publish)
+assert_eq "${rc}" "0" "test2: rc=0 when webhook enabled and mock returns 200"
+
+REQS="$(mock_requests)"
+N="$(printf '%s' "${REQS}" | jq '.requests | length')"
+# 2 proposals + 2 events + 0 digest (no digest file written) = 4
+assert_eq "${N}" "4" "test2: mock received 4 envelopes (2 proposals + 2 events)"
+
+# First request: proposal_001 with correct envelope shape.
+first_kind="$(printf '%s' "${REQS}" | jq -r '.requests[0].body_json.kind')"
+assert_eq "${first_kind}" "proposal" "test2: first envelope kind=proposal"
+
+first_machine="$(printf '%s' "${REQS}" | jq -r '.requests[0].body_json.machine_id')"
+assert_eq "${first_machine}" "test-host-001" "test2: first envelope machine_id propagated"
+
+first_session="$(printf '%s' "${REQS}" | jq -r '.requests[0].body_json.session_id')"
+# proposals don't carry session_id at the top level; expect empty string
+assert_eq "${first_session}" "" "test2: first envelope session_id (proposal has none)"
+
+first_data_id="$(printf '%s' "${REQS}" | jq -r '.requests[0].body_json.data.id')"
+assert_eq "${first_data_id}" "prop_001" "test2: first envelope data.id=prop_001"
+
+first_auth="$(printf '%s' "${REQS}" | jq -r '.requests[0].authorization')"
+assert_eq "${first_auth}" "Bearer ${TOKEN}" "test2: Authorization header sent"
+
+first_ct="$(printf '%s' "${REQS}" | jq -r '.requests[0].content_type')"
+assert_eq "${first_ct}" "application/json" "test2: Content-Type header sent"
+
+# Event envelopes appear after the two proposals; verify ordering.
+third_kind="$(printf '%s' "${REQS}" | jq -r '.requests[2].body_json.kind')"
+assert_eq "${third_kind}" "event" "test2: third envelope kind=event"
+
+third_data_id="$(printf '%s' "${REQS}" | jq -r '.requests[2].body_json.data.id')"
+assert_eq "${third_data_id}" "evt_001" "test2: third envelope data.id=evt_001"
+
+third_session="$(printf '%s' "${REQS}" | jq -r '.requests[2].body_json.session_id')"
+assert_eq "${third_session}" "s1" "test2: event envelope session_id propagated"
+
+# Cursor file written; both kinds advanced.
+CURSOR_FILE="${AUTOHEAL_DIR}/published/${TODAY}.last"
+assert_file_exists "${CURSOR_FILE}" "test2: cursor file created"
+cursor_proposal="$(awk '$1=="proposal" {print $2}' "${CURSOR_FILE}")"
+cursor_event="$(awk '$1=="event" {print $2}' "${CURSOR_FILE}")"
+assert_eq "${cursor_proposal}" "2" "test2: proposal cursor advanced to 2"
+assert_eq "${cursor_event}" "2" "test2: event cursor advanced to 2"
+
+# ===========================================================================
+# Test 2b: idempotent re-run — no additional POSTs since cursor is caught up.
+# ===========================================================================
+
+reset_mock
+rc=$(run_publish)
+assert_eq "${rc}" "0" "test2b: rc=0 on idempotent re-run"
+
+REQS_AFTER="$(mock_requests)"
+N_AFTER="$(printf '%s' "${REQS_AFTER}" | jq '.requests | length')"
+assert_eq "${N_AFTER}" "0" "test2b: idempotent rerun sends 0 envelopes"
+
+stop_mock
+
+# ===========================================================================
+# Test 3: 500 response → cursor unchanged for the failing kind, err log
+# written, exit 0 (no block).
+# ===========================================================================
+
+# Reset cursor file: simulate a fresh day where nothing has been published.
+rm -f "${AUTOHEAL_DIR}/published/${TODAY}.last"
+
+start_mock --fail-with 500 || exit 1
+MOCK_PORT="$(cat "${MOCK_PORTFILE}")"
+MOCK_BASE_URL="http://127.0.0.1:${MOCK_PORT}"
+reset_mock
+
+make_config "${MOCK_BASE_URL}"
+rc=$(run_publish)
+assert_eq "${rc}" "0" "test3: rc=0 even on 500 (failures non-fatal)"
+
+# Mock recorded one request per kind: each kind stops on its own first
+# failure (avoid DOSing a broken endpoint within a kind), but kinds are
+# processed independently. proposals → 1 attempt (500, stop), then
+# events → 1 attempt (500, stop). digest has no file → 0 attempts. = 2.
+REQS="$(mock_requests)"
+N="$(printf '%s' "${REQS}" | jq '.requests | length')"
+assert_eq "${N}" "2" "test3: mock recorded 2 requests (one per kind, each stopped)"
+
+# Cursor file should either be absent or contain proposal=0 / event=0.
+if [ -f "${AUTOHEAL_DIR}/published/${TODAY}.last" ]; then
+    cursor_proposal="$(awk 'BEGIN{n=0} $1=="proposal" {n=$2} END{print n+0}' "${AUTOHEAL_DIR}/published/${TODAY}.last")"
+    cursor_event="$(awk 'BEGIN{n=0} $1=="event" {n=$2} END{print n+0}' "${AUTOHEAL_DIR}/published/${TODAY}.last")"
+    assert_eq "${cursor_proposal:-0}" "0" "test3: proposal cursor stayed at 0"
+    assert_eq "${cursor_event:-0}" "0" "test3: event cursor stayed at 0"
+else
+    PASS=$((PASS + 2))
+fi
+
+# Publish log written with 500 + url.
+LOG_FILE="${TMPROOT}/logs/autoheal-publish-${TODAY}.log"
+assert_file_exists "${LOG_FILE}" "test3: publish log written"
+if [ -f "${LOG_FILE}" ]; then
+    log_body="$(cat "${LOG_FILE}")"
+    assert_contains "${log_body}" "500" "test3: log captures 500 status"
+    assert_contains "${log_body}" "/v1/ingest" "test3: log captures ingest URL"
+fi
+
+stop_mock
+
+# ===========================================================================
+# Test 4: 2xx after retry → cursor advances on retry; second run is a no-op.
+#
+# Scenario:
+#   - Attempt 1: mock returns 500 → proposal+event cursors stay at 0.
+#   - Attempt 2: mock now returns 200 → cursors advance to 2,2.
+#   - Attempt 3: idempotent → 0 POSTs.
+#
+# We model this by restarting the mock between attempts so attempt 1 has
+# fail-with 500 and attempt 2 is a clean (always-200) mock.
+# ===========================================================================
+
+# Fresh cursor for the new scenario.
+rm -f "${AUTOHEAL_DIR}/published/${TODAY}.last"
+rm -f "${TMPROOT}/logs/autoheal-publish-${TODAY}.log"
+
+start_mock --fail-with 500 || exit 1
+MOCK_PORT="$(cat "${MOCK_PORTFILE}")"
+MOCK_BASE_URL="http://127.0.0.1:${MOCK_PORT}"
+reset_mock
+
+make_config "${MOCK_BASE_URL}"
+
+# Attempt 1: all POSTs fail (500), each kind stops on its first attempt.
+rc=$(run_publish)
+assert_eq "${rc}" "0" "test4: attempt 1 rc=0 (all 500)"
+
+REQS="$(mock_requests)"
+N1="$(printf '%s' "${REQS}" | jq '.requests | length')"
+# Each kind stops on first failure: 1 proposal + 1 event = 2.
+assert_eq "${N1}" "2" "test4: attempt 1 sent 2 requests (1 per kind, all failed)"
+
+# Cursors: both should be 0 (or absent).
+cursor_proposal_a="$(awk 'BEGIN{n=0} $1=="proposal" {n=$2} END{print n+0}' "${AUTOHEAL_DIR}/published/${TODAY}.last" 2>/dev/null || echo 0)"
+cursor_event_a="$(awk 'BEGIN{n=0} $1=="event" {n=$2} END{print n+0}' "${AUTOHEAL_DIR}/published/${TODAY}.last" 2>/dev/null || echo 0)"
+assert_eq "${cursor_proposal_a}" "0" "test4: proposal cursor unchanged after attempt 1 (failure)"
+assert_eq "${cursor_event_a}" "0" "test4: event cursor unchanged after attempt 1 (failure)"
+
+# Stop the failing mock and start a healthy one on a new port for the
+# retry. We point the config at the new URL — this is the "operator
+# fixed the receiver" simulation.
+stop_mock
+start_mock || exit 1
+MOCK_PORT="$(cat "${MOCK_PORTFILE}")"
+MOCK_BASE_URL="http://127.0.0.1:${MOCK_PORT}"
+reset_mock
+make_config "${MOCK_BASE_URL}"
+
+# Attempt 2: mock now returns 200. Cursors should advance fully.
+rc=$(run_publish)
+assert_eq "${rc}" "0" "test4: attempt 2 rc=0 (healthy mock)"
+
+REQS="$(mock_requests)"
+N2="$(printf '%s' "${REQS}" | jq '.requests | length')"
+# Attempt 2 sends 2 proposals + 2 events (all from cursor=0). Total = 4.
+assert_eq "${N2}" "4" "test4: attempt 2 sent 4 records (catching up after failure)"
+
+cursor_proposal_b="$(awk 'BEGIN{n=0} $1=="proposal" {n=$2} END{print n+0}' "${AUTOHEAL_DIR}/published/${TODAY}.last")"
+cursor_event_b="$(awk 'BEGIN{n=0} $1=="event" {n=$2} END{print n+0}' "${AUTOHEAL_DIR}/published/${TODAY}.last")"
+assert_eq "${cursor_proposal_b}" "2" "test4: proposal cursor advanced after retry"
+assert_eq "${cursor_event_b}" "2" "test4: event cursor advanced after retry"
+
+# Attempt 3: full no-op (everything published). reset mock req log only.
+reset_mock
+rc=$(run_publish)
+assert_eq "${rc}" "0" "test4: attempt 3 rc=0"
+
+REQS="$(mock_requests)"
+N3="$(printf '%s' "${REQS}" | jq '.requests | length')"
+assert_eq "${N3}" "0" "test4: attempt 3 sends 0 (caught up)"
+
+stop_mock
+
+echo ""
+echo "test-webhook-publisher.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
 exit 0


### PR DESCRIPTION
## Summary

Wave 5 Epic 12 — robustness pack. Five hardening items: per-repo overrides schema, webhook publisher seam (future dev.lem.work integration), retention sweep, plus tests for cross-clone lock and platform seam coverage.

Closes #484.

## Files

- `lib/repo-config-schema.json` — JSON schema for per-repo `.autoheal/config.json`. `additionalProperties: false` enforces the R21 security boundary (no field can secretly mutate behavior). `additional_allow_patterns` is the only ADDITIVE mutating field — cannot REMOVE deny entries.
- `bin/autoheal-publish.sh` — webhook seam per plan §3.10. No-op when `webhook_url` is null. When set: TSV cursor at `~/.claude/autoheal/published/{today}.last`, envelope shape `{kind, ts, session_id, machine_id, data}` POSTed to `${url}/v1/ingest` with `Authorization: Bearer ${webhook_token}`. Cursor advances on 2xx; logs on 4xx/5xx; always exit 0; stops a kind on first failure (avoid DOSing a broken endpoint).
- `bin/autoheal-retention.sh` — idempotent two-phase sweep. Gzip raw files older than `retention_gzip_days` (default 30); delete `.gz` files older than `retention_delete_days` (default 60). Across `events/`, `proposals/`, `digests/`, `applied/`, `sent/`.

### Tests
- `tests/test-cross-clone-lock-concurrent.sh` — delegates to Epic 1's canonical 4-writer test under `modules/hooks/tests/test-cross-clone-file-lock.sh` (with header documenting why duplication would be redundant).
- `tests/test-repo-config-merge.sh` — 11 assertions. Walks `hook_utils.load_repo_config` from a nested cwd; covers field-by-field pass-through, missing config, malformed JSON, schema sanity (`additionalProperties:false`).
- `tests/test-retention-sweep.sh` — 17 assertions. Three age boundaries (15/45/75 days); verifies untouched/gzipped/deleted; idempotent re-run.
- `tests/test-webhook-publisher.sh` — 37 assertions. Local mock server only — no real network. Covers null url, full publish + envelope assertions, 500-failure preserves cursor, restart-and-retry advances cursor, idempotent re-run sends 0.
- `tests/fixtures/webhook-server-mock.py` — ThreadingHTTPServer with `/v1/ingest`, `/requests`, `/reset`, `--fail-with`, `--fail-once`. Modeled on `resend-mock-server.py` for shape consistency.

## Test plan

- [x] `bash modules/autoheal/tests/test-cross-clone-lock-concurrent.sh` → delegates to 6/6 in hooks module
- [x] `bash modules/autoheal/tests/test-repo-config-merge.sh` → 11 passed
- [x] `bash modules/autoheal/tests/test-retention-sweep.sh` → 17 passed
- [x] `bash modules/autoheal/tests/test-webhook-publisher.sh` → 37 passed
- [x] `bash modules/autoheal/tests/run-all.sh` → all autoheal scripts pass
- [x] `bash tests/test-modules.sh` → 1182 passed
- [x] `bash tests/test-no-personal-data.sh` → PASS

## Implementer-flagged concerns (DONE_WITH_CONCERNS, accepted as follow-up)

Two non-fatal observations on JSONL-write helpers (not fixed per spec instruction to flag-not-fix):

1. **`bin/autoheal-analyze.sh:681-700`** — `log_rejection()` and `append_cost()` use plain `open(path, "a")` without fcntl.flock. These are per-clone rejection log + tsv cost ledger, not cross-clone JSONL, but two clones running `autoheal-analyze.sh` concurrently could interleave writes. Low-risk because the analyzer is daily (single-fire). The proposal-append helper at line 660 (`append_jsonl`) IS correctly locked.
2. **`hooks/post-prompt-introspect.py:159`** — `_mark_seen()` writes session-dedup signatures with plain `open(path, "a")`. Session-local file (one file per session id), so cross-clone is moot, but worth noting.

Will file a small follow-up issue.

Webhook publisher seam is INERT until `webhook_url` is set in config — the future `dev.lem.work` agent only needs to deploy a `/v1/ingest` endpoint and tell the user the URL+token.
