### PR TITLE
#547: show ultracode as 'Ultra' in the statusline effort slot

### DIFF
--- a/lib/statusline.sh
+++ b/lib/statusline.sh
@@ -51,6 +51,25 @@ if [ -z "$effort_raw" ] && [ -n "$cwd" ]; then
   [ -z "$effort_raw" ] && effort_raw=$(read_effort_from "$cwd/.claude/settings.json")
 fi
 [ -z "$effort_raw" ] && effort_raw=$(read_effort_from "$HOME/.claude/settings.json")
+
+# Ultracode is a session mode (xhigh effort + standing dynamic-workflow
+# orchestration), tracked as a SEPARATE boolean from effort. Claude Code (2.1.x)
+# resolves .effort.level to "xhigh" when it's on and does NOT put the flag in the
+# statusline payload, so a session-only toggle is invisible here — we can only
+# see it via the `ultracode` settings key. Check every channel that could declare
+# it (mirroring the effort cascade) so this also auto-works if a future CC adds
+# `.ultracode` / effort=="ultracode" to stdin.
+read_ultracode_from() {
+  [ -f "$1" ] && jq -e '.ultracode == true' "$1" >/dev/null 2>&1
+}
+ultracode=""
+if   [ "$(echo "$input" | jq -r '.ultracode // empty')" = "true" ]; then ultracode=1
+elif [ "$effort_raw" = "ultracode" ] || [ "${CLAUDE_CODE_EFFORT_LEVEL:-}" = "ultracode" ]; then ultracode=1
+elif [ -n "$cwd" ] && read_ultracode_from "$cwd/.claude/settings.local.json"; then ultracode=1
+elif [ -n "$cwd" ] && read_ultracode_from "$cwd/.claude/settings.json"; then ultracode=1
+elif read_ultracode_from "$HOME/.claude/settings.json"; then ultracode=1
+fi
+
 case "$effort_raw" in
   low)    effort_abbr="L" ;;
   medium) effort_abbr="M" ;;
@@ -59,6 +78,9 @@ case "$effort_raw" in
   max)    effort_abbr="Max" ;;
   *)      effort_abbr="" ;;
 esac
+# Ultracode presents as xhigh effort; surface it as its own top-tier label,
+# shown in place of XH/Max when active.
+[ -n "$ultracode" ] && effort_abbr="Ultra"
 
 # --- Git branch (skip optional locks to avoid hangs in multi-clone repos)
 git_branch=""
@@ -85,6 +107,7 @@ RED='\033[31m'
 DIM='\033[2m'
 BLUE='\033[34m'
 ORANGE='\033[38;5;208m'
+VIOLET='\033[38;5;135m'
 
 # Compact usage bar: 5 chars wide
 make_bar() {
@@ -109,11 +132,12 @@ if [ -n "$model_abbr" ]; then
   effort_suffix=""
   if [ -n "$effort_abbr" ]; then
     case "$effort_abbr" in
-      Max) effort_color="$RED" ;;
-      XH)  effort_color="$ORANGE" ;;
-      H)   effort_color="$YELLOW" ;;
-      M)   effort_color="$GREEN" ;;
-      *)   effort_color="$DIM" ;;
+      Ultra) effort_color="$VIOLET" ;;
+      Max)   effort_color="$RED" ;;
+      XH)    effort_color="$ORANGE" ;;
+      H)     effort_color="$YELLOW" ;;
+      M)     effort_color="$GREEN" ;;
+      *)     effort_color="$DIM" ;;
     esac
     effort_suffix="$(printf " ${effort_color}%s${RESET}" "$effort_abbr")"
   fi

--- a/modules/commands-utility/tests/test_statusline.sh
+++ b/modules/commands-utility/tests/test_statusline.sh
@@ -69,6 +69,46 @@ check "Haiku 5"              "⚠️ H-5"
 check ""                      "$(basename "$TMPHOME")"   # no model -> dir is first field
 check "Claude Gizmo 9"        "Gizmo"                    # unknown family -> sed fallback, plain
 
+# --- Effort + ultracode label ---
+# Pass effort explicitly; the model field carries the effort suffix
+# ("🧠 O-4.8 Max"). The first " | "-delimited field is model + effort.
+field_first() {  # $1 = full stdin JSON, $2 = HOME dir
+  printf '%s' "$1" \
+    | env -u CLAUDE_CODE_EFFORT_LEVEL HOME="$2" bash "$STATUSLINE" \
+    | sed 's/\x1b\[[0-9;]*m//g' \
+    | sed 's/ | .*//'
+}
+check_effort() {  # $1 = label, $2 = stdin JSON, $3 = HOME, $4 = expected
+  local got
+  got="$(field_first "$2" "$3")"
+  if [ "$got" = "$4" ]; then
+    PASS=$((PASS + 1)); echo "  PASS: $1 -> '$got'"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: $1 -> got '$got', expected '$4'"
+  fi
+}
+
+echo ""
+echo "=== effort + ultracode ==="
+M='{"model":{"display_name":"Opus 4.8"},"cwd":"'"$TMPHOME"'"'
+# Baseline effort labels (no ultracode) — must be unchanged.
+check_effort "max"               "$M,\"effort\":{\"level\":\"max\"}}"                     "$TMPHOME" "🧠 O-4.8 Max"
+check_effort "xhigh"             "$M,\"effort\":{\"level\":\"xhigh\"}}"                   "$TMPHOME" "🧠 O-4.8 XH"
+# Ultracode via stdin .effort.level (defensive: auto-works if CC reports it raw).
+check_effort "effort=ultracode"  "$M,\"effort\":{\"level\":\"ultracode\"}}"               "$TMPHOME" "🧠 O-4.8 Ultra"
+# Ultracode via a stdin boolean (defensive: auto-works if CC adds the flag).
+check_effort "stdin .ultracode"  "$M,\"effort\":{\"level\":\"xhigh\"},\"ultracode\":true}" "$TMPHOME" "🧠 O-4.8 Ultra"
+# Ultracode shown in place of max.
+check_effort "ultracode>max"     "$M,\"effort\":{\"level\":\"max\"},\"ultracode\":true}"   "$TMPHOME" "🧠 O-4.8 Ultra"
+
+# Ultracode via the `ultracode` settings key — the channel that works today.
+# CC resolves effort to xhigh under ultracode, so stdin reports xhigh here.
+UCHOME="$(mktemp -d)"
+mkdir -p "$UCHOME/.claude"
+printf '{"ultracode": true}' > "$UCHOME/.claude/settings.json"
+check_effort "settings ultracode" "{\"model\":{\"display_name\":\"Opus 4.8\"},\"cwd\":\"$UCHOME\",\"effort\":{\"level\":\"xhigh\"}}" "$UCHOME" "🧠 O-4.8 Ultra"
+rm -rf "$UCHOME"
+
 echo ""
 echo "  Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Adds an `Ultra` (violet) effort label for the **ultracode** session mode, shown in place of `XH`/`Max` when active. Closes #547.

## Why it's not just another effort case

Reverse-engineered from the Claude Code binary (2.1.156):
- The effort enum is `low|medium|high|xhigh|max` — `ultracode` is **not** an effort value.
- Ultracode is a **separate boolean** (`ultracode` settings key). Enabling it sets `effortValue:"xhigh", ultracode:true`.
- The statusline stdin payload carries only `effort.level` (the *resolved* value → `xhigh` under ultracode) and **no ultracode flag**.

So `.effort.level` alone cannot reveal ultracode. Detection mirrors the effort cascade and checks every channel that could declare it:
1. stdin `.ultracode == true` (defensive — auto-works if a future CC adds it)
2. stdin `.effort.level == "ultracode"` or env `CLAUDE_CODE_EFFORT_LEVEL == "ultracode"` (defensive)
3. `ultracode: true` in `cwd/.claude/settings{.local,}.json` or `~/.claude/settings.json` (**the channel that works today**)

When detected, the effort label becomes `Ultra` (violet `38;5;135`).

## ⚠️ Known limitation (Claude Code, not this script)

A **session-only** ultracode toggle (`/effort` → ultracode "this session only") is **invisible** to the statusline in CC 2.1.156: the payload reports `effort.level: xhigh` with no ultracode flag. This script reflects ultracode only when it's set as a persistent `ultracode: true` settings key — or automatically once a future CC exposes the flag in the statusline payload (the defensive stdin checks already handle that).

## Test

Extends `modules/commands-utility/tests/test_statusline.sh` (now 26 cases): baseline `max`/`xhigh` unchanged; ultracode via stdin level, stdin boolean, override-of-max, and the settings key all render `Ultra`.

Full suite green: pytest OK, 2 shell suites, `test-modules.sh` 1215/0, no personal data.