### PR TITLE
#497: move autoheal cost pricing into config (per-model entries)

### DIFF
--- a/modules/autoheal/bin/autoheal-analyze.sh
+++ b/modules/autoheal/bin/autoheal-analyze.sh
@@ -547,6 +547,8 @@ PY
             "${day_iso}" \
             "$(cost_log_path)" \
             "${TODAY_ISO}" \
+            "$(config_path)" \
+            "${DEFAULT_MODEL}" \
         <<'PY'
 import datetime as dt
 import json
@@ -562,6 +564,8 @@ calibration_mode = sys.argv[6] == "true"
 day_iso = sys.argv[7]
 cost_log_path = sys.argv[8]
 today_iso = sys.argv[9]
+config_path = sys.argv[10]
+fallback_model = sys.argv[11]
 
 
 def load_schema(path):
@@ -697,9 +701,51 @@ def log_rejection(path, prop, reason):
     append_locked(path, json.dumps(record, ensure_ascii=False))
 
 
-def append_cost(path, today, input_tokens, output_tokens, cost_usd):
-    line = f"{today}\t{input_tokens}\t{output_tokens}\t{cost_usd:.6f}"
+def append_cost(path, today, input_tokens, output_tokens, cost_usd, model):
+    # `model` is appended as a 5th tab-separated field. Older cost.log
+    # lines lacking this field still parse (today_cost_cents only reads
+    # parts[0..3]); see issue #497.
+    line = f"{today}\t{input_tokens}\t{output_tokens}\t{cost_usd:.6f}\t{model}"
     append_locked(path, line)
+
+
+# Per-model pricing fallback. Matches autoheal-install.sh defaults; the
+# install step is the source of truth, this dict only fires when the
+# config file is unreadable or its cost_pricing block is missing entirely.
+FALLBACK_PRICING = {
+    "claude-sonnet-4-6": {"input_per_million": 3.0, "output_per_million": 15.0},
+    "claude-opus-4-7": {"input_per_million": 15.0, "output_per_million": 75.0},
+    "claude-haiku-4-5": {"input_per_million": 0.80, "output_per_million": 4.0},
+}
+SONNET_FALLBACK = FALLBACK_PRICING["claude-sonnet-4-6"]
+
+
+def load_cfg(path):
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            cfg = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(cfg, dict):
+        return {}
+    return cfg
+
+
+def resolve_pricing(cfg, fallback_model):
+    """Return (model_id, pricing_dict). Emits a stderr warning when the
+    configured model has no cost_pricing entry."""
+    model = cfg.get("default_model") or cfg.get("model") or fallback_model
+    pricing_map = cfg.get("cost_pricing")
+    if not isinstance(pricing_map, dict):
+        pricing_map = FALLBACK_PRICING
+    pricing = pricing_map.get(model)
+    if not isinstance(pricing, dict) or "input_per_million" not in pricing or "output_per_million" not in pricing:
+        sys.stderr.write(
+            f"WARNING: no cost_pricing for model {model}; "
+            f"falling back to claude-sonnet-4-6 pricing\n"
+        )
+        pricing = SONNET_FALLBACK
+    return model, pricing
 
 
 schema = load_schema(schema_path)
@@ -717,10 +763,14 @@ if isinstance(usage, dict):
 else:
     in_tok = 0
     out_tok = 0
-# Sonnet 4 pricing: $3/M in, $15/M out. Conservative — we under-report
-# if the model id ever changes; tune in config if needed.
-cost = (in_tok * 3.0 + out_tok * 15.0) / 1_000_000.0
-append_cost(cost_log_path, today_iso, in_tok, out_tok, cost)
+
+cfg = load_cfg(config_path)
+model_id, pricing = resolve_pricing(cfg, fallback_model)
+cost = (
+    in_tok * float(pricing["input_per_million"])
+    + out_tok * float(pricing["output_per_million"])
+) / 1_000_000.0
+append_cost(cost_log_path, today_iso, in_tok, out_tok, cost, model_id)
 
 text = extract_assistant_text(response)
 proposals = parse_proposals(text)

--- a/modules/autoheal/bin/autoheal-install.sh
+++ b/modules/autoheal/bin/autoheal-install.sh
@@ -58,12 +58,56 @@ if [ ! -f "${AUTOHEAL_DIR}/config.json" ]; then
   "webhook_kinds": ["proposal", "event", "digest"],
   "webhook_max_per_run": 100,
   "model": "claude-sonnet-4-6",
+  "default_model": "claude-sonnet-4-6",
+  "cost_pricing": {
+    "claude-sonnet-4-6":  {"input_per_million": 3,    "output_per_million": 15},
+    "claude-opus-4-7":    {"input_per_million": 15,   "output_per_million": 75},
+    "claude-haiku-4-5":   {"input_per_million": 0.80, "output_per_million": 4}
+  },
   "daily_cost_cap_usd": 0.50,
   "retention_gzip_days": 30,
   "retention_delete_days": 60
 }
 EOF
     echo "autoheal-install: wrote default config to ${AUTOHEAL_DIR}/config.json"
+else
+    # Idempotent merge: ensure cost_pricing + default_model exist in an
+    # already-installed config without clobbering user customizations.
+    python3 - "${AUTOHEAL_DIR}/config.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+
+DEFAULT_PRICING = {
+    "claude-sonnet-4-6":  {"input_per_million": 3,    "output_per_million": 15},
+    "claude-opus-4-7":    {"input_per_million": 15,   "output_per_million": 75},
+    "claude-haiku-4-5":   {"input_per_million": 0.80, "output_per_million": 4},
+}
+
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        cfg = json.load(fh)
+except (OSError, json.JSONDecodeError):
+    sys.exit(0)
+
+if not isinstance(cfg, dict):
+    sys.exit(0)
+
+dirty = False
+if "cost_pricing" not in cfg or not isinstance(cfg.get("cost_pricing"), dict):
+    cfg["cost_pricing"] = DEFAULT_PRICING
+    dirty = True
+if "default_model" not in cfg:
+    cfg["default_model"] = cfg.get("model", "claude-sonnet-4-6")
+    dirty = True
+
+if dirty:
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(cfg, fh, indent=2)
+        fh.write("\n")
+    print(f"autoheal-install: merged cost_pricing/default_model into {path}")
+PY
 fi
 
 # ---------------------------------------------------------------------

--- a/modules/autoheal/tests/test-analyzer-api-call.sh
+++ b/modules/autoheal/tests/test-analyzer-api-call.sh
@@ -317,6 +317,176 @@ assert_contains "${ANALYZER_SRC}" "fcntl.flock" "locked-append: analyzer uses fc
 assert_contains "${ANALYZER_SRC}" "append_locked(path" "locked-append: log_rejection/append_cost route through append_locked"
 
 # ---------------------------------------------------------------------
+# Test 7 — per-model cost pricing (issue #497).
+# Fixture usage block is {input: 1200, output: 240}. Verify:
+#   - sonnet default config -> $3/M in + $15/M out
+#       cost = (1200*3 + 240*15) / 1e6 = (3600 + 3600) / 1e6 = 0.007200
+#   - opus default_model -> $15/M in + $75/M out
+#       cost = (1200*15 + 240*75) / 1e6 = (18000 + 18000) / 1e6 = 0.036000
+#   - unknown model -> stderr warning + sonnet fallback (0.007200)
+#   - cost.log lines include the model id as the 5th tab-separated field
+# ---------------------------------------------------------------------
+
+write_config() {
+    # write_config <path> <default_model> [include_pricing]
+    local path="$1"
+    local default_model="$2"
+    local include_pricing="${3:-1}"
+    mkdir -p "$(dirname "${path}")"
+    if [ "${include_pricing}" = "1" ]; then
+        cat > "${path}" <<EOF
+{
+  "default_model": "${default_model}",
+  "cost_pricing": {
+    "claude-sonnet-4-6":  {"input_per_million": 3,    "output_per_million": 15},
+    "claude-opus-4-7":    {"input_per_million": 15,   "output_per_million": 75},
+    "claude-haiku-4-5":   {"input_per_million": 0.80, "output_per_million": 4}
+  }
+}
+EOF
+    else
+        cat > "${path}" <<EOF
+{
+  "default_model": "${default_model}"
+}
+EOF
+    fi
+}
+
+read_cost_field() {
+    # read_cost_field <cost.log path> <today> <0-based field index>
+    python3 - "$1" "$2" "$3" <<'PY'
+import sys
+path, today, idx = sys.argv[1], sys.argv[2], int(sys.argv[3])
+with open(path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        parts = line.split("\t")
+        if parts and parts[0] == today:
+            print(parts[idx] if idx < len(parts) else "")
+            break
+PY
+}
+
+# Test 7a — sonnet default pricing.
+T7A_HOME=$(mktemp -d -t autoheal_t7a.XXXXXX)
+T7A_DIR="${T7A_HOME}/autoheal"
+mk_state "${T7A_DIR}"
+write_events "${T7A_DIR}/events/${YESTERDAY}.jsonl" 1
+write_config "${T7A_DIR}/config.json" "claude-sonnet-4-6"
+
+env \
+    HOME="${T7A_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T7A_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" >"${T7A_HOME}/run.out" 2>"${T7A_HOME}/run.err"
+RC=$?
+assert_eq "${RC}" "0" "pricing sonnet: analyzer exits 0"
+
+T7A_COST_VAL=$(read_cost_field "${T7A_DIR}/cost.log" "${TODAY}" 3)
+assert_eq "${T7A_COST_VAL}" "0.007200" "pricing sonnet: cost matches \$3/M + \$15/M"
+T7A_MODEL_VAL=$(read_cost_field "${T7A_DIR}/cost.log" "${TODAY}" 4)
+assert_eq "${T7A_MODEL_VAL}" "claude-sonnet-4-6" "pricing sonnet: model id recorded in cost.log"
+
+T7A_ERR=$(cat "${T7A_HOME}/run.err")
+case "${T7A_ERR}" in
+    *"no cost_pricing"*)
+        FAIL=$((FAIL + 1))
+        echo "FAIL: pricing sonnet: should not emit unknown-model warning"
+        ;;
+    *)
+        PASS=$((PASS + 1))
+        ;;
+esac
+
+# Test 7b — opus default_model uses opus pricing.
+T7B_HOME=$(mktemp -d -t autoheal_t7b.XXXXXX)
+T7B_DIR="${T7B_HOME}/autoheal"
+mk_state "${T7B_DIR}"
+write_events "${T7B_DIR}/events/${YESTERDAY}.jsonl" 1
+write_config "${T7B_DIR}/config.json" "claude-opus-4-7"
+
+env \
+    HOME="${T7B_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T7B_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" >"${T7B_HOME}/run.out" 2>"${T7B_HOME}/run.err"
+RC=$?
+assert_eq "${RC}" "0" "pricing opus: analyzer exits 0"
+
+T7B_COST_VAL=$(read_cost_field "${T7B_DIR}/cost.log" "${TODAY}" 3)
+assert_eq "${T7B_COST_VAL}" "0.036000" "pricing opus: cost matches \$15/M + \$75/M"
+T7B_MODEL_VAL=$(read_cost_field "${T7B_DIR}/cost.log" "${TODAY}" 4)
+assert_eq "${T7B_MODEL_VAL}" "claude-opus-4-7" "pricing opus: model id recorded in cost.log"
+
+# Test 7c — unknown model falls back to sonnet pricing AND warns.
+T7C_HOME=$(mktemp -d -t autoheal_t7c.XXXXXX)
+T7C_DIR="${T7C_HOME}/autoheal"
+mk_state "${T7C_DIR}"
+write_events "${T7C_DIR}/events/${YESTERDAY}.jsonl" 1
+write_config "${T7C_DIR}/config.json" "claude-mystery-9-9"
+
+env \
+    HOME="${T7C_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T7C_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" >"${T7C_HOME}/run.out" 2>"${T7C_HOME}/run.err"
+RC=$?
+assert_eq "${RC}" "0" "pricing unknown: analyzer exits 0"
+
+T7C_COST_VAL=$(read_cost_field "${T7C_DIR}/cost.log" "${TODAY}" 3)
+assert_eq "${T7C_COST_VAL}" "0.007200" "pricing unknown: cost falls back to sonnet (\$3/M + \$15/M)"
+T7C_MODEL_VAL=$(read_cost_field "${T7C_DIR}/cost.log" "${TODAY}" 4)
+assert_eq "${T7C_MODEL_VAL}" "claude-mystery-9-9" "pricing unknown: configured model id still recorded for traceability"
+
+T7C_ERR=$(cat "${T7C_HOME}/run.err")
+assert_contains "${T7C_ERR}" "no cost_pricing for model claude-mystery-9-9" "pricing unknown: stderr warning emitted"
+assert_contains "${T7C_ERR}" "falling back" "pricing unknown: stderr explains fallback"
+
+# Test 7d — back-compat: a cost.log written by older code (no model
+# field) parses cleanly when summing today's spend (cap check).
+T7D_HOME=$(mktemp -d -t autoheal_t7d.XXXXXX)
+T7D_DIR="${T7D_HOME}/autoheal"
+mk_state "${T7D_DIR}"
+write_events "${T7D_DIR}/events/${YESTERDAY}.jsonl" 1
+# Legacy 4-field line (no model). Sum is 0.40, well below the 50c cap so
+# the analyzer must proceed. If today_cost_cents() crashes on a missing
+# 5th field, the analyzer exits 1 instead of 0.
+printf '%s\t100000\t5000\t0.400000\n' "${TODAY}" > "${T7D_DIR}/cost.log"
+
+env \
+    HOME="${T7D_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T7D_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" >"${T7D_HOME}/run.out" 2>"${T7D_HOME}/run.err"
+RC=$?
+assert_eq "${RC}" "0" "pricing back-compat: legacy 4-field cost.log still parses"
+
+# After the run, a new 5-field line should sit alongside the legacy one.
+LEGACY_LINE_COUNT=$(grep -c "^${TODAY}" "${T7D_DIR}/cost.log" || true)
+if [ "${LEGACY_LINE_COUNT}" -ge 2 ]; then
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: pricing back-compat: expected legacy + new cost.log lines, got ${LEGACY_LINE_COUNT}"
+fi
+
+# Cleanup test 7 dirs.
+for d in "${T7A_HOME}" "${T7B_HOME}" "${T7C_HOME}" "${T7D_HOME}"; do
+    rm -rf "${d}"
+done
+
+# ---------------------------------------------------------------------
 # Summary.
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #497. Hardcoded Sonnet 4 pricing ($3/M in, $15/M out) moved to `cost_pricing` block in `~/.claude/autoheal/config.json` with entries for sonnet, opus, haiku. Unknown models fall back to sonnet pricing with stderr warning. `cost.log` now records the model id as a 5th tab field; legacy 4-field lines remain parseable. autoheal-install.sh writes the block on fresh install and adds it idempotently to existing configs. Tests: 37 passed (was 25).