### PR TITLE
#533: align docs with new /handoff behavior after #531

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -939,16 +939,18 @@ Sets up isolated workspace directories with multiple clones for parallel agent w
 
 ### /handoff
 
-**Write a handoff note for peer clones.**
+**Write a session handoff with copy-paste kickoff prompt.**
 
-Writes a short markdown handoff under `~/.claude/handoffs/{repo}/` so sibling clones on this machine can orient quickly on startup. `auto-startup.py` reads these on SessionStart, filters out the current agent's own notes and anything older than 7 days, and injects a compact block into the fresh session. Lightweight alternative between "nothing" and a full `/recall` transcript dive.
+Writes a structured 6-section markdown handoff under `~/.claude/handoffs/{repo}/` and prints a 3-sentence copy-paste prompt the next session can paste into a fresh Claude Code conversation. The same file also feeds peer-clone auto-injection on the next `/startup` (`summarize_for_startup --include-self` surfaces both peer handoffs and the current clone's own, marked `(you)`).
 
-**When to use**: After `gh pr merge` on non-trivial work, before ending a session that touched shared code, or when handing off a blocker.
+**Sections**: Current state / Next steps / Decisions & rationale / Files in progress / Gotchas / Blockers.
+
+**When to use**: End of a working session you do not want to resume via `claude --continue` (bloated, switching machines, going headless); mid-task checkpoint where `/compact` would lose too much; end-of-day pause.
 
 **Usage**:
 ```
-/handoff                           # Prompt yourself to fill in three sections
-/handoff {one-line description}    # Pre-seed the title
+/handoff                           # Build the handoff from current session context
+/handoff {one-line description}    # Same, but seed the title
 ```
 
 **Installed by**: multi-agent module

--- a/modules/multi-agent/lib/handoff.py
+++ b/modules/multi-agent/lib/handoff.py
@@ -16,21 +16,31 @@ File format (markdown with YAML frontmatter):
     ---
     agent: agent-w0-c0
     repo: ccgm
-    branch: 370-multi-agent-handoff
-    pr: 371
-    issue: 370
-    timestamp: 2026-04-21T05:49:00Z
+    branch: 531-refactor-handoff-session
+    pr: 532
+    issue: 531
+    timestamp: 2026-05-21T16:46:25Z
+    title: Refactor /handoff
     ---
 
-    # Handoff — #370 ...
+    # Handoff — Refactor /handoff
 
-    ## What I did
+    ## Current state
     ...
 
-    ## What's next
+    ## Next steps
+    1. ...
+
+    ## Decisions & rationale
+    - ...
+
+    ## Files in progress
+    - `path:line` — state — note
+
+    ## Gotchas
     ...
 
-    ## Blockers / context
+    ## Blockers
     ...
 
 This module provides:

--- a/modules/startup-dashboard/lib/startup-summary-prompt.md
+++ b/modules/startup-dashboard/lib/startup-summary-prompt.md
@@ -24,8 +24,9 @@ Last handoff
   Mark self-authored entries with "(you)" preserved from the HANDOFFS data —
   these are notes the previous session in this clone wrote for "future-me"
   (e.g., from /sds), so prioritize surfacing them.
-- If a handoff entry has a "What's next" line, indent it as a sub-bullet
-  beneath the entry so the next action is visible at a glance.
+- If a handoff entry has a "Next steps" line (or legacy "What's next"),
+  indent it as a sub-bullet beneath the entry so the next action is
+  visible at a glance.
 - OMIT this section entirely if HANDOFFS is empty or missing.
 
 Recent activity (last 48h)
@@ -47,8 +48,9 @@ Live sessions
 
 Next up
 - ONE concrete, grounded action. Priority order:
-  1. self-handoff "What's next" (HANDOFFS marked "(you)" — the previous
-     session in this clone left a concrete next step; honor it)
+  1. self-handoff "Next steps" / legacy "What's next" (HANDOFFS marked
+     "(you)" — the previous session in this clone left a concrete next
+     step; honor it)
   2. open PR to review (name it: "Review PR #X")
   3. dirty working tree (clone mode)
   4. dirty clones (workspace mode — name them)


### PR DESCRIPTION
Closes #533

Post-merge documentation cleanup for #531 (the /handoff refactor). Three surfaces still described the old 3-section template.

## Changes

- **`docs/commands.md`** /handoff section — rewritten to describe the 6-section template (Current state / Next steps / Decisions & rationale / Files in progress / Gotchas / Blockers) and to lead with the copy-paste kickoff prompt as the primary user-visible feature. Also corrects the inaccurate "filters out the current agent's own notes" claim — `summarize_for_startup --include-self` surfaces both peer handoffs and the current clone's own.
- **`modules/multi-agent/lib/handoff.py`** module docstring — updated the example file format to match the new template, with a realistic post-#531 set of frontmatter values.
- **`modules/startup-dashboard/lib/startup-summary-prompt.md`** — the summarizer prompt told the model to find a "What's next" line in handoffs. New handoffs use "Next steps". Updated to "Next steps" / legacy "What's next" so the 30-day prune window of older handoffs keeps rendering correctly.

## Test plan

- [x] `python3 -m unittest modules.multi-agent.tests.test_handoff` — 13 pass
- [x] `bash tests/test-no-personal-data.sh` — PASS
- [x] No code paths touched; only docstrings and prompt text

## Out of scope

- `/sds` Phase 5 template alignment — `/sds` still produces 3-section handoffs by passing `--body` directly. Behaviorally accurate, just a different shape from `/handoff`. Separate PR if/when we decide to align.