### PR TITLE
#496: thread transcript_path through autoheal event schema + loggers

### DIFF
--- a/modules/autoheal/hooks/failure-logger.py
+++ b/modules/autoheal/hooks/failure-logger.py
@@ -86,6 +86,10 @@ def _build_failure_record(data: dict) -> dict:
     if not isinstance(exit_code, int):
         exit_code = None
 
+    transcript_path = data.get("transcript_path")
+    if not isinstance(transcript_path, str):
+        transcript_path = None
+
     return {
         "kind": "tool_failure",
         "timestamp": _now_iso(),
@@ -97,6 +101,7 @@ def _build_failure_record(data: dict) -> dict:
         "permission_decision": None,
         "cwd": data.get("cwd"),
         "clone_path": data.get("cwd"),
+        "transcript_path": transcript_path,
     }
 
 

--- a/modules/autoheal/hooks/permission-event-logger.py
+++ b/modules/autoheal/hooks/permission-event-logger.py
@@ -110,6 +110,10 @@ def _build_record(data: dict, kind: str) -> dict:
         if isinstance(decision, str):
             permission_decision = decision
 
+    transcript_path = data.get("transcript_path")
+    if not isinstance(transcript_path, str):
+        transcript_path = None
+
     return {
         "kind": kind,
         "timestamp": _now_iso(),
@@ -121,6 +125,7 @@ def _build_record(data: dict, kind: str) -> dict:
         "permission_decision": permission_decision,
         "cwd": data.get("cwd"),
         "clone_path": data.get("cwd"),
+        "transcript_path": transcript_path,
     }
 
 

--- a/modules/autoheal/hooks/user-correction-detector.py
+++ b/modules/autoheal/hooks/user-correction-detector.py
@@ -160,6 +160,10 @@ def main() -> None:
         )
         context_ids = _recent_tool_use_ids(events_path)
 
+        transcript_path = data.get("transcript_path")
+        if not isinstance(transcript_path, str):
+            transcript_path = None
+
         record = {
             "kind": "user_correction",
             "timestamp": _now_iso(),
@@ -173,6 +177,7 @@ def main() -> None:
             "clone_path": data.get("cwd"),
             "correction_pattern_matched": pattern,
             "context_event_ids": context_ids,
+            "transcript_path": transcript_path,
         }
         hook_utils.file_locked_append(events_path, json.dumps(record))
     except Exception:

--- a/modules/autoheal/lib/event-schema.json
+++ b/modules/autoheal/lib/event-schema.json
@@ -75,6 +75,10 @@
     "id": {
       "type": "string",
       "description": "Optional event id (uuid4 short). Set when downstream code needs to reference this event by id."
+    },
+    "transcript_path": {
+      "type": ["string", "null"],
+      "description": "Path to the Claude Code session transcript JSONL, copied from the top-level hook stdin envelope. Enables autoheal-analyze.sh to pre-extract ±3-turn transcript excerpts around each event before calling the Anthropic API. Optional; older events written before this field was introduced omit it."
     }
   }
 }

--- a/modules/autoheal/tests/test-event-logging.sh
+++ b/modules/autoheal/tests/test-event-logging.sh
@@ -194,6 +194,98 @@ echo 'not even valid json {{{' | python3 "${HOOK}"
 rc=$?
 assert_eq "${rc}" "0" "malformed stdin exits 0"
 
+# 8. transcript_path is captured when present in stdin envelope.
+rm -f "$(events_file)"
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","tool_name":"Bash","tool_input":{"command":"git status"},"cwd":"/tmp/repo","transcript_path":"/tmp/fake/transcript-abc.jsonl"}'
+tp=$(python3 -c "
+import json
+print(json.loads(open('$(events_file)').readline())['transcript_path'])
+")
+assert_eq "${tp}" "/tmp/fake/transcript-abc.jsonl" "transcript_path captured from stdin"
+
+# 9. transcript_path is null when stdin omits it (backward compatible).
+rm -f "$(events_file)"
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","tool_name":"Bash","tool_input":{"command":"git status"},"cwd":"/tmp/repo"}'
+tp=$(python3 -c "
+import json
+rec = json.loads(open('$(events_file)').readline())
+print('present' if 'transcript_path' in rec else 'absent', rec.get('transcript_path'))
+")
+assert_eq "${tp}" "present None" "transcript_path is null when stdin omits it"
+
+# 10. transcript_path is null when stdin provides a non-string (defensive).
+rm -f "$(events_file)"
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","tool_name":"Bash","tool_input":{"command":"git status"},"cwd":"/tmp/repo","transcript_path":42}'
+tp=$(python3 -c "
+import json
+rec = json.loads(open('$(events_file)').readline())
+print(rec['transcript_path'])
+")
+assert_eq "${tp}" "None" "transcript_path is null when stdin provides non-string"
+
+# 11. transcript_path is captured by the PostToolUseFailure path too.
+rm -f "$(events_file)"
+run_hook '{"hook_event_name":"PostToolUseFailure","session_id":"s1","tool_name":"Bash","tool_input":{"command":"false"},"exit_code":1,"stderr":"boom","cwd":"/tmp/repo","transcript_path":"/tmp/fake/transcript-fail.jsonl"}'
+tp=$(python3 -c "
+import json
+print(json.loads(open('$(events_file)').readline())['transcript_path'])
+")
+assert_eq "${tp}" "/tmp/fake/transcript-fail.jsonl" "transcript_path captured on PostToolUseFailure"
+
+# 12. transcript_path is captured by the PermissionRequest path too.
+rm -f "$(events_file)"
+run_hook '{"hook_event_name":"PermissionRequest","session_id":"s1","tool_name":"Bash","tool_input":{"command":"git push --force feat-x"},"cwd":"/tmp/repo","transcript_path":"/tmp/fake/transcript-perm.jsonl"}'
+tp=$(python3 -c "
+import json
+print(json.loads(open('$(events_file)').readline())['transcript_path'])
+")
+assert_eq "${tp}" "/tmp/fake/transcript-perm.jsonl" "transcript_path captured on PermissionRequest"
+
+# 13. Schema accepts records with transcript_path string, null, and absent.
+#
+# Minimal hand-rolled validator: read the schema and verify that
+# (a) transcript_path is a declared property, (b) it accepts string|null,
+# (c) records produced above satisfy the additionalProperties constraint.
+SCHEMA_PATH="${MODULE_ROOT}/lib/event-schema.json"
+validate_ok=$(python3 <<PY
+import json
+with open("${SCHEMA_PATH}") as fh:
+    schema = json.load(fh)
+
+props = schema.get("properties", {})
+add_props = schema.get("additionalProperties", True)
+
+# (a) transcript_path declared.
+assert "transcript_path" in props, "transcript_path missing from schema properties"
+# (b) accepts string|null.
+tp_type = props["transcript_path"].get("type")
+assert tp_type == ["string", "null"] or set(tp_type) == {"string", "null"}, \
+    f"transcript_path type unexpected: {tp_type!r}"
+
+# (c) Verify three on-disk record shapes are structurally schema-conforming.
+declared = set(props.keys())
+required = set(schema.get("required", []))
+
+# Build three sample records:
+samples = [
+    # transcript_path = string
+    {"kind":"tool_use","timestamp":"2026-05-18T00:00:00+00:00","session_id":"s","tool_name":"Bash","transcript_path":"/tmp/x.jsonl"},
+    # transcript_path = null
+    {"kind":"tool_use","timestamp":"2026-05-18T00:00:00+00:00","session_id":"s","tool_name":"Bash","transcript_path":None},
+    # transcript_path absent (backward compat)
+    {"kind":"tool_use","timestamp":"2026-05-18T00:00:00+00:00","session_id":"s","tool_name":"Bash"},
+]
+for rec in samples:
+    missing = required - set(rec.keys())
+    assert not missing, f"required fields missing: {missing}"
+    if add_props is False:
+        extra = set(rec.keys()) - declared
+        assert not extra, f"undeclared fields present: {extra}"
+print("ok")
+PY
+)
+assert_eq "${validate_ok}" "ok" "schema accepts transcript_path string|null|absent"
+
 echo ""
 echo "test-event-logging.sh: ${PASS} passed, ${FAIL} failed"
 [ "${FAIL}" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #496. Adds `transcript_path: string|null` to event-schema.json. The 3 event-logger hooks (permission-event-logger, failure-logger, user-correction-detector) now copy `transcript_path` from the hook stdin envelope. Defensive isinstance check coerces non-strings to null. Tests: 20 passed (was 14). Once present, autoheal-analyze.sh's pre-extract excerpt phase will produce populated ±3-turn context for each event automatically.