### PR TITLE
#551: add `--add <module>` to install one module into an existing setup

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -112,12 +112,214 @@ write_manifest() {
   ui_success "Wrote manifest: $manifest_file"
 }
 
+# --- Add mode helper ---
+# Non-interactive fast path: install one or more modules into an existing
+# CCGM setup. Inherits link-mode + scope from the existing manifest, resolves
+# dependencies, skips already-installed modules, and merges the new modules
+# and files into the manifest. Bypasses the entire interactive installer.
+#
+# The plan-build and execute loops below intentionally mirror Step 8 (preview)
+# and Step 11 (install) of main(). That logic is inlined in the monolithic
+# main(); duplicating the small faithful copy here keeps --add isolated from
+# the interactive path rather than refactoring the core installer in this PR.
+run_add_mode() {
+  if ! command -v jq &>/dev/null; then
+    ui_error "--add requires jq."
+    exit 1
+  fi
+
+  local global_dir="$HOME/.claude"
+  local project_dir
+  project_dir="$(pwd)/.claude"
+
+  # Locate the manifest: prefer global, fall back to a project install.
+  local manifest_file=""
+  if [ -f "${global_dir}/.ccgm-manifest.json" ]; then
+    manifest_file="${global_dir}/.ccgm-manifest.json"
+  elif [ -f "${project_dir}/.ccgm-manifest.json" ]; then
+    manifest_file="${project_dir}/.ccgm-manifest.json"
+  else
+    ui_error "No existing CCGM install found (looked in ${global_dir} and ${project_dir})."
+    ui_info "Run ./start.sh first to set up CCGM, then use --add to add modules."
+    exit 1
+  fi
+
+  # Inherit install settings from the manifest (do not re-prompt).
+  LINK_MODE=$(jq -r '.linkMode // false' "$manifest_file")
+  SCOPE=$(jq -r '.scope // "global"' "$manifest_file")
+  PRESET_NAME=$(jq -r '.preset // "custom"' "$manifest_file")
+
+  local install_global=false
+  local install_project=false
+  case "$SCOPE" in
+    global)  install_global=true ;;
+    project) install_project=true ;;
+    both)    install_global=true; install_project=true ;;
+    *) ui_error "Manifest has invalid scope: $SCOPE"; exit 1 ;;
+  esac
+
+  # .ccgm.env (for template expansion) is written to the global dir by the
+  # installer; fall back to the project dir for a project-only install.
+  local env_file="${global_dir}/.ccgm.env"
+  [ -f "$env_file" ] || env_file="${project_dir}/.ccgm.env"
+
+  # Modules already recorded as installed.
+  local existing_modules=()
+  local m
+  while IFS= read -r m; do
+    [ -n "$m" ] && existing_modules+=("$m")
+  done < <(jq -r '.modules[]?' "$manifest_file")
+
+  # Validate each requested module exists before doing any work.
+  local req
+  for req in "${ADD_MODULES[@]}"; do
+    if [ ! -f "${CCGM_ROOT}/modules/${req}/module.json" ]; then
+      ui_error "Unknown module: $req"
+      ui_info "Run ./start.sh and choose 'Custom module selection' to see available modules."
+      exit 1
+    fi
+  done
+
+  # Resolve dependencies (dep-first order).
+  local resolved=()
+  while IFS= read -r m; do
+    [ -n "$m" ] && resolved+=("$m")
+  done < <(resolve_dependencies "${ADD_MODULES[@]}")
+
+  if [ ${#resolved[@]} -eq 0 ]; then
+    ui_error "Could not resolve modules: ${ADD_MODULES[*]}"
+    exit 1
+  fi
+
+  # Filter out modules already installed.
+  local to_install=()
+  local e found
+  for m in "${resolved[@]}"; do
+    found=false
+    for e in ${existing_modules[@]+"${existing_modules[@]}"}; do
+      if [ "$e" = "$m" ]; then found=true; break; fi
+    done
+    if [ "$found" = false ]; then to_install+=("$m"); fi
+  done
+
+  ui_header "Add Modules"
+  ui_info "Requested: ${ADD_MODULES[*]}"
+  ui_info "Scope: $SCOPE | Mode: $([ "$LINK_MODE" = true ] && echo symlink || echo copy)"
+
+  if [ ${#to_install[@]} -eq 0 ]; then
+    ui_success "Already installed: ${ADD_MODULES[*]} (with dependencies). Nothing to do."
+    exit 0
+  fi
+  ui_info "Installing (${#to_install[@]}): ${to_install[*]}"
+  echo ""
+
+  # Ensure target dirs exist and clear stale symlinks (as the main flow does).
+  [ "$install_global" = true ] && mkdir -p "$global_dir" && repair_dangling_symlinks "$global_dir"
+  [ "$install_project" = true ] && mkdir -p "$project_dir" && repair_dangling_symlinks "$project_dir"
+
+  # --- Build install plan (mirror of main() Step 8) ---
+  local install_plan=()
+  for m in "${to_install[@]}"; do
+    local src target template merge
+    while IFS='|' read -r src target _ template merge; do
+      local full_src="${CCGM_ROOT}/modules/${m}/${src}"
+      local scope_list mod_scope
+      scope_list=$(get_module_scope "$m")
+      while IFS= read -r mod_scope; do
+        local target_dir=""
+        case "$mod_scope" in
+          global)  [ "$install_global" = true ] && target_dir="$global_dir" ;;
+          project) [ "$install_project" = true ] && target_dir="$project_dir" ;;
+        esac
+        [ -z "$target_dir" ] && continue
+        local full_target="${target_dir}/${target}"
+        local action="copy"
+        [ "$LINK_MODE" = true ] && [ "$merge" != "true" ] && action="link"
+        [ "$merge" = "true" ] && action="merge"
+        install_plan+=("${action}|${full_src}|${full_target}|${template}|${m}")
+      done <<< "$scope_list"
+    done < <(get_module_files "$m")
+  done
+
+  # --- Execute install plan (mirror of main() Step 11) ---
+  INSTALLED_FILES=()
+  local entry action src target template mod_name
+  for entry in ${install_plan[@]+"${install_plan[@]}"}; do
+    IFS='|' read -r action src target template mod_name <<< "$entry"
+    mkdir -p "$(dirname "$target")"
+    case "$action" in
+      merge)
+        init_settings "$target"
+        if [ "$template" = "true" ]; then
+          local tmp_merge
+          tmp_merge=$(mktemp)
+          cp "$src" "$tmp_merge"
+          expand_templates "$tmp_merge" "$env_file"
+          merge_settings "$target" "$tmp_merge"
+          rm -f "$tmp_merge"
+        else
+          merge_settings "$target" "$src"
+        fi
+        ui_success "Merged: $target"
+        ;;
+      link)
+        { [ -e "$target" ] || [ -L "$target" ]; } && rm -f "$target"
+        if [ "$template" = "true" ]; then
+          cp "$src" "$target"
+          expand_templates "$target" "$env_file"
+          ui_success "Copied+expanded (template): $target"
+        else
+          ln -s "$src" "$target"
+          ui_success "Linked: $target"
+        fi
+        ;;
+      copy)
+        cp "$src" "$target"
+        if [ "$template" = "true" ]; then
+          expand_templates "$target" "$env_file"
+          ui_success "Copied+expanded: $target"
+        else
+          ui_success "Copied: $target"
+        fi
+        ;;
+    esac
+    INSTALLED_FILES+=("$target")
+  done
+
+  # --- Merge into the manifest (existing entries preserved) ---
+  local existing_files=()
+  local f
+  while IFS= read -r f; do
+    [ -n "$f" ] && existing_files+=("$f")
+  done < <(jq -r '.files[]?' "$manifest_file")
+
+  local existing_backups=()
+  local b
+  while IFS= read -r b; do
+    [ -n "$b" ] && existing_backups+=("$b")
+  done < <(jq -r '.backups[]?' "$manifest_file")
+
+  RESOLVED_MODULES=("${existing_modules[@]+"${existing_modules[@]}"}" "${to_install[@]}")
+  INSTALLED_FILES=("${existing_files[@]+"${existing_files[@]}"}" "${INSTALLED_FILES[@]+"${INSTALLED_FILES[@]}"}")
+  BACKUP_DIRS=("${existing_backups[@]+"${existing_backups[@]}"}")
+
+  echo ""
+  ui_header "Updating Manifest"
+  [ "$install_global" = true ] && write_manifest "$global_dir"
+  [ "$install_project" = true ] && write_manifest "$project_dir"
+
+  echo ""
+  ui_success "Added ${#to_install[@]} module(s): ${to_install[*]}"
+  ui_info "Open a new Claude Code session to pick up the new config."
+}
+
 # --- Main ---
 main() {
   # Parse arguments
   LINK_MODE=false
   PRESET_NAME=""
   SCOPE=""
+  ADD_MODULES=()
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -133,6 +335,14 @@ main() {
         SCOPE="$2"
         shift 2
         ;;
+      --add)
+        if [ $# -lt 2 ]; then
+          echo "Error: --add requires a module name"
+          exit 1
+        fi
+        ADD_MODULES+=("$2")
+        shift 2
+        ;;
       --help|-h)
         echo "CCGM - Claude Code God Mode"
         echo ""
@@ -142,12 +352,15 @@ main() {
         echo "  --link              Create symlinks instead of copies"
         echo "  --preset <name>     Use preset (minimal, standard, full, team)"
         echo "  --scope <scope>     Installation scope (global, project, both)"
+        echo "  --add <module>      Add a module to an existing install (repeatable);"
+        echo "                      inherits link-mode and scope from the manifest"
         echo "  -h, --help          Show this help"
         echo ""
         echo "Examples:"
         echo "  ./start.sh                        Interactive installation"
         echo "  ./start.sh --preset standard       Quick install with standard preset"
         echo "  ./start.sh --link --preset full    Symlink full preset"
+        echo "  ./start.sh --add argus             Add the argus module to an existing install"
         exit 0
         ;;
       *)
@@ -157,6 +370,16 @@ main() {
         ;;
     esac
   done
+
+  # --- Add mode: fast path to install module(s) into an existing setup ---
+  if [ ${#ADD_MODULES[@]} -gt 0 ]; then
+    if [ -n "$PRESET_NAME" ]; then
+      ui_error "--add cannot be combined with --preset."
+      exit 1
+    fi
+    run_add_mode
+    exit 0
+  fi
 
   # ===========================================================
   # Step 1: Welcome

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -275,6 +275,145 @@ else
 fi
 echo ""
 
+# ============================================================
+# Test 5: --add installs a single module into an existing setup
+# ============================================================
+echo "--- Test 5: --add single module ---"
+
+TEST5_HOME="$TMPDIR/test5"
+mkdir -p "$TEST5_HOME/.claude"
+export HOME="$TEST5_HOME"
+export CCGM_CODE_DIR="$TEST5_HOME/code"
+
+# Base install: minimal preset, symlink mode
+set +e
+"$REPO_ROOT/start.sh" --link --preset minimal --scope global </dev/null >/dev/null 2>&1
+base_exit=$?
+set -e
+if [ $base_exit -eq 0 ]; then
+  pass "Base minimal install for --add test"
+else
+  fail "Base minimal install failed (exit $base_exit)"
+fi
+
+manifest="$TEST5_HOME/.claude/.ccgm-manifest.json"
+
+# Precondition: shadcn not part of minimal
+if [ ! -e "$TEST5_HOME/.claude/rules/shadcn.md" ]; then
+  pass "Precondition: rules/shadcn.md absent before --add"
+else
+  fail "Precondition failed: rules/shadcn.md already present"
+fi
+
+# --- Add a simple dependency-free module ---
+set +e
+"$REPO_ROOT/start.sh" --add shadcn </dev/null >/dev/null 2>&1
+add_exit=$?
+set -e
+if [ $add_exit -eq 0 ]; then
+  pass "--add shadcn exited successfully"
+else
+  fail "--add shadcn exited with code $add_exit"
+fi
+
+if [ -e "$TEST5_HOME/.claude/rules/shadcn.md" ]; then
+  pass "rules/shadcn.md installed after --add"
+else
+  fail "rules/shadcn.md missing after --add"
+fi
+
+if jq -e '.modules | index("shadcn")' "$manifest" >/dev/null 2>&1; then
+  pass "Manifest includes shadcn after --add"
+else
+  fail "Manifest does not include shadcn"
+fi
+
+# Original modules preserved
+if jq -e '.modules | index("git-workflow")' "$manifest" >/dev/null 2>&1; then
+  pass "Manifest retains original modules (git-workflow)"
+else
+  fail "Manifest lost original modules after --add"
+fi
+
+# Link mode inherited from manifest (file is a symlink, base was --link)
+if [ -L "$TEST5_HOME/.claude/rules/shadcn.md" ]; then
+  pass "--add inherited link mode from manifest"
+else
+  fail "--add did not inherit link mode (expected symlink)"
+fi
+
+# --- Idempotency: re-add shadcn ---
+mod_count_before=$(jq -r '.modules | length' "$manifest")
+set +e
+"$REPO_ROOT/start.sh" --add shadcn </dev/null >/dev/null 2>&1
+readd_exit=$?
+set -e
+mod_count_after=$(jq -r '.modules | length' "$manifest")
+if [ $readd_exit -eq 0 ] && [ "$mod_count_before" = "$mod_count_after" ]; then
+  pass "--add shadcn is idempotent (exit 0, no duplicate module entry)"
+else
+  fail "--add shadcn not idempotent (exit $readd_exit, count $mod_count_before -> $mod_count_after)"
+fi
+
+# --- Dependency resolution: agent-native pulls in subagent-patterns ---
+set +e
+"$REPO_ROOT/start.sh" --add agent-native </dev/null >/dev/null 2>&1
+dep_exit=$?
+set -e
+if [ $dep_exit -eq 0 ]; then
+  pass "--add agent-native exited successfully"
+else
+  fail "--add agent-native exited with code $dep_exit"
+fi
+if [ -e "$TEST5_HOME/.claude/rules/agent-native.md" ] && [ -e "$TEST5_HOME/.claude/rules/subagent-patterns.md" ]; then
+  pass "--add resolves dependencies (agent-native + subagent-patterns installed)"
+else
+  fail "--add did not resolve dependency subagent-patterns"
+fi
+if jq -e '.modules | index("subagent-patterns")' "$manifest" >/dev/null 2>&1; then
+  pass "Manifest includes auto-resolved dependency subagent-patterns"
+else
+  fail "Manifest missing auto-resolved dependency"
+fi
+
+# --- Error: unknown module ---
+set +e
+"$REPO_ROOT/start.sh" --add no-such-module-xyz </dev/null >/dev/null 2>&1
+unknown_exit=$?
+set -e
+if [ $unknown_exit -ne 0 ]; then
+  pass "--add unknown module fails with non-zero exit"
+else
+  fail "--add unknown module unexpectedly succeeded"
+fi
+
+# --- Error: --add with no prior manifest ---
+TEST5B_HOME="$TMPDIR/test5b"
+mkdir -p "$TEST5B_HOME/.claude"
+export HOME="$TEST5B_HOME"
+set +e
+"$REPO_ROOT/start.sh" --add shadcn </dev/null >/dev/null 2>&1
+nomanifest_exit=$?
+set -e
+if [ $nomanifest_exit -ne 0 ]; then
+  pass "--add with no existing manifest fails with non-zero exit"
+else
+  fail "--add with no manifest unexpectedly succeeded"
+fi
+
+# --- Error: --add combined with --preset is rejected ---
+export HOME="$TEST5_HOME"
+set +e
+"$REPO_ROOT/start.sh" --add shadcn --preset minimal </dev/null >/dev/null 2>&1
+combo_exit=$?
+set -e
+if [ $combo_exit -ne 0 ]; then
+  pass "--add combined with --preset is rejected"
+else
+  fail "--add + --preset unexpectedly succeeded"
+fi
+echo ""
+
 # Restore HOME
 export HOME="$TMPDIR/home"
 


### PR DESCRIPTION
Closes #551.

## Summary

Adds a non-interactive `./start.sh --add <module>` fast path to install one or more modules into an existing CCGM setup, without re-running the full interactive installer or hand-symlinking. `modules/autoheal/...` docs and the root `CLAUDE.md` already referenced `start.sh --add <module>` as if it existed — this makes it real.

## Behavior

- Reads the existing `.ccgm-manifest.json` (global, falling back to a project install) and **inherits `linkMode` + `scope`** — no re-prompting.
- Resolves the requested module(s) + dependencies via the existing `resolve_dependencies` helper (dep-first order).
- Skips modules already recorded in the manifest (idempotent; exits 0 with "Nothing to do" when all requested are present).
- Builds + executes the install plan for the new module(s) only, reusing the same link / copy / merge + template-expansion logic against the existing `.ccgm.env`.
- Merges the new modules/files into the manifest via the existing `write_manifest` (existing entries preserved).
- Bypasses the entire interactive flow (prereqs, user-info prompts, scope choice, selection, config prompts, preview, confirm, backup, identity gen, alias setup, MCP migration).
- `--add` is repeatable: `--add a --add b`.

### Error handling
- No prior manifest → exits non-zero with guidance to run `./start.sh` first.
- Unknown module name → exits non-zero.
- `--add` combined with `--preset` → rejected (mutually exclusive).
- `--add` with no value → rejected.

## Changes

- `start.sh`: new `run_add_mode()` helper; `--add` arg parsing + dispatch in `main()`; `--help` updated. The plan-build/execute loops intentionally mirror `main()`'s Step 8/Step 11 (inlined in the monolithic `main()`); the small faithful copy keeps `--add` isolated from the interactive path rather than refactoring the core installer here. Noted in a comment as a future unification point.
- `tests/test-installer.sh`: new **Test 5** — base install → add (link-mode inherited) → idempotent re-add → dependency resolution (`agent-native` pulls in `subagent-patterns`) → three error cases.

## Test plan

- `bash tests/test-installer.sh` → **46 passed, 0 failed** (Test 5 added; written failing-first, then implemented).
- `bash tests/run-all.sh` → **9 suites passed, 0 failed**; 198 unit tests pass.
- `shellcheck -S warning start.sh` → no new warnings vs `origin/main` (the one pre-existing `type`-unused in `main()` is untouched and out of scope).
- Manual smoke test of all six paths (happy path, idempotent, no-manifest, unknown module, `--add`+`--preset`, missing value) — each emits the intended message.

## Notes

- This is the supported replacement for the manual symlinking used to install `argus`. Running `./start.sh --add argus` later is self-healing: it re-links idempotently and records `argus` in the manifest (which the manual install skipped).