### PR TITLE
#545: parse statusline model family+version generically

### DIFF
--- a/lib/statusline.sh
+++ b/lib/statusline.sh
@@ -4,21 +4,32 @@
 
 input=$(cat)
 
-# --- Model (abbreviated: O-4.6, S-4.6, H-4.5, etc.) with tier indicators
+# --- Model: render as "{family}-{version}" with a tier that drives color/emoji.
+# Family and version are parsed from display_name generically, so NEW MODEL
+# RELEASES NEED NO EDITS HERE. Examples:
+#   "Opus 4.8 (1M context)" -> 🧠 O-4.8   "Sonnet 4.6" -> 🐢 S-4.6   "Haiku 4.5" -> ⚠️ H-4.5
 model_raw=$(echo "$input" | jq -r '.model.display_name // ""')
+
+# First version token in the name, e.g. "4.8" (empty when the name has none).
+model_ver=$(printf '%s' "$model_raw" | grep -oE '[0-9]+(\.[0-9]+)?' | head -n1)
+
 case "$model_raw" in
-  *"Opus 4.8"*)   model_abbr="O-4.8"; model_tier="opus-best" ;;
-  *"Opus 4.7"*)   model_abbr="O-4.7"; model_tier="opus-best" ;;
-  *"Opus 4.6"*)   model_abbr="O-4.6"; model_tier="opus-best" ;;
-  *"Opus 4.5"*)   model_abbr="O-4.5"; model_tier="opus-other" ;;
-  *"Opus 4"*)     model_abbr="O-4"; model_tier="opus-other" ;;
-  *"Sonnet 4.6"*) model_abbr="S-4.6"; model_tier="sonnet" ;;
-  *"Sonnet 4.5"*) model_abbr="S-4.5"; model_tier="sonnet" ;;
-  *"Sonnet 4"*)   model_abbr="S-4"; model_tier="sonnet" ;;
-  *"Haiku 4.5"*)  model_abbr="H-4.5"; model_tier="haiku" ;;
-  *"Haiku"*)      model_abbr="H"; model_tier="haiku" ;;
-  "")             model_abbr=""; model_tier="" ;;
-  *)              model_abbr=$(echo "$model_raw" | sed 's/Claude //;s/ .*//'); model_tier="unknown" ;;
+  *Opus*)
+    model_abbr="O${model_ver:+-$model_ver}"
+    # Opus is flagship (🧠) at 4.6 or newer, plain below. The check is numeric
+    # and monotonic, so future versions (4.9, 5.0, …) are flagship automatically.
+    ver_major=${model_ver%%.*}; ver_minor=${model_ver#*.}
+    [ "$ver_minor" = "$model_ver" ] && ver_minor=0
+    if [ "${ver_major:-0}" -gt 4 ] || { [ "${ver_major:-0}" -eq 4 ] && [ "${ver_minor:-0}" -ge 6 ]; }; then
+      model_tier="opus-best"
+    else
+      model_tier="opus-other"
+    fi
+    ;;
+  *Sonnet*) model_abbr="S${model_ver:+-$model_ver}"; model_tier="sonnet" ;;
+  *Haiku*)  model_abbr="H${model_ver:+-$model_ver}"; model_tier="haiku" ;;
+  "")       model_abbr=""; model_tier="" ;;
+  *)        model_abbr=$(echo "$model_raw" | sed 's/Claude //;s/ .*//'); model_tier="unknown" ;;
 esac
 
 # --- Directory: immediate dir name only

--- a/modules/commands-utility/tests/test_statusline.sh
+++ b/modules/commands-utility/tests/test_statusline.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Unit test: lib/statusline.sh model rendering.
+#
+# Pins the generic family+version parsing. The point of these cases is that
+# NEW model releases (4.9, 5.0, Sonnet 5, …) must render correctly with NO
+# change to statusline.sh — if a future model ever needs a code edit here, one
+# of the "future" assertions below will fail and tell us the parser regressed.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+STATUSLINE="$REPO_ROOT/lib/statusline.sh"
+
+PASS=0
+FAIL=0
+
+TMPHOME="$(mktemp -d)"
+trap 'rm -rf "$TMPHOME"' EXIT
+
+# Render and return ONLY the model field. Hermetic: an empty HOME + cwd and a
+# stripped effort env var mean no effort suffix, git branch, or settings noise —
+# the output is just "<model> | <tmpdir>", so the model is everything before
+# the first " | " separator.
+model_field() {
+  local out
+  out="$(printf '{"model":{"display_name":"%s"},"cwd":"%s"}' "$1" "$TMPHOME" \
+    | env -u CLAUDE_CODE_EFFORT_LEVEL HOME="$TMPHOME" bash "$STATUSLINE" \
+    | sed 's/\x1b\[[0-9;]*m//g')"
+  printf '%s' "${out%% | *}"
+}
+
+check() {  # $1 = display_name, $2 = expected model field
+  local got
+  got="$(model_field "$1")"
+  if [ "$got" = "$2" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: '$1' -> '$got'"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: '$1' -> got '$got', expected '$2'"
+  fi
+}
+
+echo "=== statusline model rendering ==="
+
+# --- Current models (must match prior behavior exactly) ---
+check "Opus 4.8 (1M context)" "🧠 O-4.8"
+check "Opus 4.8"              "🧠 O-4.8"
+check "Opus 4.7"              "🧠 O-4.7"
+check "Opus 4.6"              "🧠 O-4.6"
+check "Opus 4.5"              "O-4.5"
+check "Opus 4"                "O-4"
+check "Sonnet 4.6"            "🐢 S-4.6"
+check "Sonnet 4.5"            "🐢 S-4.5"
+check "Sonnet 4"              "🐢 S-4"
+check "Haiku 4.5"             "⚠️ H-4.5"
+check "Haiku"                 "⚠️ H"
+
+# --- Future models: NO code edit should ever be needed for these ---
+check "Opus 4.9"              "🧠 O-4.9"
+check "Opus 4.10"             "🧠 O-4.10"
+check "Opus 5"                "🧠 O-5"
+check "Opus 5.2 (1M context)" "🧠 O-5.2"
+check "Sonnet 5"             "🐢 S-5"
+check "Sonnet 4.8"           "🐢 S-4.8"
+check "Haiku 5"              "⚠️ H-5"
+
+# --- Edges ---
+check ""                      "$(basename "$TMPHOME")"   # no model -> dir is first field
+check "Claude Gizmo 9"        "Gizmo"                    # unknown family -> sed fallback, plain
+
+echo ""
+echo "  Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Replaces the hardcoded per-version `case` list in `lib/statusline.sh` with generic parsing of family + version from `.model.display_name`. New model releases now render correctly with **no code edits**. Closes #545.

## How

- Family word → letter: `Opus`→O, `Sonnet`→S, `Haiku`→H.
- Version = first `N` / `N.N` token in the name (e.g. `4.8`).
- Opus tier is numeric + monotonic: flagship 🧠 at `>= 4.6`, plain below — so 4.9 / 5.0 / … are flagship automatically. Sonnet → 🐢, Haiku → ⚠️ unconditionally.
- Unknown family falls back to the existing `sed` name extraction.

## Test

New hermetic suite `modules/commands-utility/tests/test_statusline.sh` (auto-discovered by `tests/run-unit-tests.sh`), 20 cases:
- All current models match prior behavior exactly (incl. `Opus 4.5`/`4` staying plain).
- **Future** models (`Opus 4.9`, `Opus 4.10`, `Opus 5`, `Sonnet 5`, `Haiku 5`) render correctly with no code change — these guard the future-proofing.
- Edges: empty model, unknown family.

Full suite green: 198 pytest, 2 shell suites, `test-modules.sh` 1215/0, no personal data.