### PR TITLE
#529: bump default daily_cost_cap_usd from $1.00 to $10.00

### DIFF
--- a/modules/autoheal/bin/autoheal-analyze.sh
+++ b/modules/autoheal/bin/autoheal-analyze.sh
@@ -129,13 +129,17 @@ MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # days (700+ events from cross-clone activity) were the most likely to
 # contain proposal-worthy friction but were also the only ones that
 # blew the previous 40K cap. 200K input @ Sonnet pricing is $0.60/day
-# ceiling — well within the $1.00 daily_cost_cap_usd. Override via the
+# ceiling — well within the $10.00 daily_cost_cap_usd. Override via the
 # config.json `max_input_tokens` key.
+#
+# Issue #529 bumped the daily cost cap default from $1.00 to $10.00 so
+# catch-up days, manual `--force-day` reruns, and potential Opus
+# upgrades (5× Sonnet pricing) fit without blowing the cap.
 # ---------------------------------------------------------------------
 
 MAX_INPUT_TOKENS_DEFAULT=200000     # Hard input cap (rough char/4 estimate).
 MAX_INPUT_TOKENS="${MAX_INPUT_TOKENS_DEFAULT}"
-DAILY_COST_CAP_CENTS_DEFAULT=100    # $1.00/day in cents.
+DAILY_COST_CAP_CENTS_DEFAULT=1000   # $10.00/day in cents (issue #529).
 DAILY_COST_CAP_CENTS="${DAILY_COST_CAP_CENTS_DEFAULT}"
 DEFAULT_MODEL="claude-sonnet-4-6"   # Configurable in config.json.
 DEFAULT_MAX_OUTPUT_TOKENS=4096

--- a/modules/autoheal/bin/autoheal-install.sh
+++ b/modules/autoheal/bin/autoheal-install.sh
@@ -103,7 +103,7 @@ if [ ! -f "${AUTOHEAL_DIR}/config.json" ]; then
     "claude-haiku-4-5":   {"input_per_million": 0.80, "output_per_million": 4}
   },
   "max_input_tokens": 200000,
-  "daily_cost_cap_usd": 1.00,
+  "daily_cost_cap_usd": 10.00,
   "retention_gzip_days": 30,
   "retention_delete_days": 60
 }
@@ -145,11 +145,11 @@ if "default_model" not in cfg:
 if "max_input_tokens" not in cfg:
     cfg["max_input_tokens"] = 200000
     dirty = True
-# Issue #517: bump default cost cap from $0.50 to $1.00, but only when
-# the existing value is the legacy default (don't silently rewrite a
-# user-customized cap).
-if cfg.get("daily_cost_cap_usd") in (0.5, 0.50):
-    cfg["daily_cost_cap_usd"] = 1.00
+# Issue #529: bump default cost cap to $10.00 from prior legacy
+# defaults ($0.50, $1.00), but only when the existing value is one of
+# those legacy defaults (don't silently rewrite a user-customized cap).
+if cfg.get("daily_cost_cap_usd") in (0.5, 0.50, 1.0, 1.00):
+    cfg["daily_cost_cap_usd"] = 10.00
     dirty = True
 
 if dirty:


### PR DESCRIPTION
Closes #529.

## Why

The previous \$1.00 default leaves almost no headroom:

- One full-cap Sonnet analysis (200K input) ≈ \$0.66 → only ~\$0.34 of daily budget left
- A single backlog catch-up day eats most of that headroom
- Manual `--force-day` reruns accumulate against the same daily total
- A future Opus upgrade (5× Sonnet pricing) blows the cap on the first call

\$10/day is ~\$300/mo absolute max, ~\$20/mo realistic at typical Sonnet usage. Matches the user's spend-now-to-save-downstream framing for the autoheal loop.

The live config at `~/.claude/autoheal/config.json` is already on 10.00. This PR aligns the CCGM-shipped default so future installs and the analyzer fallback constant agree.

## Changes

- `modules/autoheal/bin/autoheal-install.sh`:
  - New-install default is now `10.00` (was `1.00`).
  - Idempotent merge now bumps existing configs that are still on a legacy default (`0.50` OR `1.00`) up to `10.00`. A user-customized value is left alone.
- `modules/autoheal/bin/autoheal-analyze.sh`:
  - Fallback constant `DAILY_COST_CAP_CENTS_DEFAULT` raised from `100` to `1000` so the analyzer matches the shipped config when the config file is missing.
  - Updated comments to reflect the new ceiling.

## Tests

Ran `bash modules/autoheal/tests/run-all.sh` — **25 test files, all passing, 0 failures.**

Test fixtures that intentionally pin specific cap values to exercise rejection mechanics (e.g. `test-analyzer-api-call.sh` Test 3 with `\$0.50` cap + `\$0.51` synthesized spend) are left alone — they exercise the cap mechanism, not the default value.

## Out of scope

Clustering, dedup, analyzer prompt, chain logic — no changes.