### PR TITLE
#549: show ultracode as ✨XH✨ instead of replacing effort with 'Ultra'

### DIFF
--- a/lib/statusline.sh
+++ b/lib/statusline.sh
@@ -78,9 +78,9 @@ case "$effort_raw" in
   max)    effort_abbr="Max" ;;
   *)      effort_abbr="" ;;
 esac
-# Ultracode presents as xhigh effort; surface it as its own top-tier label,
-# shown in place of XH/Max when active.
-[ -n "$ultracode" ] && effort_abbr="Ultra"
+# Ultracode always runs at xhigh effort, so show the accurate level (XH); the
+# render bookends it with sparkles (✨XH✨) to flag the mode without hiding it.
+[ -n "$ultracode" ] && effort_abbr="XH"
 
 # --- Git branch (skip optional locks to avoid hangs in multi-clone repos)
 git_branch=""
@@ -107,7 +107,6 @@ RED='\033[31m'
 DIM='\033[2m'
 BLUE='\033[34m'
 ORANGE='\033[38;5;208m'
-VIOLET='\033[38;5;135m'
 
 # Compact usage bar: 5 chars wide
 make_bar() {
@@ -132,14 +131,18 @@ if [ -n "$model_abbr" ]; then
   effort_suffix=""
   if [ -n "$effort_abbr" ]; then
     case "$effort_abbr" in
-      Ultra) effort_color="$VIOLET" ;;
-      Max)   effort_color="$RED" ;;
-      XH)    effort_color="$ORANGE" ;;
-      H)     effort_color="$YELLOW" ;;
-      M)     effort_color="$GREEN" ;;
-      *)     effort_color="$DIM" ;;
+      Max) effort_color="$RED" ;;
+      XH)  effort_color="$ORANGE" ;;
+      H)   effort_color="$YELLOW" ;;
+      M)   effort_color="$GREEN" ;;
+      *)   effort_color="$DIM" ;;
     esac
-    effort_suffix="$(printf " ${effort_color}%s${RESET}" "$effort_abbr")"
+    if [ -n "$ultracode" ]; then
+      # Ultracode: keep the accurate effort color, bookend with sparkles (✨XH✨).
+      effort_suffix="$(printf " ✨${effort_color}%s${RESET}✨" "$effort_abbr")"
+    else
+      effort_suffix="$(printf " ${effort_color}%s${RESET}" "$effort_abbr")"
+    fi
   fi
   case "$model_tier" in
     opus-best)

--- a/modules/commands-utility/tests/test_statusline.sh
+++ b/modules/commands-utility/tests/test_statusline.sh
@@ -94,19 +94,22 @@ M='{"model":{"display_name":"Opus 4.8"},"cwd":"'"$TMPHOME"'"'
 # Baseline effort labels (no ultracode) — must be unchanged.
 check_effort "max"               "$M,\"effort\":{\"level\":\"max\"}}"                     "$TMPHOME" "🧠 O-4.8 Max"
 check_effort "xhigh"             "$M,\"effort\":{\"level\":\"xhigh\"}}"                   "$TMPHOME" "🧠 O-4.8 XH"
-# Ultracode via stdin .effort.level (defensive: auto-works if CC reports it raw).
-check_effort "effort=ultracode"  "$M,\"effort\":{\"level\":\"ultracode\"}}"               "$TMPHOME" "🧠 O-4.8 Ultra"
-# Ultracode via a stdin boolean (defensive: auto-works if CC adds the flag).
-check_effort "stdin .ultracode"  "$M,\"effort\":{\"level\":\"xhigh\"},\"ultracode\":true}" "$TMPHOME" "🧠 O-4.8 Ultra"
-# Ultracode shown in place of max.
-check_effort "ultracode>max"     "$M,\"effort\":{\"level\":\"max\"},\"ultracode\":true}"   "$TMPHOME" "🧠 O-4.8 Ultra"
+# Ultracode keeps the accurate effort (always xhigh -> XH) and bookends with ✨.
+# Via stdin .effort.level=="ultracode" (defensive: no effort case -> forced XH).
+check_effort "effort=ultracode"  "$M,\"effort\":{\"level\":\"ultracode\"}}"               "$TMPHOME" "🧠 O-4.8 ✨XH✨"
+# Via a stdin boolean (defensive: auto-works if CC adds the flag).
+check_effort "stdin .ultracode"  "$M,\"effort\":{\"level\":\"xhigh\"},\"ultracode\":true}" "$TMPHOME" "🧠 O-4.8 ✨XH✨"
+# Ultracode forces XH even if stdin claims another level (ultracode IS xhigh).
+check_effort "ultracode forces XH" "$M,\"effort\":{\"level\":\"max\"},\"ultracode\":true}" "$TMPHOME" "🧠 O-4.8 ✨XH✨"
 
 # Ultracode via the `ultracode` settings key — the channel that works today.
-# CC resolves effort to xhigh under ultracode, so stdin reports xhigh here.
 UCHOME="$(mktemp -d)"
 mkdir -p "$UCHOME/.claude"
 printf '{"ultracode": true}' > "$UCHOME/.claude/settings.json"
-check_effort "settings ultracode" "{\"model\":{\"display_name\":\"Opus 4.8\"},\"cwd\":\"$UCHOME\",\"effort\":{\"level\":\"xhigh\"}}" "$UCHOME" "🧠 O-4.8 Ultra"
+# CC resolves effort to xhigh under ultracode, so stdin reports xhigh here.
+check_effort "settings ultracode" "{\"model\":{\"display_name\":\"Opus 4.8\"},\"cwd\":\"$UCHOME\",\"effort\":{\"level\":\"xhigh\"}}" "$UCHOME" "🧠 O-4.8 ✨XH✨"
+# Settings flag with NO stdin effort -> still ✨XH✨ (forced from the ultracode flag).
+check_effort "settings ultracode, no stdin effort" "{\"model\":{\"display_name\":\"Opus 4.8\"},\"cwd\":\"$UCHOME\"}" "$UCHOME" "🧠 O-4.8 ✨XH✨"
 rm -rf "$UCHOME"
 
 echo ""


### PR DESCRIPTION
## Summary

Refines #548. Replacing the effort label with `Ultra` hid the real effort level. Now the status line shows the **accurate** effort and **adds** an ultracode flag: `✨XH✨`. Closes #549.

## Changes
- When ultracode is detected, force `effort_abbr=XH` (ultracode always runs at xhigh) instead of `Ultra`.
- Render bookends the effort with sparkles when ultracode is active; `XH` keeps its normal orange effort color, so both facts read accurately (real level + mode).
- Dropped the now-unused `VIOLET` color and `Ultra)` render case.

## Test
`test_statusline.sh` now 27 cases. Ultracode via stdin level, stdin boolean, forced-XH-over-max, settings key, and **settings-flag-with-no-stdin-effort** all render `✨XH✨`. Baselines (`max`→Max, `xhigh`→XH) unchanged.

Full suite green: run-unit-tests OK, `test-modules.sh` 1215/0, no personal data.