### PR TITLE
#503: route remaining autoheal appends through fcntl-locked path

### DIFF
--- a/modules/autoheal/bin/autoheal-analyze.sh
+++ b/modules/autoheal/bin/autoheal-analyze.sh
@@ -657,16 +657,21 @@ def passes_privilege_gate(prop, calibration_mode):
     return True, ""
 
 
-def append_jsonl(path, record):
+def append_locked(path, data):
     """Locked append using the same shape as hook_utils.file_locked_append.
-    We call it here directly so we don't need to import the hook lib
-    from a script that runs outside the hook environment."""
+    We inline the locking here so we don't need to import the hook lib
+    from a script that runs outside the hook environment.
+
+    Cross-clone-safe: fcntl.flock(LOCK_EX) on the open file descriptor
+    serializes appends so concurrent writers from sibling clones cannot
+    tear records mid-write.
+    """
     import fcntl
 
     parent = os.path.dirname(path)
     if parent:
         os.makedirs(parent, exist_ok=True)
-    payload = json.dumps(record, ensure_ascii=False) + "\n"
+    payload = data if data.endswith("\n") else data + "\n"
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
@@ -678,26 +683,23 @@ def append_jsonl(path, record):
         os.close(fd)
 
 
+def append_jsonl(path, record):
+    """Locked JSONL append. Convenience wrapper around append_locked."""
+    append_locked(path, json.dumps(record, ensure_ascii=False))
+
+
 def log_rejection(path, prop, reason):
-    parent = os.path.dirname(path)
-    if parent:
-        os.makedirs(parent, exist_ok=True)
     record = {
         "ts": dt.datetime.now(dt.timezone.utc).isoformat(),
         "reason": reason,
         "proposal": prop,
     }
-    with open(path, "a", encoding="utf-8") as fh:
-        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    append_locked(path, json.dumps(record, ensure_ascii=False))
 
 
 def append_cost(path, today, input_tokens, output_tokens, cost_usd):
-    parent = os.path.dirname(path)
-    if parent:
-        os.makedirs(parent, exist_ok=True)
-    line = f"{today}\t{input_tokens}\t{output_tokens}\t{cost_usd:.6f}\n"
-    with open(path, "a", encoding="utf-8") as fh:
-        fh.write(line)
+    line = f"{today}\t{input_tokens}\t{output_tokens}\t{cost_usd:.6f}"
+    append_locked(path, line)
 
 
 schema = load_schema(schema_path)

--- a/modules/autoheal/hooks/post-prompt-introspect.py
+++ b/modules/autoheal/hooks/post-prompt-introspect.py
@@ -39,6 +39,9 @@ import json
 import os
 import sys
 
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
+
 # Locked friction kinds. permission_request fires when the user is asked
 # to approve a tool call; tool_failure fires on a non-zero exit from a
 # PostToolUseFailure event. Both indicate a tool call did not glide
@@ -153,11 +156,7 @@ def _load_seen(path: str) -> set[str]:
 def _mark_seen(path: str, signature: str) -> None:
     """Append a signature to the seen file. Best-effort: never raises."""
     try:
-        parent = os.path.dirname(path)
-        if parent:
-            os.makedirs(parent, exist_ok=True)
-        with open(path, "a", encoding="utf-8") as fh:
-            fh.write(signature + "\n")
+        hook_utils.file_locked_append(path, signature)
     except OSError:
         # Dedup is a nice-to-have; failing to record a seen entry just
         # means the next Stop fires the same suggestion again. That is

--- a/modules/autoheal/tests/test-analyzer-api-call.sh
+++ b/modules/autoheal/tests/test-analyzer-api-call.sh
@@ -306,6 +306,17 @@ NK_ERR=$(cat "${T5_HOME}/run.err")
 assert_contains "${NK_ERR}" "ANTHROPIC_API_KEY not set" "no API key: stderr explains the skip"
 
 # ---------------------------------------------------------------------
+# Test 6 — rejection log + cost log use locked appends (issue #503).
+# log_rejection and append_cost must route through the same fcntl.flock
+# path as append_jsonl so concurrent clones cannot tear writes. Guard
+# the property at the source level.
+# ---------------------------------------------------------------------
+
+ANALYZER_SRC=$(cat "${ANALYZER}")
+assert_contains "${ANALYZER_SRC}" "fcntl.flock" "locked-append: analyzer uses fcntl.flock"
+assert_contains "${ANALYZER_SRC}" "append_locked(path" "locked-append: log_rejection/append_cost route through append_locked"
+
+# ---------------------------------------------------------------------
 # Summary.
 # ---------------------------------------------------------------------
 

--- a/modules/autoheal/tests/test-post-prompt-introspect.sh
+++ b/modules/autoheal/tests/test-post-prompt-introspect.sh
@@ -227,6 +227,12 @@ EOF
 )
 assert_not_contains "${out}" "<autoheal-suggestion>" "scenario 10: stop_hook_active suppresses suggestion"
 
+# ---------- Scenario 11: _mark_seen uses locked append (issue #503) ----
+# Per-session dedup writes must route through hook_utils.file_locked_append
+# so concurrent Stop hooks across sibling clones do not tear the seen file.
+HOOK_SRC=$(cat "${HOOK}")
+assert_contains "${HOOK_SRC}" "hook_utils.file_locked_append" "scenario 11: _mark_seen uses hook_utils.file_locked_append"
+
 echo ""
 echo "test-post-prompt-introspect.sh: ${PASS} passed, ${FAIL} failed"
 [ "${FAIL}" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #503. Three plain `open(path, "a")` appends now use the locked path:
- `bin/autoheal-analyze.sh`: extracted `append_locked()` helper from `append_jsonl`. `log_rejection` and `append_cost` route through it.
- `hooks/post-prompt-introspect.py`: `_mark_seen()` uses `hook_utils.file_locked_append`.

Source-level test assertions verify the locked helper is used. Tests: analyzer 23 (was 21), introspect 14 (was 13), all autoheal 22/22, repo-wide 1182/0.