### PR TITLE
#523: document git pathspec-from-subdir pitfall

### DIFF
--- a/modules/git-workflow/rules/git-workflow.md
+++ b/modules/git-workflow/rules/git-workflow.md
@@ -87,3 +87,11 @@ git pull origin main --ff-only
 ```
 
 This ensures the working directory reflects the latest merged state and avoids stale branch confusion.
+
+---
+
+# Pathspecs Resolve From cwd, Not Repo Root
+
+**`git add packages/foo/...` will fail with exit 128 ("pathspec did not match any files") if you run it from inside another sub-package directory.** Git resolves pathspecs relative to the current working directory, not the repository root. This bites in monorepos when you start in a package subdir and stage paths from sibling packages.
+
+**Fix**: `cd` to the repo root first, or use `git -C <repo-root> add <paths>`. Same rule applies to every git subcommand that takes pathspecs (`add`, `rm`, `restore`, `checkout -- <paths>`, etc.).


### PR DESCRIPTION
Closes #523.

Merges two autoheal proposals into one fix:

- `prop_7d4e1b8c3f92` (suggested `modules/core/rules/git-workflow.md`, which does not exist — model hallucinated path)
- `prop_7c2e5f9b1a04` (suggested creating `modules/autoheal/docs/git-worktree-cwd-pitfall.md`, a low-visibility module-internal note)

Both describe the same pitfall observed in session `f8193097`: an agent ran `git add packages/evothos-core/... packages/evothos-features/...` from inside a sub-package directory, which failed with exit 128 because git resolves pathspecs relative to cwd. The agent self-corrected by prepending `cd <repo-root> &&`.

## Summary

Adds a short section to `modules/git-workflow/rules/git-workflow.md` (the canonical location for git-workflow rules, used as a global rule by CCGM installs). Documents the symptom (exit 128, "pathspec did not match"), the cause (cwd resolution), and the fix (`cd` to repo root or `git -C`).

## Changes

- `modules/git-workflow/rules/git-workflow.md`: +8 lines, one new section at end.

## Test plan

- [x] Section reads in the existing voice of the file (terse, headed, fix-first)
- [x] No code paths changed; pure rule addition