### PR TITLE
#537: post-merge docupdate after #535 (argus module)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Instructions for Claude Code when working on the CCGM (Claude Code God Mode) rep
 
 ## What This Repo Is
 
-CCGM is a modular Claude Code configuration system. It contains 35 modules that users can selectively install to configure Claude Code's behavior, hooks, commands, and permissions.
+CCGM is a modular Claude Code configuration system. It contains 66 modules that users can selectively install to configure Claude Code's behavior, hooks, commands, and permissions.
 
 ## Repository Structure
 
@@ -19,7 +19,7 @@ ccgm/
 │   ├── merge.sh        # settings.json merge via jq
 │   ├── modules.sh      # Module discovery + deps
 │   └── backup.sh       # Backup/restore
-├── modules/            # 35 self-contained modules
+├── modules/            # 66 self-contained modules
 │   └── {name}/
 │       ├── module.json # Manifest
 │       ├── README.md   # Module docs

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ For a quick install with a preset:
 |--------|---------|----------|
 | **minimal** | global-claude-md, autonomy, git-workflow | Getting started |
 | **standard** | global-claude-md, autonomy, identity, git-workflow, hooks, settings, commands-core, commands-utility | Most users |
-| **full** | All 46 stable modules | Power users |
+| **full** | 48 modules | Power users |
 | **team** | global-claude-md, autonomy, git-workflow, hooks, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification | Teams |
 
 ### Other install options
@@ -319,8 +319,8 @@ The `docs/` directory contains comprehensive documentation:
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
 | [Install via Agent](docs/install-via-agent.md) | Per-preset paste-blocks and how to dry-run them safely |
-| [Module Catalog](docs/modules.md) | Detailed reference for all 64 modules |
-| [Commands Reference](docs/commands.md) | All 36 slash commands with usage examples |
+| [Module Catalog](docs/modules.md) | Detailed reference for all 66 modules |
+| [Commands Reference](docs/commands.md) | All 72 slash commands with usage examples |
 | [Hooks Reference](docs/hooks.md) | All 13 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1354,6 +1354,23 @@ Walks every doc under `docs/solutions/**/*.md` and classifies each as Keep / Upd
 
 ---
 
+### /argus
+
+**Visual-ATDD convergence loop.**
+
+Develops a feature's UI against a per-feature design spec and signs off on its own work — functional and visual — by grounding every judgment in deterministic gates plus a separate `argus-judge` subagent that scores the render against the spec, a reference image, and the design system (never the diff). Loops to two consecutive rubric passes, then commits a snapshot baseline. Platform-agnostic via a pluggable sensor+gates adapter (web built in; iOS via a project adapter).
+
+**Usage**:
+```
+/argus feature:habits                     # converge every target in the spec
+/argus feature:habits target:list         # one target
+/argus feature:habits mode:report-only    # one dry iteration, no edits
+```
+
+**Installed by**: argus module
+
+---
+
 ### /design-review
 
 **Visual design review for web pages.**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ The installer offers four presets, or you can select modules one by one:
 | **minimal** | Core autonomy + git workflow rules | Trying CCGM for the first time |
 | **standard** | Minimal + hooks, settings, core commands | Most individual developers |
 | **team** | Standard + github-protocols, code-quality, debugging, verification | Teams with shared repos |
-| **full** | All 56 modules | Power users who want everything |
+| **full** | 48 modules | Power users who want everything |
 
 See [Presets](presets.md) for detailed breakdowns.
 
@@ -140,7 +140,7 @@ Removes only CCGM-installed files (tracked via a manifest). Your personal files 
 
 ## Next steps
 
-- [Module Catalog](modules.md) - explore all 56 modules in detail
+- [Module Catalog](modules.md) - explore all 66 modules in detail
 - [Commands Reference](commands.md) - learn every slash command
 - [Hooks Reference](hooks.md) - understand the workflow automation
 - [Configuration](configuration.md) - customize CCGM after installation

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,6 @@
 # Module Catalog
 
-CCGM contains 64 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
+CCGM contains 66 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
 
 ## How modules work
 
@@ -844,6 +844,18 @@ File-based review-finding tracker for things that don't merit a GitHub issue.
 **What it does**: Review findings, PR nitpicks, and tech debt that fall between "fix immediately" and "cut a full issue" go to `.claude/todos/NNN-{status}-{priority}-{description}.md` with YAML frontmatter. Three skills compose — `/todo-create` (canonical writer), `/todo-triage` (interactive pending→ready transition), `/todo-resolve` (batch-resolve ready todos via parallel subagents).
 
 **Dependencies**: skill-authoring, subagent-patterns
+
+---
+
+### argus
+
+Visual-ATDD convergence loop: develop UI against a design spec and self-sign-off via deterministic gates plus a separate judge agent.
+
+**Installs**: `skills/argus/SKILL.md` (`/argus`), `agents/argus-judge.md`, `rules/argus.md`, plus spec/verdict/gate/rubric schemas and six dependency-free deterministic gate scripts under `skills/argus/`
+
+**What it does**: Runs an implement → render → externally-judge → converge loop for a feature's UI. An `implementer` subagent edits code, deterministic gates (build/lint/type/WCAG-contrast/a11y/snapshot/flows) form an ungameable floor, and a *separate* `argus-judge` subagent scores the render against the spec, a reference image, and the design system — never seeing the diff. The loop signs off after two consecutive rubric passes (3-attempt-per-dimension cap, then freeze + document), then commits a snapshot baseline. Platform-agnostic via a pluggable sensor+gates adapter: a web adapter is built in (Chrome capture); iOS/macOS plug in via a project adapter. Minimal human input — ≤1 reference image per screen plus one spot-check.
+
+**Dependencies**: subagent-patterns
 
 ---
 


### PR DESCRIPTION
Closes #537. Post-merge documentation sync after the `argus` module landed in #536.

## Changes

- **docs/modules.md** — module count 64 → **66**; added the `argus` section under Category: workflow.
- **docs/commands.md** — added `/argus` to the Skills section.
- **README.md** — catalog "all 64 modules" → **66**; "36 slash commands" → **72** (both were stale); `full` preset "All 46 stable modules" → **48**.
- **docs/getting-started.md** — `full` preset "All 56 modules" → **48**; catalog link "all 56 modules" → **66**.
- **CLAUDE.md** (and `AGENTS.md`, its symlink) — "35 modules" → **66** (×2).

Counts were stale beyond just the argus delta (35 / 56 / 64 in different docs); all corrected to current reality: **66 modules total, 48 in `full`, 72 documented slash commands**, verified against `ls modules/`, `jq length presets/full.json`, and `grep -c '^### /' docs/commands.md`.

## Noted but NOT changed (out of scope for this PR)
- `docs/presets.md` says cloud-agent has **42** modules; `presets/cloud-agent.json` has **44**. Pre-existing drift, unrelated to argus — flagging for a separate fix.

## Test Plan
- `bash tests/test-modules.sh` → 1215 passed, 0 failed.
- `bash tests/test-no-personal-data.sh` → PASS.
- `grep -cE '^### ' docs/modules.md` → 66 (matches module count).