### PR TITLE
#531: refactor /handoff to richer 6-section template + copy-paste kickoff prompt

### DIFF
--- a/modules/multi-agent/README.md
+++ b/modules/multi-agent/README.md
@@ -22,8 +22,8 @@ Key capabilities:
 | `multi-agent-system.md` | doc | Full multi-agent coordination documentation |
 | `commands/mawf.md` | command | Multi-Agent Workflow command (/mawf) |
 | `commands/workspace-setup.md` | command | Creates a workspace-based multi-clone directory structure (/workspace-setup) |
-| `commands/handoff.md` | command | Writes a handoff note for peer clones (/handoff) |
-| `lib/handoff.py` | lib | Helper library backing the /handoff command |
+| `commands/handoff.md` | command | Writes a session handoff with a copy-paste kickoff prompt; also feeds peer-clone auto-injection (/handoff) |
+| `lib/handoff.py` | lib | Helper library backing the /handoff command (6-section template + kickoff prompt renderer) |
 | `port-registry.json` | config | Per-repo port allocation registry (template) |
 
 ## Dependencies

--- a/modules/multi-agent/commands/handoff.md
+++ b/modules/multi-agent/commands/handoff.md
@@ -90,11 +90,11 @@ You (the agent) must show the user the **full output verbatim**, including the d
 Example:
 
 ```
-/Users/lem/.claude/handoffs/ccgm/2026-05-21T16-46-25-agent-w0-c0.md
+~/.claude/handoffs/myrepo/2026-05-21T16-46-25-agent-w0-c0.md
 
 Copy the prompt below into your next session:
 ----------------------------------------------------------------
-Continue from session handoff at /Users/lem/.claude/handoffs/ccgm/2026-05-21T16-46-25-agent-w0-c0.md.
+Continue from session handoff at ~/.claude/handoffs/myrepo/2026-05-21T16-46-25-agent-w0-c0.md.
 
 Read it completely before doing anything else. Trust the context it gives you — do not re-explore the codebase unless the handoff is wrong or incomplete. Then start with item #1 in "Next steps".
 

--- a/modules/multi-agent/commands/handoff.md
+++ b/modules/multi-agent/commands/handoff.md
@@ -1,50 +1,120 @@
-# /handoff — Write a handoff note for peer clones
+# /handoff — Write a session handoff with copy-paste kickoff prompt
 
-Write a short markdown handoff so sibling clones on this machine can orient quickly on startup. Handoffs are the lightweight level between "nothing" and a full `/recall` transcript dive.
+Write a structured markdown handoff to disk AND emit a copy-paste-ready kickoff prompt the next session can paste into a fresh Claude Code conversation. Solves the problem of context bloat: end a session before it degrades, paste the prompt into a new session, the next agent reads the handoff and picks up cleanly.
 
 ## Usage
 
 ```
-/handoff                        Prompt yourself to fill in the three sections
-/handoff {one-line description} Pre-seed the title; still fill in the sections
+/handoff                          Build the handoff from current session context
+/handoff {one-line description}   Same, but seed the title
 ```
+
+The skill is **always interactive**: you (the agent) gather the six sections from session context, write the file, and print the kickoff prompt verbatim. Do not skip sections — every one has a purpose. If a section genuinely has no content, write `(none)` and move on.
 
 ## When to use
 
-- **After `gh pr merge`** on non-trivial work. The post-merge reflection hook already reminds you.
-- **Before ending a session** that touched shared code another agent might need to pick up.
-- **When you hand off a blocker** — name it explicitly so the next agent does not rediscover it.
+- **End of a working session** that you don't want to resume via `claude --continue` (session is bloated, you're switching machines, you're going headless, etc.)
+- **Mid-task context checkpoint** when `/compact` would lose too much. Write the handoff, `/clear`, paste the kickoff prompt back in.
+- **Before a risky operation** — handoff acts as a known-good restore point.
+- **End-of-day pause**. Resume tomorrow with the kickoff prompt.
 
-Skip for trivial one-liner commits (typo fixes, dependency bumps) and for work entirely inside throwaway experiments.
+Skip for trivial one-liner commits or work entirely inside throwaway experiments. For the peer-clone broadcast use case, the same `handoff.py` lib also feeds `/startup` auto-injection — you do not need a separate command.
 
-## What to write
+## The six sections (in priority order)
 
-A handoff answers three questions, in order:
+A good handoff is one a fresh agent can read in under 2 minutes and act on within 5. Target 200-400 words total, never more. Use file:line anchors instead of pasted file contents.
 
-1. **What I did** — one paragraph. Shipped PR / functionality. Name files or modules touched. Link the PR if there is one.
-2. **What's next** — immediate follow-ups. Open questions that block the next step. Ideally concrete enough that the next agent can act without re-deriving context.
-3. **Blockers / context for the next agent** — known landmines, decisions made and their reason, anything that would surprise someone who did not sit through this session. Say nothing if nothing applies.
-
-Keep the whole thing under ~200 words. If it needs more, you are writing docs, not a handoff.
-
-## How it gets consumed
-
-`auto-startup.py` reads `~/.claude/handoffs/{repo}/*.md` on SessionStart, filters out the current agent's own handoffs and anything older than 7 days, and injects a compact block into the fresh session. Peer agents see your handoff at the top of their next session's context.
-
-Handoffs older than 30 days are pruned on startup.
+1. **Current state** — One paragraph snapshot of where things are right now. Not a journal of what you did; a state read.
+2. **Next steps** — Numbered, immediate, actionable. Item #1 is what the next agent should do first.
+3. **Decisions & rationale** — What you chose AND why. Without rationale, the next agent can't judge edge cases.
+4. **Files in progress** — `path:lineStart-lineEnd — state — one-line note`. States: `editing`, `partial`, `needs_review`, `ready`.
+5. **Gotchas** — Anti-patterns you discovered, surprises, things that look right but aren't. The "if I forgot to tell you this, you'd waste an hour" section.
+6. **Blockers** — What's stopping forward progress and what would unblock it. `(none)` if nothing.
 
 ## Implementation
 
-Invoke the helper:
+Gather the six sections, then invoke the helper. Prefer the `--body` heredoc form for multi-line content (file lists, numbered next steps with sub-bullets):
 
 ```bash
-python3 ~/.claude/lib/handoff.py --repo "$(git remote get-url origin | sed 's#.*[:/]##;s#\.git$##')"
+python3 ~/.claude/lib/handoff.py write --body "$(cat <<'EOF'
+# Handoff — <one-line description>
+
+## Current state
+
+<one paragraph>
+
+## Next steps
+
+1. <action>
+2. <action>
+
+## Decisions & rationale
+
+- **<decision>**: <why> (`file:line` if relevant)
+
+## Files in progress
+
+- `path/to/file.ts:40-80` — editing — <note>
+
+## Gotchas
+
+<anti-patterns, surprises>
+
+## Blockers
+
+<what's stuck, or (none)>
+EOF
+)"
 ```
 
-Or invoke the CLI shim installed alongside the lib. The helper reads `.env.clone` / cwd to derive agent identity, introspects git for branch/PR/issue, and writes the file.
+For single-line sections (a quick checkpoint), the per-section flags work too:
+
+```bash
+python3 ~/.claude/lib/handoff.py write \
+  --title "Fix auth bug" \
+  --state "..." --next "..." --decisions "..." \
+  --files "..." --gotchas "..." --blockers "..."
+```
+
+The lib auto-detects repo, branch, agent (from `.env.clone`), PR, and issue. Pass `--repo`/`--agent` explicitly only when detection fails.
+
+## Output contract
+
+The CLI prints two things, in this order:
+
+1. **Line 1**: absolute path to the new handoff file (script-safe, capturable via `head -n1`)
+2. **Below the divider**: the copy-paste kickoff prompt — three sentences plus an optional `[USER DIRECTIVE]` slot
+
+You (the agent) must show the user the **full output verbatim**, including the divider, so they can grab the prompt with a single triple-click or drag-select. Do not paraphrase, reformat, or wrap it in extra markdown.
+
+Example:
+
+```
+/Users/lem/.claude/handoffs/ccgm/2026-05-21T16-46-25-agent-w0-c0.md
+
+Copy the prompt below into your next session:
+----------------------------------------------------------------
+Continue from session handoff at /Users/lem/.claude/handoffs/ccgm/2026-05-21T16-46-25-agent-w0-c0.md.
+
+Read it completely before doing anything else. Trust the context it gives you — do not re-explore the codebase unless the handoff is wrong or incomplete. Then start with item #1 in "Next steps".
+
+[USER DIRECTIVE: leave blank to let the agent propose the next action, or fill in to override]
+----------------------------------------------------------------
+```
+
+Pass `--no-kickoff` only if you have a specific script-side reason; the default is always on.
+
+## How it gets consumed
+
+Two paths, both supported:
+
+- **Copy-paste path (primary):** the user takes the kickoff prompt and pastes it as the first message in a fresh Claude Code session (same repo, different machine, or `claude -p` headless). The receiving agent reads the absolute path, opens the doc, and starts with item #1.
+- **Auto-injection path (secondary):** if the user runs `/startup` in a new session in this clone, `startup-gather.sh` calls `handoff.py summary --include-self --max 3 --days 3` and surfaces recent handoffs (including peers') in the dashboard. This is the same lib feeding the same files; no second mechanism.
+
+Handoffs older than 30 days are pruned on startup. Each handoff is timestamped — never overwrite; write a new one if you need to revise.
 
 ## Conventions
 
-- One handoff per "unit of handed-off work" (typically one PR). Multiple handoffs in the same session is fine.
-- Do not overwrite — each handoff is timestamped; editing is done by writing a new one.
-- No secrets. Handoffs live on-disk unencrypted under `~/.claude/handoffs/`.
+- One handoff per "unit of handed-off work" (typically one session-end). Multiple handoffs in the same session is fine.
+- No secrets. Handoffs live unencrypted under `~/.claude/handoffs/`. Never include env vars, API keys, or API response bodies. File paths only.
+- Keep it terse. Two sentences in a section beats six. The next agent has fresh context — they don't need a tutorial, they need a state read.

--- a/modules/multi-agent/lib/handoff.py
+++ b/modules/multi-agent/lib/handoff.py
@@ -394,28 +394,78 @@ def detect_pr(cwd: str | None = None) -> str | None:
 
 _TEMPLATE = """# Handoff{title_suffix}
 
-## What I did
+## Current state
 
-{body_did}
+{body_state}
 
-## What's next
+## Next steps
 
 {body_next}
 
-## Blockers / context
+## Decisions & rationale
+
+{body_decisions}
+
+## Files in progress
+
+{body_files}
+
+## Gotchas
+
+{body_gotchas}
+
+## Blockers
 
 {body_blockers}
 """
 
 
-def _render_body(title: str | None, did: str, nxt: str, blockers: str) -> str:
+def _render_body(
+    title: str | None,
+    state: str,
+    nxt: str,
+    decisions: str,
+    files: str,
+    gotchas: str,
+    blockers: str,
+) -> str:
+    """Render the 6-section handoff template.
+
+    Section vocabulary chosen to force a state snapshot, not a journal:
+      - Current state replaces the older "What I did" — snapshot, not retrospective
+      - Decisions & rationale and Files in progress are new; both flagged as
+        critical-for-handoff by every template source surveyed
+      - Gotchas captures anti-patterns the writer learned NOT to repeat
+    """
     title_suffix = f" — {title}" if title else ""
     return _TEMPLATE.format(
         title_suffix=title_suffix,
-        body_did=did.strip() or "(not filled in)",
+        body_state=state.strip() or "(not filled in)",
         body_next=nxt.strip() or "(not filled in)",
+        body_decisions=decisions.strip() or "(none)",
+        body_files=files.strip() or "(none)",
+        body_gotchas=gotchas.strip() or "(none)",
         body_blockers=blockers.strip() or "(none)",
     )
+
+
+_KICKOFF_DIVIDER = "-" * 64
+
+_KICKOFF_TEMPLATE = """Continue from session handoff at {path}.
+
+Read it completely before doing anything else. Trust the context it gives you — do not re-explore the codebase unless the handoff is wrong or incomplete. Then start with item #1 in "Next steps".
+
+[USER DIRECTIVE: leave blank to let the agent propose the next action, or fill in to override]"""
+
+
+def render_kickoff_prompt(path: str | os.PathLike) -> str:
+    """Render the copy-paste kickoff prompt the next session pastes in.
+
+    3 sentences + an optional [USER DIRECTIVE] slot. Format chosen for
+    copy-paste safety: no smart quotes, ASCII-safe punctuation, framed
+    so the receiving agent reads first and does not re-explore.
+    """
+    return _KICKOFF_TEMPLATE.format(path=str(path))
 
 
 def _cli_write(args) -> int:
@@ -435,7 +485,17 @@ def _cli_write(args) -> int:
         if not _sys.stdin.isatty():
             body = _sys.stdin.read()
     if not body:
-        body = _render_body(args.title, args.did or "", args.next or "", args.blockers or "")
+        # --state is preferred; --did is back-compat alias mapping to Current state
+        state = args.state or args.did or ""
+        body = _render_body(
+            args.title,
+            state,
+            args.next or "",
+            args.decisions or "",
+            args.files or "",
+            args.gotchas or "",
+            args.blockers or "",
+        )
 
     dest = write_handoff(
         body=body,
@@ -446,7 +506,16 @@ def _cli_write(args) -> int:
         issue=issue,
         title=args.title,
     )
+    # First line is the path so script callers using `head -n1` or capturing
+    # stdout still get a clean answer. The kickoff block follows visually
+    # separated, so a human running the CLI directly can copy-paste it.
     print(dest)
+    if not args.no_kickoff:
+        print()
+        print("Copy the prompt below into your next session:")
+        print(_KICKOFF_DIVIDER)
+        print(render_kickoff_prompt(dest))
+        print(_KICKOFF_DIVIDER)
     return 0
 
 
@@ -504,10 +573,19 @@ def main(argv: list[str] | None = None) -> int:
     w.add_argument("--pr")
     w.add_argument("--issue")
     w.add_argument("--title")
-    w.add_argument("--did", help="What-I-did section (plain text)")
-    w.add_argument("--next", help="What's-next section")
+    w.add_argument("--state", help="Current state section (snapshot of where things are)")
+    w.add_argument("--next", help="Next steps section (numbered, immediate actions)")
+    w.add_argument("--decisions", help="Decisions & rationale section (what + why)")
+    w.add_argument("--files", help="Files in progress section (path:line + state)")
+    w.add_argument("--gotchas", help="Gotchas section (anti-patterns, surprises)")
     w.add_argument("--blockers", help="Blockers section")
+    w.add_argument("--did", help="(back-compat alias for --state)")
     w.add_argument("--body", help="Full markdown body override (skips template)")
+    w.add_argument(
+        "--no-kickoff",
+        action="store_true",
+        help="Suppress the copy-paste kickoff prompt printed after the path",
+    )
     w.set_defaults(func=_cli_write)
 
     ls = sub.add_parser("list", help="List peer handoffs for the current repo")

--- a/modules/multi-agent/tests/test_handoff.py
+++ b/modules/multi-agent/tests/test_handoff.py
@@ -39,7 +39,15 @@ class HandoffTestCase(unittest.TestCase):
 
     def _write(self, **kw) -> Path:
         defaults = dict(
-            body="# H\n## What I did\nThing.\n## What's next\nMore.\n## Blockers / context\nNone.\n",
+            body=(
+                "# H\n"
+                "## Current state\nSnapshot.\n"
+                "## Next steps\n1. Do thing.\n"
+                "## Decisions & rationale\nNone.\n"
+                "## Files in progress\nNone.\n"
+                "## Gotchas\nNone.\n"
+                "## Blockers\nNone.\n"
+            ),
             repo="ccgm",
             agent="agent-w0-c0",
         )
@@ -61,7 +69,50 @@ class HandoffTestCase(unittest.TestCase):
         self.assertIn("pr: 42", content)
         self.assertIn("issue: 40", content)
         self.assertIn("title: Fix X", content)
-        self.assertIn("## What I did", content)
+        self.assertIn("## Current state", content)
+
+    def test_render_body_six_sections(self) -> None:
+        body = self.ho._render_body(
+            title="Refactor X",
+            state="Mid-refactor.",
+            nxt="1. Finish ParserY.",
+            decisions="Picked Z because faster.",
+            files="src/parser.ts:40-80 - editing",
+            gotchas="Watch for null in line 73.",
+            blockers="Need user input on API shape.",
+        )
+        for header in (
+            "# Handoff — Refactor X",
+            "## Current state",
+            "## Next steps",
+            "## Decisions & rationale",
+            "## Files in progress",
+            "## Gotchas",
+            "## Blockers",
+        ):
+            self.assertIn(header, body)
+        self.assertIn("Mid-refactor.", body)
+        self.assertIn("ParserY", body)
+        self.assertIn("API shape", body)
+
+    def test_render_body_empty_sections_have_placeholders(self) -> None:
+        body = self.ho._render_body(
+            title=None, state="", nxt="", decisions="", files="", gotchas="", blockers="",
+        )
+        # Current state and Next steps are required content; everything else
+        # falls back to (none) so the doc still parses with structure intact.
+        self.assertIn("(not filled in)", body)
+        self.assertIn("(none)", body)
+
+    def test_render_kickoff_prompt_format(self) -> None:
+        prompt = self.ho.render_kickoff_prompt("/tmp/handoff/abc.md")
+        self.assertIn("/tmp/handoff/abc.md", prompt)
+        self.assertIn("Read it completely before doing anything else", prompt)
+        self.assertIn("Trust the context", prompt)
+        self.assertIn("Next steps", prompt)
+        self.assertIn("[USER DIRECTIVE:", prompt)
+        # 3 sentences + directive line; sanity-check token-economy
+        self.assertLess(len(prompt), 600)
 
     def test_list_peer_handoffs_excludes_self(self) -> None:
         self._write(agent="agent-w0-c0", when=datetime.now(timezone.utc) - timedelta(hours=1))


### PR DESCRIPTION
Closes #531

## What

Refactor `/handoff` so it produces an **explicit, copy-paste-friendly session handoff** instead of just a peer-clone note. Same command, same file location, richer content + a kickoff prompt printed at the end.

Driven by [`~/code/docs/research/ai-agent-session-handoff/research.md`](../code/docs/research/ai-agent-session-handoff/research.md) — 5-query Exa deep-research pass over Anthropic docs, community templates (softaworks, davila7, alirezarezvani, blackdoglabs), failure-mode bug reports (#43941, #24341), and context-engineering blog posts.

## Why

Auto-injection via `/startup` (`summarize_for_startup --include-self`) already works — verified live in this session — but the user wants explicit control: a copy-paste prompt they can paste into a fresh session on a different machine, in headless mode, or after a session has bloated past `--resume`'s ability to load cleanly.

Research consensus across 5+ template sources: a good handoff doc has 6 sections (Current state / Next steps / Decisions+rationale / Files in progress / Gotchas / Blockers) and is paired with a 3-sentence kickoff prompt with an optional `[USER DIRECTIVE]` slot.

## Changes

| File | Change |
|---|---|
| `modules/multi-agent/lib/handoff.py` | Replaced 3-section `_TEMPLATE` with 6-section template. New `render_kickoff_prompt()` helper. `_cli_write` now prints path on line 1 then visually-separated kickoff block; `--no-kickoff` suppresses it. New flags: `--state`, `--decisions`, `--files`, `--gotchas`. `--did` is back-compat alias for `--state`. |
| `modules/multi-agent/commands/handoff.md` | Rewrote spec around session-handoff use case (with peer auto-injection as secondary path). Documents the 6 sections, the output contract, and the divider format. |
| `modules/multi-agent/tests/test_handoff.py` | Updated fixture body to new section names. Added `test_render_body_six_sections`, `test_render_body_empty_sections_have_placeholders`, `test_render_kickoff_prompt_format`. 13 tests, all green. |
| `modules/multi-agent/README.md` | Updated module-table descriptions. |

## Back-compat

- `/sds` Phase 5 uses `handoff.py write --body "$(cat <<EOF ...)"` and **bypasses the template entirely**. Unaffected by this change. (A future PR can update `/sds` to match the richer 6-section template if desired — out of scope here.)
- `/startup` calls `handoff.py summary --include-self` which parses by frontmatter + first-heading, not by section names. Unaffected.
- First line of CLI output is still the absolute path, so any script doing `head -n1` keeps working.
- `--did` is preserved as an alias for `--state` for any existing callers.

## Output example

```
/Users/lem/.claude/handoffs/ccgm/2026-05-21T16-46-25-agent-w0-c0.md

Copy the prompt below into your next session:
----------------------------------------------------------------
Continue from session handoff at /Users/lem/.claude/handoffs/ccgm/2026-05-21T16-46-25-agent-w0-c0.md.

Read it completely before doing anything else. Trust the context it gives you — do not re-explore the codebase unless the handoff is wrong or incomplete. Then start with item #1 in "Next steps".

[USER DIRECTIVE: leave blank to let the agent propose the next action, or fill in to override]
----------------------------------------------------------------
```

## Test plan

- [x] `python3 -m unittest modules.multi-agent.tests.test_handoff` — 13 tests pass
- [x] Smoke test the CLI end-to-end with all 6 new flags; verified template renders correctly with frontmatter intact
- [x] Verified divider is ASCII-only, no smart quotes, no merge-conflict-marker false positives
- [ ] Real-world test: run `/handoff` in a session, paste the kickoff prompt into a fresh session, verify the next agent picks up cleanly without re-exploring

## Out of scope

- `/sds` Phase 5 template alignment (separate follow-up)
- New SessionStart hook for auto-detecting `LATEST.md` (research suggested as v2 enhancement)
- Archive cleanup of handoffs > N days (existing `prune_old_handoffs` already handles 30-day window on startup)