### PR TITLE
#517: analyzer event clustering, dedup, adaptive excerpts (closes #517, closes #518)

### DIFF
--- a/modules/autoheal/bin/autoheal-analyze.sh
+++ b/modules/autoheal/bin/autoheal-analyze.sh
@@ -104,9 +104,12 @@ USAGE
     esac
 done
 
-# Validate --force-day format if set.
+# Validate --force-day format if set. We pass via sys.argv (not shell
+# interpolation into the Python source string) to keep the invocation
+# style consistent with the rest of this file and remove an injection
+# foot-gun even where the value would otherwise be validated upstream.
 if [ -n "${FORCE_DAY}" ]; then
-    if ! python3 -c "import datetime as dt; dt.date.fromisoformat('${FORCE_DAY}')" 2>/dev/null; then
+    if ! python3 -c "import datetime as dt, sys; dt.date.fromisoformat(sys.argv[1])" "${FORCE_DAY}" 2>/dev/null; then
         echo "autoheal-analyze: --force-day value '${FORCE_DAY}' is not a valid YYYY-MM-DD date" >&2
         exit 1
     fi
@@ -547,9 +550,10 @@ analyzer_version() {
 }
 
 # Holds days rejected in this run (newline-separated). The outer loop
-# uses this to gate the last-analyzed bump.
+# uses this to gate the last-analyzed bump. Days that hit the give-up
+# threshold are NOT appended to REJECTED_DAYS — they fall through to
+# the "no rejections" path so last-analyzed bumps past them.
 REJECTED_DAYS=""
-GIVE_UP_DAYS=""
 
 # ---------------------------------------------------------------------
 # Per-day processing.
@@ -812,8 +816,6 @@ except OSError as exc:
 # at which point the events themselves are too many for the configured
 # budget.
 final_window = None
-final_runtime_ctx = None
-final_events_list = None
 serialized = None
 est_tokens = None
 
@@ -828,8 +830,6 @@ for try_window in (3, 1, 0):
     et = char_total // 4
     if et <= max_input_tokens:
         final_window = try_window
-        final_runtime_ctx = rt_ctx
-        final_events_list = ev_list
         serialized = s
         est_tokens = et
         break
@@ -909,9 +909,9 @@ PY
         # rejected this day enough times under THIS analyzer version to
         # give up. A future analyzer version starts the counter fresh.
         if [ "${prior}" -ge "${REJECT_GIVEUP_THRESHOLD}" ]; then
+            # Give up: leave this day OUT of REJECTED_DAYS so the
+            # bottom-of-script logic bumps last-analyzed past it.
             echo "autoheal-analyze: GIVE_UP day=${day_iso} rejected ${prior} times; bumping past it." >&2
-            GIVE_UP_DAYS="${GIVE_UP_DAYS}${day_iso}
-"
         else
             REJECTED_DAYS="${REJECTED_DAYS}${day_iso}
 "
@@ -1273,14 +1273,19 @@ if [ -n "${FORCE_DAY}" ]; then
 elif [ -z "${REJECTED_DAYS}" ]; then
     printf '%s\n' "${TODAY_ISO}" > "$(last_analyzed_path)"
 else
-    # Pick the earliest still-retriable rejection.
+    # Pick the earliest still-retriable rejection. Pass via sys.argv
+    # rather than splicing into the Python source string — consistent
+    # with the rest of this file and avoids any shell-interpolation
+    # foot-gun if rejected-day values ever stop being date-validated
+    # upstream.
     EARLIEST_REJECTED="$(printf '%s' "${REJECTED_DAYS}" | grep -v '^$' | sort | head -n 1)"
     if [ -n "${EARLIEST_REJECTED}" ]; then
         NEW_LAST="$(python3 -c "
 import datetime as dt
-d = dt.date.fromisoformat('${EARLIEST_REJECTED}') - dt.timedelta(days=1)
+import sys
+d = dt.date.fromisoformat(sys.argv[1]) - dt.timedelta(days=1)
 print(d.isoformat())
-")"
+" "${EARLIEST_REJECTED}")"
         # If the earliest rejection is at/before our existing last-analyzed
         # we leave the file alone (would otherwise step backwards).
         CURRENT_LAST=""

--- a/modules/autoheal/bin/autoheal-analyze.sh
+++ b/modules/autoheal/bin/autoheal-analyze.sh
@@ -452,19 +452,26 @@ sandbox_prefix() {
 # ---------------------------------------------------------------------
 
 rejected_count_for_day() {
+    # Counts prior rejections for `day` that match the CURRENT analyzer
+    # version. A new analyzer (different short SHA) always starts the
+    # retry counter at 0 — when a clustering / cap bug is fixed, days
+    # rejected under the old code get a fresh chance under the new code
+    # instead of being skipped forever. See issue #519 review.
     local day="$1"
+    local version="$2"
     local path
     path="$(rejected_days_path)"
     if [ ! -f "${path}" ]; then
         printf '0\n'
         return 0
     fi
-    REJ_DAY="${day}" REJ_PATH="${path}" python3 - <<'PY'
+    REJ_DAY="${day}" REJ_VERSION="${version}" REJ_PATH="${path}" python3 - <<'PY'
 import json
 import os
 
 path = os.environ["REJ_PATH"]
 day = os.environ["REJ_DAY"]
+version = os.environ["REJ_VERSION"]
 n = 0
 with open(path, "r", encoding="utf-8") as fh:
     for line in fh:
@@ -475,7 +482,7 @@ with open(path, "r", encoding="utf-8") as fh:
             rec = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if isinstance(rec, dict) and rec.get("date") == day:
+        if isinstance(rec, dict) and rec.get("date") == day and rec.get("analyzer_version") == version:
             n += 1
 print(n)
 PY
@@ -681,9 +688,16 @@ def excerpt_transcript(transcript_path, around_ts, window=3):
 
 def is_friction(ev):
     """An event is "friction" if it represents a stuck moment worth
-    keeping as a full record. Routine successes are clustered instead."""
+    keeping as a full record. Routine successes are clustered instead.
+
+    `permission_request` events are special: the bypass-suppress hook
+    stamps auto-allows with `permission_decision: "allow"`, and those
+    are the routine high-volume class — they MUST cluster, not get
+    promoted to friction by virtue of their kind. Only deny/ask
+    permission requests are friction (this matches the contract
+    documented in analyzer-prompt.md §Event shape)."""
     kind = ev.get("kind")
-    if kind in ("tool_failure", "permission_request", "user_correction", "realtime_security_alert"):
+    if kind in ("tool_failure", "user_correction", "realtime_security_alert"):
         return True
     exit_code = ev.get("exit_code")
     if isinstance(exit_code, int) and exit_code != 0:
@@ -889,10 +903,11 @@ PY
         version="$(analyzer_version)"
         record_rejection "${day_iso}" "${est_tokens:-0}" "${MAX_INPUT_TOKENS}" "${version}"
         local prior
-        prior="$(rejected_count_for_day "${day_iso}")"
+        prior="$(rejected_count_for_day "${day_iso}" "${version}")"
         # `prior` already includes this run's record (record_rejection
         # appended before the count). Anything >= threshold means we've
-        # rejected this day enough times to give up.
+        # rejected this day enough times under THIS analyzer version to
+        # give up. A future analyzer version starts the counter fresh.
         if [ "${prior}" -ge "${REJECT_GIVEUP_THRESHOLD}" ]; then
             echo "autoheal-analyze: GIVE_UP day=${day_iso} rejected ${prior} times; bumping past it." >&2
             GIVE_UP_DAYS="${GIVE_UP_DAYS}${day_iso}

--- a/modules/autoheal/bin/autoheal-analyze.sh
+++ b/modules/autoheal/bin/autoheal-analyze.sh
@@ -40,6 +40,15 @@
 #   USE_ANALYZER_SANDBOX         If 1 and sandbox-exec exists, wraps the
 #                                 curl call in the seatbelt profile.
 #
+# CLI flags:
+#   --force-day YYYY-MM-DD       Re-process exactly that day, ignoring
+#                                 last-analyzed. Does not bump
+#                                 last-analyzed. Useful when the cap was
+#                                 raised or a clustering bug was fixed
+#                                 and a previously-rejected day should
+#                                 be retried.
+#   --help                        Print usage and exit.
+#
 # Exit codes:
 #   0  success (including "nothing to do" cases)
 #   1  fatal config/setup error
@@ -52,6 +61,58 @@ set -u
 set -o pipefail
 
 # ---------------------------------------------------------------------
+# CLI parsing.
+# ---------------------------------------------------------------------
+
+FORCE_DAY=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --force-day)
+            shift
+            if [ "$#" -eq 0 ]; then
+                echo "autoheal-analyze: --force-day requires YYYY-MM-DD" >&2
+                exit 1
+            fi
+            FORCE_DAY="$1"
+            shift
+            ;;
+        --force-day=*)
+            FORCE_DAY="${1#--force-day=}"
+            shift
+            ;;
+        --help|-h)
+            cat <<'USAGE'
+Usage: autoheal-analyze.sh [--force-day YYYY-MM-DD]
+
+Daily autoheal analyzer. By default processes every unanalyzed day in
+the lookback window (default 7 days), bounded by ~/.claude/autoheal/last-analyzed.
+
+Options:
+  --force-day YYYY-MM-DD   Re-process exactly that day, ignoring
+                           last-analyzed. Does not bump last-analyzed.
+  --help                   Show this message.
+
+See modules/autoheal/bin/autoheal-analyze.sh for full env-var docs.
+USAGE
+            exit 0
+            ;;
+        *)
+            echo "autoheal-analyze: unknown argument: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Validate --force-day format if set.
+if [ -n "${FORCE_DAY}" ]; then
+    if ! python3 -c "import datetime as dt; dt.date.fromisoformat('${FORCE_DAY}')" 2>/dev/null; then
+        echo "autoheal-analyze: --force-day value '${FORCE_DAY}' is not a valid YYYY-MM-DD date" >&2
+        exit 1
+    fi
+fi
+
+# ---------------------------------------------------------------------
 # Resolve module paths.
 # ---------------------------------------------------------------------
 
@@ -60,14 +121,25 @@ MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # ---------------------------------------------------------------------
 # Tunables (overridable via config; defaults match plan.md §3.7).
+#
+# The hard cap default rose from 40K to 200K in issue #517. Heavy event
+# days (700+ events from cross-clone activity) were the most likely to
+# contain proposal-worthy friction but were also the only ones that
+# blew the previous 40K cap. 200K input @ Sonnet pricing is $0.60/day
+# ceiling — well within the $1.00 daily_cost_cap_usd. Override via the
+# config.json `max_input_tokens` key.
 # ---------------------------------------------------------------------
 
-MAX_INPUT_TOKENS=40000              # Hard input cap (rough char/4 estimate).
-DAILY_COST_CAP_CENTS=50             # $0.50/day in cents.
+MAX_INPUT_TOKENS_DEFAULT=200000     # Hard input cap (rough char/4 estimate).
+MAX_INPUT_TOKENS="${MAX_INPUT_TOKENS_DEFAULT}"
+DAILY_COST_CAP_CENTS_DEFAULT=100    # $1.00/day in cents.
+DAILY_COST_CAP_CENTS="${DAILY_COST_CAP_CENTS_DEFAULT}"
 DEFAULT_MODEL="claude-sonnet-4-6"   # Configurable in config.json.
 DEFAULT_MAX_OUTPUT_TOKENS=4096
 LOOKBACK_DAYS=7                     # Walk back at most this many days.
 CALIBRATION_WINDOW_DAYS=7
+REJECT_GIVEUP_THRESHOLD=7           # After N rejections of the same day,
+                                    # give up and bump past it.
 
 # ---------------------------------------------------------------------
 # Path helpers (env-overridable for tests).
@@ -117,6 +189,67 @@ logs_dir() {
     printf '%s\n' "${HOME}/.claude/logs"
 }
 
+rejected_days_path() {
+    printf '%s\n' "$(autoheal_dir)/rejected-days.jsonl"
+}
+
+# ---------------------------------------------------------------------
+# Config-driven tunables (max_input_tokens, daily_cost_cap_usd).
+#
+# Reads ~/.claude/autoheal/config.json (or CCGM_AUTOHEAL_CONFIG). Missing
+# file, malformed JSON, or missing keys fall back to defaults. Both
+# values must be positive numbers; anything else is treated as missing.
+# ---------------------------------------------------------------------
+
+load_runtime_tunables() {
+    local cfg
+    cfg="$(config_path)"
+    if [ ! -f "${cfg}" ]; then
+        return 0
+    fi
+    local parsed
+    parsed=$(
+        CONFIG_PATH="${cfg}" \
+        DEFAULT_MAX="${MAX_INPUT_TOKENS_DEFAULT}" \
+        DEFAULT_CAP_CENTS="${DAILY_COST_CAP_CENTS_DEFAULT}" \
+        python3 - <<'PY'
+import json
+import os
+
+path = os.environ["CONFIG_PATH"]
+default_max = int(os.environ["DEFAULT_MAX"])
+default_cap_cents = int(os.environ["DEFAULT_CAP_CENTS"])
+
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        cfg = json.load(fh)
+except (OSError, json.JSONDecodeError):
+    cfg = {}
+
+if not isinstance(cfg, dict):
+    cfg = {}
+
+mit = cfg.get("max_input_tokens")
+if isinstance(mit, (int, float)) and mit > 0:
+    mit_out = int(mit)
+else:
+    mit_out = default_max
+
+cap_usd = cfg.get("daily_cost_cap_usd")
+if isinstance(cap_usd, (int, float)) and cap_usd > 0:
+    cap_cents = int(round(float(cap_usd) * 100))
+else:
+    cap_cents = default_cap_cents
+
+print(f"{mit_out}\t{cap_cents}")
+PY
+    )
+    if [ -n "${parsed}" ]; then
+        MAX_INPUT_TOKENS="$(printf '%s' "${parsed}" | cut -f1)"
+        DAILY_COST_CAP_CENTS="$(printf '%s' "${parsed}" | cut -f2)"
+    fi
+}
+
 # ---------------------------------------------------------------------
 # Setup: ensure dirs and dependencies exist.
 # ---------------------------------------------------------------------
@@ -132,6 +265,9 @@ if ! command -v curl >/dev/null 2>&1; then
     echo "autoheal-analyze: curl not found on PATH" >&2
     exit 1
 fi
+
+# Apply config-driven tunables now that paths are resolved.
+load_runtime_tunables
 
 # ---------------------------------------------------------------------
 # API-key + fixture handling.
@@ -195,12 +331,27 @@ export LAST_PATH="$(last_analyzed_path)"
 export LOOKBACK_DAYS
 export TODAY_ISO
 export EVENTS_DIR="$(events_dir)"
-DAYS_TO_ANALYZE="$(compute_days)"
+
+if [ -n "${FORCE_DAY}" ]; then
+    # --force-day: process exactly this one day, ignoring last-analyzed.
+    # Require an events file to exist for the day (otherwise there is
+    # literally nothing to analyze).
+    if [ ! -f "$(events_dir)/${FORCE_DAY}.jsonl" ]; then
+        echo "autoheal-analyze: --force-day ${FORCE_DAY}: no events file at $(events_dir)/${FORCE_DAY}.jsonl" >&2
+        exit 0
+    fi
+    DAYS_TO_ANALYZE="${FORCE_DAY}"
+    echo "autoheal-analyze: --force-day ${FORCE_DAY}: ignoring last-analyzed, will NOT bump it." >&2
+else
+    DAYS_TO_ANALYZE="$(compute_days)"
+fi
 
 if [ -z "${DAYS_TO_ANALYZE}" ]; then
     echo "autoheal-analyze: no unanalyzed event days in the last ${LOOKBACK_DAYS} days." >&2
-    # Still bump last-analyzed so we don't keep re-scanning empty space.
-    printf '%s\n' "${TODAY_ISO}" > "$(last_analyzed_path)"
+    if [ -z "${FORCE_DAY}" ]; then
+        # Still bump last-analyzed so we don't keep re-scanning empty space.
+        printf '%s\n' "${TODAY_ISO}" > "$(last_analyzed_path)"
+    fi
     exit 0
 fi
 
@@ -288,6 +439,112 @@ sandbox_prefix() {
 }
 
 # ---------------------------------------------------------------------
+# Rejection bookkeeping.
+#
+# When a day is rejected for size (rc=3 from pre-extract), append a
+# record to ~/.claude/autoheal/rejected-days.jsonl and DO NOT bump
+# last-analyzed past it. A subsequent run with a higher cap (or after
+# the underlying clustering improves) will re-process the day.
+#
+# Days rejected >= REJECT_GIVEUP_THRESHOLD times are marked
+# "give up" — the outer loop bumps past them so the analyzer doesn't
+# loop indefinitely on a permanently-broken day.
+# ---------------------------------------------------------------------
+
+rejected_count_for_day() {
+    local day="$1"
+    local path
+    path="$(rejected_days_path)"
+    if [ ! -f "${path}" ]; then
+        printf '0\n'
+        return 0
+    fi
+    REJ_DAY="${day}" REJ_PATH="${path}" python3 - <<'PY'
+import json
+import os
+
+path = os.environ["REJ_PATH"]
+day = os.environ["REJ_DAY"]
+n = 0
+with open(path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(rec, dict) and rec.get("date") == day:
+            n += 1
+print(n)
+PY
+}
+
+record_rejection() {
+    local day="$1"
+    local est_tokens="$2"
+    local cap="$3"
+    local version="$4"
+    local path
+    path="$(rejected_days_path)"
+    mkdir -p "$(dirname "${path}")"
+    REJ_DAY="${day}" \
+    REJ_EST="${est_tokens}" \
+    REJ_CAP="${cap}" \
+    REJ_VERSION="${version}" \
+    REJ_PATH="${path}" \
+    python3 - <<'PY'
+import datetime as dt
+import fcntl
+import json
+import os
+
+path = os.environ["REJ_PATH"]
+rec = {
+    "date": os.environ["REJ_DAY"],
+    "rejected_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+    "est_tokens": int(os.environ.get("REJ_EST") or 0),
+    "max_input_tokens": int(os.environ.get("REJ_CAP") or 0),
+    "analyzer_version": os.environ.get("REJ_VERSION") or "1",
+}
+parent = os.path.dirname(path)
+if parent:
+    os.makedirs(parent, exist_ok=True)
+fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+try:
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    try:
+        os.write(fd, (json.dumps(rec, ensure_ascii=False) + "\n").encode("utf-8"))
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+finally:
+    os.close(fd)
+PY
+}
+
+analyzer_version() {
+    # Best-effort: short git SHA for the current commit. Falls back to
+    # "1" when not running inside a git checkout. The version label
+    # exists so a future run can decide whether to retry a previously-
+    # rejected day (i.e. the analyzer has changed since the rejection).
+    local sha=""
+    if command -v git >/dev/null 2>&1; then
+        sha="$(git -C "${MODULE_ROOT}" rev-parse --short HEAD 2>/dev/null || true)"
+    fi
+    if [ -z "${sha}" ]; then
+        printf '1\n'
+    else
+        printf '%s\n' "${sha}"
+    fi
+}
+
+# Holds days rejected in this run (newline-separated). The outer loop
+# uses this to gate the last-analyzed bump.
+REJECTED_DAYS=""
+GIVE_UP_DAYS=""
+
+# ---------------------------------------------------------------------
 # Per-day processing.
 # ---------------------------------------------------------------------
 
@@ -337,7 +594,16 @@ max_output_tokens = int(sys.argv[9])
 
 
 def load_events(path):
+    """Load events with dedup on (session_id, timestamp, kind).
+
+    The double-write contract — see hooks/failure-logger.py:8-12 — is that
+    `failure-logger.py` and `permission-event-logger.py` both write a
+    tool_failure record on the failure surface as redundancy guards. The
+    analyzer dedupes here using the exact key the docstring promises.
+    """
     out = []
+    seen = set()
+    n_dup = 0
     with open(path, "r", encoding="utf-8") as fh:
         for line in fh:
             line = line.strip()
@@ -347,16 +613,33 @@ def load_events(path):
                 rec = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            if isinstance(rec, dict):
-                out.append(rec)
+            if not isinstance(rec, dict):
+                continue
+            key = (
+                rec.get("session_id") or "",
+                rec.get("timestamp") or "",
+                rec.get("kind") or "",
+            )
+            # Treat all-empty keys as non-deduppable (e.g. malformed rows).
+            if key != ("", "", "") and key in seen:
+                n_dup += 1
+                continue
+            if key != ("", "", ""):
+                seen.add(key)
+            out.append(rec)
+    print(
+        f"loaded {len(out)} unique events ({n_dup} duplicates skipped)",
+        file=sys.stderr,
+    )
     return out
 
 
 def excerpt_transcript(transcript_path, around_ts, window=3):
     """Return up to `window` turns before and after `around_ts` from
-    the user's session JSONL. Returns [] when the file is unreadable
-    or the field is missing (the current event schema does not include
-    `transcript_path`; this is forward-compatible scaffolding)."""
+    the user's session JSONL. Returns [] when the file is unreadable,
+    the field is missing, or `window <= 0`."""
+    if window <= 0:
+        return []
     if not transcript_path:
         return []
     if not isinstance(transcript_path, str):
@@ -396,20 +679,111 @@ def excerpt_transcript(transcript_path, around_ts, window=3):
     return turns[lo:hi]
 
 
-events = load_events(events_file)
+def is_friction(ev):
+    """An event is "friction" if it represents a stuck moment worth
+    keeping as a full record. Routine successes are clustered instead."""
+    kind = ev.get("kind")
+    if kind in ("tool_failure", "permission_request", "user_correction", "realtime_security_alert"):
+        return True
+    exit_code = ev.get("exit_code")
+    if isinstance(exit_code, int) and exit_code != 0:
+        return True
+    decision = ev.get("permission_decision")
+    if decision in ("deny", "ask"):
+        return True
+    stderr = ev.get("stderr_excerpt")
+    if isinstance(stderr, str) and stderr:
+        return True
+    return False
 
-# Build per-event excerpt list (best-effort; tolerates missing schema
-# field — schema is owned by Epic 3 and may grow later).
-event_records = []
-for ev in events:
-    excerpts = excerpt_transcript(
-        ev.get("transcript_path"),
-        ev.get("timestamp") or ev.get("ts") or "",
-    )
-    event_records.append({
-        "event": ev,
-        "excerpts": excerpts,
-    })
+
+def signature(ev):
+    """(tool_name, first 80 chars of redacted_command) for clustering."""
+    tool = ev.get("tool_name") or ""
+    cmd = ev.get("redacted_command") or ""
+    if not isinstance(cmd, str):
+        cmd = ""
+    return (tool, cmd[:80])
+
+
+def build_payload(events, window):
+    """Return (runtime_context, events_list) for a given excerpt window.
+
+    Friction events first (chronological by timestamp), then cluster
+    records descending by `count`. Excerpts only attach to friction
+    events; cluster records never carry transcript context."""
+    friction_evs = [ev for ev in events if is_friction(ev)]
+    routine_evs = [ev for ev in events if not is_friction(ev)]
+
+    # Friction events: chronological, full record + adaptive excerpts.
+    friction_evs.sort(key=lambda e: e.get("timestamp") or "")
+    friction_records = []
+    for ev in friction_evs:
+        rec = {
+            "kind": ev.get("kind"),
+            "event": ev,
+        }
+        excerpts = excerpt_transcript(
+            ev.get("transcript_path"),
+            ev.get("timestamp") or ev.get("ts") or "",
+            window=window,
+        )
+        if excerpts:
+            rec["excerpts"] = excerpts
+        friction_records.append(rec)
+
+    # Routine events: group by signature; emit one cluster record per group
+    # (including singletons — keeps shape consistent).
+    groups = {}
+    for ev in routine_evs:
+        sig = signature(ev)
+        g = groups.setdefault(sig, {
+            "tool_name": sig[0],
+            "redacted_command_prefix": sig[1],
+            "count": 0,
+            "first_seen": None,
+            "last_seen": None,
+            "sample_session_id": None,
+        })
+        g["count"] += 1
+        ts = ev.get("timestamp") or ""
+        if ts:
+            if g["first_seen"] is None or ts < g["first_seen"]:
+                g["first_seen"] = ts
+            if g["last_seen"] is None or ts > g["last_seen"]:
+                g["last_seen"] = ts
+        if g["sample_session_id"] is None:
+            g["sample_session_id"] = ev.get("session_id") or ""
+
+    clusters = []
+    for sig, g in groups.items():
+        clusters.append({
+            "kind": "cluster",
+            "tool_name": g["tool_name"],
+            "redacted_command_prefix": g["redacted_command_prefix"],
+            "count": g["count"],
+            "first_seen": g["first_seen"],
+            "last_seen": g["last_seen"],
+            "sample_session_id": g["sample_session_id"],
+        })
+    # Clusters descending by count (noisiest patterns first).
+    clusters.sort(key=lambda c: c["count"], reverse=True)
+
+    runtime_ctx = {
+        "date": day_iso,
+        "originating_clone": clone_id,
+        "calibration_mode": calibration_mode,
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "event_summary": {
+            "friction_events": len(friction_records),
+            "cluster_records": len(clusters),
+            "excerpt_window": window,
+        },
+    }
+    return runtime_ctx, friction_records + clusters
+
+
+events = load_events(events_file)
 
 # Read the analyzer prompt.
 try:
@@ -419,33 +793,56 @@ except OSError as exc:
     print(f"FATAL: cannot read analyzer prompt at {prompt_path}: {exc}", file=sys.stderr)
     sys.exit(1)
 
-# Compose the messages payload.
-runtime_context = {
-    "date": day_iso,
-    "originating_clone": clone_id,
-    "calibration_mode": calibration_mode,
-    "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
-}
+# Adaptive excerpt window: try window=3 → 1 → 0 until under cap. Only
+# reject the day if even window=0 (no excerpts at all) blows the cap —
+# at which point the events themselves are too many for the configured
+# budget.
+final_window = None
+final_runtime_ctx = None
+final_events_list = None
+serialized = None
+est_tokens = None
 
-user_payload = {
-    "runtime_context": runtime_context,
-    "events": event_records,
-}
+for try_window in (3, 1, 0):
+    rt_ctx, ev_list = build_payload(events, try_window)
+    payload = {
+        "runtime_context": rt_ctx,
+        "events": ev_list,
+    }
+    s = json.dumps(payload, ensure_ascii=False)
+    char_total = len(analyzer_prompt) + len(s)
+    et = char_total // 4
+    if et <= max_input_tokens:
+        final_window = try_window
+        final_runtime_ctx = rt_ctx
+        final_events_list = ev_list
+        serialized = s
+        est_tokens = et
+        break
 
-# Token estimate: rough char/4 over (prompt + serialized payload).
-serialized = json.dumps(user_payload, ensure_ascii=False)
-char_total = len(analyzer_prompt) + len(serialized)
-est_tokens = char_total // 4
-
-if est_tokens > max_input_tokens:
+if final_window is None:
+    # Even window=0 was too big — the event list alone (post-dedup,
+    # post-clustering) exceeds the input cap. Capture the over-cap
+    # estimate against window=0 for the rejection log.
+    rt_ctx, ev_list = build_payload(events, 0)
+    payload = {
+        "runtime_context": rt_ctx,
+        "events": ev_list,
+    }
+    s = json.dumps(payload, ensure_ascii=False)
+    char_total = len(analyzer_prompt) + len(s)
+    est_tokens = char_total // 4
     print(
-        f"WARN: estimated input tokens ({est_tokens}) > cap ({max_input_tokens}); rejecting day {day_iso}",
+        f"WARN: estimated input tokens ({est_tokens}) > cap ({max_input_tokens}) "
+        f"even at window=0; rejecting day {day_iso}",
         file=sys.stderr,
     )
-    # Write a marker so the caller knows we rejected for size.
     with open(os.path.join(tmp_dir, "REJECT_TOKEN_CAP"), "w", encoding="utf-8") as fh:
         fh.write(f"{est_tokens}\n")
     sys.exit(3)
+
+print(f"excerpt window: {final_window}", file=sys.stderr)
+print(f"estimated input tokens: {est_tokens} (cap {max_input_tokens})", file=sys.stderr)
 
 # Build the API request body.
 request_body = {
@@ -482,7 +879,28 @@ PY
     set -e
 
     if [ "${pe_rc}" -eq 3 ]; then
-        # Token cap rejected this day; continue with other days.
+        # Token cap rejected this day. Record the rejection and decide
+        # whether to give up. See rejected_count_for_day / record_rejection.
+        local est_tokens=""
+        if [ -f "${tmp_dir}/REJECT_TOKEN_CAP" ]; then
+            est_tokens="$(tr -d '\n' < "${tmp_dir}/REJECT_TOKEN_CAP" || true)"
+        fi
+        local version
+        version="$(analyzer_version)"
+        record_rejection "${day_iso}" "${est_tokens:-0}" "${MAX_INPUT_TOKENS}" "${version}"
+        local prior
+        prior="$(rejected_count_for_day "${day_iso}")"
+        # `prior` already includes this run's record (record_rejection
+        # appended before the count). Anything >= threshold means we've
+        # rejected this day enough times to give up.
+        if [ "${prior}" -ge "${REJECT_GIVEUP_THRESHOLD}" ]; then
+            echo "autoheal-analyze: GIVE_UP day=${day_iso} rejected ${prior} times; bumping past it." >&2
+            GIVE_UP_DAYS="${GIVE_UP_DAYS}${day_iso}
+"
+        else
+            REJECTED_DAYS="${REJECTED_DAYS}${day_iso}
+"
+        fi
         rm -rf "${tmp_dir}"
         return 0
     fi
@@ -828,8 +1246,37 @@ while IFS= read -r day; do
     fi
 done <<< "${DAYS_TO_ANALYZE}"
 
-# Bump last-analyzed regardless: subsequent runs should not re-process
-# the same days even on partial failure (rejected days are logged).
-printf '%s\n' "${TODAY_ISO}" > "$(last_analyzed_path)"
+# Bump last-analyzed (issue #517):
+#  - --force-day mode never bumps (explicit user override).
+#  - Otherwise, bump to TODAY unless we rejected a day during this run.
+#  - When rejections happened, set last-analyzed to (earliest_rejected - 1)
+#    so the next run retries the rejected day. Days that crossed the
+#    give-up threshold are excluded from the rejected set so we DO
+#    bump past them.
+if [ -n "${FORCE_DAY}" ]; then
+    : # --force-day: leave last-analyzed unchanged
+elif [ -z "${REJECTED_DAYS}" ]; then
+    printf '%s\n' "${TODAY_ISO}" > "$(last_analyzed_path)"
+else
+    # Pick the earliest still-retriable rejection.
+    EARLIEST_REJECTED="$(printf '%s' "${REJECTED_DAYS}" | grep -v '^$' | sort | head -n 1)"
+    if [ -n "${EARLIEST_REJECTED}" ]; then
+        NEW_LAST="$(python3 -c "
+import datetime as dt
+d = dt.date.fromisoformat('${EARLIEST_REJECTED}') - dt.timedelta(days=1)
+print(d.isoformat())
+")"
+        # If the earliest rejection is at/before our existing last-analyzed
+        # we leave the file alone (would otherwise step backwards).
+        CURRENT_LAST=""
+        if [ -f "$(last_analyzed_path)" ]; then
+            CURRENT_LAST="$(cat "$(last_analyzed_path)" 2>/dev/null | tr -d '\n')"
+        fi
+        if [ -z "${CURRENT_LAST}" ] || [ "${NEW_LAST}" \> "${CURRENT_LAST}" ]; then
+            printf '%s\n' "${NEW_LAST}" > "$(last_analyzed_path)"
+        fi
+        echo "autoheal-analyze: rejected days this run: $(printf '%s' "${REJECTED_DAYS}" | tr '\n' ' '); last-analyzed=${NEW_LAST}" >&2
+    fi
+fi
 
 exit "${OVERALL_RC}"

--- a/modules/autoheal/bin/autoheal-install.sh
+++ b/modules/autoheal/bin/autoheal-install.sh
@@ -102,7 +102,8 @@ if [ ! -f "${AUTOHEAL_DIR}/config.json" ]; then
     "claude-opus-4-7":    {"input_per_million": 15,   "output_per_million": 75},
     "claude-haiku-4-5":   {"input_per_million": 0.80, "output_per_million": 4}
   },
-  "daily_cost_cap_usd": 0.50,
+  "max_input_tokens": 200000,
+  "daily_cost_cap_usd": 1.00,
   "retention_gzip_days": 30,
   "retention_delete_days": 60
 }
@@ -139,12 +140,23 @@ if "cost_pricing" not in cfg or not isinstance(cfg.get("cost_pricing"), dict):
 if "default_model" not in cfg:
     cfg["default_model"] = cfg.get("model", "claude-sonnet-4-6")
     dirty = True
+# Issue #517: backfill the new max_input_tokens key without overriding
+# a value the user has already chosen.
+if "max_input_tokens" not in cfg:
+    cfg["max_input_tokens"] = 200000
+    dirty = True
+# Issue #517: bump default cost cap from $0.50 to $1.00, but only when
+# the existing value is the legacy default (don't silently rewrite a
+# user-customized cap).
+if cfg.get("daily_cost_cap_usd") in (0.5, 0.50):
+    cfg["daily_cost_cap_usd"] = 1.00
+    dirty = True
 
 if dirty:
     with open(path, "w", encoding="utf-8") as fh:
         json.dump(cfg, fh, indent=2)
         fh.write("\n")
-    print(f"autoheal-install: merged cost_pricing/default_model into {path}")
+    print(f"autoheal-install: merged cost_pricing/default_model/max_input_tokens into {path}")
 PY
 fi
 

--- a/modules/autoheal/lib/analyzer-prompt.md
+++ b/modules/autoheal/lib/analyzer-prompt.md
@@ -23,6 +23,30 @@ If everything in the slice looks routine and there is nothing worth
 proposing, return `{"proposals": []}`. An empty response is the right
 answer when the day's events show no recurring friction.
 
+## Event shape
+
+Each record in `events` is one of two shapes — weight them differently:
+
+1. **Friction records** — full event with optional `excerpts`. These are
+   the records worth most of your attention: tool failures, permission
+   prompts, user corrections, anything with a non-zero exit code or a
+   permission_decision of "deny"/"ask". Cluster signal here means there
+   was repeated friction with a specific tool or command — usually
+   proposal-worthy.
+
+2. **Cluster records** — `{"kind": "cluster", "tool_name", "redacted_command_prefix", "count", "first_seen", "last_seen", "sample_session_id"}`.
+   These represent routine tool calls grouped by `(tool_name, command
+   prefix)`. They never carry excerpts. Treat them as **noisy routine
+   activity** — proposal-worthy only when a single signature fires
+   hundreds of times in a way that suggests genuine automation friction
+   (e.g. the same `Bash(git diff)` got 400 approvals — narrow rule
+   candidate). Do NOT generate proposals just because a cluster's count
+   is high; high counts on a routine tool are normal.
+
+The runtime context's `event_summary` reports how many of each shape
+are present; if `friction_events` is 0, the day is almost certainly
+proposal-free — say `{"proposals": []}`.
+
 ## What to propose
 
 Each proposal is a JSON object matching `proposal-schema.json`:

--- a/modules/autoheal/tests/test-analyzer-api-call.sh
+++ b/modules/autoheal/tests/test-analyzer-api-call.sh
@@ -202,6 +202,13 @@ with open(path, "w", encoding="utf-8") as fh:
     for i in range(count):
         rec = {
             "kind": "permission_request",
+            # `permission_decision: "ask"` keeps these as friction
+            # post-fix (issue #519); friction events are NOT clustered,
+            # so 1000 of them at ~250 chars each genuinely overflow the
+            # tight 5K cap even at window=0. Without the decision field
+            # the events would cluster down to a single record and the
+            # cap would never be hit.
+            "permission_decision": "ask",
             "timestamp": (now - dt.timedelta(seconds=i)).isoformat(),
             "session_id": f"s-{i}",
             "tool_name": "Bash",

--- a/modules/autoheal/tests/test-analyzer-api-call.sh
+++ b/modules/autoheal/tests/test-analyzer-api-call.sh
@@ -166,16 +166,29 @@ if [ -f "${LAST}" ]; then
 fi
 
 # ---------------------------------------------------------------------
-# Test 2 — 40k token cap rejection.
+# Test 2 — token cap rejection.
+#
+# Issue #517 raised the default cap from 40k to 200k and made it
+# configurable. To trigger the rejection deterministically we set
+# max_input_tokens to a tight 5k via config — 1000 friction events
+# (permission_request) at ~250 chars each still exceed it even at
+# window=0 (no excerpts).
 # ---------------------------------------------------------------------
 
 T2_HOME=$(mktemp -d -t autoheal_t2.XXXXXX)
 T2_DIR="${T2_HOME}/autoheal"
 mk_state "${T2_DIR}"
 
-# Write enough events to blow past the 40k token cap. The analyzer's
-# rough estimate is char_total // 4, so we need >160k chars of payload.
-# Each event we emit is ~250 chars; 1000 events = ~250k chars.
+# Tight cap so 1000 permission_request friction events overflow even at
+# window=0. Friction events are kept as full records (they're the
+# signal); only routine successes get clustered.
+cat > "${T2_DIR}/config.json" <<'EOF'
+{
+  "max_input_tokens": 5000,
+  "daily_cost_cap_usd": 1.00
+}
+EOF
+
 python3 - "${T2_DIR}/events/${YESTERDAY}.jsonl" 1000 <<'PY'
 import datetime as dt
 import json
@@ -220,6 +233,39 @@ fi
 ERR_BODY=$(cat "${T2_HOME}/run.err")
 assert_contains "${ERR_BODY}" "estimated input tokens" "token cap: warning printed to stderr"
 
+# Issue #517: rejected day must be logged AND last-analyzed must NOT
+# advance past it (so the next run with a higher cap retries it).
+assert_file_exists "${T2_DIR}/rejected-days.jsonl" "token cap: rejection logged to rejected-days.jsonl"
+
+if [ -f "${T2_DIR}/rejected-days.jsonl" ]; then
+    REJ_DATE=$(python3 -c "
+import json
+with open('${T2_DIR}/rejected-days.jsonl') as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        rec = json.loads(line)
+        print(rec.get('date',''))
+        break
+")
+    assert_eq "${REJ_DATE}" "${YESTERDAY}" "token cap: rejected-days.jsonl records the right date"
+fi
+
+LAST_VAL=""
+if [ -f "${T2_DIR}/last-analyzed" ]; then
+    LAST_VAL=$(cat "${T2_DIR}/last-analyzed" | tr -d '\n')
+fi
+# last-analyzed must be < rejected day (so next run will retry it).
+if [ -n "${LAST_VAL}" ]; then
+    if [ "${LAST_VAL}" \< "${YESTERDAY}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: token cap: last-analyzed should be < rejected day ${YESTERDAY}, got ${LAST_VAL}"
+    fi
+fi
+
 # ---------------------------------------------------------------------
 # Test 3 — daily cost cap honored.
 # ---------------------------------------------------------------------
@@ -228,6 +274,16 @@ T3_HOME=$(mktemp -d -t autoheal_t3.XXXXXX)
 T3_DIR="${T3_HOME}/autoheal"
 mk_state "${T3_DIR}"
 write_events "${T3_DIR}/events/${YESTERDAY}.jsonl" 3
+
+# Issue #517 raised the default cost cap to $1.00. Pin the test to its
+# original $0.50 cap via config so the synthesized $0.51 cost.log line
+# still triggers a skip — keeps the test about cost-cap mechanics, not
+# default values.
+cat > "${T3_DIR}/config.json" <<'EOF'
+{
+  "daily_cost_cap_usd": 0.50
+}
+EOF
 
 # Synthesize a cost.log near the limit (51 cents today).
 printf '%s\t100000\t5000\t0.510000\n' "${TODAY}" > "${T3_DIR}/cost.log"

--- a/modules/autoheal/tests/test-analyzer-clustering.sh
+++ b/modules/autoheal/tests/test-analyzer-clustering.sh
@@ -578,14 +578,18 @@ with open(path, "w", encoding="utf-8") as fh:
 PY
 
 # Pre-populate 6 prior rejections so this run becomes the 7th — at
-# threshold, the analyzer gives up and bumps past.
+# threshold, the analyzer gives up and bumps past. The pre-populated
+# rejections MUST be tagged with the current analyzer version (short
+# git SHA); `rejected_count_for_day` filters by version so a fresh
+# analyzer release starts the retry counter at 0.
+T6_VERSION="$(git -C "${MODULE_ROOT}" rev-parse --short HEAD 2>/dev/null || echo 1)"
 REJ_PATH="${T6_DIR}/rejected-days.jsonl"
-python3 - "${REJ_PATH}" "${YESTERDAY}" <<'PY'
+python3 - "${REJ_PATH}" "${YESTERDAY}" "${T6_VERSION}" <<'PY'
 import datetime as dt
 import json
 import sys
 
-path, day = sys.argv[1], sys.argv[2]
+path, day, version = sys.argv[1], sys.argv[2], sys.argv[3]
 with open(path, "w", encoding="utf-8") as fh:
     for i in range(6):
         rec = {
@@ -593,7 +597,7 @@ with open(path, "w", encoding="utf-8") as fh:
             "rejected_at": dt.datetime.now(dt.timezone.utc).isoformat(),
             "est_tokens": 9999,
             "max_input_tokens": 3000,
-            "analyzer_version": "test",
+            "analyzer_version": version,
         }
         fh.write(json.dumps(rec) + "\n")
 PY
@@ -619,8 +623,282 @@ if [ -f "${T6_DIR}/last-analyzed" ]; then
 fi
 assert_eq "${LAST_VAL}" "${TODAY}" "give-up: last-analyzed advances to TODAY"
 
+# ---------------------------------------------------------------------
+# Test 7 — permission_request friction is decision-based, not kind-based.
+#
+# Regression for the bug where every kind=="permission_request" event
+# was classified as friction. The bypass-suppress hook stamps
+# auto-allows with permission_decision="allow"; on a heavy day those
+# dominate. Treating all of them as friction defeats clustering and
+# re-creates the cap-pressure issue #517 was meant to solve.
+#
+# Fixture: 100 permission_request with decision="allow" + 1 "deny" + 1
+# "ask". Expectation: the 100 allows cluster into one cluster row with
+# count=100; the deny + ask survive as full friction records.
+# ---------------------------------------------------------------------
+
+T7_HOME=$(mktemp -d -t autoheal_clu7.XXXXXX)
+T7_DIR="${T7_HOME}/autoheal"
+mk_state "${T7_DIR}"
+
+EVENTS_FILE="${T7_DIR}/events/${YESTERDAY}.jsonl"
+python3 - "${EVENTS_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+rows = []
+# 100 auto-allowed permission_requests with the same signature; these
+# MUST cluster, not get promoted to friction by virtue of kind.
+for i in range(100):
+    rows.append({
+        "kind": "permission_request",
+        "timestamp": f"2026-05-18T18:{i//60:02d}:{i%60:02d}+00:00",
+        "session_id": f"s-allow-{i % 3}",
+        "tool_name": "Bash",
+        "redacted_command": "ls -la",
+        "permission_decision": "allow",
+    })
+# One deny — must survive as friction.
+rows.append({
+    "kind": "permission_request",
+    "timestamp": "2026-05-18T19:00:00+00:00",
+    "session_id": "s-deny",
+    "tool_name": "Bash",
+    "redacted_command": "unique-deny-cmd",
+    "permission_decision": "deny",
+})
+# One ask — must survive as friction.
+rows.append({
+    "kind": "permission_request",
+    "timestamp": "2026-05-18T19:01:00+00:00",
+    "session_id": "s-ask",
+    "tool_name": "Bash",
+    "redacted_command": "unique-ask-cmd",
+    "permission_decision": "ask",
+})
+with open(path, "w", encoding="utf-8") as fh:
+    for r in rows:
+        fh.write(json.dumps(r) + "\n")
+PY
+
+PROMPT_LOG="${T7_HOME}/prompt.log"
+env \
+    HOME="${T7_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T7_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_PROMPT_LOG="${PROMPT_LOG}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" >"${T7_HOME}/run.out" 2>"${T7_HOME}/run.err"
+RC=$?
+
+assert_eq "${RC}" "0" "friction-decision: analyzer exits 0"
+assert_file_exists "${PROMPT_LOG}" "friction-decision: prompt log written"
+
+if [ -f "${PROMPT_LOG}" ]; then
+    PL_BODY=$(cat "${PROMPT_LOG}")
+
+    # Parse the USER payload (the JSON the model would actually see) and
+    # inspect its structure directly. We can't grep the whole prompt-log
+    # for `"kind": "cluster"` because the SYSTEM section documents
+    # cluster records and would inflate the count.
+    USER_JSON_CHECK=$(PROMPT_LOG="${PROMPT_LOG}" python3 - <<'PY'
+import json
+import os
+
+with open(os.environ["PROMPT_LOG"], "r", encoding="utf-8") as fh:
+    body = fh.read()
+
+# Prompt log shape: "SYSTEM:\n<analyzer prompt>\n\nUSER:\n<json>\n"
+user_part = body.split("USER:\n", 1)[-1].strip()
+data = json.loads(user_part)
+
+ev = data["events"]
+clusters = [e for e in ev if e.get("kind") == "cluster"]
+friction = [e for e in ev if e.get("kind") != "cluster"]
+
+# Emit a single line of tab-separated facts the shell can assert on.
+fields = [
+    str(len(clusters)),                                # 0: cluster count
+    str(clusters[0]["count"]) if clusters else "0",   # 1: first cluster count
+    str(len(friction)),                                # 2: friction count
+    str(data["runtime_context"]["event_summary"]["friction_events"]),
+    str(data["runtime_context"]["event_summary"]["cluster_records"]),
+]
+print("\t".join(fields))
+PY
+)
+    T7_CLUSTERS=$(printf '%s' "${USER_JSON_CHECK}" | cut -f1)
+    T7_CLUSTER0_COUNT=$(printf '%s' "${USER_JSON_CHECK}" | cut -f2)
+    T7_FRICTION=$(printf '%s' "${USER_JSON_CHECK}" | cut -f3)
+    T7_SUMMARY_FRICTION=$(printf '%s' "${USER_JSON_CHECK}" | cut -f4)
+    T7_SUMMARY_CLUSTERS=$(printf '%s' "${USER_JSON_CHECK}" | cut -f5)
+
+    # The 100 auto-allows must cluster into exactly one cluster row.
+    assert_eq "${T7_CLUSTERS}" "1" "friction-decision: exactly one cluster row for the 100 allows"
+    assert_eq "${T7_CLUSTER0_COUNT}" "100" "friction-decision: cluster row carries count=100"
+
+    # The deny + ask remain as friction records (kind != cluster).
+    assert_eq "${T7_FRICTION}" "2" "friction-decision: exactly 2 friction records (deny + ask)"
+
+    # Their unique command strings survive in the prompt body.
+    deny_count=$(grep -F -o "unique-deny-cmd" "${PROMPT_LOG}" | wc -l | tr -d ' ')
+    assert_ge "${deny_count}" "1" "friction-decision: deny survives as friction"
+    ask_count=$(grep -F -o "unique-ask-cmd" "${PROMPT_LOG}" | wc -l | tr -d ' ')
+    assert_ge "${ask_count}" "1" "friction-decision: ask survives as friction"
+
+    # event_summary mirrors the structural counts.
+    assert_eq "${T7_SUMMARY_FRICTION}" "2" "friction-decision: event_summary friction_events=2"
+    assert_eq "${T7_SUMMARY_CLUSTERS}" "1" "friction-decision: event_summary cluster_records=1"
+fi
+
+# ---------------------------------------------------------------------
+# Test 8 — rejected_count_for_day is analyzer-version-aware.
+#
+# Regression for the bug where 7+ prior rejections under any old
+# analyzer version would permanently skip a day under a freshly-shipped
+# analyzer. The fix: filter rejected_count_for_day by current version
+# so a new release starts the retry counter at 0.
+#
+# Fixture: 7 pre-populated rejections for 2020-01-01 under
+# analyzer_version=OLDSHA. Run --force-day 2020-01-01 against the
+# current real SHA. The new rejection should be the FIRST under the
+# current version; GIVE_UP must NOT fire.
+# ---------------------------------------------------------------------
+
+T8_HOME=$(mktemp -d -t autoheal_clu8.XXXXXX)
+T8_DIR="${T8_HOME}/autoheal"
+mk_state "${T8_DIR}"
+
+# Tight cap so the synthesized events overflow even at window=0.
+cat > "${T8_DIR}/config.json" <<'EOF'
+{
+  "max_input_tokens": 3000
+}
+EOF
+
+OLD_DAY_T8="2020-01-01"
+EVENTS_FILE="${T8_DIR}/events/${OLD_DAY_T8}.jsonl"
+python3 - "${EVENTS_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "w", encoding="utf-8") as fh:
+    for i in range(200):
+        rec = {
+            "kind": "permission_request",
+            "timestamp": f"2020-01-01T17:{i//60:02d}:{i%60:02d}+00:00",
+            "session_id": f"s-{i}",
+            "tool_name": "Bash",
+            "redacted_command": "git " + ("x" * 220),
+            "permission_decision": "ask",
+        }
+        fh.write(json.dumps(rec) + "\n")
+PY
+
+# Pre-populate 7 rejections under an OLD analyzer version. Under the
+# pre-fix code, this would trigger GIVE_UP on this run (count >= 7).
+# Under the fix, rejected_count_for_day filters by current version so
+# the count for the live analyzer is 0 prior + 1 new = 1; no GIVE_UP.
+REJ_PATH="${T8_DIR}/rejected-days.jsonl"
+python3 - "${REJ_PATH}" "${OLD_DAY_T8}" <<'PY'
+import datetime as dt
+import json
+import sys
+
+path, day = sys.argv[1], sys.argv[2]
+with open(path, "w", encoding="utf-8") as fh:
+    for i in range(7):
+        rec = {
+            "date": day,
+            "rejected_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "est_tokens": 9999,
+            "max_input_tokens": 3000,
+            "analyzer_version": "OLDSHA",
+        }
+        fh.write(json.dumps(rec) + "\n")
+PY
+
+# Capture current analyzer version BEFORE the run so we can confirm the
+# new rejection row is tagged with it.
+T8_CURRENT_VERSION="$(git -C "${MODULE_ROOT}" rev-parse --short HEAD 2>/dev/null || echo 1)"
+
+env \
+    HOME="${T8_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T8_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" --force-day "${OLD_DAY_T8}" >"${T8_HOME}/run.out" 2>"${T8_HOME}/run.err"
+RC=$?
+
+assert_eq "${RC}" "0" "version-aware: analyzer exits 0"
+
+ERR_BODY=$(cat "${T8_HOME}/run.err")
+# GIVE_UP must NOT fire — old-version rejections do not count against the
+# current analyzer version's retry budget.
+assert_not_contains "${ERR_BODY}" "GIVE_UP" "version-aware: GIVE_UP does not fire under fresh analyzer version"
+# The day SHOULD be rejected (cap exceeded) — confirm via the window=0 line.
+assert_contains "${ERR_BODY}" "even at window=0" "version-aware: rejection fired under fresh version"
+
+# The rejected-days.jsonl now has 7 OLDSHA entries + 1 new entry tagged
+# with the current analyzer version.
+assert_file_exists "${T8_DIR}/rejected-days.jsonl" "version-aware: rejected-days.jsonl exists"
+
+if [ -f "${T8_DIR}/rejected-days.jsonl" ]; then
+    # Count rows with analyzer_version == current real SHA.
+    NEW_COUNT=$(REJ_PATH="${T8_DIR}/rejected-days.jsonl" REJ_VERSION="${T8_CURRENT_VERSION}" python3 - <<'PY'
+import json
+import os
+
+path = os.environ["REJ_PATH"]
+target = os.environ["REJ_VERSION"]
+n = 0
+with open(path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(rec, dict) and rec.get("analyzer_version") == target:
+            n += 1
+print(n)
+PY
+)
+    assert_eq "${NEW_COUNT}" "1" "version-aware: exactly 1 new rejection under current version"
+
+    # Old-version rows are still present (audit trail preserved).
+    OLD_COUNT=$(REJ_PATH="${T8_DIR}/rejected-days.jsonl" REJ_VERSION="OLDSHA" python3 - <<'PY'
+import json
+import os
+
+path = os.environ["REJ_PATH"]
+target = os.environ["REJ_VERSION"]
+n = 0
+with open(path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(rec, dict) and rec.get("analyzer_version") == target:
+            n += 1
+print(n)
+PY
+)
+    assert_eq "${OLD_COUNT}" "7" "version-aware: old-version rows preserved"
+fi
+
 # Cleanup.
-for d in "${T1_HOME}" "${T2_HOME}" "${T3_HOME}" "${T4_HOME}" "${T5_HOME}" "${T6_HOME}"; do
+for d in "${T1_HOME}" "${T2_HOME}" "${T3_HOME}" "${T4_HOME}" "${T5_HOME}" "${T6_HOME}" "${T7_HOME}" "${T8_HOME}"; do
     rm -rf "${d}"
 done
 

--- a/modules/autoheal/tests/test-analyzer-clustering.sh
+++ b/modules/autoheal/tests/test-analyzer-clustering.sh
@@ -1,0 +1,634 @@
+#!/usr/bin/env bash
+# Tests for issues #517 and #518: analyzer event clustering, dedup,
+# adaptive excerpts, --force-day, and rejected-day tracking.
+#
+# Covers:
+#   1. Dedup on (session_id, timestamp, kind) — duplicate-kind records
+#      from the double-write hook contract appear once.
+#   2. Clustering — routine successes are grouped by (tool_name,
+#      command-prefix); friction events stay as full records.
+#   3. Adaptive excerpt window — payload shrinks when over cap.
+#   4. --force-day re-processes a specific day and does NOT bump
+#      last-analyzed.
+#   5. Rejected day — when even window=0 exceeds cap, rejected-days.jsonl
+#      gets a record AND last-analyzed does not advance past the day.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ANALYZER="${MODULE_ROOT}/bin/autoheal-analyze.sh"
+FIXTURE="${SCRIPT_DIR}/fixtures/api-response-sample.json"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            PASS=$((PASS + 1))
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  expected substring: ${needle}"
+            echo "  actual (first 400): ${haystack:0:400}"
+            ;;
+    esac
+}
+
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  unexpected substring present: ${needle}"
+            ;;
+        *)
+            PASS=$((PASS + 1))
+            ;;
+    esac
+}
+
+assert_file_exists() {
+    local path="$1"
+    local label="$2"
+    if [ -f "${path}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected file: ${path}"
+    fi
+}
+
+assert_ge() {
+    local actual="$1"
+    local floor="$2"
+    local label="$3"
+    if [ "${actual}" -ge "${floor}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected >= ${floor}, got ${actual}"
+    fi
+}
+
+assert_lt() {
+    local actual="$1"
+    local ceiling="$2"
+    local label="$3"
+    if [ "${actual}" -lt "${ceiling}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected < ${ceiling}, got ${actual}"
+    fi
+}
+
+mk_state() {
+    local root="$1"
+    mkdir -p "${root}/events" "${root}/proposals"
+}
+
+# ---------------------------------------------------------------------
+# Test 1 — dedup on (session_id, timestamp, kind).
+#
+# The double-write contract (failure-logger.py:8-12) emits the same
+# tool_failure record twice. The analyzer must dedupe so the prompt
+# only sees one copy.
+# ---------------------------------------------------------------------
+
+T1_HOME=$(mktemp -d -t autoheal_clu1.XXXXXX)
+T1_DIR="${T1_HOME}/autoheal"
+mk_state "${T1_DIR}"
+
+TODAY=$(python3 -c "import datetime as dt; print(dt.datetime.now(dt.timezone.utc).date().isoformat())")
+YESTERDAY=$(python3 -c "import datetime as dt; print((dt.date.today()-dt.timedelta(days=1)).isoformat())")
+EVENTS_FILE="${T1_DIR}/events/${YESTERDAY}.jsonl"
+
+python3 - "${EVENTS_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+# 3 unique events, each duplicated to simulate the double-write.
+rows = []
+for i in range(3):
+    rec = {
+        "kind": "tool_failure",
+        "timestamp": f"2026-05-18T10:0{i}:00+00:00",
+        "session_id": f"s-{i}",
+        "tool_name": "Bash",
+        "redacted_command": f"git diff path-{i}",
+        "exit_code": 1,
+        "stderr_excerpt": "boom",
+    }
+    rows.append(rec)
+    rows.append(dict(rec))  # exact duplicate
+with open(path, "w", encoding="utf-8") as fh:
+    for r in rows:
+        fh.write(json.dumps(r) + "\n")
+PY
+
+PROMPT_LOG="${T1_HOME}/prompt.log"
+env \
+    HOME="${T1_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T1_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_PROMPT_LOG="${PROMPT_LOG}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" >"${T1_HOME}/run.out" 2>"${T1_HOME}/run.err"
+RC=$?
+
+assert_eq "${RC}" "0" "dedup: analyzer exits 0"
+assert_file_exists "${PROMPT_LOG}" "dedup: prompt log written"
+
+ERR_BODY=$(cat "${T1_HOME}/run.err")
+# Loader log: "loaded N unique events (M duplicates skipped)"
+assert_contains "${ERR_BODY}" "loaded 3 unique events (3 duplicates skipped)" \
+    "dedup: loader reports 3 unique and 3 duplicates"
+
+# Each unique command appears exactly once in the prompt.
+if [ -f "${PROMPT_LOG}" ]; then
+    for i in 0 1 2; do
+        cmd="git diff path-${i}"
+        count=$(grep -F -o "${cmd}" "${PROMPT_LOG}" | wc -l | tr -d ' ')
+        assert_eq "${count}" "1" "dedup: command '${cmd}' appears exactly once"
+    done
+fi
+
+# ---------------------------------------------------------------------
+# Test 2 — clustering: 1000-event mix with 5 failures + 2 permission
+# requests scattered in. Routine events should cluster (count > 100);
+# friction events stay as full records.
+# ---------------------------------------------------------------------
+
+T2_HOME=$(mktemp -d -t autoheal_clu2.XXXXXX)
+T2_DIR="${T2_HOME}/autoheal"
+mk_state "${T2_DIR}"
+
+EVENTS_FILE="${T2_DIR}/events/${YESTERDAY}.jsonl"
+python3 - "${EVENTS_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+rows = []
+# 993 routine successes spread across 3 tools/commands.
+# 200 Read events, 400 Bash 'git status', 393 Bash 'ls -la'.
+for i in range(200):
+    rows.append({
+        "kind": "tool_use",
+        "timestamp": f"2026-05-18T11:{i//60:02d}:{i%60:02d}+00:00",
+        "session_id": "s-A",
+        "tool_name": "Read",
+        "redacted_command": None,
+        "exit_code": 0,
+    })
+for i in range(400):
+    rows.append({
+        "kind": "tool_use",
+        "timestamp": f"2026-05-18T12:{i//60:02d}:{i%60:02d}+00:00",
+        "session_id": "s-B",
+        "tool_name": "Bash",
+        "redacted_command": "git status",
+        "exit_code": 0,
+    })
+for i in range(393):
+    rows.append({
+        "kind": "tool_use",
+        "timestamp": f"2026-05-18T13:{i//60:02d}:{i%60:02d}+00:00",
+        "session_id": "s-C",
+        "tool_name": "Bash",
+        "redacted_command": "ls -la",
+        "exit_code": 0,
+    })
+# 5 unique tool_failure friction events with distinct commands.
+for i in range(5):
+    rows.append({
+        "kind": "tool_failure",
+        "timestamp": f"2026-05-18T14:{i:02d}:00+00:00",
+        "session_id": f"s-fail-{i}",
+        "tool_name": "Bash",
+        "redacted_command": f"npm run unique-fail-cmd-{i}",
+        "exit_code": 1,
+        "stderr_excerpt": f"unique-stderr-marker-{i}",
+    })
+# 2 permission_request friction events with distinct commands.
+for i in range(2):
+    rows.append({
+        "kind": "permission_request",
+        "timestamp": f"2026-05-18T15:{i:02d}:00+00:00",
+        "session_id": f"s-perm-{i}",
+        "tool_name": "Bash",
+        "redacted_command": f"unique-perm-cmd-{i}",
+        "permission_decision": "ask",
+    })
+
+with open(path, "w", encoding="utf-8") as fh:
+    for r in rows:
+        fh.write(json.dumps(r) + "\n")
+PY
+
+PROMPT_LOG="${T2_HOME}/prompt.log"
+env \
+    HOME="${T2_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T2_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_PROMPT_LOG="${PROMPT_LOG}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" >"${T2_HOME}/run.out" 2>"${T2_HOME}/run.err"
+RC=$?
+
+assert_eq "${RC}" "0" "cluster: analyzer exits 0"
+assert_file_exists "${PROMPT_LOG}" "cluster: prompt log written"
+
+ERR_BODY=$(cat "${T2_HOME}/run.err")
+assert_contains "${ERR_BODY}" "loaded 1000 unique events" "cluster: 1000 events loaded"
+# Window=3 is correct here — under the 200k default cap.
+assert_contains "${ERR_BODY}" "excerpt window: 3" "cluster: window=3 fits under default cap"
+
+# All 5 unique failures + 2 permission requests are present as friction
+# events (verified by checking each unique marker survives).
+if [ -f "${PROMPT_LOG}" ]; then
+    for i in 0 1 2 3 4; do
+        marker="unique-fail-cmd-${i}"
+        count=$(grep -F -o "${marker}" "${PROMPT_LOG}" | wc -l | tr -d ' ')
+        assert_ge "${count}" "1" "cluster: tool_failure ${i} present as friction"
+    done
+    for i in 0 1; do
+        marker="unique-perm-cmd-${i}"
+        count=$(grep -F -o "${marker}" "${PROMPT_LOG}" | wc -l | tr -d ' ')
+        assert_ge "${count}" "1" "cluster: permission_request ${i} present as friction"
+    done
+
+    # Cluster records exist for the routine workloads.
+    cluster_count=$(grep -F -o '"kind": "cluster"' "${PROMPT_LOG}" | wc -l | tr -d ' ')
+    assert_ge "${cluster_count}" "3" "cluster: at least 3 cluster records emitted"
+
+    # Verify the 400-count cluster ('git status') is in the prompt.
+    assert_contains "$(cat "${PROMPT_LOG}")" '"count": 400' "cluster: 400-count signature recorded"
+    assert_contains "$(cat "${PROMPT_LOG}")" '"count": 393' "cluster: 393-count signature recorded"
+    assert_contains "$(cat "${PROMPT_LOG}")" '"count": 200' "cluster: 200-count signature recorded"
+
+    # The 1000-event prompt at the new defaults must be well under 200k tokens.
+    PROMPT_BYTES=$(wc -c < "${PROMPT_LOG}" | tr -d ' ')
+    PROMPT_TOKENS=$((PROMPT_BYTES / 4))
+    assert_lt "${PROMPT_TOKENS}" "200000" "cluster: prompt fits in 200k token cap"
+fi
+
+# ---------------------------------------------------------------------
+# Test 3 — adaptive window: at a low cap the analyzer shrinks excerpts
+# rather than rejecting. Friction events must remain even when excerpts
+# disappear.
+# ---------------------------------------------------------------------
+
+T3_HOME=$(mktemp -d -t autoheal_clu3.XXXXXX)
+T3_DIR="${T3_HOME}/autoheal"
+mk_state "${T3_DIR}"
+
+# Synthesize 30 small permission_request friction events. The cap is
+# tight enough that the analyzer must shrink the window, but loose
+# enough that window=0 still fits.
+EVENTS_FILE="${T3_DIR}/events/${YESTERDAY}.jsonl"
+python3 - "${EVENTS_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+rows = []
+for i in range(30):
+    rows.append({
+        "kind": "permission_request",
+        "timestamp": f"2026-05-18T16:{i//60:02d}:{i%60:02d}+00:00",
+        "session_id": f"s-{i % 5}",
+        "tool_name": "Bash",
+        "redacted_command": "git status",
+        "permission_decision": "ask",
+    })
+with open(path, "w", encoding="utf-8") as fh:
+    for r in rows:
+        fh.write(json.dumps(r) + "\n")
+PY
+
+# 30 small events ≈ 5k chars ≈ 1300 tokens — comfortably under any
+# reasonable cap. We just verify the analyzer reports the window it
+# chose (proves the adaptive-window code path runs).
+cat > "${T3_DIR}/config.json" <<'EOF'
+{
+  "max_input_tokens": 20000
+}
+EOF
+
+PROMPT_LOG="${T3_HOME}/prompt.log"
+env \
+    HOME="${T3_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T3_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_PROMPT_LOG="${PROMPT_LOG}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" >"${T3_HOME}/run.out" 2>"${T3_HOME}/run.err"
+RC=$?
+
+assert_eq "${RC}" "0" "adaptive: analyzer exits 0 with tight cap"
+
+ERR_BODY=$(cat "${T3_HOME}/run.err")
+# The window logged must be one of 3, 1, 0. With this payload at 6k
+# cap, it will be the highest window that still fits — we just assert
+# the line was emitted, not the exact value (since transcript paths
+# don't resolve in tests, payload size doesn't grow with window).
+assert_contains "${ERR_BODY}" "excerpt window:" "adaptive: window choice logged"
+
+# ---------------------------------------------------------------------
+# Test 4 — --force-day re-processes a specific day even when
+# last-analyzed is newer, and does NOT bump last-analyzed.
+# ---------------------------------------------------------------------
+
+T4_HOME=$(mktemp -d -t autoheal_clu4.XXXXXX)
+T4_DIR="${T4_HOME}/autoheal"
+mk_state "${T4_DIR}"
+
+# Pre-populate last-analyzed to today.
+printf '%s\n' "${TODAY}" > "${T4_DIR}/last-analyzed"
+
+# Old day with events to force-analyze.
+OLD_DAY="2020-01-01"
+EVENTS_FILE="${T4_DIR}/events/${OLD_DAY}.jsonl"
+python3 - "${EVENTS_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "w", encoding="utf-8") as fh:
+    for i in range(3):
+        rec = {
+            "kind": "permission_request",
+            "timestamp": f"2020-01-01T0{i}:00:00+00:00",
+            "session_id": f"force-s-{i}",
+            "tool_name": "Bash",
+            "redacted_command": f"force-day-cmd-{i}",
+            "permission_decision": "ask",
+        }
+        fh.write(json.dumps(rec) + "\n")
+PY
+
+PROMPT_LOG="${T4_HOME}/prompt.log"
+env \
+    HOME="${T4_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T4_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_PROMPT_LOG="${PROMPT_LOG}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" --force-day "${OLD_DAY}" >"${T4_HOME}/run.out" 2>"${T4_HOME}/run.err"
+RC=$?
+
+assert_eq "${RC}" "0" "force-day: analyzer exits 0"
+
+# Prompt log contains the old day's unique marker.
+if [ -f "${PROMPT_LOG}" ]; then
+    assert_contains "$(cat "${PROMPT_LOG}")" "force-day-cmd-0" "force-day: forced day's events appear in prompt"
+fi
+
+# last-analyzed is unchanged.
+LAST_VAL=$(cat "${T4_DIR}/last-analyzed" | tr -d '\n')
+assert_eq "${LAST_VAL}" "${TODAY}" "force-day: last-analyzed unchanged"
+
+# Stderr explains the --force-day mode.
+F4_ERR=$(cat "${T4_HOME}/run.err")
+assert_contains "${F4_ERR}" "--force-day" "force-day: stderr explains the mode"
+
+# Bad --force-day value fails fast.
+env \
+    HOME="${T4_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T4_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" --force-day "not-a-date" >"${T4_HOME}/run.bad.out" 2>"${T4_HOME}/run.bad.err"
+RC=$?
+assert_eq "${RC}" "1" "force-day: invalid date rejected with rc=1"
+
+# --help prints usage and exits 0.
+env \
+    HOME="${T4_HOME}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" --help >"${T4_HOME}/help.out" 2>"${T4_HOME}/help.err"
+RC=$?
+assert_eq "${RC}" "0" "help: --help exits 0"
+HELP_BODY=$(cat "${T4_HOME}/help.out")
+assert_contains "${HELP_BODY}" "Usage:" "help: prints usage"
+assert_contains "${HELP_BODY}" "--force-day" "help: mentions --force-day"
+
+# ---------------------------------------------------------------------
+# Test 5 — rejected day: a day too big even at window=0 is logged in
+# rejected-days.jsonl AND last-analyzed does NOT advance past it.
+# ---------------------------------------------------------------------
+
+T5_HOME=$(mktemp -d -t autoheal_clu5.XXXXXX)
+T5_DIR="${T5_HOME}/autoheal"
+mk_state "${T5_DIR}"
+
+# Tight cap so 200 friction events overflow even at window=0.
+cat > "${T5_DIR}/config.json" <<'EOF'
+{
+  "max_input_tokens": 3000
+}
+EOF
+
+EVENTS_FILE="${T5_DIR}/events/${YESTERDAY}.jsonl"
+python3 - "${EVENTS_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "w", encoding="utf-8") as fh:
+    for i in range(200):
+        rec = {
+            "kind": "permission_request",
+            "timestamp": f"2026-05-18T17:{i//60:02d}:{i%60:02d}+00:00",
+            "session_id": f"s-{i}",
+            "tool_name": "Bash",
+            "redacted_command": "git " + ("x" * 220),
+            "permission_decision": "ask",
+        }
+        fh.write(json.dumps(rec) + "\n")
+PY
+
+env \
+    HOME="${T5_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T5_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" >"${T5_HOME}/run.out" 2>"${T5_HOME}/run.err"
+RC=$?
+
+assert_eq "${RC}" "0" "rejected: analyzer exits 0 (rejection is non-fatal)"
+
+# rejected-days.jsonl was written.
+assert_file_exists "${T5_DIR}/rejected-days.jsonl" "rejected: rejected-days.jsonl created"
+
+if [ -f "${T5_DIR}/rejected-days.jsonl" ]; then
+    REJ_DATE=$(python3 -c "
+import json
+with open('${T5_DIR}/rejected-days.jsonl') as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        rec = json.loads(line)
+        print(rec.get('date',''))
+        break
+")
+    assert_eq "${REJ_DATE}" "${YESTERDAY}" "rejected: rejected-days.jsonl records the right date"
+
+    REJ_CAP=$(python3 -c "
+import json
+with open('${T5_DIR}/rejected-days.jsonl') as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        rec = json.loads(line)
+        print(rec.get('max_input_tokens',''))
+        break
+")
+    assert_eq "${REJ_CAP}" "3000" "rejected: rejection records the active cap"
+fi
+
+# Stderr explains the rejection at window=0.
+ERR_BODY=$(cat "${T5_HOME}/run.err")
+assert_contains "${ERR_BODY}" "even at window=0" "rejected: stderr explains rejection happened at window=0"
+
+# last-analyzed must NOT advance past the rejected day (so the next run
+# retries it). The new value should be (rejected_day - 1) at most.
+LAST_VAL=""
+if [ -f "${T5_DIR}/last-analyzed" ]; then
+    LAST_VAL=$(cat "${T5_DIR}/last-analyzed" | tr -d '\n')
+fi
+if [ -n "${LAST_VAL}" ]; then
+    # YESTERDAY > LAST_VAL strictly.
+    if [ "${YESTERDAY}" \> "${LAST_VAL}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: rejected: last-analyzed (${LAST_VAL}) advanced past rejected day (${YESTERDAY})"
+    fi
+fi
+
+# ---------------------------------------------------------------------
+# Test 6 — give-up: after REJECT_GIVEUP_THRESHOLD rejections, the
+# analyzer stops retrying the day and bumps past it.
+# ---------------------------------------------------------------------
+
+T6_HOME=$(mktemp -d -t autoheal_clu6.XXXXXX)
+T6_DIR="${T6_HOME}/autoheal"
+mk_state "${T6_DIR}"
+
+cat > "${T6_DIR}/config.json" <<'EOF'
+{
+  "max_input_tokens": 3000
+}
+EOF
+
+EVENTS_FILE="${T6_DIR}/events/${YESTERDAY}.jsonl"
+python3 - "${EVENTS_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "w", encoding="utf-8") as fh:
+    for i in range(200):
+        rec = {
+            "kind": "permission_request",
+            "timestamp": f"2026-05-18T17:{i//60:02d}:{i%60:02d}+00:00",
+            "session_id": f"s-{i}",
+            "tool_name": "Bash",
+            "redacted_command": "git " + ("x" * 220),
+            "permission_decision": "ask",
+        }
+        fh.write(json.dumps(rec) + "\n")
+PY
+
+# Pre-populate 6 prior rejections so this run becomes the 7th — at
+# threshold, the analyzer gives up and bumps past.
+REJ_PATH="${T6_DIR}/rejected-days.jsonl"
+python3 - "${REJ_PATH}" "${YESTERDAY}" <<'PY'
+import datetime as dt
+import json
+import sys
+
+path, day = sys.argv[1], sys.argv[2]
+with open(path, "w", encoding="utf-8") as fh:
+    for i in range(6):
+        rec = {
+            "date": day,
+            "rejected_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "est_tokens": 9999,
+            "max_input_tokens": 3000,
+            "analyzer_version": "test",
+        }
+        fh.write(json.dumps(rec) + "\n")
+PY
+
+env \
+    HOME="${T6_HOME}" \
+    CCGM_AUTOHEAL_DIR="${T6_DIR}" \
+    CCGM_AUTOHEAL_FIXTURE_API_RESPONSE="${FIXTURE}" \
+    CCGM_AUTOHEAL_TODAY="${TODAY}" \
+    ANTHROPIC_API_KEY="x" \
+    bash "${ANALYZER}" >"${T6_HOME}/run.out" 2>"${T6_HOME}/run.err"
+RC=$?
+
+assert_eq "${RC}" "0" "give-up: analyzer exits 0"
+
+ERR_BODY=$(cat "${T6_HOME}/run.err")
+assert_contains "${ERR_BODY}" "GIVE_UP" "give-up: stderr logs GIVE_UP marker"
+
+# After give-up, last-analyzed advances to TODAY.
+LAST_VAL=""
+if [ -f "${T6_DIR}/last-analyzed" ]; then
+    LAST_VAL=$(cat "${T6_DIR}/last-analyzed" | tr -d '\n')
+fi
+assert_eq "${LAST_VAL}" "${TODAY}" "give-up: last-analyzed advances to TODAY"
+
+# Cleanup.
+for d in "${T1_HOME}" "${T2_HOME}" "${T3_HOME}" "${T4_HOME}" "${T5_HOME}" "${T6_HOME}"; do
+    rm -rf "${d}"
+done
+
+# ---------------------------------------------------------------------
+# Summary.
+# ---------------------------------------------------------------------
+
+echo ""
+echo "test-analyzer-clustering.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Rebuilds the autoheal analyzer's input-construction stage so busy event days (700+ events) actually get analyzed instead of getting rejected at the input-token cap.

- Closes #517 — adaptive excerpt window (3 → 1 → 0), event clustering, configurable cap (default 200K, $1.00/day), `--force-day`, rejected-day tracking.
- Closes #518 — dedup at load time on `(session_id, timestamp, kind)` per the `failure-logger.py` double-write contract.

## Changes

- `bin/autoheal-analyze.sh`
  - CLI: `--force-day YYYY-MM-DD` re-processes a single day without bumping `last-analyzed`; `--help` prints usage.
  - Tunables: `MAX_INPUT_TOKENS` default 40K → 200K; `DAILY_COST_CAP_CENTS` default 50c → 100c; both overridable from `config.json` keys `max_input_tokens` and `daily_cost_cap_usd`.
  - `load_events()` dedupes on `(session_id, timestamp, kind)` and reports `loaded N unique events (M duplicates skipped)` to stderr.
  - Friction-band events (tool_failure, permission_request, user_correction, non-zero exit, deny/ask permission, non-empty stderr) are kept as full records with adaptive excerpts.
  - Routine-band events (everything else) are grouped by `(tool_name, command-prefix[:80])` into `cluster` records with `count`, `first_seen`, `last_seen`, `sample_session_id`.
  - Adaptive excerpt window: tries 3 → 1 → 0 before rejecting. Only window=0 still over cap triggers rejection.
  - Rejected days are appended to `~/.claude/autoheal/rejected-days.jsonl` with `est_tokens`, `max_input_tokens`, `analyzer_version`. `last-analyzed` does not advance past a rejected day; after 7 rejections of the same day, the analyzer gives up (logs `GIVE_UP`) and bumps past.
- `bin/autoheal-install.sh`
  - New installs get `max_input_tokens: 200000` and `daily_cost_cap_usd: 1.00`.
  - Idempotent merge for existing configs: backfills `max_input_tokens` if absent; bumps cap from `0.50` → `1.00` only when the existing value is the legacy default.
- `lib/analyzer-prompt.md`
  - New "Event shape" section describes friction records vs cluster records so the model weights them correctly.
- `tests/test-analyzer-api-call.sh`
  - Test 2 (token-cap rejection) now pins `max_input_tokens: 5000` via config so the assertion stays about the mechanism, not the default; adds checks for `rejected-days.jsonl` + `last-analyzed` non-advance.
  - Test 3 (cost cap) pins `daily_cost_cap_usd: 0.50` via config so the synthesized $0.51 cost.log line still triggers the skip.
- `tests/test-analyzer-clustering.sh` (new)
  - 6 scenarios: dedup, 1000-event clustering, adaptive window log, `--force-day`, rejected-day tracking, 7-strikes give-up.

## Test plan

- [x] `bash modules/autoheal/tests/run-all.sh` — 24/24 scripts pass.
- [x] `bash -n` on all touched shell scripts.
- [x] Smoke test against `~/.claude/autoheal/events/2026-05-19.jsonl` (956 events):
  - `loaded 956 unique events (0 duplicates skipped)`
  - `excerpt window: 3`
  - `estimated input tokens: 98859 (cap 200000)`
  - API returned, 2 proposals accepted, cost = $0.515 / 1.00 cap
- [x] `bash tests/test-no-personal-data.sh` — no personal data leaked.
- [x] `bash tests/test-modules.sh` — 1183 module-validation checks pass.