### PR TITLE
#541: statusline shows Opus 4.8 correctly

### DIFF
--- a/lib/statusline.sh
+++ b/lib/statusline.sh
@@ -7,6 +7,7 @@ input=$(cat)
 # --- Model (abbreviated: O-4.6, S-4.6, H-4.5, etc.) with tier indicators
 model_raw=$(echo "$input" | jq -r '.model.display_name // ""')
 case "$model_raw" in
+  *"Opus 4.8"*)   model_abbr="O-4.8"; model_tier="opus-best" ;;
   *"Opus 4.7"*)   model_abbr="O-4.7"; model_tier="opus-best" ;;
   *"Opus 4.6"*)   model_abbr="O-4.6"; model_tier="opus-best" ;;
   *"Opus 4.5"*)   model_abbr="O-4.5"; model_tier="opus-other" ;;


### PR DESCRIPTION
## Summary

The status line rendered the current model as `O-4` (looks like `0-4` in the terminal font) with no tier emoji, instead of `O-4.8`. Closes #541.

## Root cause

`lib/statusline.sh` matches `.model.display_name` against a hardcoded per-version `case`. There was no `Opus 4.8` branch, so `"Opus 4.8 (1M context)"` fell through to the generic `*"Opus 4"*` branch → `model_abbr="O-4"`, tier `opus-other` (no 🧠).

## Changes

- Add `*"Opus 4.8"*` case (`O-4.8`, tier `opus-best`) ahead of the generic Opus branch, matching the existing newest-first convention.

(`modules/commands-utility/statusline-command.sh` is a committed symlink to `lib/statusline.sh`, which is the real source.)

## Test plan

- `Opus 4.8 (1M context)` and `Opus 4.8` → `🧠 O-4.8` (blue, opus-best)
- Regression-checked `Opus 4.7` → `🧠 O-4.7`, `Opus 4.5` → `O-4.5`, `Sonnet 4.6` → `🐢 S-4.6`, `Haiku 4.5` → `⚠️ H-4.5` — all unchanged
- `bash -n` parses; `tests/test-modules.sh` 1215/0; `tests/test-no-personal-data.sh` PASS