### PR TITLE
#582: severity+confidence rubric (rule-level, deterministic) + validator + orphan-check-id gate

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -102,6 +102,16 @@
       "target": "skills/audit/scripts/detect-ecosystems.sh",
       "type": "script",
       "template": false
+    },
+    "skills/audit/schemas/severity-rubric.json": {
+      "target": "skills/audit/schemas/severity-rubric.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/scripts/lint-rubric.py": {
+      "target": "skills/audit/scripts/lint-rubric.py",
+      "type": "script",
+      "template": false
     }
   },
   "tags": [

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -1155,6 +1155,12 @@ Never block on the network - fall back to offline pattern + metadata analysis.
 
 ---
 
+## Severity Sourcing
+
+**Agents MUST source severity, confidence, and fix_confidence from `schemas/severity-rubric.json`.** Do NOT invent or guess these values. For every finding whose `check_id` appears in the rubric, copy the rubric's `severity`, `confidence`, and `fix_confidence` verbatim. Preserve the agent-reported value in `properties.agentReportedSeverity` if it differs. For `check_id`s not yet in the rubric, set confidence to `"low"` and flag for rubric expansion.
+
+---
+
 ## Notes
 
 - **Always prompt the user** when `/audit` is called without flags - let them choose scope and execution strategy

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "ccgm/audit/severity-rubric.json",
+  "title": "CCGM Audit Severity Rubric",
+  "description": "Rule-level, deterministic severity/confidence table. Agents source severity from here; they do NOT invent it. Keyed by check_id (pattern: <pack>/<check>, matching finding.schema.json). Pack epics add entries under their own namespace; use the [RUBRIC-serial] gate to avoid concurrent edits.",
+  "_format": {
+    "severity": "critical|high|medium|low|info",
+    "confidence": "high|medium|low — signal precision (how often this check fires correctly)",
+    "fix_confidence": "high|medium|low — safety confidence for auto-fix when applicable"
+  },
+  "checks": {
+    "security/hardcoded-secret": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "security/sensitive-console-log": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "security/sql-injection": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "security/xss-vulnerability": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "security/missing-security-headers": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "security/edge-function-auth-bypass": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dependencies/npm-audit-vulnerability": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dependencies/outdated-minor": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dependencies/outdated-major": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "dependencies/unused-dependency": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "dependencies/duplicate-dependency": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "code-quality/eslint-violation": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "code-quality/prettier-violation": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "code-quality/unused-import": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "code-quality/long-method": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "code-quality/large-file": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "code-quality/empty-catch-block": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "architecture/circular-dependency": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "architecture/god-object": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "architecture/improper-layering": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "architecture/wrong-layer-import": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "medium"
+    },
+    "typescript/excessive-any": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "typescript/missing-return-type": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "typescript/react-hooks-violation": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "typescript/fast-refresh-violation": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "typescript/missing-key-prop": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "testing/missing-test-file": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "testing/no-assertions": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "testing/missing-edge-cases": {
+      "severity": "low",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "documentation/missing-jsdoc": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "documentation/stale-comment": {
+      "severity": "low",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "documentation/incomplete-readme": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "performance/n-plus-one-query": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "performance/missing-react-memo": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "medium"
+    },
+    "performance/large-bundle-import": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/copyleft-in-proprietary": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/non-commercial-in-commercial": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/missing-attribution": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/unlicensed-dependency": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/scraping-prohibited-site": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/credential-misuse": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/remote-code-extension": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/overbroad-extension-permissions": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-output-training-competitor": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/undisclosed-telemetry": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    }
+  }
+}

--- a/modules/commands-extra/skills/audit/scripts/lint-rubric.py
+++ b/modules/commands-extra/skills/audit/scripts/lint-rubric.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+lint-rubric.py — Validates schemas/severity-rubric.json structure and enums.
+
+Checks:
+  1. The file parses as valid JSON.
+  2. Every entry under "checks" has exactly the required keys.
+  3. All enum values are within the allowed sets.
+  4. Orphan check-id gate: every check-id found in packs/**/pack.json has a rubric entry.
+
+Exit codes:
+  0 — all checks pass
+  1 — validation failures found (details printed to stderr)
+
+Usage:
+  python3 lint-rubric.py [--rubric PATH] [--packs-dir PATH]
+
+Defaults (relative to this script's parent directory, i.e. the audit skill root):
+  --rubric    schemas/severity-rubric.json
+  --packs-dir packs
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+VALID_SEVERITIES = {"critical", "high", "medium", "low", "info"}
+VALID_CONFIDENCES = {"high", "medium", "low"}
+REQUIRED_KEYS = {"severity", "confidence", "fix_confidence"}
+
+# check_id must match the pattern from finding.schema.json: ^[a-z0-9_-]+/[a-z0-9_.-]+$
+import re
+CHECK_ID_RE = re.compile(r'^[a-z0-9_-]+/[a-z0-9_.-]+$')
+
+
+def load_rubric(rubric_path: Path) -> dict:
+    try:
+        with open(rubric_path) as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        print(f"ERROR: rubric file not found: {rubric_path}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"ERROR: rubric file is not valid JSON: {e}", file=sys.stderr)
+        sys.exit(1)
+    return data
+
+
+def validate_rubric(data: dict) -> list[str]:
+    errors = []
+
+    if not isinstance(data, dict):
+        return ["rubric root must be a JSON object"]
+
+    checks = data.get("checks")
+    if checks is None:
+        return ['rubric missing top-level "checks" key']
+    if not isinstance(checks, dict):
+        return ['"checks" must be a JSON object']
+
+    for check_id, entry in checks.items():
+        prefix = f"checks[{check_id!r}]"
+
+        # Validate check_id format
+        if not CHECK_ID_RE.match(check_id):
+            errors.append(
+                f"{prefix}: check_id does not match pattern ^[a-z0-9_-]+/[a-z0-9_.-]+$"
+            )
+
+        if not isinstance(entry, dict):
+            errors.append(f"{prefix}: entry must be a JSON object, got {type(entry).__name__}")
+            continue
+
+        # Check required keys present
+        missing = REQUIRED_KEYS - entry.keys()
+        if missing:
+            errors.append(f"{prefix}: missing required keys: {sorted(missing)}")
+
+        extra = set(entry.keys()) - REQUIRED_KEYS
+        if extra:
+            errors.append(f"{prefix}: unexpected keys: {sorted(extra)}")
+
+        # Validate enum values
+        severity = entry.get("severity")
+        if severity is not None and severity not in VALID_SEVERITIES:
+            errors.append(
+                f"{prefix}: severity={severity!r} not in {sorted(VALID_SEVERITIES)}"
+            )
+
+        confidence = entry.get("confidence")
+        if confidence is not None and confidence not in VALID_CONFIDENCES:
+            errors.append(
+                f"{prefix}: confidence={confidence!r} not in {sorted(VALID_CONFIDENCES)}"
+            )
+
+        fix_confidence = entry.get("fix_confidence")
+        if fix_confidence is not None and fix_confidence not in VALID_CONFIDENCES:
+            errors.append(
+                f"{prefix}: fix_confidence={fix_confidence!r} not in {sorted(VALID_CONFIDENCES)}"
+            )
+
+    return errors
+
+
+def collect_pack_check_ids(packs_dir: Path) -> list[tuple[str, str]]:
+    """Return list of (check_id, source_path) for every check in packs/**/pack.json.
+
+    The orphan-check-id gate: every check-id shipped in a pack must have a rubric entry.
+    With zero packs this returns an empty list and the gate passes trivially.
+    Becomes meaningful as pack epics land.
+    """
+    results = []
+    for pack_file in sorted(packs_dir.rglob("pack.json")):
+        try:
+            with open(pack_file) as f:
+                pack = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"WARNING: could not read {pack_file}: {e}", file=sys.stderr)
+            continue
+
+        checks = pack.get("checks", [])
+        if not isinstance(checks, list):
+            continue
+        for check in checks:
+            if isinstance(check, dict):
+                cid = check.get("check_id") or check.get("id")
+            else:
+                cid = str(check)
+            if cid:
+                results.append((cid, str(pack_file)))
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate severity-rubric.json")
+    parser.add_argument(
+        "--rubric",
+        default=None,
+        help="Path to severity-rubric.json (default: <script_dir>/../schemas/severity-rubric.json)",
+    )
+    parser.add_argument(
+        "--packs-dir",
+        default=None,
+        help="Path to packs/ directory (default: <script_dir>/../packs)",
+    )
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).parent
+    skill_root = script_dir.parent
+
+    rubric_path = Path(args.rubric) if args.rubric else skill_root / "schemas" / "severity-rubric.json"
+    packs_dir = Path(args.packs_dir) if args.packs_dir else skill_root / "packs"
+
+    data = load_rubric(rubric_path)
+    errors = validate_rubric(data)
+
+    rubric_ids = set(data.get("checks", {}).keys())
+
+    # Orphan check-id gate
+    pack_entries = collect_pack_check_ids(packs_dir)
+    orphan_errors = []
+    for check_id, source in pack_entries:
+        if check_id not in rubric_ids:
+            orphan_errors.append(
+                f"ORPHAN check_id {check_id!r} (from {source}) has no rubric entry"
+            )
+
+    all_errors = errors + orphan_errors
+
+    if not all_errors:
+        check_count = len(rubric_ids)
+        pack_count = len(pack_entries)
+        print(
+            f"OK: {check_count} rubric entries valid; "
+            f"{pack_count} pack check-id(s) verified against rubric"
+        )
+        return 0
+
+    for err in all_errors:
+        print(f"ERROR: {err}", file=sys.stderr)
+    print(
+        f"\n{len(all_errors)} error(s) found in {rubric_path}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/commands-extra/skills/audit/tests/test-rubric.sh
+++ b/modules/commands-extra/skills/audit/tests/test-rubric.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# test-rubric.sh — Tests for severity-rubric.json and lint-rubric.py
+#
+# Tests:
+#   1. Rubric is valid JSON (python3 json.load)
+#   2. lint-rubric.py passes on the real rubric file (enum + structure validation)
+#   3. lint-rubric.py rejects a rubric with an invalid severity value
+#   4. lint-rubric.py rejects a rubric with a missing required key
+#   5. lint-rubric.py rejects a check_id that doesn't match the naming pattern
+#   6. Orphan-check-id gate: a pack.json with a check_id absent from the rubric fails
+#   7. Orphan-check-id gate: a pack.json with all check_ids in the rubric passes
+#   8. Orphan-check-id gate: zero packs present passes trivially
+#
+# Orphan-check-id gate documentation:
+#   This gate enforces that every check_id shipped in packs/**/pack.json has a
+#   corresponding entry in schemas/severity-rubric.json. With zero packs the gate
+#   passes trivially. As pack epics land they add both the pack.json check definition
+#   AND a rubric entry; CI catches any pack that ships without a rubric entry.
+#
+# Exit: 0 if all pass, 1 if any fail.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUBRIC="$SKILL_ROOT/schemas/severity-rubric.json"
+LINTER="$SKILL_ROOT/scripts/lint-rubric.py"
+
+PASS=0
+FAIL=0
+
+# Colour helpers (no external deps)
+_GREEN='\033[0;32m'
+_RED='\033[0;31m'
+_RESET='\033[0m'
+
+pass() { echo -e "${_GREEN}PASS${_RESET}: $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "${_RED}FAIL${_RESET}: $1"; FAIL=$((FAIL + 1)); }
+
+# Single temp directory for all ephemeral fixtures; cleaned on exit.
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# ── helper: run linter against a temporary rubric file ──────────────────────
+run_linter_on() {
+    local tmp_rubric="$1"
+    shift
+    python3 "$LINTER" --rubric "$tmp_rubric" "$@"
+}
+
+# Empty packs dir used for tests that only exercise rubric validation
+PACKS_EMPTY="$TMPROOT/packs-empty"
+mkdir -p "$PACKS_EMPTY"
+
+# ── test 1: real rubric is valid JSON ────────────────────────────────────────
+if python3 -c "import json, sys; json.load(open('$RUBRIC'))" 2>/dev/null; then
+    pass "rubric parses as valid JSON"
+else
+    fail "rubric is not valid JSON"
+fi
+
+# ── test 2: lint-rubric passes on the real file ──────────────────────────────
+if run_linter_on "$RUBRIC" --packs-dir "$PACKS_EMPTY" >/dev/null 2>&1; then
+    pass "lint-rubric passes on real severity-rubric.json"
+else
+    fail "lint-rubric reports errors on real severity-rubric.json"
+fi
+
+# ── test 3: invalid severity enum rejected ───────────────────────────────────
+BAD_SEVERITY="$TMPROOT/bad-severity.json"
+cat > "$BAD_SEVERITY" <<'EOF'
+{
+  "checks": {
+    "security/example-check": {
+      "severity": "blocker",
+      "confidence": "high",
+      "fix_confidence": "low"
+    }
+  }
+}
+EOF
+if ! run_linter_on "$BAD_SEVERITY" --packs-dir "$PACKS_EMPTY" >/dev/null 2>&1; then
+    pass "lint-rubric rejects invalid severity enum 'blocker'"
+else
+    fail "lint-rubric should have rejected invalid severity enum 'blocker'"
+fi
+
+# ── test 4: missing required key rejected ────────────────────────────────────
+MISSING_KEY="$TMPROOT/missing-key.json"
+cat > "$MISSING_KEY" <<'EOF'
+{
+  "checks": {
+    "security/example-check": {
+      "severity": "high",
+      "confidence": "medium"
+    }
+  }
+}
+EOF
+if ! run_linter_on "$MISSING_KEY" --packs-dir "$PACKS_EMPTY" >/dev/null 2>&1; then
+    pass "lint-rubric rejects entry missing 'fix_confidence'"
+else
+    fail "lint-rubric should have rejected entry missing 'fix_confidence'"
+fi
+
+# ── test 5: bad check_id format rejected ─────────────────────────────────────
+BAD_ID="$TMPROOT/bad-id.json"
+cat > "$BAD_ID" <<'EOF'
+{
+  "checks": {
+    "SecurityHardcodedSecret": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    }
+  }
+}
+EOF
+if ! run_linter_on "$BAD_ID" --packs-dir "$PACKS_EMPTY" >/dev/null 2>&1; then
+    pass "lint-rubric rejects check_id not matching namespace/name pattern"
+else
+    fail "lint-rubric should have rejected check_id 'SecurityHardcodedSecret' (no namespace)"
+fi
+
+# ── test 6: orphan check-id gate — pack check missing from rubric fails ──────
+PACKS_ORPHAN="$TMPROOT/packs-orphan"
+mkdir -p "$PACKS_ORPHAN"
+cat > "$PACKS_ORPHAN/pack.json" <<'EOF'
+{
+  "checks": [
+    { "check_id": "my-pack/orphan-check-not-in-rubric" }
+  ]
+}
+EOF
+if ! run_linter_on "$RUBRIC" --packs-dir "$PACKS_ORPHAN" >/dev/null 2>&1; then
+    pass "orphan-check-id gate: pack check absent from rubric is rejected"
+else
+    fail "orphan-check-id gate: should have rejected pack check_id absent from rubric"
+fi
+
+# ── test 7: orphan check-id gate — pack check present in rubric passes ───────
+PACKS_KNOWN="$TMPROOT/packs-known"
+mkdir -p "$PACKS_KNOWN"
+# Use a check_id that is definitely in the rubric
+cat > "$PACKS_KNOWN/pack.json" <<'EOF'
+{
+  "checks": [
+    { "check_id": "security/hardcoded-secret" }
+  ]
+}
+EOF
+if run_linter_on "$RUBRIC" --packs-dir "$PACKS_KNOWN" >/dev/null 2>&1; then
+    pass "orphan-check-id gate: pack check_id present in rubric passes"
+else
+    fail "orphan-check-id gate: should have passed for check_id 'security/hardcoded-secret'"
+fi
+
+# ── test 8: orphan check-id gate — zero packs passes trivially ───────────────
+if run_linter_on "$RUBRIC" --packs-dir "$PACKS_EMPTY" >/dev/null 2>&1; then
+    pass "orphan-check-id gate: zero packs passes trivially"
+else
+    fail "orphan-check-id gate: zero packs should pass trivially"
+fi
+
+# ── summary ──────────────────────────────────────────────────────────────────
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #582

## Summary

- **`schemas/severity-rubric.json`** — 45 seed check-ids across all 9 audit categories (security, dependencies, code-quality, architecture, typescript, testing, documentation, performance, tos-compliance). Each entry has `severity`, `confidence`, and `fix_confidence` values drawn directly from the existing SKILL.md category prompt guidance and the finding schema enums.
- **`scripts/lint-rubric.py`** — stdlib-only Python validator: checks JSON parse, required keys, enum values, check_id pattern match, and the orphan-check-id gate (every check_id in packs/**/pack.json must have a rubric entry; passes trivially with zero packs today).
- **`tests/test-rubric.sh`** — 8 tests covering all validation paths; shellcheck-clean; single temp directory for fixture isolation.
- **`SKILL.md`** — minimal "Severity Sourcing" section: agents source severity from the rubric, never invent it; preserve agent-reported value in `properties.agentReportedSeverity` when it differs.
- **`module.json`** — registers `severity-rubric.json` (type: doc) and `lint-rubric.py` (type: script).

## Test plan

- [x] `bash modules/commands-extra/skills/audit/tests/test-rubric.sh` → 8 passed, 0 failed
- [x] `python3 -c "import json; json.load(open('modules/commands-extra/skills/audit/schemas/severity-rubric.json'))"` → OK
- [x] `bash tests/test-no-personal-data.sh` → PASS: No personal data found
- [x] `shellcheck modules/commands-extra/skills/audit/tests/test-rubric.sh` → clean