### PR TITLE
#488: extract correction patterns to JSON + add plan §3.3 lock-test alias

### DIFF
--- a/modules/autoheal/hooks/user-correction-detector.py
+++ b/modules/autoheal/hooks/user-correction-detector.py
@@ -22,49 +22,59 @@ sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
 import hook_utils  # noqa: E402
 
 
-# Each tuple: (pattern_name, compiled_regex). Order matters only for
-# disambiguation when two patterns could match the same string; the first
-# match wins. Patterns are case-insensitive and word-bounded where it
-# makes sense. False positives are acceptable — the analyzer's threshold
-# logic is the second line of defense.
-_CORRECTION_PATTERNS: list[tuple[str, "re.Pattern[str]"]] = [
-    (
-        "no_not_like_that",
-        re.compile(r"\bno,?\s+not\s+like\s+that\b", re.IGNORECASE),
-    ),
-    (
-        "stop_doing",
-        re.compile(r"\bstop\s+doing\b", re.IGNORECASE),
-    ),
-    (
-        "dont_do_that",
-        re.compile(r"\b(?:don'?t|do\s+not)\s+(?:do\s+that|do\s+this)\b", re.IGNORECASE),
-    ),
-    (
-        "i_told_you",
-        re.compile(r"\bI\s+told\s+you\b", re.IGNORECASE),
-    ),
-    (
-        "wait_no",
-        re.compile(r"\bwait,?\s+no\b", re.IGNORECASE),
-    ),
-    (
-        "actually_correction",
-        re.compile(r"\bactually,?\s+(?:no|that's\s+wrong|that\s+is\s+wrong|do)\b", re.IGNORECASE),
-    ),
-    (
-        "instead",
-        re.compile(r"\b(?:do\s+\w+\s+)?instead\b", re.IGNORECASE),
-    ),
-    (
-        "thats_wrong",
-        re.compile(r"\bthat'?s\s+(?:wrong|not\s+right|incorrect)\b", re.IGNORECASE),
-    ),
-    (
-        "undo",
-        re.compile(r"\b(?:undo|revert)\s+(?:that|this|what\s+you\s+did)\b", re.IGNORECASE),
-    ),
-]
+# Default location of the patterns file once installed. Tests override
+# via CCGM_CORRECTION_PATTERNS so they can point at the in-repo source.
+# Mirrors the realtime-security-scanner.py loading pattern.
+_DEFAULT_PATTERNS_PATH = os.path.expanduser(
+    "~/.claude/lib/correction-patterns.json"
+)
+
+
+def _patterns_path() -> str:
+    override = os.environ.get("CCGM_CORRECTION_PATTERNS")
+    if override:
+        return override
+    return _DEFAULT_PATTERNS_PATH
+
+
+def _load_correction_patterns() -> list[tuple[str, "re.Pattern[str]"]]:
+    """Load (name, compiled_regex) pairs from the patterns JSON file.
+
+    Order matters only for disambiguation when two patterns could match
+    the same string; the first match wins. Patterns are case-insensitive
+    and word-bounded where it makes sense. False positives are acceptable
+    -- the analyzer's threshold logic is the second line of defense.
+
+    Falls back to an empty list if the file is missing or malformed
+    (graceful degradation: the hook becomes a no-op rather than crashing
+    the prompt pipeline).
+    """
+    try:
+        with open(_patterns_path(), "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return []
+    raw = data.get("patterns") if isinstance(data, dict) else None
+    if not isinstance(raw, list):
+        return []
+    out: list[tuple[str, "re.Pattern[str]"]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        regex_src = entry.get("regex")
+        if not isinstance(name, str) or not isinstance(regex_src, str):
+            continue
+        try:
+            compiled = re.compile(regex_src, re.IGNORECASE)
+        except re.error:
+            # Bad regex in the patterns file is a config bug. Skip it.
+            continue
+        out.append((name, compiled))
+    return out
+
+
+_CORRECTION_PATTERNS: list[tuple[str, "re.Pattern[str]"]] = _load_correction_patterns()
 
 _MAX_RECENT_CONTEXT = 3  # how many recent tool_use events to attach as context
 

--- a/modules/autoheal/lib/correction-patterns.json
+++ b/modules/autoheal/lib/correction-patterns.json
@@ -1,0 +1,50 @@
+{
+  "_description": "User-correction phrases that the UserPromptSubmit detector flags. Mirror the regex set inlined in hooks/user-correction-detector.py. The hook loads this file at module import; tests override the path via CCGM_CORRECTION_PATTERNS. Order matters only for disambiguation when two patterns could match the same string; the first match wins. Patterns are case-insensitive and word-bounded where it makes sense. False positives are acceptable -- the analyzer's threshold logic is the second line of defense.",
+  "patterns": [
+    {
+      "name": "no_not_like_that",
+      "regex": "\\bno,?\\s+not\\s+like\\s+that\\b",
+      "description": "User says 'no, not like that' -- direct rejection of the agent's last action."
+    },
+    {
+      "name": "stop_doing",
+      "regex": "\\bstop\\s+doing\\b",
+      "description": "User says 'stop doing X' -- imperative halt on the current pattern of behavior."
+    },
+    {
+      "name": "dont_do_that",
+      "regex": "\\b(?:don'?t|do\\s+not)\\s+(?:do\\s+that|do\\s+this)\\b",
+      "description": "User says 'don't do that' / 'do not do this' -- explicit prohibition."
+    },
+    {
+      "name": "i_told_you",
+      "regex": "\\bI\\s+told\\s+you\\b",
+      "description": "User says 'I told you ...' -- references a prior instruction the agent failed to follow."
+    },
+    {
+      "name": "wait_no",
+      "regex": "\\bwait,?\\s+no\\b",
+      "description": "User says 'wait, no' -- interrupts the agent mid-action with a reversal."
+    },
+    {
+      "name": "actually_correction",
+      "regex": "\\bactually,?\\s+(?:no|that's\\s+wrong|that\\s+is\\s+wrong|do)\\b",
+      "description": "User says 'actually, no' / 'actually, that's wrong' / 'actually, do ...' -- soft correction."
+    },
+    {
+      "name": "instead",
+      "regex": "\\b(?:do\\s+\\w+\\s+)?instead\\b",
+      "description": "User says '... instead' -- proposes an alternative to the agent's chosen approach."
+    },
+    {
+      "name": "thats_wrong",
+      "regex": "\\bthat'?s\\s+(?:wrong|not\\s+right|incorrect)\\b",
+      "description": "User says 'that's wrong' / 'that's not right' / 'that's incorrect' -- direct judgement."
+    },
+    {
+      "name": "undo",
+      "regex": "\\b(?:undo|revert)\\s+(?:that|this|what\\s+you\\s+did)\\b",
+      "description": "User says 'undo that' / 'revert this' / 'revert what you did' -- requests rollback."
+    }
+  ]
+}

--- a/modules/autoheal/module.json
+++ b/modules/autoheal/module.json
@@ -176,6 +176,11 @@
       "type": "lib",
       "template": false
     },
+    "lib/correction-patterns.json": {
+      "target": "lib/correction-patterns.json",
+      "type": "lib",
+      "template": false
+    },
     "lib/repo-config-schema.json": {
       "target": "lib/repo-config-schema.json",
       "type": "lib",

--- a/modules/autoheal/tests/test-correction-detection.sh
+++ b/modules/autoheal/tests/test-correction-detection.sh
@@ -15,6 +15,7 @@ MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 HOOK="${MODULE_ROOT}/hooks/user-correction-detector.py"
 HOOKS_MODULE="$(cd "${MODULE_ROOT}/../hooks" && pwd)"
 HOOK_LIB="${HOOKS_MODULE}/lib"
+PATTERNS_FILE="${MODULE_ROOT}/lib/correction-patterns.json"
 
 PASS=0
 FAIL=0
@@ -40,6 +41,11 @@ cp "${HOOK_LIB}/hook_utils.py" "${TMP_HOME}/.claude/lib/hook_utils.py"
 
 export HOME="${TMP_HOME}"
 export CCGM_AUTOHEAL_DIR="${TMP_HOME}/autoheal"
+# Point the hook at the in-repo patterns JSON. The hook normally reads
+# ~/.claude/lib/correction-patterns.json after the module installer
+# copies the file; the env override mirrors the realtime-security
+# scanner's CCGM_REALTIME_PATTERNS hook.
+export CCGM_CORRECTION_PATTERNS="${PATTERNS_FILE}"
 
 today() {
     python3 -c "import datetime; print(datetime.datetime.now(datetime.timezone.utc).date().isoformat())"
@@ -208,6 +214,50 @@ esac
 echo 'not json {{{' | python3 "${HOOK}"
 rc=$?
 assert_eq "${rc}" "0" "malformed stdin exits 0"
+
+# 6. correction-patterns.json exists and is the source of truth.
+[ -f "${PATTERNS_FILE}" ] && PASS=$((PASS + 1)) || {
+    FAIL=$((FAIL + 1))
+    echo "FAIL: ${PATTERNS_FILE} does not exist"
+}
+
+# 7. The hook loads patterns from JSON (not inlined). Verify the JSON
+#    pattern count matches the number of distinct correction events the
+#    hook emitted for the 9 test prompts above. If the hook silently fell
+#    back to an empty list (file not loaded), only 0 events would have
+#    been emitted and assertion 1 would already have failed -- but we
+#    also assert the count here for explicitness.
+JSON_COUNT=$(python3 -c "
+import json
+with open('${PATTERNS_FILE}') as fh:
+    data = json.load(fh)
+print(len(data['patterns']))
+")
+assert_eq "${JSON_COUNT}" "9" "correction-patterns.json contains 9 patterns"
+
+# 8. The hook source loads patterns from the JSON file (no inlined
+#    regex list). Grep for the load function name and the env override
+#    to lock in the contract.
+if grep -q '_load_correction_patterns' "${HOOK}" && \
+   grep -q 'CCGM_CORRECTION_PATTERNS' "${HOOK}" && \
+   ! grep -q 'no_not_like_that.*re\.compile' "${HOOK}"; then
+    PASS=$((PASS + 1))
+else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: hook source must load patterns from JSON, not inline them"
+fi
+
+# 9. Graceful degradation: when the patterns file is missing, the hook
+#    becomes a no-op (no event written) instead of crashing.
+CCGM_CORRECTION_PATTERNS_BACKUP="${CCGM_CORRECTION_PATTERNS}"
+export CCGM_CORRECTION_PATTERNS="/nonexistent/path/never-here.json"
+before_missing=$(correction_count)
+run_correction "no, not like that"
+rc=$?
+after_missing=$(correction_count)
+assert_eq "${rc}" "0" "missing patterns file: hook still exits 0"
+assert_eq "${before_missing}" "${after_missing}" "missing patterns file: no event emitted"
+export CCGM_CORRECTION_PATTERNS="${CCGM_CORRECTION_PATTERNS_BACKUP}"
 
 echo ""
 echo "test-correction-detection.sh: ${PASS} passed, ${FAIL} failed"

--- a/modules/autoheal/tests/test-cross-clone-file-lock.sh
+++ b/modules/autoheal/tests/test-cross-clone-file-lock.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Plan §3.3 names this file `test-cross-clone-file-lock.sh`. The concrete
+# 4-writer concurrent test ships at `test-cross-clone-lock-concurrent.sh`
+# (a clearer name). This stub redirects so either name works.
+exec bash "$(dirname "$0")/test-cross-clone-lock-concurrent.sh" "$@"


### PR DESCRIPTION
Closes #488. 9 user-correction regexes moved from inlined Python to `lib/correction-patterns.json` (parallel to secret-patterns.json + realtime-security-patterns.json). Hook loads at module import via `_load_correction_patterns()`; `CCGM_CORRECTION_PATTERNS` env override mirrors the realtime scanner pattern; missing/malformed JSON falls back to empty list (graceful degradation). Added 1-line redirect stub at `tests/test-cross-clone-file-lock.sh` (plan §3.3 name) delegating to `test-cross-clone-lock-concurrent.sh`. Tests: correction 26 (was 21), all autoheal 23 (was 22), repo-wide 1183/0.