### PR TITLE
#553: document `start.sh --add` in README + docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ For a quick install with a preset:
 ```bash
 ./start.sh --scope project    # Install to .claude/ in current project instead of ~/.claude/
 ./start.sh --link             # Symlink instead of copy (for CCGM developers)
+./start.sh --add <module>     # Add one module to an existing install (inherits scope + link mode)
 ```
 
 ### Update / Uninstall

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,6 +81,16 @@ Global installation is the most common choice. Project-level installation is use
 | **Copy** (default) | - | Copies files to `~/.claude/`. Independent of the CCGM repo after install. |
 | **Link** | `--link` | Creates symlinks to the CCGM repo. Changes to the repo are reflected immediately. Best for CCGM developers. |
 
+## Adding modules later
+
+To add a single module to an existing install without re-running the full installer:
+
+```bash
+./start.sh --add <module>     # e.g. ./start.sh --add shadcn
+```
+
+It inherits the scope and copy/link mode recorded in your install manifest, pulls in any dependencies, skips modules you already have, and updates the manifest. Open a new Claude Code session afterward to pick up the added config. The flag is repeatable (`--add a --add b`).
+
 ## Your first session
 
 After installation, start Claude Code:

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -180,3 +180,22 @@ CCGM_NON_INTERACTIVE=1 \
 | `CCGM_TIMEZONE` | Timezone | auto-detected |
 
 All module config prompts use their default values in non-interactive mode.
+
+## Adding a module to an existing install
+
+`--add <module>` is a non-interactive fast path that installs one or more modules into an already-installed setup, without re-running the interactive installer:
+
+```bash
+./start.sh --add argus
+./start.sh --add shadcn --add tailwind   # repeatable
+```
+
+It reads the existing `.ccgm-manifest.json` (global, falling back to a project install) and:
+
+- **Inherits** `linkMode` and `scope` from the manifest — it does not re-prompt for username, code dir, or timezone.
+- **Resolves dependencies** of the requested module(s) via the same topological sort as a full install.
+- **Skips** modules already recorded in the manifest (idempotent — re-running is a no-op that exits successfully).
+- **Builds and executes** the install plan for the new module(s) only, reusing the same link / copy / merge logic and `.ccgm.env` template expansion.
+- **Merges** the new modules and files into the manifest, preserving existing entries.
+
+It exits non-zero with a clear message if there is no existing manifest, if a requested module does not exist, or if `--add` is combined with `--preset` (mutually exclusive). Open a new Claude Code session afterward to pick up the added config.


### PR DESCRIPTION
Closes #553. Post-merge `/docupdate` for #551 / PR #552 (the new `./start.sh --add <module>` flag).

## Changes
- **README.md** — added `--add` to the "Other install options" block.
- **docs/getting-started.md** — new "Adding modules later" subsection.
- **docs/installer.md** — reference section on `--add` mechanics (manifest inheritance, dependency resolution, idempotency, error cases).

## Scope
Surgical, +30 lines across 3 files. No module counts, command lists, or TOCs were affected — this documents an installer flag, not a module/command. `test-no-personal-data.sh` passes.