### PR TITLE
#539: gitignore .env.clone + correct presets.md cloud-agent prose & count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 modules/autoheal/config.json
 **/.autoheal/config.json
 **/autoheal/.env
+
+# multi-clone workspaces: per-clone identity + dev-server ports (local-only)
+.env.clone

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -55,7 +55,7 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 **Best for**: Running CCGM on headless cloud VMs that dispatch parallel agents to work on GitHub issues. Includes the agent orchestration modules (`agent-manager`, `cloud-dispatch`) that the standard `full` preset omits.
 
-**Modules (42)**: Most of `full`, plus `agent-manager` (tmux-based agent dashboard) and `cloud-dispatch` (Hetzner Cloud VM provisioning for parallel GitHub-issue work), minus `brainstorm` (interactive design-spec gate — not useful on a headless agent).
+**Modules (44)**: Curated for headless cloud agents — `full` minus six modules that don't fit the headless use case (`brainstorm`, `skillify`, `deepresearch`, `ccgm-doctor`, `autoheal`, `argus`), plus `agent-manager` (tmux-based agent dashboard) and `cloud-dispatch` (Hetzner Cloud VM provisioning for parallel GitHub-issue work).
 
 **What you get**: The cloud-agent preset with cloud-dispatch commands (`/dispatch`, `/dispatch-status`, `/dispatch-stop`, `/vm-manage`) and the `/agents` TUI. Intended for machines that provision cloud VMs and launch autonomous agents, not day-to-day laptop use.
 


### PR DESCRIPTION
Closes #539. The two follow-ups flagged in #538.

## Changes

- **`.gitignore`** — add `.env.clone`. It's per-clone identity + dev-server ports, untracked but previously not ignored, so `git add -A` would sweep it into commits (this happened in #538 and was caught + amended before the PR). One line, prevents recurrence across every clone.
- **`docs/presets.md`** — cloud-agent count **42 → 44** (matches `presets/cloud-agent.json`), and rewrite the surrounding prose. The old wording said "Most of `full`, plus 2, minus 1 (`brainstorm`)"; the actual delta from `full` is **minus 6** (`brainstorm`, `skillify`, `deepresearch`, `ccgm-doctor`, `autoheal`, `argus`) **plus 2** (`agent-manager`, `cloud-dispatch`). New prose names all 6 omitted modules with the headless-cloud-agent rationale. 48 − 6 + 2 = 44 ✓.

## Test Plan

- `jq -n --slurpfile a presets/full.json --slurpfile b presets/cloud-agent.json '$a[0] - $b[0]'` → 6 modules (matches new prose).
- `git status` no longer shows `.env.clone` as untracked; `git check-ignore -v .env.clone` matches the new entry.
- `bash tests/test-modules.sh` → 1215 passed, 0 failed.
- `bash tests/test-no-personal-data.sh` → PASS.