### PR TITLE
#578: Phase-0 ecosystem + project-shape + tool detector

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -20,7 +20,8 @@
     "skills/audit/reference/architecture.md": { "target": "skills/audit/reference/architecture.md", "type": "doc", "template": false },
     "skills/audit/reference/fix-patterns.md": { "target": "skills/audit/reference/fix-patterns.md", "type": "doc", "template": false },
     "skills/audit/reference/multi-agent-config.md": { "target": "skills/audit/reference/multi-agent-config.md", "type": "doc", "template": false },
-    "skills/audit/reference/output-template.md": { "target": "skills/audit/reference/output-template.md", "type": "doc", "template": false }
+    "skills/audit/reference/output-template.md": { "target": "skills/audit/reference/output-template.md", "type": "doc", "template": false },
+    "skills/audit/scripts/detect-ecosystems.sh": { "target": "skills/audit/scripts/detect-ecosystems.sh", "type": "script", "template": false }
   },
   "tags": ["commands", "audit", "verification", "walkthrough", "safety", "checkpoint"],
   "configPrompts": []

--- a/modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh
+++ b/modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh
@@ -25,6 +25,14 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
+# Pre-flight: require jq
+# ---------------------------------------------------------------------------
+if ! command -v jq >/dev/null 2>&1; then
+  echo "detect-ecosystems.sh: jq is required but not installed" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
 # Resolve target directory
 # ---------------------------------------------------------------------------
 if [ -n "${1:-}" ]; then
@@ -272,16 +280,15 @@ PYEOF
   fi
 fi
 
-# Python frameworks (scan requirements.txt and pyproject.toml)
-for fw_file in "$TARGET_DIR/requirements.txt" "$TARGET_DIR/pyproject.toml"; do
-  [ -f "$fw_file" ] || continue
-  content=$(cat "$fw_file")
+# Python frameworks (scan requirements.txt)
+if [ -f "$TARGET_DIR/requirements.txt" ]; then
+  content=$(cat "$TARGET_DIR/requirements.txt")
   for fw in django flask fastapi starlette tornado sanic; do
     if echo "$content" | grep -qi "^[[:space:]]*${fw}[>=<!\[]"; then
       frameworks+=("$fw")
     fi
   done
-done
+fi
 
 # Go frameworks (scan go.mod)
 if has_file "go.mod"; then
@@ -295,11 +302,11 @@ if has_file "go.mod"; then
 fi
 
 # --- has_migrations ---
+# TRUE only when a real migration directory exists (not on presence of .sql files)
 has_migrations=false
 if has_dir "supabase/migrations" || has_dir "prisma/migrations" \
     || has_dir "db/migrate" || has_dir "db/migrations" \
-    || has_dir "database/migrations" \
-    || find_ext "sql" 4; then
+    || has_dir "database/migrations"; then
   has_migrations=true
 fi
 

--- a/modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh
+++ b/modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh
@@ -1,0 +1,441 @@
+#!/usr/bin/env bash
+# detect-ecosystems.sh
+# Phase-0 ecosystem detector for /audit (Epic 1.3)
+#
+# Usage: bash detect-ecosystems.sh [TARGET_DIR]
+#   TARGET_DIR defaults to git root (or cwd if not in a git repo)
+#
+# Output: JSON to stdout:
+#   {
+#     "detected_ecosystems": [...],
+#     "project_shape": {
+#       "monorepo_packages": [...],
+#       "frameworks": [...],
+#       "has_migrations": bool,
+#       "has_dockerfile": bool,
+#       "has_workflows": bool,
+#       "is_extension": bool,
+#       "is_mobile": bool
+#     },
+#     "available_tools": [...]
+#   }
+#
+# BSD-safe: no grep -oP; no GNU-only flags.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve target directory
+# ---------------------------------------------------------------------------
+if [ -n "${1:-}" ]; then
+  TARGET_DIR="$1"
+else
+  # Default to git root; fall back to cwd
+  TARGET_DIR=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+fi
+
+# Canonicalize (resolve symlinks, strip trailing slash)
+TARGET_DIR=$(cd "$TARGET_DIR" && pwd)
+
+# ---------------------------------------------------------------------------
+# Ecosystem detection helpers
+# ---------------------------------------------------------------------------
+
+# Check file exists under TARGET_DIR
+has_file() {
+  [ -f "$TARGET_DIR/$1" ]
+}
+
+# Check directory exists under TARGET_DIR
+has_dir() {
+  [ -d "$TARGET_DIR/$1" ]
+}
+
+# Find files matching a name pattern under TARGET_DIR (depth-limited)
+# Returns non-zero if none found
+find_files() {
+  local name="$1"
+  local maxdepth="${2:-4}"
+  find "$TARGET_DIR" -maxdepth "$maxdepth" -name "$name" 2>/dev/null \
+    | head -1 | grep -q .
+}
+
+# Find files with a given extension (depth-limited)
+# Returns non-zero if none found
+find_ext() {
+  local ext="$1"
+  local maxdepth="${2:-4}"
+  find "$TARGET_DIR" -maxdepth "$maxdepth" -name "*.$ext" 2>/dev/null \
+    | head -1 | grep -q .
+}
+
+# ---------------------------------------------------------------------------
+# Detected ecosystems
+# ---------------------------------------------------------------------------
+ecosystems=()
+
+# JavaScript: package.json present
+if has_file "package.json"; then
+  ecosystems+=("javascript")
+fi
+
+# TypeScript: tsconfig.json OR any .ts/.tsx file (additive with JS)
+if has_file "tsconfig.json" || find_ext "ts" 4 || find_ext "tsx" 4; then
+  ecosystems+=("typescript")
+fi
+
+# Go: go.mod present
+if has_file "go.mod"; then
+  ecosystems+=("go")
+fi
+
+# Python: requirements.txt OR pyproject.toml OR setup.py OR setup.cfg
+if has_file "requirements.txt" || has_file "pyproject.toml" \
+    || has_file "setup.py" || has_file "setup.cfg" \
+    || find_files "requirements*.txt" 3; then
+  ecosystems+=("python")
+fi
+
+# Rust: Cargo.toml
+if has_file "Cargo.toml"; then
+  ecosystems+=("rust")
+fi
+
+# Ruby: Gemfile OR any .gemspec
+if has_file "Gemfile" || find_files "*.gemspec" 2; then
+  ecosystems+=("ruby")
+fi
+
+# SQL: supabase/migrations OR prisma/migrations OR db/migrate OR any .sql file
+if has_dir "supabase/migrations" || has_dir "prisma/migrations" \
+    || has_dir "db/migrate" || has_dir "db/migrations" \
+    || has_dir "database/migrations" \
+    || find_ext "sql" 4; then
+  ecosystems+=("sql")
+fi
+
+# Java: pom.xml OR build.gradle
+if has_file "pom.xml" || has_file "build.gradle" || has_file "build.gradle.kts"; then
+  ecosystems+=("java")
+fi
+
+# Kotlin: any .kt file
+if find_ext "kt" 4; then
+  ecosystems+=("kotlin")
+fi
+
+# Swift: xcodeproj OR xcworkspace OR Package.swift OR any .swift file
+if find_files "*.xcodeproj" 3 || find_files "*.xcworkspace" 3 \
+    || has_file "Package.swift" || find_ext "swift" 4; then
+  ecosystems+=("swift")
+fi
+
+# Shell: any .sh file
+if find_ext "sh" 4; then
+  ecosystems+=("shell")
+fi
+
+# Docker: Dockerfile present (shape also captured in has_dockerfile)
+if has_file "Dockerfile" || find_files "Dockerfile" 3 \
+    || find_files "Dockerfile.*" 3; then
+  ecosystems+=("docker")
+fi
+
+# Terraform / HCL: any .tf file
+if find_ext "tf" 4; then
+  ecosystems+=("terraform")
+fi
+
+# ---------------------------------------------------------------------------
+# Project shape
+# ---------------------------------------------------------------------------
+
+# --- monorepo_packages ---
+monorepo_packages=()
+
+# npm/yarn/bun workspaces: parse "workspaces" from package.json
+if has_file "package.json"; then
+  raw_ws=$(python3 - "$TARGET_DIR/package.json" <<'PYEOF'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        pkg = json.load(f)
+    ws = pkg.get("workspaces", [])
+    if isinstance(ws, dict):
+        ws = ws.get("packages", [])
+    for entry in ws:
+        print(entry)
+except Exception:
+    pass
+PYEOF
+  ) || true
+
+  if [ -n "${raw_ws:-}" ]; then
+    while IFS= read -r pattern; do
+      [ -z "$pattern" ] && continue
+      # Strip trailing /* or /** to get a base directory
+      dir_pattern=$(echo "$pattern" | sed 's|/\*\*$||; s|/\*$||')
+      # Expand to concrete child directories
+      while IFS= read -r -d $'\0' d; do
+        rel="${d#"$TARGET_DIR"/}"
+        monorepo_packages+=("$rel")
+      done < <(find "$TARGET_DIR/$dir_pattern" -maxdepth 1 -mindepth 1 \
+                     -type d -print0 2>/dev/null || true)
+    done <<< "$raw_ws"
+  fi
+fi
+
+# pnpm workspaces: parse packages from pnpm-workspace.yaml
+if has_file "pnpm-workspace.yaml"; then
+  raw_ws=$(python3 - "$TARGET_DIR/pnpm-workspace.yaml" <<'PYEOF'
+import sys
+try:
+    with open(sys.argv[1]) as f:
+        content = f.read()
+    in_packages = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("packages:"):
+            in_packages = True
+            continue
+        if in_packages:
+            if stripped.startswith("- "):
+                val = stripped[2:].strip().strip('"').strip("'")
+                print(val)
+            elif stripped and not stripped.startswith("#"):
+                in_packages = False
+except Exception:
+    pass
+PYEOF
+  ) || true
+
+  if [ -n "${raw_ws:-}" ]; then
+    while IFS= read -r pattern; do
+      [ -z "$pattern" ] && continue
+      dir_pattern=$(echo "$pattern" | sed 's|/\*\*$||; s|/\*$||')
+      while IFS= read -r -d $'\0' d; do
+        rel="${d#"$TARGET_DIR"/}"
+        monorepo_packages+=("$rel")
+      done < <(find "$TARGET_DIR/$dir_pattern" -maxdepth 1 -mindepth 1 \
+                     -type d -print0 2>/dev/null || true)
+    done <<< "$raw_ws"
+  fi
+fi
+
+# --- frameworks ---
+frameworks=()
+
+if has_file "package.json"; then
+  detected_fws=$(python3 - "$TARGET_DIR/package.json" <<'PYEOF'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        pkg = json.load(f)
+    deps = {}
+    deps.update(pkg.get("dependencies", {}))
+    deps.update(pkg.get("devDependencies", {}))
+
+    # (label_to_emit, dep_key_in_package_json)
+    fw_map = [
+        ("react",     "react"),
+        ("next",      "next"),
+        ("vue",       "vue"),
+        ("nuxt",      "nuxt"),
+        ("svelte",    "svelte"),
+        ("angular",   "@angular/core"),
+        ("remix",     "@remix-run/node"),
+        ("astro",     "astro"),
+        ("solid",     "solid-js"),
+        ("express",   "express"),
+        ("fastify",   "fastify"),
+        ("hono",      "hono"),
+        ("electron",  "electron"),
+        ("tauri",     "@tauri-apps/api"),
+        ("vite",      "vite"),
+        ("webpack",   "webpack"),
+        ("turbo",     "turbo"),
+    ]
+    seen = set()
+    for label, dep in fw_map:
+        if dep in deps and label not in seen:
+            seen.add(label)
+            print(label)
+except Exception:
+    pass
+PYEOF
+  ) || true
+
+  if [ -n "${detected_fws:-}" ]; then
+    while IFS= read -r fw; do
+      [ -n "$fw" ] && frameworks+=("$fw")
+    done <<< "$detected_fws"
+  fi
+fi
+
+# Python frameworks (scan requirements.txt and pyproject.toml)
+for fw_file in "$TARGET_DIR/requirements.txt" "$TARGET_DIR/pyproject.toml"; do
+  [ -f "$fw_file" ] || continue
+  content=$(cat "$fw_file")
+  for fw in django flask fastapi starlette tornado sanic; do
+    if echo "$content" | grep -qi "^[[:space:]]*${fw}[>=<!\[]"; then
+      frameworks+=("$fw")
+    fi
+  done
+done
+
+# Go frameworks (scan go.mod)
+if has_file "go.mod"; then
+  content=$(cat "$TARGET_DIR/go.mod")
+  for fw_path in "gin-gonic/gin" "labstack/echo" "gofiber/fiber" "go-chi/chi"; do
+    fw_label="${fw_path##*/}"
+    if echo "$content" | grep -q "$fw_path"; then
+      frameworks+=("$fw_label")
+    fi
+  done
+fi
+
+# --- has_migrations ---
+has_migrations=false
+if has_dir "supabase/migrations" || has_dir "prisma/migrations" \
+    || has_dir "db/migrate" || has_dir "db/migrations" \
+    || has_dir "database/migrations" \
+    || find_ext "sql" 4; then
+  has_migrations=true
+fi
+
+# --- has_dockerfile ---
+has_dockerfile=false
+if has_file "Dockerfile" || find_files "Dockerfile" 3 \
+    || find_files "Dockerfile.*" 3 \
+    || has_file "docker-compose.yml" || has_file "docker-compose.yaml"; then
+  has_dockerfile=true
+fi
+
+# --- has_workflows ---
+has_workflows=false
+if has_dir ".github/workflows"; then
+  has_workflows=true
+fi
+
+# --- is_extension ---
+is_extension=false
+if has_file "manifest.json"; then
+  mv_check=$(python3 - "$TARGET_DIR/manifest.json" <<'PYEOF'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        m = json.load(f)
+    print("true" if "manifest_version" in m else "false")
+except Exception:
+    print("false")
+PYEOF
+  ) || mv_check="false"
+  [ "$mv_check" = "true" ] && is_extension=true
+fi
+
+# --- is_mobile ---
+is_mobile=false
+if find_files "*.xcodeproj" 3 || find_files "*.xcworkspace" 3 \
+    || has_dir "ios" || has_dir "android" \
+    || has_file "Podfile" || has_file "pubspec.yaml"; then
+  is_mobile=true
+fi
+
+# ---------------------------------------------------------------------------
+# Available tools (spine tool list)
+# ---------------------------------------------------------------------------
+spine_tools=(
+  gitleaks
+  trufflehog
+  semgrep
+  trivy
+  knip
+  eslint
+  govulncheck
+  gosec
+  bandit
+  ruff
+  pip-audit
+  cargo-audit
+  clippy
+  brakeman
+  bundler-audit
+  hadolint
+  checkov
+  actionlint
+  zizmor
+  pinact
+  squawk
+  sqlfluff
+  npm
+  pnpm
+  yarn
+  bun
+  jq
+  python3
+  node
+  go
+  cargo
+  ruby
+  docker
+)
+
+available_tools=()
+for tool in "${spine_tools[@]}"; do
+  if command -v "$tool" >/dev/null 2>&1; then
+    available_tools+=("$tool")
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# JSON assembly via jq
+# ---------------------------------------------------------------------------
+
+# Build JSON arrays from bash arrays (handle empty arrays portably)
+if [ ${#ecosystems[@]} -eq 0 ]; then
+  ecosystems_json="[]"
+else
+  ecosystems_json=$(printf '%s\n' "${ecosystems[@]}" | jq -R . | jq -s .)
+fi
+
+if [ ${#monorepo_packages[@]} -eq 0 ]; then
+  packages_json="[]"
+else
+  packages_json=$(printf '%s\n' "${monorepo_packages[@]}" | jq -R . | jq -s .)
+fi
+
+if [ ${#frameworks[@]} -eq 0 ]; then
+  frameworks_json="[]"
+else
+  frameworks_json=$(printf '%s\n' "${frameworks[@]}" | jq -R . | jq -s .)
+fi
+
+if [ ${#available_tools[@]} -eq 0 ]; then
+  tools_json="[]"
+else
+  tools_json=$(printf '%s\n' "${available_tools[@]}" | jq -R . | jq -s .)
+fi
+
+jq -n \
+  --argjson ecosystems "$ecosystems_json" \
+  --argjson packages   "$packages_json" \
+  --argjson frameworks "$frameworks_json" \
+  --arg     migrations "$has_migrations" \
+  --arg     dockerfile "$has_dockerfile" \
+  --arg     workflows  "$has_workflows" \
+  --arg     extension  "$is_extension" \
+  --arg     mobile     "$is_mobile" \
+  --argjson tools      "$tools_json" \
+  '{
+    detected_ecosystems: $ecosystems,
+    project_shape: {
+      monorepo_packages: $packages,
+      frameworks:        $frameworks,
+      has_migrations:    ($migrations == "true"),
+      has_dockerfile:    ($dockerfile == "true"),
+      has_workflows:     ($workflows  == "true"),
+      is_extension:      ($extension  == "true"),
+      is_mobile:         ($mobile     == "true")
+    },
+    available_tools: $tools
+  }'

--- a/modules/commands-extra/skills/audit/tests/test-detect-ecosystems.sh
+++ b/modules/commands-extra/skills/audit/tests/test-detect-ecosystems.sh
@@ -348,6 +348,45 @@ MOB_JSON=$(run_detector "$FIX_MOB")
 assert_bool         "mobile: is_mobile true"    "$MOB_JSON" ".project_shape.is_mobile" "true"
 
 # ---------------------------------------------------------------------------
+# Fixture 11: Polyglot repo (go.mod + package.json) → both ecosystems detected
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: Polyglot repo (Go + JavaScript) ==="
+FIX_POLY=$(make_fixture "polyglot-repo")
+cat > "$FIX_POLY/go.mod" <<'GOMOD'
+module github.com/example/polyapp
+
+go 1.21
+GOMOD
+cat > "$FIX_POLY/package.json" <<'JSON'
+{
+  "name": "polyapp-frontend",
+  "version": "1.0.0"
+}
+JSON
+
+POLY_JSON=$(run_detector "$FIX_POLY")
+assert_contains     "poly: detected go"          "$POLY_JSON" ".detected_ecosystems" "go"
+assert_contains     "poly: detected javascript"  "$POLY_JSON" ".detected_ecosystems" "javascript"
+
+# ---------------------------------------------------------------------------
+# Fixture 12: has_migrations false-positive guard
+#   - repo has fixtures/seed.sql (.sql file) but NO migration directory
+#   - has_migrations must be false; sql ecosystem must still be detected
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: seed.sql only (no migration dir) ==="
+FIX_SEED=$(make_fixture "seed-only-repo")
+mkdir -p "$FIX_SEED/fixtures"
+cat > "$FIX_SEED/fixtures/seed.sql" <<'SQL'
+INSERT INTO users (email) VALUES ('test@example.com');
+SQL
+
+SEED_JSON=$(run_detector "$FIX_SEED")
+assert_bool         "seed: has_migrations false" "$SEED_JSON" ".project_shape.has_migrations" "false"
+assert_contains     "seed: sql ecosystem present" "$SEED_JSON" ".detected_ecosystems" "sql"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/modules/commands-extra/skills/audit/tests/test-detect-ecosystems.sh
+++ b/modules/commands-extra/skills/audit/tests/test-detect-ecosystems.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+# test-detect-ecosystems.sh
+# Tests for Epic 1.3: Phase-0 ecosystem + project-shape + tool detector
+#
+# Fixtures:
+#   - JS repo (package.json)
+#   - Go repo (go.mod)
+#   - Python repo (requirements.txt)
+#   - Repo with supabase/migrations/ directory
+#   - Browser extension (manifest.json with manifest_version)
+#
+# Usage: bash modules/commands-extra/skills/audit/tests/test-detect-ecosystems.sh
+# Exit:  0 = all pass, non-zero = at least one failure
+
+set -euo pipefail
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILURES=()
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DETECT_SCRIPT="$SCRIPT_DIR/../scripts/detect-ecosystems.sh"
+
+# Verify the detector exists before attempting tests
+if [ ! -f "$DETECT_SCRIPT" ]; then
+  echo "ERROR: detector script not found at: $DETECT_SCRIPT" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+  local name="$1"
+  echo "  PASS: $name"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+  local name="$1"
+  local detail="${2:-}"
+  echo "  FAIL: $name${detail:+ — $detail}"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  FAILURES+=("$name${detail:+: $detail}")
+}
+
+# Run the detector on a directory and capture output
+run_detector() {
+  bash "$DETECT_SCRIPT" "$1"
+}
+
+# Assert a JSON array field contains a specific value
+assert_contains() {
+  local name="$1"
+  local json="$2"
+  local field="$3"
+  local value="$4"
+  if echo "$json" | jq -e --arg v "$value" "$field | index(\$v) != null" >/dev/null 2>&1; then
+    pass "$name"
+  else
+    actual=$(echo "$json" | jq -r "$field" 2>/dev/null || echo "(parse error)")
+    fail "$name" "expected '$value' in $field, got: $actual"
+  fi
+}
+
+# Assert a JSON array field does NOT contain a specific value
+assert_not_contains() {
+  local name="$1"
+  local json="$2"
+  local field="$3"
+  local value="$4"
+  if echo "$json" | jq -e --arg v "$value" "$field | index(\$v) == null" >/dev/null 2>&1; then
+    pass "$name"
+  else
+    fail "$name" "expected '$value' NOT in $field, but it was present"
+  fi
+}
+
+# Assert a JSON boolean field equals expected value (true/false)
+assert_bool() {
+  local name="$1"
+  local json="$2"
+  local field="$3"
+  local expected="$4"  # "true" or "false"
+  actual=$(echo "$json" | jq -r "$field" 2>/dev/null || echo "parse_error")
+  if [ "$actual" = "$expected" ]; then
+    pass "$name"
+  else
+    fail "$name" "expected $field=$expected, got $actual"
+  fi
+}
+
+# Assert a JSON array field is empty
+assert_empty_array() {
+  local name="$1"
+  local json="$2"
+  local field="$3"
+  count=$(echo "$json" | jq -r "$field | length" 2>/dev/null || echo "-1")
+  if [ "$count" = "0" ]; then
+    pass "$name"
+  else
+    fail "$name" "expected empty array for $field, got length=$count"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Create temp fixtures
+# ---------------------------------------------------------------------------
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+# Each fixture is a plain directory (not a git repo) — pass as explicit TARGET_DIR
+make_fixture() {
+  local name="$1"
+  local dir="$TMPDIR_ROOT/$name"
+  mkdir -p "$dir"
+  echo "$dir"
+}
+
+# ---------------------------------------------------------------------------
+# Fixture 1: JavaScript repo
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: JavaScript repo ==="
+FIX_JS=$(make_fixture "js-repo")
+cat > "$FIX_JS/package.json" <<'JSON'
+{
+  "name": "my-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "^18.0.0",
+    "express": "^4.18.0"
+  }
+}
+JSON
+
+JS_JSON=$(run_detector "$FIX_JS")
+assert_contains     "js: detected javascript"    "$JS_JSON" ".detected_ecosystems" "javascript"
+assert_not_contains "js: no go ecosystem"        "$JS_JSON" ".detected_ecosystems" "go"
+assert_not_contains "js: no python ecosystem"    "$JS_JSON" ".detected_ecosystems" "python"
+assert_bool         "js: no migrations"          "$JS_JSON" ".project_shape.has_migrations" "false"
+assert_bool         "js: no dockerfile"          "$JS_JSON" ".project_shape.has_dockerfile" "false"
+assert_bool         "js: no workflows"           "$JS_JSON" ".project_shape.has_workflows"  "false"
+assert_bool         "js: not extension"          "$JS_JSON" ".project_shape.is_extension"   "false"
+assert_bool         "js: not mobile"             "$JS_JSON" ".project_shape.is_mobile"      "false"
+assert_contains     "js: react framework"        "$JS_JSON" ".project_shape.frameworks" "react"
+assert_contains     "js: express framework"      "$JS_JSON" ".project_shape.frameworks" "express"
+
+# ---------------------------------------------------------------------------
+# Fixture 2: Go repo
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: Go repo ==="
+FIX_GO=$(make_fixture "go-repo")
+cat > "$FIX_GO/go.mod" <<'GOMOD'
+module github.com/example/myapp
+
+go 1.21
+GOMOD
+
+GO_JSON=$(run_detector "$FIX_GO")
+assert_contains     "go: detected go"         "$GO_JSON" ".detected_ecosystems" "go"
+assert_not_contains "go: no javascript"       "$GO_JSON" ".detected_ecosystems" "javascript"
+assert_not_contains "go: no python"           "$GO_JSON" ".detected_ecosystems" "python"
+assert_bool         "go: no migrations"       "$GO_JSON" ".project_shape.has_migrations" "false"
+assert_bool         "go: no dockerfile"       "$GO_JSON" ".project_shape.has_dockerfile" "false"
+
+# ---------------------------------------------------------------------------
+# Fixture 3: Python repo
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: Python repo ==="
+FIX_PY=$(make_fixture "py-repo")
+cat > "$FIX_PY/requirements.txt" <<'TXT'
+flask>=2.3.0
+requests>=2.28.0
+TXT
+
+PY_JSON=$(run_detector "$FIX_PY")
+assert_contains     "py: detected python"     "$PY_JSON" ".detected_ecosystems" "python"
+assert_not_contains "py: no javascript"       "$PY_JSON" ".detected_ecosystems" "javascript"
+assert_not_contains "py: no go"               "$PY_JSON" ".detected_ecosystems" "go"
+assert_bool         "py: no migrations"       "$PY_JSON" ".project_shape.has_migrations" "false"
+assert_bool         "py: no dockerfile"       "$PY_JSON" ".project_shape.has_dockerfile" "false"
+
+# ---------------------------------------------------------------------------
+# Fixture 4: Repo with supabase/migrations/
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: supabase/migrations ==="
+FIX_SQL=$(make_fixture "sql-repo")
+mkdir -p "$FIX_SQL/supabase/migrations"
+cat > "$FIX_SQL/supabase/migrations/20240101_init.sql" <<'SQL'
+CREATE TABLE users (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email text NOT NULL UNIQUE
+);
+SQL
+
+SQL_JSON=$(run_detector "$FIX_SQL")
+assert_contains     "sql: detected sql"           "$SQL_JSON" ".detected_ecosystems" "sql"
+assert_bool         "sql: has_migrations true"    "$SQL_JSON" ".project_shape.has_migrations" "true"
+assert_bool         "sql: no dockerfile"          "$SQL_JSON" ".project_shape.has_dockerfile" "false"
+assert_bool         "sql: not extension"          "$SQL_JSON" ".project_shape.is_extension"   "false"
+
+# ---------------------------------------------------------------------------
+# Fixture 5: Browser extension (manifest.json with manifest_version)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: Browser extension ==="
+FIX_EXT=$(make_fixture "ext-repo")
+cat > "$FIX_EXT/manifest.json" <<'JSON'
+{
+  "manifest_version": 3,
+  "name": "My Extension",
+  "version": "1.0.0",
+  "description": "A test browser extension"
+}
+JSON
+cat > "$FIX_EXT/package.json" <<'JSON'
+{
+  "name": "my-extension",
+  "version": "1.0.0"
+}
+JSON
+
+EXT_JSON=$(run_detector "$FIX_EXT")
+assert_bool         "ext: is_extension true"      "$EXT_JSON" ".project_shape.is_extension"   "true"
+assert_contains     "ext: detected javascript"    "$EXT_JSON" ".detected_ecosystems" "javascript"
+
+# ---------------------------------------------------------------------------
+# Fixture 6: manifest.json WITHOUT manifest_version (NOT an extension)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: manifest.json (not an extension) ==="
+FIX_NOEXT=$(make_fixture "noext-repo")
+cat > "$FIX_NOEXT/manifest.json" <<'JSON'
+{
+  "name": "some-config",
+  "version": "1.0.0"
+}
+JSON
+
+NOEXT_JSON=$(run_detector "$FIX_NOEXT")
+assert_bool         "noext: is_extension false"   "$NOEXT_JSON" ".project_shape.is_extension" "false"
+
+# ---------------------------------------------------------------------------
+# Fixture 7: Repo with Dockerfile → has_dockerfile=true
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: Dockerfile ==="
+FIX_DOCK=$(make_fixture "docker-repo")
+cat > "$FIX_DOCK/Dockerfile" <<'EOF'
+FROM node:20-alpine
+WORKDIR /app
+COPY . .
+RUN npm install
+CMD ["node", "index.js"]
+EOF
+
+DOCK_JSON=$(run_detector "$FIX_DOCK")
+assert_bool         "docker: has_dockerfile true" "$DOCK_JSON" ".project_shape.has_dockerfile" "true"
+assert_contains     "docker: detected docker"     "$DOCK_JSON" ".detected_ecosystems" "docker"
+
+# ---------------------------------------------------------------------------
+# Fixture 8: Repo with .github/workflows/ → has_workflows=true
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: .github/workflows ==="
+FIX_GHA=$(make_fixture "gha-repo")
+mkdir -p "$FIX_GHA/.github/workflows"
+cat > "$FIX_GHA/.github/workflows/ci.yml" <<'YAML'
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+YAML
+
+GHA_JSON=$(run_detector "$FIX_GHA")
+assert_bool         "gha: has_workflows true"     "$GHA_JSON" ".project_shape.has_workflows" "true"
+
+# ---------------------------------------------------------------------------
+# available_tools: reflects real command -v results
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== available_tools accuracy ==="
+FIX_TOOLS=$(make_fixture "tools-check")
+TOOLS_JSON=$(run_detector "$FIX_TOOLS")
+
+# jq is always available (we depend on it) — must appear in available_tools
+assert_contains "tools: jq present" "$TOOLS_JSON" ".available_tools" "jq"
+
+# python3 is always available (used by the script itself)
+assert_contains "tools: python3 present" "$TOOLS_JSON" ".available_tools" "python3"
+
+# Cross-check: every tool in available_tools must pass command -v
+tools_list=$(echo "$TOOLS_JSON" | jq -r '.available_tools[]' 2>/dev/null || true)
+tool_check_fail=0
+if [ -n "$tools_list" ]; then
+  while IFS= read -r tool; do
+    [ -z "$tool" ] && continue
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      fail "tools: '$tool' in available_tools but not found by command -v"
+      tool_check_fail=1
+    fi
+  done <<< "$tools_list"
+  if [ "$tool_check_fail" -eq 0 ]; then
+    pass "tools: all reported tools pass command -v"
+  fi
+else
+  pass "tools: empty available_tools is valid (no spine tools installed)"
+fi
+
+# Cross-check: a tool we know is NOT installed must NOT appear in available_tools
+FAKE_TOOL="definitely-not-a-real-tool-xyz123"
+assert_not_contains "tools: fake tool absent" "$TOOLS_JSON" ".available_tools" "$FAKE_TOOL"
+
+# ---------------------------------------------------------------------------
+# Fixture 9: Empty repo → all flags false, ecosystems empty
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: empty repo ==="
+FIX_EMPTY=$(make_fixture "empty-repo")
+EMPTY_JSON=$(run_detector "$FIX_EMPTY")
+assert_empty_array  "empty: no ecosystems"      "$EMPTY_JSON" ".detected_ecosystems"
+assert_empty_array  "empty: no frameworks"      "$EMPTY_JSON" ".project_shape.frameworks"
+assert_empty_array  "empty: no packages"        "$EMPTY_JSON" ".project_shape.monorepo_packages"
+assert_bool         "empty: no migrations"      "$EMPTY_JSON" ".project_shape.has_migrations" "false"
+assert_bool         "empty: no dockerfile"      "$EMPTY_JSON" ".project_shape.has_dockerfile" "false"
+assert_bool         "empty: no workflows"       "$EMPTY_JSON" ".project_shape.has_workflows"  "false"
+assert_bool         "empty: not extension"      "$EMPTY_JSON" ".project_shape.is_extension"   "false"
+assert_bool         "empty: not mobile"         "$EMPTY_JSON" ".project_shape.is_mobile"      "false"
+
+# ---------------------------------------------------------------------------
+# Fixture 10: Mobile repo (ios/ directory)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: Mobile repo (ios dir) ==="
+FIX_MOB=$(make_fixture "mobile-repo")
+mkdir -p "$FIX_MOB/ios"
+touch "$FIX_MOB/ios/Info.plist"
+
+MOB_JSON=$(run_detector "$FIX_MOB")
+assert_bool         "mobile: is_mobile true"    "$MOB_JSON" ".project_shape.is_mobile" "true"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=================================="
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+echo "=================================="
+
+if [ ${#FAILURES[@]} -gt 0 ]; then
+  echo ""
+  echo "Failed tests:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Add `modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh` — portable bash + jq script (BSD-safe, no `grep -oP`) that inspects a target directory and emits JSON with `detected_ecosystems[]`, `project_shape{}`, and `available_tools[]`
- Add `modules/commands-extra/skills/audit/tests/test-detect-ecosystems.sh` — 43-test suite covering 10 fixtures (JS, Go, Python, supabase/migrations, extension, non-extension manifest, Dockerfile, GitHub Actions workflows, empty repo, mobile)
- Register `scripts/detect-ecosystems.sh` in `modules/commands-extra/module.json` (per-file, ADV-003)

## Test plan

- [x] `bash modules/commands-extra/skills/audit/tests/test-detect-ecosystems.sh` → 43 passed, 0 failed
- [x] Detector run on CCGM repo itself → `has_workflows=true`, `shell`+`terraform` detected, `available_tools` matches real `command -v`
- [x] `bash tests/test-no-personal-data.sh` → PASS
- [x] `shellcheck scripts/detect-ecosystems.sh` → clean (exit 0)
- [x] `shellcheck tests/test-detect-ecosystems.sh` → clean (exit 0)
- [x] `bash tests/test-modules.sh` → 1238 passed, 0 failed (no dangling refs)

Closes #578