### PR TITLE
#521: fix Python SyntaxWarning in enforce-git-workflow.py

### DIFF
--- a/modules/hooks/hooks/enforce-git-workflow.py
+++ b/modules/hooks/hooks/enforce-git-workflow.py
@@ -9,7 +9,7 @@ survive bypass mode. `ALLOW_MAIN_COMMIT=1` is the explicit escape hatch.
 
 BLOCKS (via hard_block, bypass-proof):
 1. Commits on protected branches (must use feature branch)
-2. Commit messages without issue number prefix (^#\d+:)
+2. Commit messages without issue number prefix (^#\\d+:)
 3. Direct pushes to protected branches (must use PR workflow)
 
 ALLOWS:


### PR DESCRIPTION
Closes #521.

Surfaced via autoheal proposal `prop_a3f7c2d19e84` (confidence 7, 18 occurrences across 4 sessions).

## Summary

The module docstring at line 12 contained `\d` (literal `\` + `d`), which Python 3.12+ flags as an invalid escape sequence. Every Bash `PreToolUse` hook invocation was emitting:

```
modules/hooks/hooks/enforce-git-workflow.py:12: SyntaxWarning: "\d" is an invalid escape sequence. ...
```

The active regex at line 197 already uses a raw string (`r"^#\d+:"`), so this was purely docstring noise. Fixed by escaping the backslash in the docstring (`\\d`).

## Changes

- `modules/hooks/hooks/enforce-git-workflow.py`: one-character fix in module docstring.

## Test plan

- [x] Reproduced the warning: `echo '{"tool_name":"Bash","tool_input":{"command":"git status"}}' | python3 -W default modules/hooks/hooks/enforce-git-workflow.py 2>&1 | grep SyntaxWarning` -> printed warning before fix
- [x] Confirmed clean after fix: same command -> no output, exit 1 from grep
- [x] Behavior unchanged: docstring text only, no executable code touched