### PR TITLE
#556: docupdate — add /etp to commands reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ The `docs/` directory contains comprehensive documentation:
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
 | [Install via Agent](docs/install-via-agent.md) | Per-preset paste-blocks and how to dry-run them safely |
 | [Module Catalog](docs/modules.md) | Detailed reference for all 66 modules |
-| [Commands Reference](docs/commands.md) | All 72 slash commands with usage examples |
+| [Commands Reference](docs/commands.md) | All 73 slash commands with usage examples |
 | [Hooks Reference](docs/hooks.md) | All 13 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -891,6 +891,25 @@ Reconstructs context from plan files (`progress.md`, `plan.md`, `decisions.md`, 
 
 ---
 
+### /etp
+
+**Execute an existing plan end-to-end with parallel agents, adversarial PR review, and follow-up completion.**
+
+Resolves a plan (file path, directory, or the in-progress plan), decomposes it into dependency-ordered waves, and runs each wave with parallel implementation agents. Every PR gets a two-stage adversarial review by a *separate* agent (`spec-compliance-reviewer` then `code-quality-reviewer`) that never sees the implementer's rationale — reasonable-and-valid findings are fixed, speculative ones deferred. Follow-up work that arises is tracked, triaged, and the in-scope items get the same review. Reconciles against live git/GitHub state so finished work is skipped (resumable). Runs to completion, stopping only for absolute blockers, which it reports while continuing all non-blocked work. Unlike `/xplan-resume` (which resumes an xplan-native run), `/etp` executes any plan file.
+
+**Usage**:
+```
+/etp ~/code/plans/my-project/plan.md
+/etp                         # autodetect the in-progress plan
+/etp <plan> --dry-run        # preview the execution model, don't execute
+/etp <plan> --confirm        # one go/no-go gate before executing
+/etp <plan> --max-agents 3   # cap parallel agents
+```
+
+**Installed by**: xplan module
+
+---
+
 ### /mawf
 
 **Multi-Agent Workflow.**


### PR DESCRIPTION
Post-merge docupdate for #557 (`/etp`), per the repo's mandatory post-merge rule.

## Changes
- `docs/commands.md` — add the `### /etp` section (mirrors the `/xplan-resume` format; notes it executes any plan file vs xplan-native resume).
- `README.md` — bump the commands count `72 → 73` (verified: `grep -cE '^### /' docs/commands.md` = 73).

Doc-only.