### PR TITLE
#577: pack + finding JSON schemas + registry loader

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -20,7 +20,10 @@
     "skills/audit/reference/architecture.md": { "target": "skills/audit/reference/architecture.md", "type": "doc", "template": false },
     "skills/audit/reference/fix-patterns.md": { "target": "skills/audit/reference/fix-patterns.md", "type": "doc", "template": false },
     "skills/audit/reference/multi-agent-config.md": { "target": "skills/audit/reference/multi-agent-config.md", "type": "doc", "template": false },
-    "skills/audit/reference/output-template.md": { "target": "skills/audit/reference/output-template.md", "type": "doc", "template": false }
+    "skills/audit/reference/output-template.md": { "target": "skills/audit/reference/output-template.md", "type": "doc", "template": false },
+    "skills/audit/schemas/pack.schema.json": { "target": "skills/audit/schemas/pack.schema.json", "type": "doc", "template": false },
+    "skills/audit/schemas/finding.schema.json": { "target": "skills/audit/schemas/finding.schema.json", "type": "doc", "template": false },
+    "skills/audit/scripts/registry.py": { "target": "skills/audit/scripts/registry.py", "type": "doc", "template": false }
   },
   "tags": ["commands", "audit", "verification", "walkthrough", "safety", "checkpoint"],
   "configPrompts": []

--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -23,7 +23,7 @@
     "skills/audit/reference/output-template.md": { "target": "skills/audit/reference/output-template.md", "type": "doc", "template": false },
     "skills/audit/schemas/pack.schema.json": { "target": "skills/audit/schemas/pack.schema.json", "type": "doc", "template": false },
     "skills/audit/schemas/finding.schema.json": { "target": "skills/audit/schemas/finding.schema.json", "type": "doc", "template": false },
-    "skills/audit/scripts/registry.py": { "target": "skills/audit/scripts/registry.py", "type": "doc", "template": false }
+    "skills/audit/scripts/registry.py": { "target": "skills/audit/scripts/registry.py", "type": "script", "template": false }
   },
   "tags": ["commands", "audit", "verification", "walkthrough", "safety", "checkpoint"],
   "configPrompts": []

--- a/modules/commands-extra/skills/audit/schemas/finding.schema.json
+++ b/modules/commands-extra/skills/audit/schemas/finding.schema.json
@@ -58,7 +58,7 @@
         },
         "end_line": {
           "type": "integer",
-          "description": "1-based end line (inclusive). Omit for single-line findings.",
+          "description": "1-based end line (inclusive). Omit for single-line findings. When present, must be >= line.",
           "minimum": 1
         }
       }
@@ -69,8 +69,8 @@
     },
     "fingerprint": {
       "type": "string",
-      "description": "Stable baseline-matching key: sha256(lower(strip_all_whitespace(<primary_line ± 2 lines>)))[:16] + ':1', OR the tool's own partialFingerprint verbatim. Must not change when the file is reformatted.",
-      "pattern": "^[a-f0-9]{16}:[0-9]+$"
+      "description": "Stable per-finding identity for baseline matching. OUR computed fingerprints use `sha256(normalized ±2 lines)[:16] + ':<gen>'`; where a source tool emits its own fingerprint it is stored VERBATIM. Must be a stable, non-empty identifier.",
+      "pattern": "^[A-Za-z0-9_.:+/=-]{8,128}$"
     },
     "detection": {
       "type": "string",

--- a/modules/commands-extra/skills/audit/schemas/finding.schema.json
+++ b/modules/commands-extra/skills/audit/schemas/finding.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "ccgm/audit/finding.schema.json",
+  "title": "CCGM Audit Finding",
+  "description": "Schema for a single finding — one JSON object / one JSONL line in `.audit/current/findings.jsonl`. NOT SARIF; forward-compatible with a v2 SARIF emitter. Gate decision #30.",
+  "type": "object",
+  "required": [
+    "check_id",
+    "rule_id",
+    "severity",
+    "confidence",
+    "location",
+    "message",
+    "fingerprint",
+    "detection",
+    "source"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "check_id": {
+      "type": "string",
+      "description": "The check that produced this finding, e.g. `dm/unquoted-reserved-keyword`. Namespaced `<pack>/<check>`.",
+      "pattern": "^[a-z0-9_-]+/[a-z0-9_.-]+$"
+    },
+    "rule_id": {
+      "type": "string",
+      "description": "The specific rule within the tool or LLM check that fired, e.g. `RF04` or `sql/reserved-keyword`."
+    },
+    "severity": {
+      "type": "string",
+      "description": "Consequence severity. Mechanically overwritten by the severity-rubric.json emitter for known check_ids; agent-reported value preserved in properties.agentReportedSeverity.",
+      "enum": ["critical", "high", "medium", "low", "info"]
+    },
+    "confidence": {
+      "type": "string",
+      "description": "Signal precision. Separate axis from severity.",
+      "enum": ["high", "medium", "low"]
+    },
+    "fix_confidence": {
+      "type": "string",
+      "description": "Safety confidence for auto-fix, if applicable.",
+      "enum": ["high", "medium", "low"]
+    },
+    "location": {
+      "type": "object",
+      "description": "Source location of the finding.",
+      "required": ["path", "line"],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Repo-relative file path, e.g. `src/auth/session.ts`."
+        },
+        "line": {
+          "type": "integer",
+          "description": "1-based start line.",
+          "minimum": 1
+        },
+        "end_line": {
+          "type": "integer",
+          "description": "1-based end line (inclusive). Omit for single-line findings.",
+          "minimum": 1
+        }
+      }
+    },
+    "message": {
+      "type": "string",
+      "description": "Human-readable description of the finding. Secret values MUST be redacted before this field is written."
+    },
+    "fingerprint": {
+      "type": "string",
+      "description": "Stable baseline-matching key: sha256(lower(strip_all_whitespace(<primary_line ± 2 lines>)))[:16] + ':1', OR the tool's own partialFingerprint verbatim. Must not change when the file is reformatted.",
+      "pattern": "^[a-f0-9]{16}:[0-9]+$"
+    },
+    "detection": {
+      "type": "string",
+      "description": "How this finding was produced.",
+      "enum": ["tool", "llm", "hybrid"]
+    },
+    "source": {
+      "type": "string",
+      "description": "Which runtime component emitted this finding: a deterministic spine tool or an LLM worker agent.",
+      "enum": ["tool", "llm"]
+    },
+    "suppression": {
+      "type": "object",
+      "description": "Present when this finding has been suppressed. Suppressed criticals still surface as [SUPPRESSED] in reports.",
+      "required": ["justification"],
+      "additionalProperties": false,
+      "properties": {
+        "justification": {
+          "type": "string",
+          "description": "Why this finding was suppressed."
+        },
+        "expires": {
+          "type": "string",
+          "description": "ISO 8601 date after which the suppression should be re-reviewed, e.g. `2026-12-31`.",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        }
+      }
+    },
+    "properties": {
+      "type": "object",
+      "description": "Open bag for tool-specific or calibration metadata. Well-known keys: `agentReportedSeverity` (when rubric overwrote it), `owner` (CODEOWNERS entry), `package` (dep name for vuln findings).",
+      "additionalProperties": true
+    }
+  }
+}

--- a/modules/commands-extra/skills/audit/schemas/pack.schema.json
+++ b/modules/commands-extra/skills/audit/schemas/pack.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "ccgm/audit/pack.schema.json",
+  "title": "CCGM Audit Pack Manifest",
+  "description": "Schema for a CCGM /audit check pack manifest. `applies_when` is the sole gating mechanism — conditions are project-shape flags, language predicates, or the literal `always`.",
+  "type": "object",
+  "required": ["id", "name", "version", "applies_when", "checks"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Stable, namespaced pack identifier, e.g. `ccgm/data-migrations`.",
+      "pattern": "^[a-z0-9_-]+/[a-z0-9_-]+$"
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable pack name."
+    },
+    "version": {
+      "type": "string",
+      "description": "Semantic version string, e.g. `1.0.0`.",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "applies_when": {
+      "type": "array",
+      "description": "Gating conditions. ALL items must be satisfied for the pack to run. Items are project-shape flags, `language:<lang>` predicates, or the literal `always`.",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "anyOf": [
+          {
+            "description": "Run on all repos, unconditionally.",
+            "const": "always"
+          },
+          {
+            "description": "Project-shape flags emitted by the ecosystem detector.",
+            "enum": [
+              "has_migrations",
+              "has_dockerfile",
+              "has_workflows",
+              "is_extension",
+              "is_mobile"
+            ]
+          },
+          {
+            "description": "Language predicate — `language:<lang>` where lang is lowercase.",
+            "pattern": "^language:[a-z][a-z0-9_-]*$"
+          }
+        ]
+      }
+    },
+    "tags": {
+      "type": "array",
+      "description": "Free-form labels for filtering and display.",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "severity_floor": {
+      "type": "string",
+      "description": "Minimum severity a check in this pack will ever emit; used for display filtering.",
+      "enum": ["critical", "high", "medium", "low", "info"],
+      "default": "low"
+    },
+    "tools": {
+      "type": "array",
+      "description": "Spine tools this pack may invoke. Tools not present are skipped gracefully.",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "checks": {
+      "type": "array",
+      "description": "Ordered list of checks this pack defines.",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/check"
+      }
+    }
+  },
+  "$defs": {
+    "check": {
+      "type": "object",
+      "required": ["id", "severity", "confidence", "detection"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable check identifier, e.g. `dm/unquoted-reserved-keyword`. Must be unique within the pack.",
+          "pattern": "^[a-z0-9_-]+/[a-z0-9_.-]+$"
+        },
+        "severity": {
+          "type": "string",
+          "description": "Consequence severity of this check finding. Declared here and enforced by the rubric emitter.",
+          "enum": ["critical", "high", "medium", "low", "info"]
+        },
+        "confidence": {
+          "type": "string",
+          "description": "Precision of this check's signal. Separate from severity.",
+          "enum": ["high", "medium", "low"]
+        },
+        "detection": {
+          "type": "string",
+          "description": "How this check produces findings: deterministic tool, LLM agent, or hybrid (tool finds candidates, LLM confirms).",
+          "enum": ["tool", "llm", "hybrid"]
+        },
+        "tool": {
+          "type": "string",
+          "description": "Spine tool that runs this check. Required when detection is `tool` or `hybrid`."
+        },
+        "rule": {
+          "type": "string",
+          "description": "Rule identifier within the tool, e.g. a Semgrep rule ID or ESLint rule name."
+        },
+        "fallback": {
+          "type": "string",
+          "description": "Fallback mechanism when the primary tool is absent, e.g. `grep` or `llm`."
+        },
+        "auto_fixable": {
+          "type": "boolean",
+          "description": "Whether findings from this check can be automatically fixed.",
+          "default": false
+        }
+      }
+    }
+  }
+}

--- a/modules/commands-extra/skills/audit/scripts/registry.py
+++ b/modules/commands-extra/skills/audit/scripts/registry.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+CCGM /audit pack registry loader.
+
+Input  (stdin or first positional arg): detector JSON produced by detect-ecosystems.sh
+  {
+    "detected_ecosystems": ["javascript", "typescript"],
+    "project_shape": {
+      "has_migrations": true,
+      "has_dockerfile": false,
+      "has_workflows": true,
+      "is_extension": false,
+      "is_mobile": false,
+      "monorepo_packages": [],
+      "frameworks": ["react"]
+    },
+    "available_tools": ["semgrep", "gitleaks"]
+  }
+
+Output (stdout): JSON array of applicable pack objects, each validated against
+  pack.schema.json (stdlib validation — no jsonschema dep).
+
+Exit codes:
+  0  success
+  1  input/schema error
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Minimal stdlib JSON Schema validator (subset used by pack.schema.json)
+# Covers: type, required, additionalProperties, enum, const, pattern,
+#         minItems, anyOf, $ref (local defs only), array items.
+# ---------------------------------------------------------------------------
+
+_VALID_SEVERITIES = {"critical", "high", "medium", "low", "info"}
+_VALID_CONFIDENCES = {"high", "medium", "low"}
+_VALID_DETECTIONS = {"tool", "llm", "hybrid"}
+_VALID_SHAPE_FLAGS = {
+    "has_migrations", "has_dockerfile", "has_workflows", "is_extension", "is_mobile"
+}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def _validate_check(check: object, path: str) -> None:
+    """Validate a single check object against the check $def."""
+    if not isinstance(check, dict):
+        raise ValidationError(f"{path}: must be an object")
+
+    required = {"id", "severity", "confidence", "detection"}
+    missing = required - check.keys()
+    if missing:
+        raise ValidationError(f"{path}: missing required fields: {sorted(missing)}")
+
+    allowed = {"id", "severity", "confidence", "detection", "tool", "rule", "fallback", "auto_fixable"}
+    extra = check.keys() - allowed
+    if extra:
+        raise ValidationError(f"{path}: unexpected fields: {sorted(extra)}")
+
+    _id = check["id"]
+    if not isinstance(_id, str) or not re.fullmatch(r"[a-z0-9_-]+/[a-z0-9_.,-]+", _id):
+        raise ValidationError(f"{path}.id: must match pattern ^[a-z0-9_-]+/[a-z0-9_.-]+$ (got {_id!r})")
+
+    if check["severity"] not in _VALID_SEVERITIES:
+        raise ValidationError(f"{path}.severity: must be one of {sorted(_VALID_SEVERITIES)}")
+
+    if check["confidence"] not in _VALID_CONFIDENCES:
+        raise ValidationError(f"{path}.confidence: must be one of {sorted(_VALID_CONFIDENCES)}")
+
+    if check["detection"] not in _VALID_DETECTIONS:
+        raise ValidationError(f"{path}.detection: must be one of {sorted(_VALID_DETECTIONS)}")
+
+    if "auto_fixable" in check and not isinstance(check["auto_fixable"], bool):
+        raise ValidationError(f"{path}.auto_fixable: must be a boolean")
+
+    for field in ("tool", "rule", "fallback"):
+        if field in check and not isinstance(check[field], str):
+            raise ValidationError(f"{path}.{field}: must be a string")
+
+
+def _validate_applies_when_item(item: object, path: str) -> None:
+    """Validate a single applies_when item."""
+    if not isinstance(item, str):
+        raise ValidationError(f"{path}: must be a string")
+
+    # const "always"
+    if item == "always":
+        return
+
+    # project-shape flags
+    if item in _VALID_SHAPE_FLAGS:
+        return
+
+    # language predicates
+    if re.fullmatch(r"language:[a-z][a-z0-9_-]*", item):
+        return
+
+    raise ValidationError(
+        f"{path}: {item!r} is not a valid applies_when item. "
+        f"Must be 'always', a project-shape flag {sorted(_VALID_SHAPE_FLAGS)}, "
+        "or a 'language:<lang>' predicate."
+    )
+
+
+def validate_pack(pack: object, pack_path: str = "<unknown>") -> None:
+    """
+    Validate a pack manifest against the rules encoded in pack.schema.json.
+    Raises ValidationError with a descriptive message on failure.
+    """
+    if not isinstance(pack, dict):
+        raise ValidationError(f"{pack_path}: pack must be a JSON object")
+
+    required = {"id", "name", "version", "applies_when", "checks"}
+    missing = required - pack.keys()
+    if missing:
+        raise ValidationError(f"{pack_path}: missing required fields: {sorted(missing)}")
+
+    allowed = {"id", "name", "version", "applies_when", "tags", "severity_floor", "tools", "checks"}
+    extra = pack.keys() - allowed
+    if extra:
+        raise ValidationError(f"{pack_path}: unexpected fields: {sorted(extra)}")
+
+    # id
+    _id = pack["id"]
+    if not isinstance(_id, str) or not re.fullmatch(r"[a-z0-9_-]+/[a-z0-9_-]+", _id):
+        raise ValidationError(f"{pack_path}.id: must match pattern ^[a-z0-9_-]+/[a-z0-9_-]+$ (got {_id!r})")
+
+    # name
+    if not isinstance(pack["name"], str) or not pack["name"].strip():
+        raise ValidationError(f"{pack_path}.name: must be a non-empty string")
+
+    # version
+    if not isinstance(pack["version"], str) or not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", pack["version"]):
+        raise ValidationError(f"{pack_path}.version: must be a semver string like '1.0.0'")
+
+    # applies_when
+    aw = pack["applies_when"]
+    if not isinstance(aw, list) or len(aw) < 1:
+        raise ValidationError(f"{pack_path}.applies_when: must be a non-empty array")
+    for i, item in enumerate(aw):
+        _validate_applies_when_item(item, f"{pack_path}.applies_when[{i}]")
+
+    # tags (optional)
+    if "tags" in pack:
+        if not isinstance(pack["tags"], list):
+            raise ValidationError(f"{pack_path}.tags: must be an array")
+        for i, t in enumerate(pack["tags"]):
+            if not isinstance(t, str):
+                raise ValidationError(f"{pack_path}.tags[{i}]: must be a string")
+
+    # severity_floor (optional)
+    if "severity_floor" in pack:
+        if pack["severity_floor"] not in _VALID_SEVERITIES:
+            raise ValidationError(f"{pack_path}.severity_floor: must be one of {sorted(_VALID_SEVERITIES)}")
+
+    # tools (optional)
+    if "tools" in pack:
+        if not isinstance(pack["tools"], list):
+            raise ValidationError(f"{pack_path}.tools: must be an array")
+        for i, t in enumerate(pack["tools"]):
+            if not isinstance(t, str):
+                raise ValidationError(f"{pack_path}.tools[{i}]: must be a string")
+
+    # checks
+    checks = pack["checks"]
+    if not isinstance(checks, list) or len(checks) < 1:
+        raise ValidationError(f"{pack_path}.checks: must be a non-empty array")
+    for i, check in enumerate(checks):
+        _validate_check(check, f"{pack_path}.checks[{i}]")
+
+
+# ---------------------------------------------------------------------------
+# Pack applicability selection
+# ---------------------------------------------------------------------------
+
+def build_truthy_conditions(detector: dict) -> set:
+    """
+    Build the set of truthy condition tokens from detector output.
+
+    Rules (plan §3.3):
+    - Each detected ecosystem → "language:<ecosystem>" (lowercased)
+    - Each project_shape flag that is True → that flag name
+    - Always include the literal "always"
+    """
+    conditions = {"always"}
+
+    ecosystems = detector.get("detected_ecosystems", [])
+    for eco in ecosystems:
+        if isinstance(eco, str):
+            conditions.add(f"language:{eco.lower()}")
+
+    shape = detector.get("project_shape", {})
+    for flag in _VALID_SHAPE_FLAGS:
+        if shape.get(flag) is True:
+            conditions.add(flag)
+
+    return conditions
+
+
+def is_pack_applicable(pack: dict, conditions: set) -> bool:
+    """
+    A pack is applicable iff EVERY item in its applies_when[] is in the
+    truthy condition set.
+    """
+    applies_when = pack.get("applies_when", [])
+    return all(item in conditions for item in applies_when)
+
+
+# ---------------------------------------------------------------------------
+# Pack discovery
+# ---------------------------------------------------------------------------
+
+def discover_packs(packs_dir: Path) -> list:
+    """
+    Discover all pack.json files under packs_dir, validate each,
+    and return the list of valid pack dicts.
+
+    Emits a warning to stderr for any pack that fails validation
+    (does not abort — lets the registry proceed with valid packs).
+    """
+    packs = []
+    if not packs_dir.is_dir():
+        return packs
+
+    for pack_file in sorted(packs_dir.rglob("pack.json")):
+        try:
+            with open(pack_file, "r", encoding="utf-8") as fh:
+                pack = json.load(fh)
+        except json.JSONDecodeError as exc:
+            print(f"WARNING: {pack_file}: invalid JSON: {exc}", file=sys.stderr)
+            continue
+
+        try:
+            validate_pack(pack, str(pack_file))
+        except ValidationError as exc:
+            print(f"WARNING: {pack_file}: validation failed: {exc}", file=sys.stderr)
+            continue
+
+        packs.append(pack)
+
+    return packs
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: list) -> int:
+    # Read detector JSON from a file arg or stdin
+    if len(argv) > 1:
+        path = argv[1]
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                raw = fh.read()
+        except OSError as exc:
+            print(f"ERROR: cannot read {path!r}: {exc}", file=sys.stderr)
+            return 1
+    else:
+        raw = sys.stdin.read()
+
+    try:
+        detector = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: detector input is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(detector, dict):
+        print("ERROR: detector input must be a JSON object", file=sys.stderr)
+        return 1
+
+    # Build truthy condition set
+    conditions = build_truthy_conditions(detector)
+
+    # Locate packs directory. CCGM_PACKS_DIR env var overrides the default
+    # (used by tests to inject fixture packs without touching the real packs dir).
+    packs_dir_env = os.environ.get("CCGM_PACKS_DIR")
+    if packs_dir_env:
+        packs_dir = Path(packs_dir_env)
+    else:
+        script_dir = Path(__file__).parent
+        packs_dir = script_dir.parent / "packs"
+
+    # Discover and validate packs
+    all_packs = discover_packs(packs_dir)
+
+    # Select applicable packs
+    applicable = [p for p in all_packs if is_pack_applicable(p, conditions)]
+
+    print(json.dumps(applicable, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/modules/commands-extra/skills/audit/scripts/registry.py
+++ b/modules/commands-extra/skills/audit/scripts/registry.py
@@ -65,7 +65,7 @@ def _validate_check(check: object, path: str) -> None:
         raise ValidationError(f"{path}: unexpected fields: {sorted(extra)}")
 
     _id = check["id"]
-    if not isinstance(_id, str) or not re.fullmatch(r"[a-z0-9_-]+/[a-z0-9_.,-]+", _id):
+    if not isinstance(_id, str) or not re.fullmatch(r"[a-z0-9_-]+/[a-z0-9_.-]+", _id):
         raise ValidationError(f"{path}.id: must match pattern ^[a-z0-9_-]+/[a-z0-9_.-]+$ (got {_id!r})")
 
     if check["severity"] not in _VALID_SEVERITIES:

--- a/modules/commands-extra/skills/audit/tests/fixtures/pack-go.json
+++ b/modules/commands-extra/skills/audit/tests/fixtures/pack-go.json
@@ -1,0 +1,29 @@
+{
+  "id": "ccgm/go-security",
+  "name": "Go Security",
+  "version": "1.0.0",
+  "applies_when": ["language:go"],
+  "tags": ["go", "security", "vulnerabilities"],
+  "severity_floor": "low",
+  "tools": ["govulncheck", "gosec"],
+  "checks": [
+    {
+      "id": "go/known-vuln",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "tool",
+      "tool": "govulncheck",
+      "auto_fixable": false
+    },
+    {
+      "id": "go/sql-injection",
+      "severity": "critical",
+      "confidence": "medium",
+      "detection": "hybrid",
+      "tool": "gosec",
+      "rule": "G201",
+      "fallback": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/tests/fixtures/pack-malformed.json
+++ b/modules/commands-extra/skills/audit/tests/fixtures/pack-malformed.json
@@ -1,0 +1,14 @@
+{
+  "id": "bad/pack",
+  "name": "Malformed Pack",
+  "version": "not-semver",
+  "applies_when": ["language:js"],
+  "checks": [
+    {
+      "id": "bad/check",
+      "severity": "INVALID_SEVERITY",
+      "confidence": "high",
+      "detection": "tool"
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/tests/fixtures/pack-secrets.json
+++ b/modules/commands-extra/skills/audit/tests/fixtures/pack-secrets.json
@@ -1,0 +1,27 @@
+{
+  "id": "ccgm/secrets",
+  "name": "Secrets & Credentials",
+  "version": "1.0.0",
+  "applies_when": ["always"],
+  "tags": ["secrets", "credentials", "security"],
+  "severity_floor": "medium",
+  "tools": ["gitleaks"],
+  "checks": [
+    {
+      "id": "secrets/hardcoded-api-key",
+      "severity": "critical",
+      "confidence": "high",
+      "detection": "tool",
+      "tool": "gitleaks",
+      "auto_fixable": false
+    },
+    {
+      "id": "secrets/env-file-committed",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "llm",
+      "fallback": "grep",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/tests/test-registry.sh
+++ b/modules/commands-extra/skills/audit/tests/test-registry.sh
@@ -8,6 +8,8 @@
 #   3. Given detected_ecosystems=[javascript], pack-go.json (language:go) is EXCLUDED
 #   4. Given detected_ecosystems=[javascript], pack-secrets.json (always) is INCLUDED
 #   5. pack-malformed.json fails validation with a clear error message
+#   6. check-id containing a comma is REJECTED by the validator (Fix 1 pin)
+#   7. tool-native fingerprint validates against finding.schema.json; empty fingerprint is REJECTED (Fix 2 pin)
 #
 # Passes: exit 0.  Fails: exit 1.
 set -euo pipefail
@@ -170,6 +172,190 @@ else
         fail "pack-malformed.json rejected but error message unclear: ${result}"
     fi
 fi
+
+# ---------------------------------------------------------------------------
+# Helper: validate a finding JSON file against finding.schema.json using
+# Python stdlib (validates pattern, type, required, enum, additionalProperties).
+# Prints "VALID" and exits 0 on success; "INVALID: <msg>" and exits 1 on failure.
+# ---------------------------------------------------------------------------
+FINDING_SCHEMA="${AUDIT_DIR}/schemas/finding.schema.json"
+
+# Write the Python validator script to a temp file so it can be called without
+# heredoc-inside-command-substitution issues.
+_FINDING_VALIDATOR_PY="$(mktemp /tmp/finding_validator_XXXXXX.py)"
+cat > "${_FINDING_VALIDATOR_PY}" <<'PYEOF'
+import sys, json, re
+
+schema_path = sys.argv[1]
+finding_path = sys.argv[2]
+
+with open(schema_path, encoding="utf-8") as fh:
+    schema = json.load(fh)
+
+with open(finding_path, encoding="utf-8") as fh:
+    finding = json.load(fh)
+
+# Validate required fields
+required = schema.get("required", [])
+missing = [f for f in required if f not in finding]
+if missing:
+    print("INVALID: missing required fields: " + str(sorted(missing)))
+    sys.exit(1)
+
+# Validate each property
+props = schema.get("properties", {})
+for key, val in finding.items():
+    if key not in props:
+        if not schema.get("additionalProperties", True):
+            print("INVALID: unexpected field: " + key)
+            sys.exit(1)
+        continue
+    prop = props[key]
+    if prop.get("type") == "string" and not isinstance(val, str):
+        print("INVALID: " + key + " must be a string")
+        sys.exit(1)
+    pattern = prop.get("pattern")
+    if pattern and isinstance(val, str):
+        if not re.fullmatch(pattern, val):
+            print("INVALID: " + key + " does not match pattern " + pattern + " (got " + repr(val) + ")")
+            sys.exit(1)
+    enum = prop.get("enum")
+    if enum and val not in enum:
+        print("INVALID: " + key + " must be one of " + str(enum) + " (got " + repr(val) + ")")
+        sys.exit(1)
+
+print("VALID")
+sys.exit(0)
+PYEOF
+# shellcheck disable=SC2064
+trap "rm -f '${_FINDING_VALIDATOR_PY}'" EXIT
+
+validate_finding_file() {
+    local finding_file="$1"
+    python3 "${_FINDING_VALIDATOR_PY}" "${FINDING_SCHEMA}" "${finding_file}"
+}
+
+# Write the pack-id validator script to a temp file (avoids heredoc-in-subshell)
+_PACK_VALIDATE_PY="$(mktemp /tmp/pack_validate_XXXXXX.py)"
+cat > "${_PACK_VALIDATE_PY}" <<'PYEOF'
+import sys, json, importlib.util, pathlib
+
+registry_py = pathlib.Path(sys.argv[1])
+pack_file   = pathlib.Path(sys.argv[2])
+
+spec = importlib.util.spec_from_file_location("registry", str(registry_py))
+mod  = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+with open(pack_file, encoding="utf-8") as fh:
+    pack = json.load(fh)
+
+try:
+    mod.validate_pack(pack, str(pack_file))
+    print("VALID")
+    sys.exit(0)
+except mod.ValidationError as exc:
+    print("INVALID: " + str(exc))
+    sys.exit(1)
+PYEOF
+# shellcheck disable=SC2064
+trap "rm -f '${_PACK_VALIDATE_PY}' '${_FINDING_VALIDATOR_PY}'" EXIT
+
+validate_pack_from_file() {
+    local pack_file="$1"
+    python3 "${_PACK_VALIDATE_PY}" "${REGISTRY}" "${pack_file}"
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: check-id with comma is REJECTED (pins Fix 1 — validator regex no comma)
+# ---------------------------------------------------------------------------
+echo "--- Test 6: check-id with comma is rejected"
+_T6_PACK="$(mktemp /tmp/pack_comma_XXXXXX.json)"
+cat > "${_T6_PACK}" <<'JSON'
+{
+  "id": "ccgm/test-comma",
+  "name": "Comma Test",
+  "version": "1.0.0",
+  "applies_when": ["always"],
+  "checks": [
+    {
+      "id": "bad/check,id",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "tool"
+    }
+  ]
+}
+JSON
+result=""
+if result=$(validate_pack_from_file "${_T6_PACK}" 2>&1) && echo "${result}" | grep -q "^VALID$"; then
+    fail "check-id 'bad/check,id' should have been rejected but was VALID"
+else
+    if echo "${result}" | grep -q "INVALID:"; then
+        pass "check-id 'bad/check,id' correctly rejected: ${result}"
+    else
+        fail "check-id 'bad/check,id' rejected but error unclear: ${result}"
+    fi
+fi
+rm -f "${_T6_PACK}"
+
+# ---------------------------------------------------------------------------
+# Test 7a: tool-native fingerprint validates against finding.schema.json (pins Fix 2)
+# ---------------------------------------------------------------------------
+echo "--- Test 7a: tool-native fingerprint validates against finding.schema.json"
+# gitleaks-style fingerprint: hex+colon+path+colon+rule+colon+lineno
+TOOL_NATIVE_FINGERPRINT="a1b2c3d4e5f6a7b8:path/to/file:rule-name:42"
+_T7A_FINDING="$(mktemp /tmp/finding_tool_XXXXXX.json)"
+cat > "${_T7A_FINDING}" <<JSON
+{
+  "check_id": "secrets/hardcoded-api-key",
+  "rule_id": "generic-api-key",
+  "severity": "critical",
+  "confidence": "high",
+  "location": {"path": "src/config.js", "line": 10},
+  "message": "Hardcoded API key detected",
+  "fingerprint": "${TOOL_NATIVE_FINGERPRINT}",
+  "detection": "tool",
+  "source": "tool"
+}
+JSON
+result=""
+if result=$(validate_finding_file "${_T7A_FINDING}" 2>&1) && echo "${result}" | grep -q "^VALID$"; then
+    pass "tool-native fingerprint '${TOOL_NATIVE_FINGERPRINT}' accepted by finding.schema.json"
+else
+    fail "tool-native fingerprint '${TOOL_NATIVE_FINGERPRINT}' was incorrectly rejected: ${result}"
+fi
+rm -f "${_T7A_FINDING}"
+
+# ---------------------------------------------------------------------------
+# Test 7b: empty fingerprint is REJECTED by finding.schema.json (pins Fix 2)
+# ---------------------------------------------------------------------------
+echo "--- Test 7b: empty fingerprint is rejected by finding.schema.json"
+_T7B_FINDING="$(mktemp /tmp/finding_emptyfp_XXXXXX.json)"
+cat > "${_T7B_FINDING}" <<'JSON'
+{
+  "check_id": "secrets/hardcoded-api-key",
+  "rule_id": "generic-api-key",
+  "severity": "critical",
+  "confidence": "high",
+  "location": {"path": "src/config.js", "line": 10},
+  "message": "Hardcoded API key detected",
+  "fingerprint": "",
+  "detection": "tool",
+  "source": "tool"
+}
+JSON
+result=""
+if result=$(validate_finding_file "${_T7B_FINDING}" 2>&1) && echo "${result}" | grep -q "^VALID$"; then
+    fail "empty fingerprint should have been rejected but was VALID"
+else
+    if echo "${result}" | grep -q "INVALID:"; then
+        pass "empty fingerprint correctly rejected: ${result}"
+    else
+        fail "empty fingerprint rejected but error unclear: ${result}"
+    fi
+fi
+rm -f "${_T7B_FINDING}"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/modules/commands-extra/skills/audit/tests/test-registry.sh
+++ b/modules/commands-extra/skills/audit/tests/test-registry.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# test-registry.sh — unit tests for the pack registry loader + schema validation.
+# Module-local; NOT registered in module.json.
+#
+# Tests:
+#   1. pack-go.json validates against pack.schema.json (stdlib validator)
+#   2. pack-secrets.json validates against pack.schema.json (stdlib validator)
+#   3. Given detected_ecosystems=[javascript], pack-go.json (language:go) is EXCLUDED
+#   4. Given detected_ecosystems=[javascript], pack-secrets.json (always) is INCLUDED
+#   5. pack-malformed.json fails validation with a clear error message
+#
+# Passes: exit 0.  Fails: exit 1.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REGISTRY="${AUDIT_DIR}/scripts/registry.py"
+FIXTURES="${SCRIPT_DIR}/fixtures"
+
+PASS=0
+FAIL=0
+
+pass() { printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1)); }
+fail() { printf "  FAIL: %s\n" "$1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Helper: validate a pack JSON file via registry.py's validate_pack function.
+# Prints "VALID" and exits 0 on success; "INVALID: <msg>" and exits 1 on failure.
+# ---------------------------------------------------------------------------
+validate_pack_file() {
+    local pack_file="$1"
+    python3 - "$REGISTRY" "$pack_file" <<'PYEOF'
+import sys, json, importlib.util, pathlib
+
+registry_py = pathlib.Path(sys.argv[1])
+pack_path   = pathlib.Path(sys.argv[2])
+
+spec = importlib.util.spec_from_file_location("registry", str(registry_py))
+mod  = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+with open(pack_path, encoding="utf-8") as fh:
+    pack = json.load(fh)
+
+try:
+    mod.validate_pack(pack, str(pack_path))
+    print("VALID")
+    sys.exit(0)
+except mod.ValidationError as exc:
+    print("INVALID: " + str(exc))
+    sys.exit(1)
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run registry.py with a given detector JSON and a temp packs directory
+# populated from the given fixture pack files.
+# ---------------------------------------------------------------------------
+run_registry_with_packs() {
+    local detector_json="$1"
+    shift
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '${tmpdir}'" RETURN
+
+    for pf in "$@"; do
+        local pack_name
+        pack_name="$(basename "${pf}" .json)"
+        mkdir -p "${tmpdir}/${pack_name}"
+        cp "${pf}" "${tmpdir}/${pack_name}/pack.json"
+    done
+
+    CCGM_PACKS_DIR="${tmpdir}" python3 "${REGISTRY}" <<< "${detector_json}"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: assert that a JSON list returned by registry contains/excludes an id
+# ---------------------------------------------------------------------------
+assert_includes() {
+    local json="$1"
+    local pack_id="$2"
+    echo "${json}" | python3 -c "
+import json, sys
+packs = json.load(sys.stdin)
+ids = [p['id'] for p in packs]
+assert '$pack_id' in ids, '$pack_id should be in result, got: ' + str(ids)
+"
+}
+
+assert_excludes() {
+    local json="$1"
+    local pack_id="$2"
+    echo "${json}" | python3 -c "
+import json, sys
+packs = json.load(sys.stdin)
+ids = [p['id'] for p in packs]
+assert '$pack_id' not in ids, '$pack_id should NOT be in result, got: ' + str(ids)
+"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: pack-go.json is valid
+# ---------------------------------------------------------------------------
+echo "--- Test 1: pack-go.json validates (stdlib)"
+result=""
+if result=$(validate_pack_file "${FIXTURES}/pack-go.json" 2>&1) && echo "${result}" | grep -q "^VALID$"; then
+    pass "pack-go.json is valid"
+else
+    fail "pack-go.json failed validation: ${result}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: pack-secrets.json is valid
+# ---------------------------------------------------------------------------
+echo "--- Test 2: pack-secrets.json validates (stdlib)"
+result=""
+if result=$(validate_pack_file "${FIXTURES}/pack-secrets.json" 2>&1) && echo "${result}" | grep -q "^VALID$"; then
+    pass "pack-secrets.json is valid"
+else
+    fail "pack-secrets.json failed validation: ${result}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: language:go pack EXCLUDED when detected_ecosystems = [javascript]
+# ---------------------------------------------------------------------------
+echo "--- Test 3: language:go pack excluded for javascript ecosystem"
+DETECTOR_JS='{"detected_ecosystems":["javascript"],"project_shape":{},"available_tools":[]}'
+result=""
+if result=$(run_registry_with_packs "${DETECTOR_JS}" \
+        "${FIXTURES}/pack-go.json" \
+        "${FIXTURES}/pack-secrets.json" 2>/dev/null); then
+    if assert_excludes "${result}" "ccgm/go-security" 2>/dev/null; then
+        pass "ccgm/go-security excluded when detected_ecosystems=[javascript]"
+    else
+        fail "ccgm/go-security was incorrectly included. Registry output: ${result}"
+    fi
+else
+    fail "registry.py returned non-zero for test 3: ${result}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: always pack INCLUDED when detected_ecosystems = [javascript]
+# ---------------------------------------------------------------------------
+echo "--- Test 4: always pack included for javascript ecosystem"
+result=""
+if result=$(run_registry_with_packs "${DETECTOR_JS}" \
+        "${FIXTURES}/pack-go.json" \
+        "${FIXTURES}/pack-secrets.json" 2>/dev/null); then
+    if assert_includes "${result}" "ccgm/secrets" 2>/dev/null; then
+        pass "ccgm/secrets included (applies_when=[always]) when detected_ecosystems=[javascript]"
+    else
+        fail "ccgm/secrets was incorrectly excluded. Registry output: ${result}"
+    fi
+else
+    fail "registry.py returned non-zero for test 4: ${result}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: malformed pack fails validation with a clear error
+# ---------------------------------------------------------------------------
+echo "--- Test 5: pack-malformed.json fails validation"
+result=""
+if result=$(validate_pack_file "${FIXTURES}/pack-malformed.json" 2>&1); then
+    fail "pack-malformed.json should have failed validation but passed: ${result}"
+else
+    if echo "${result}" | grep -q "INVALID:"; then
+        pass "pack-malformed.json correctly rejected with clear error: ${result}"
+    else
+        fail "pack-malformed.json rejected but error message unclear: ${result}"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf "\nResults: %d passed, %d failed\n" "${PASS}" "${FAIL}"
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `schemas/pack.schema.json` — JSON Schema for an audit pack manifest with `applies_when[]` as the sole gating mechanism (project-shape flags, `language:<lang>` predicates, or `always`; no separate `languages[]` field per §1.5/ADV-010).
- Adds `schemas/finding.schema.json` — internal JSONL finding schema (gate #30): `check_id`, `rule_id`, `severity`, `confidence`, `fix_confidence?`, `location{path,line,end_line?}`, `message`, `fingerprint`, `detection`, `source`, `suppression?`, `properties{}`. Explicitly NOT SARIF; forward-compatible with v2 SARIF emitter.
- Adds `scripts/registry.py` — stdlib-only Python; reads detector JSON, builds truthy condition set (`language:<eco>` + shape flags + `always`), validates each discovered pack, returns applicable subset.
- Registers all 3 runtime files in `modules/commands-extra/module.json` matching the existing `skills/audit/...` per-file entry shape (ADV-003).
- Adds `tests/test-registry.sh` (not registered) with 5 tests: schema validation for 2 sample packs, exclusion of `language:go` pack when ecosystem is `[javascript]`, inclusion of `always` pack, and clear validation error for a malformed pack.

## Test plan

- [x] `bash modules/commands-extra/skills/audit/tests/test-registry.sh` → 5/5 passed, 0 failed
- [x] `python3 -c "import json; json.load(...pack.schema.json); json.load(...finding.schema.json)"` → no error
- [x] `bash tests/test-modules.sh` → 1240 passed, 0 failed (all 3 new entries show PASS)
- [x] `bash tests/test-no-personal-data.sh` → PASS: No personal data found
- [x] `shellcheck tests/test-registry.sh` → clean

Closes #577