### PR TITLE
#528: fix autoheal doc drift

### DIFF
--- a/modules/autoheal/README.md
+++ b/modules/autoheal/README.md
@@ -4,8 +4,9 @@ Self-healing observability loop for Claude Code. Captures permission events, too
 
 ## What this module installs
 
-- **5 event-capture hooks** on `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `UserPromptSubmit`, and `Stop`.
-- **2 response hooks**: `permission-request-suppress.py` (contextual auto-allow) and `realtime-security-scanner.py` (opt-in mid-session alerts).
+- **6 hooks** across `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `UserPromptSubmit`, and `Stop`:
+  - **4 event-capture hooks**: `permission-event-logger.py` (PostToolUse / PostToolUseFailure / PermissionRequest), `failure-logger.py` (PostToolUseFailure), `user-correction-detector.py` (UserPromptSubmit), `post-prompt-introspect.py` (Stop).
+  - **2 response hooks**: `permission-request-suppress.py` (PermissionRequest contextual auto-allow) and `realtime-security-scanner.py` (PostToolUse opt-in mid-session alerts).
 - **7 slash commands**: `/permission-fix`, `/permission-audit`, `/autoheal`, `/autoheal-digest`, `/autoheal-toggle`, `/autoheal-snooze`, `/autoheal-apply`.
 - **Daily LaunchAgent** (macOS) calling `bin/autoheal-daily.sh` at 08:00 local. Linux scheduling is an architectural seam, not built in v1.
 

--- a/modules/autoheal/rules/autoheal.md
+++ b/modules/autoheal/rules/autoheal.md
@@ -44,7 +44,7 @@ To enable the analyzer: add `ANTHROPIC_API_KEY=sk-ant-...` to `~/.claude/autohea
 - `/autoheal` — help + status.
 - `/autoheal-digest [date]` — render today's (or a specific date's) digest.
 - `/autoheal-toggle [pause|resume|status|realtime|autoapply|webhook]` — flip config flags.
-- `/autoheal-snooze <id> [days]` — snooze a proposal for N days (default 7).
+- `/autoheal-snooze <id> [days]` — snooze a proposal for N days (default 30).
 - `/autoheal-apply [id|list]` — formal apply path; same shape as `/permission-fix apply`.
 
 ## When NOT to invoke


### PR DESCRIPTION
Closes #528

Reconciles two pre-existing documentation drifts in the autoheal module (surfaced during the #526 docupdate, left out of scope there). Doc-only, no code impact.

## Fix 1 — snooze default
`modules/autoheal/rules/autoheal.md` documented the `/autoheal-snooze` default as **7 days**, contradicting the command surface (`commands/autoheal.md` overview and `commands/autoheal-snooze.md`), which consistently document **30 days**. The command file is the user-facing source of truth, so the rule file was corrected to 30. The only stale `default 7` reference inside `modules/autoheal/` was this one line; the remaining `default 7` elsewhere (`bin/autoheal-analyze.sh`) refers to the analyzer lookback window, not the snooze default, and was left untouched.

## Fix 2 — hook count
`modules/autoheal/README.md` claimed "5 event-capture hooks ... 2 response hooks" (= 7), but only **6** hook files exist in `modules/autoheal/hooks/`. Updated the breakdown to match the files on disk:
- 4 event-capture hooks: `permission-event-logger.py`, `failure-logger.py`, `user-correction-detector.py`, `post-prompt-introspect.py`
- 2 response hooks: `permission-request-suppress.py`, `realtime-security-scanner.py`