### PR TITLE
#504: docupdate — add autoheal coverage to docs/

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -739,6 +739,84 @@ Synthesizes what shipped in a time window by walking the git log, surfacing hots
 
 ---
 
+## Autoheal commands
+
+Installed by the **autoheal** module. The autoheal pipeline observes hook events, runs a daily transcript analyzer, and surfaces actionable proposals through these commands.
+
+---
+
+### /autoheal
+
+**Help / overview for the autoheal pipeline.**
+
+Lists every autoheal subcommand, the config flags (`realtime_alerts_enabled`, `auto_apply_enabled`, `email_enabled`, `webhook_url`), and the default-OFF posture for the three opt-in surfaces (real-time alerts, auto-apply, webhook publisher).
+
+**Installed by**: autoheal module
+
+---
+
+### /autoheal-digest
+
+**Render today's autoheal digest (or one from a past date).**
+
+Reads `~/.claude/autoheal/digests/{date}.md` rendered by `autoheal-digest.sh` from that day's proposals (capped at 5 per day; backfill summary lists unemailed past days). Secrets in proposal rationale are redacted via the 17-pattern set before render.
+
+**Usage**: `/autoheal-digest` (today) or `/autoheal-digest 2026-05-18`.
+
+**Installed by**: autoheal module
+
+---
+
+### /autoheal-toggle
+
+**Flip an autoheal config flag without editing `~/.claude/autoheal/config.json` directly.**
+
+Subcommands cover the opt-in surfaces — `pause | resume | status | realtime | autoapply | email | digest | webhook`. The webhook variant accepts a URL setter (`/autoheal-toggle webhook url https://dev.lem.work/v1/ingest`).
+
+**Installed by**: autoheal module
+
+---
+
+### /autoheal-snooze
+
+**Suppress a specific proposal fingerprint for N days (default 30).**
+
+Writes to `~/.claude/autoheal/snoozed.json` keyed by the proposal's fingerprint. Useful when the analyzer keeps re-proposing a change you have already decided against.
+
+**Installed by**: autoheal module
+
+---
+
+### /autoheal-apply
+
+**Apply a confidence-gated autoheal proposal to canonical CCGM source.**
+
+`/autoheal-apply` lists pending proposals from the past 8 days (skips snoozed + already-applied). `/autoheal-apply <id>` runs the shared apply path (`lib/apply-proposal.py`): resolves the canonical clone, creates branch `autoheal/{id}`, applies the diff, runs `tests/test-modules.sh` + `tests/test-no-personal-data.sh`, commits with `#auto:` prefix, prints diff + undo + `gh pr create` suggestion. Never auto-merges.
+
+**Installed by**: autoheal module
+
+---
+
+### /permission-fix
+
+**In-session fix proposal for permission friction in the current turn.**
+
+`/permission-fix latest` finds the most recent `permission_request` or `tool_failure` event in today's events and proposes a minimal hook/settings change (paraphrased, breadth-filtered). `/permission-fix apply <id>` routes through the same shared apply logic as `/autoheal-apply`. Triggered automatically by the `post-prompt-introspect.py` Stop-hook when the same friction signature fires ≥2 times in one session.
+
+**Installed by**: autoheal module
+
+---
+
+### /permission-audit
+
+**Read-only static audit of the hook + deny-list alignment.**
+
+Classifies each `modules/hooks/hooks/*.py` as bypass-suppressible / bypass-retained / legacy by inspection (does it import `hook_utils`? does it use `is_bypass_mode`? does it use `hard_block`?), counts deny entries, and flags overlaps where a deny rule is now redundant with a hook hard_block. Supports `--hooks-dir` and `--settings-file` overrides for testing on fixture trees; `--format json` for programmatic consumption.
+
+**Installed by**: autoheal module
+
+---
+
 ## Workflow commands
 
 Installed by the **xplan**, **multi-agent**, and **startup-dashboard** modules.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -284,6 +284,60 @@ Experimental (OFF by default). Injects a rule-enforcement meta-instruction at fr
 
 ---
 
+## Autoheal hooks
+
+Installed by the **autoheal** module. They are registered alongside the core hooks but emit/log only — they do NOT enforce. Three opt-in surfaces (real-time alerts, auto-apply, webhook publisher) are gated by config flags in `~/.claude/autoheal/config.json` and default OFF.
+
+### permission-event-logger.py
+
+**Type**: PostToolUse + PostToolUseFailure + PermissionRequest (no matcher)
+**Module**: autoheal
+**Can block**: No (observational)
+
+Appends one JSONL record per event to `~/.claude/autoheal/events/{date}.jsonl`, cross-clone safe via `hook_utils.file_locked_append`. Commands are redacted via the 17-pattern set BEFORE truncation, so secrets never enter the log even when the truncation point falls mid-token.
+
+### failure-logger.py
+
+**Type**: PostToolUseFailure (no matcher)
+**Module**: autoheal
+**Can block**: No
+
+Specialization of the event logger for tool failures — captures `exit_code` and a redacted `stderr_excerpt` (≤200 chars) for analyzer context.
+
+### user-correction-detector.py
+
+**Type**: UserPromptSubmit (no matcher)
+**Module**: autoheal
+**Can block**: No
+
+Pattern-matches 9 user-correction phrases ("no, not like that", "stop doing", "actually", "wait, no", etc.) in the submitted prompt. On match: logs a `user_correction` event with the last 3 tool-use event IDs as context. Never modifies the prompt.
+
+### permission-request-suppress.py
+
+**Type**: PermissionRequest (no matcher)
+**Module**: autoheal
+**Can block**: Yes (auto-allow only)
+
+Conservative auto-allow gate: fires only when ALL hold — `is_bypass_mode()` is True, the `(tool, command-prefix)` signature has ≥3 prior approvals across ≥2 distinct sessions, and the signature is not in `~/.claude/autoheal/snoozed.json`. Otherwise exits silently.
+
+### post-prompt-introspect.py
+
+**Type**: Stop
+**Module**: autoheal
+**Can block**: No (emits suggestion to stderr)
+
+Session-level dedup'd Stop hook. When ≥2 same-signature `permission_request` or `tool_failure` events fire in the current session, emits an `<autoheal-suggestion>` block on stderr suggesting `/permission-fix latest`. One suggestion per signature per session.
+
+### realtime-security-scanner.py
+
+**Type**: PostToolUse with `async: true, asyncRewake: true` (no matcher)
+**Module**: autoheal
+**Can block**: Yes (`exit 2` wakes Claude mid-session)
+
+Strictly opt-in. Reads `~/.claude/autoheal/config.json` → if `realtime_alerts_enabled` is false or missing, exits 0 immediately without touching the patterns file. When enabled: applies 7 regexes (GitHub/AWS/Anthropic tokens in commit/echo; force-push-to-main without `ALLOW_MAIN_COMMIT`; `rm -rf /…`; `sudo` destructive; `DROP TABLE` against prod-tagged connection strings). On match: logs `realtime_security_alert` event and `exit 2` with an `<autoheal-security-alert>` envelope.
+
+---
+
 ## Agent tracking library
 
 The hooks module also installs `lib/agent_tracking.py`, a Python module and CLI tool used by the tracking hooks.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -726,6 +726,18 @@ Experimental UserPromptSubmit hook that injects iron-law principles before slash
 
 ---
 
+### autoheal
+
+Continuous self-improvement loop: capture hook events, daily transcript analysis via direct Anthropic API, local digest plus optional Resend email, opt-in real-time security alerts, opt-in confidence-gated auto-apply, cross-clone file locking, per-repo overrides, retention sweep, and a webhook publisher seam pre-built for future dev.lem.work integration.
+
+**Installs**: 6 hooks (`permission-event-logger.py`, `failure-logger.py`, `user-correction-detector.py`, `permission-request-suppress.py`, `post-prompt-introspect.py`, `realtime-security-scanner.py`), 7 commands (`/autoheal`, `/autoheal-apply`, `/autoheal-digest`, `/autoheal-snooze`, `/autoheal-toggle`, `/permission-audit`, `/permission-fix`), 10 bin scripts under `~/.claude/autoheal/`, `rules/autoheal.md`, JSONL schemas, redaction patterns, and a LaunchAgent installer.
+
+**What it does**: Four event-capture hooks (`PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `UserPromptSubmit`) record permission requests, tool failures, and user-correction phrases to `~/.claude/autoheal/events/{date}.jsonl` (cross-clone fcntl-locked). A daily `launchd` LaunchAgent runs `autoheal-analyze.sh` (direct `curl` to Anthropic — no claude -p, no exec-escape surface), which proposes small hook/settings fixes filtered by a privilege-escalation gate. Proposals render to a local markdown digest, optionally email via Resend (multi-recipient with per-recipient idempotency keys), and feed into `/permission-fix` (in-session) and `/autoheal-apply` (manual or auto-applied via the strict confidence-9 / breadth-1 / settings-only gate). Default OFF for the three opt-in surfaces (real-time alerts, auto-apply, email/webhook).
+
+**Dependencies**: hooks
+
+---
+
 ### compound-knowledge
 
 Team-shared learnings persisted in `docs/solutions/` and re-injected as grounding into later runs.

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -33,22 +33,23 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 **Best for**: Teams with shared repositories who want consistent practices across contributors.
 
-**Modules (10)**:
+**Modules**:
 - Everything in **standard** (minus `identity` and `commands-utility`), plus:
 - `github-protocols` - issue-first workflow, PR conventions, label taxonomy, code review standards
 - `code-quality` - code standards, testing requirements, error handling, security, build verification
 - `systematic-debugging` - structured 4-phase debugging methodology
 - `verification` - evidence-before-claims, fresh execution requirement
+- `autoheal` - continuous self-improvement loop with multi-recipient digest support
 
-**What you get**: Everything in standard (with a team-focused selection), plus rules that enforce consistent development practices across a team.
+**What you get**: Everything in standard (with a team-focused selection), plus rules that enforce consistent development practices across a team. The autoheal module's multi-recipient digest (`digest_email: ["a@b", "c@d"]`) is particularly useful for sharing weekly insights with teammates.
 
 ### full
 
 **Best for**: Power users who want the complete CCGM experience, including multi-agent coordination, brand research, and tech-specific guides.
 
-**Modules (46)**: All stable modules. The `agent-manager` (beta) and `cloud-dispatch` modules are not included by default; install them individually via the module selector (or use the `cloud-agent` preset).
+**Modules**: All stable modules including **autoheal** (continuous self-improvement; opt-in real-time alerts and auto-apply). The `agent-manager` (beta) and `cloud-dispatch` modules are not included by default; install them individually via the module selector (or use the `cloud-agent` preset).
 
-**What you get**: The full suite. Includes multi-agent workflows, planning frameworks, tech-specific patterns (Cloudflare, Supabase, Tailwind, shadcn, MCP development), and specialized commands.
+**What you get**: The full suite. Includes multi-agent workflows, planning frameworks, tech-specific patterns (Cloudflare, Supabase, Tailwind, shadcn, MCP development), specialized commands, and the autoheal observability loop with three opt-in toggles (`/autoheal-toggle realtime|autoapply|webhook`).
 
 ### cloud-agent
 


### PR DESCRIPTION
Post-execution docs sync for ccgm-autoheal (#473-#484). Adds entries for:

- `docs/modules.md` — autoheal module entry (after `commands-preamble`, before `compound-knowledge`)
- `docs/commands.md` — 7 new commands: /autoheal, /autoheal-digest, /autoheal-toggle, /autoheal-snooze, /autoheal-apply, /permission-fix, /permission-audit
- `docs/hooks.md` — 6 new hooks: permission-event-logger, failure-logger, user-correction-detector, permission-request-suppress, post-prompt-introspect, realtime-security-scanner
- `docs/presets.md` — autoheal noted in `team` and `full` preset descriptions

Closes #504.

Tests: 1182 passed; no personal data leaks.