### PR TITLE
#583: findings JSONL emitter + stable fingerprint (v1 JSONL per gate #30)

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -102,6 +102,11 @@
       "target": "skills/audit/scripts/detect-ecosystems.sh",
       "type": "script",
       "template": false
+    },
+    "skills/audit/scripts/emit-findings.py": {
+      "target": "skills/audit/scripts/emit-findings.py",
+      "type": "script",
+      "template": false
     }
   },
   "tags": [

--- a/modules/commands-extra/skills/audit/scripts/emit-findings.py
+++ b/modules/commands-extra/skills/audit/scripts/emit-findings.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+CCGM /audit findings JSONL emitter (Epic 1.6).
+
+Gate decision #30: emits line-delimited JSON (one finding per line), NOT SARIF.
+
+Input (stdin OR first positional arg): JSON array of raw finding objects.
+
+Each raw finding MUST include at minimum:
+  check_id    str   "pack/check"
+  rule_id     str
+  severity    str   critical|high|medium|low|info
+  confidence  str   high|medium|low
+  detection   str   tool|llm|hybrid
+  source      str   tool|llm
+  message     str
+  location    obj   { path: str, line: int }
+
+Optional on raw input:
+  fingerprint   str   If present, kept VERBATIM (source-tool fingerprint)
+  end_line      int   Forwarded to location if present
+  fix_confidence str
+  suppression   obj
+  properties    obj
+
+Output: .audit/current/findings.jsonl
+  One JSON object per line, each conforming to finding.schema.json.
+  Writes to the output file; directory is created if absent.
+
+Fingerprint algorithm (section 3.7, when no source fingerprint is present):
+  context = strip_all_whitespace(lower(primary_line +/- 2 lines))
+  fingerprint = sha256(context.encode())[:16] + ":1"
+
+  Primary line +/- 2 lines means lines [line-2, line+2] inclusive (1-based),
+  clamped to the actual file length. If the file is missing or unreadable,
+  fingerprint is computed from just the normalized message + location string
+  so the caller always gets a stable, non-empty value.
+
+  strip_all_whitespace removes ALL whitespace characters (spaces, tabs,
+  newlines) before hashing, so reformatting the primary line does not change
+  the fingerprint.
+
+Exit codes:
+  0  success
+  1  input / validation error
+"""
+
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_VALID_SEVERITIES = {"critical", "high", "medium", "low", "info"}
+_VALID_CONFIDENCES = {"high", "medium", "low"}
+_VALID_DETECTIONS = {"tool", "llm", "hybrid"}
+_VALID_SOURCES = {"tool", "llm"}
+_FINGERPRINT_GEN = ":1"
+
+# Compiled patterns matching finding.schema.json
+_RE_CHECK_ID = re.compile(r"^[a-z0-9_-]+/[a-z0-9_.-]+$")
+_RE_FINGERPRINT = re.compile(r"^[A-Za-z0-9_.:+/=-]{8,128}$")
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_all_whitespace(text: str) -> str:
+    """Remove every whitespace character (spaces, tabs, newlines)."""
+    return "".join(text.split())
+
+
+def _read_context_lines(path: str, line: int) -> str:
+    """
+    Read lines [line-2, line+2] (1-based) from path, concatenated.
+    Returns an empty string if the file cannot be read.
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            all_lines = fh.readlines()
+    except OSError:
+        return ""
+
+    total = len(all_lines)
+    if total == 0:
+        return ""
+
+    # line is 1-based; convert to 0-based index for slicing
+    start = max(0, line - 3)    # index of line-2
+    end = min(total, line + 2)  # exclusive upper bound (line+2 inclusive)
+    return "".join(all_lines[start:end])
+
+
+def compute_fingerprint(path: str, line: int, message: str) -> str:
+    """
+    Compute a stable fingerprint per section 3.7.
+    Falls back to message+location if the file is missing or unreadable.
+    """
+    raw_context = _read_context_lines(path, line)
+    if raw_context:
+        normalized = _strip_all_whitespace(raw_context.lower())
+    else:
+        # Graceful fallback: hash message+location so the value is still stable
+        fallback = f"{path}:{line}:{message}"
+        normalized = _strip_all_whitespace(fallback.lower())
+
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return digest[:16] + _FINGERPRINT_GEN
+
+
+# ---------------------------------------------------------------------------
+# Schema-level validation helpers
+# ---------------------------------------------------------------------------
+
+
+class ValidationError(Exception):
+    pass
+
+
+def _check_enum(value: object, allowed: set, field: str) -> None:
+    if value not in allowed:
+        raise ValidationError(
+            f"{field}: '{value}' not in {sorted(allowed)}"
+        )
+
+
+def validate_finding(obj: dict) -> None:
+    """Validate a coerced finding against finding.schema.json constraints."""
+    required = {
+        "check_id", "rule_id", "severity", "confidence",
+        "location", "message", "fingerprint", "detection", "source",
+    }
+    missing = required - obj.keys()
+    if missing:
+        raise ValidationError(f"missing required fields: {sorted(missing)}")
+
+    _check_enum(obj["severity"], _VALID_SEVERITIES, "severity")
+    _check_enum(obj["confidence"], _VALID_CONFIDENCES, "confidence")
+    _check_enum(obj["detection"], _VALID_DETECTIONS, "detection")
+    _check_enum(obj["source"], _VALID_SOURCES, "source")
+
+    if "fix_confidence" in obj:
+        _check_enum(obj["fix_confidence"], _VALID_CONFIDENCES, "fix_confidence")
+
+    loc = obj["location"]
+    if not isinstance(loc, dict):
+        raise ValidationError("location must be an object")
+    if "path" not in loc or "line" not in loc:
+        raise ValidationError("location requires 'path' and 'line'")
+    if not isinstance(loc["line"], int) or loc["line"] < 1:
+        raise ValidationError("location.line must be an integer >= 1")
+    if "end_line" in loc:
+        if not isinstance(loc["end_line"], int) or loc["end_line"] < loc["line"]:
+            raise ValidationError(
+                "location.end_line must be integer >= location.line"
+            )
+
+    if not _RE_CHECK_ID.match(obj["check_id"]):
+        raise ValidationError(
+            f"check_id '{obj['check_id']}' does not match "
+            "^[a-z0-9_-]+/[a-z0-9_.-]+$"
+        )
+
+    if not _RE_FINGERPRINT.match(obj["fingerprint"]):
+        raise ValidationError(
+            f"fingerprint '{obj['fingerprint']}' does not match "
+            "^[A-Za-z0-9_.:+/=-]{{8,128}}$"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Coercion
+# ---------------------------------------------------------------------------
+
+
+def coerce_finding(raw: dict, repo_root: str) -> dict:
+    """
+    Normalise a raw finding dict into a schema-conformant object.
+    - Adds/computes fingerprint if absent.
+    - Resolves location.path relative to repo_root for context reads.
+    - Strips unknown top-level keys (forward-compat).
+    """
+    # Validate presence of required raw fields before coercing
+    required_raw = {
+        "check_id", "rule_id", "severity", "confidence",
+        "detection", "source", "message", "location",
+    }
+    missing = required_raw - raw.keys()
+    if missing:
+        raise ValidationError(f"missing required raw fields: {sorted(missing)}")
+
+    out: dict = {}
+
+    # Required string fields
+    for key in ("check_id", "rule_id", "severity", "confidence",
+                "detection", "source", "message"):
+        out[key] = raw[key]
+
+    # Optional scalar
+    if "fix_confidence" in raw:
+        out["fix_confidence"] = raw["fix_confidence"]
+
+    # location
+    loc_raw = raw["location"]
+    if not isinstance(loc_raw, dict):
+        raise ValidationError("location must be an object")
+    if "path" not in loc_raw or "line" not in loc_raw:
+        raise ValidationError("location requires 'path' and 'line'")
+    loc: dict = {"path": str(loc_raw["path"]), "line": int(loc_raw["line"])}
+    if "end_line" in loc_raw:
+        loc["end_line"] = int(loc_raw["end_line"])
+    out["location"] = loc
+
+    # fingerprint: keep source-tool value VERBATIM; compute otherwise
+    if raw.get("fingerprint"):
+        out["fingerprint"] = str(raw["fingerprint"])
+    else:
+        abs_path = (
+            loc["path"]
+            if os.path.isabs(loc["path"])
+            else os.path.join(repo_root, loc["path"])
+        )
+        out["fingerprint"] = compute_fingerprint(
+            abs_path, loc["line"], raw["message"]
+        )
+
+    # Optional structured fields
+    if "suppression" in raw:
+        out["suppression"] = raw["suppression"]
+    if "properties" in raw:
+        out["properties"] = raw["properties"]
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    # --- Determine input source ---
+    if len(sys.argv) > 1 and sys.argv[1] != "-":
+        input_path = sys.argv[1]
+        try:
+            with open(input_path, "r", encoding="utf-8") as fh:
+                raw_text = fh.read()
+        except OSError as exc:
+            print(f"emit-findings: cannot read input file: {exc}", file=sys.stderr)
+            return 1
+    else:
+        raw_text = sys.stdin.read()
+
+    # --- Parse input ---
+    try:
+        findings_raw = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        print(f"emit-findings: invalid JSON input: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(findings_raw, list):
+        print("emit-findings: input must be a JSON array", file=sys.stderr)
+        return 1
+
+    # --- Determine output path ---
+    # Default: .audit/current/findings.jsonl relative to cwd (repo root)
+    output_path = os.environ.get(
+        "AUDIT_FINDINGS_PATH",
+        os.path.join(os.getcwd(), ".audit", "current", "findings.jsonl"),
+    )
+    output_dir = os.path.dirname(output_path)
+    os.makedirs(output_dir, exist_ok=True)
+
+    repo_root = os.getcwd()
+
+    # --- Coerce and validate ---
+    errors: list = []
+    lines: list = []
+
+    for idx, raw in enumerate(findings_raw):
+        if not isinstance(raw, dict):
+            errors.append(f"finding[{idx}]: must be an object")
+            continue
+        try:
+            finding = coerce_finding(raw, repo_root)
+            validate_finding(finding)
+            lines.append(json.dumps(finding, separators=(",", ":")))
+        except (KeyError, ValidationError) as exc:
+            errors.append(f"finding[{idx}]: {exc}")
+
+    if errors:
+        for err in errors:
+            print(f"emit-findings: {err}", file=sys.stderr)
+        return 1
+
+    with open(output_path, "w", encoding="utf-8") as fh:
+        for line in lines:
+            fh.write(line + "\n")
+
+    print(f"emit-findings: wrote {len(lines)} finding(s) to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/commands-extra/skills/audit/tests/test-emit-findings.sh
+++ b/modules/commands-extra/skills/audit/tests/test-emit-findings.sh
@@ -1,0 +1,555 @@
+#!/usr/bin/env bash
+# test-emit-findings.sh
+# Tests for Epic 1.6: findings JSONL emitter + stable fingerprint
+#
+# Verifies:
+#   - Every output line parses as JSON and validates against finding.schema.json
+#   - Fingerprint is stable across an unrelated line insertion elsewhere in the file
+#   - Fingerprint is stable across whitespace reformat of the primary line
+#   - NO SARIF document is produced (no runs[]/tool.driver)
+#   - Source-tool fingerprints are preserved VERBATIM
+#
+# Usage: bash modules/commands-extra/skills/audit/tests/test-emit-findings.sh
+# Exit:  0 = all pass, non-zero = at least one failure
+
+set -euo pipefail
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILURES=()
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EMIT_SCRIPT="$SCRIPT_DIR/../scripts/emit-findings.py"
+SCHEMA_FILE="$SCRIPT_DIR/../schemas/finding.schema.json"
+
+# Verify prerequisites
+if [ ! -f "$EMIT_SCRIPT" ]; then
+  echo "ERROR: emit-findings.py not found at: $EMIT_SCRIPT" >&2
+  exit 1
+fi
+if [ ! -f "$SCHEMA_FILE" ]; then
+  echo "ERROR: finding.schema.json not found at: $SCHEMA_FILE" >&2
+  exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 not found" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq not found" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+  local name="$1"
+  echo "  PASS: $name"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+  local name="$1"
+  local detail="${2:-}"
+  echo "  FAIL: $name${detail:+ — $detail}"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  FAILURES+=("$name${detail:+: $detail}")
+}
+
+# Minimal stdlib schema validator — checks required fields and enum values.
+# Returns 0 if the object is valid, 1 with a message otherwise.
+validate_against_schema() {
+  local json="$1"
+  python3 - "$json" <<'PYEOF'
+import json, re, sys
+
+obj = json.loads(sys.argv[1])
+
+required = {"check_id","rule_id","severity","confidence","location","message","fingerprint","detection","source"}
+missing = required - obj.keys()
+if missing:
+    print(f"missing fields: {sorted(missing)}", end="")
+    sys.exit(1)
+
+for field, allowed in [
+    ("severity", {"critical","high","medium","low","info"}),
+    ("confidence", {"high","medium","low"}),
+    ("detection", {"tool","llm","hybrid"}),
+    ("source", {"tool","llm"}),
+]:
+    if obj[field] not in allowed:
+        print(f"{field}='{obj[field]}' not in {sorted(allowed)}", end="")
+        sys.exit(1)
+
+loc = obj["location"]
+if not isinstance(loc, dict) or "path" not in loc or "line" not in loc:
+    print("location missing path/line", end="")
+    sys.exit(1)
+if not isinstance(loc["line"], int) or loc["line"] < 1:
+    print(f"location.line={loc['line']!r} invalid", end="")
+    sys.exit(1)
+
+if not re.match(r"^[a-z0-9_-]+/[a-z0-9_.-]+$", obj["check_id"]):
+    print(f"check_id '{obj['check_id']}' pattern mismatch", end="")
+    sys.exit(1)
+
+fp = obj["fingerprint"]
+if not re.match(r"^[A-Za-z0-9_.:+/=-]{8,128}$", fp):
+    print(f"fingerprint '{fp}' pattern mismatch", end="")
+    sys.exit(1)
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Temp workspace
+# ---------------------------------------------------------------------------
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+# ---------------------------------------------------------------------------
+# Minimal valid finding template (no fingerprint — should be computed)
+# ---------------------------------------------------------------------------
+make_finding() {
+  local path="$1"
+  local line="$2"
+  cat <<JSON
+{
+  "check_id": "sq/sql-injection",
+  "rule_id": "sql-injection-001",
+  "severity": "high",
+  "confidence": "medium",
+  "detection": "tool",
+  "source": "tool",
+  "message": "Potential SQL injection via unsanitised user input",
+  "location": { "path": "$path", "line": $line }
+}
+JSON
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Output lines parse as JSON and validate against schema
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 1: Output lines are valid JSON conforming to finding.schema.json ==="
+
+T1_DIR=$(mktemp -d "$TMPDIR_ROOT/t1-XXXXX")
+# Create a small source file so fingerprint can read context
+mkdir -p "$T1_DIR/src"
+cat > "$T1_DIR/src/db.py" <<'PYEOF'
+import sqlite3
+
+def run_query(conn, user_input):
+    # line 4 — potential injection
+    cursor = conn.execute("SELECT * FROM users WHERE name = " + user_input)
+    return cursor.fetchall()
+PYEOF
+
+T1_INPUT="$T1_DIR/input.json"
+cat > "$T1_INPUT" <<JSON
+[
+  $(make_finding "src/db.py" 4)
+]
+JSON
+
+T1_OUT=$(AUDIT_FINDINGS_PATH="$T1_DIR/findings.jsonl" \
+  python3 "$EMIT_SCRIPT" "$T1_INPUT" 2>&1 && echo "exit:0" || echo "exit:1")
+
+if echo "$T1_OUT" | grep -q "exit:1"; then
+  fail "t1: emitter exit code" "$T1_OUT"
+else
+  pass "t1: emitter exited 0"
+fi
+
+if [ -f "$T1_DIR/findings.jsonl" ]; then
+  pass "t1: findings.jsonl created"
+  LINE_COUNT=$(wc -l < "$T1_DIR/findings.jsonl" | tr -d ' ')
+  if [ "$LINE_COUNT" -eq 1 ]; then
+    pass "t1: one line per finding"
+  else
+    fail "t1: one line per finding" "got $LINE_COUNT lines"
+  fi
+
+  # Parse every line as JSON
+  ALL_VALID=1
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    if ! echo "$line" | python3 -c "import json,sys; json.load(sys.stdin)" 2>/dev/null; then
+      fail "t1: line is valid JSON" "not parseable: ${line:0:80}"
+      ALL_VALID=0
+    fi
+  done < "$T1_DIR/findings.jsonl"
+  [ "$ALL_VALID" -eq 1 ] && pass "t1: all lines parse as JSON"
+
+  # Schema validation
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    ERR=$(validate_against_schema "$line" 2>&1) || true
+    if [ -n "$ERR" ]; then
+      fail "t1: schema validation" "$ERR"
+    else
+      pass "t1: line validates against finding.schema.json"
+    fi
+  done < "$T1_DIR/findings.jsonl"
+else
+  fail "t1: findings.jsonl created" "file not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: Fingerprint is stable across an unrelated line insertion elsewhere
+#
+# Strategy: the finding is at line 4. The unrelated insertion goes AFTER line 7
+# (well outside the +-2 window of line 4), so the context lines [2..6] are
+# identical in both versions and the fingerprint must not change.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 2: Fingerprint stable across unrelated line insertion ==="
+
+T2_DIR=$(mktemp -d "$TMPDIR_ROOT/t2-XXXXX")
+mkdir -p "$T2_DIR/src"
+
+# Version A: 7 lines; finding is at line 4
+cat > "$T2_DIR/src/auth.py" <<'PYEOF'
+import os
+import db
+
+def authenticate(user, pwd):
+    query = "SELECT * FROM users WHERE user=" + user
+    return db.execute(query)
+
+PYEOF
+
+T2_INPUT_A="$T2_DIR/input_a.json"
+cat > "$T2_INPUT_A" <<JSON
+[
+  $(make_finding "src/auth.py" 5)
+]
+JSON
+
+AUDIT_FINDINGS_PATH="$T2_DIR/a.jsonl" \
+  python3 "$EMIT_SCRIPT" "$T2_INPUT_A" >/dev/null 2>&1
+FP_A=$(python3 -c "import json,sys; print(json.loads(open('$T2_DIR/a.jsonl').readline())['fingerprint'])")
+
+# Version B: insert two unrelated lines AFTER line 8 (outside the +-2 window);
+# the finding line (5) and its +-2 context are IDENTICAL to version A.
+cat > "$T2_DIR/src/auth.py" <<'PYEOF'
+import os
+import db
+
+def authenticate(user, pwd):
+    query = "SELECT * FROM users WHERE user=" + user
+    return db.execute(query)
+
+# Unrelated new helper added below — well outside the +-2 window of line 5
+def logout(session):
+    session.clear()
+PYEOF
+
+# Finding still at line 5 — same content, same context window
+T2_INPUT_B="$T2_DIR/input_b.json"
+cat > "$T2_INPUT_B" <<JSON
+[
+  $(make_finding "src/auth.py" 5)
+]
+JSON
+
+AUDIT_FINDINGS_PATH="$T2_DIR/b.jsonl" \
+  python3 "$EMIT_SCRIPT" "$T2_INPUT_B" >/dev/null 2>&1
+FP_B=$(python3 -c "import json,sys; print(json.loads(open('$T2_DIR/b.jsonl').readline())['fingerprint'])")
+
+if [ "$FP_A" = "$FP_B" ]; then
+  pass "t2: fingerprint stable across unrelated line insertion"
+else
+  fail "t2: fingerprint stable across unrelated line insertion" \
+    "A='$FP_A' B='$FP_B' (context at the finding line should be identical)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: Fingerprint stable across whitespace reformat of the primary line
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 3: Fingerprint stable across whitespace reformat ==="
+
+T3_DIR=$(mktemp -d "$TMPDIR_ROOT/t3-XXXXX")
+mkdir -p "$T3_DIR/src"
+
+# Version A: compact spacing
+cat > "$T3_DIR/src/query.py" <<'PYEOF'
+import db
+
+def get_user(name):
+    return db.execute("SELECT * FROM users WHERE name="+name)
+
+def other():
+    pass
+PYEOF
+
+T3_INPUT_A="$T3_DIR/input_a.json"
+cat > "$T3_INPUT_A" <<JSON
+[
+  $(make_finding "src/query.py" 4)
+]
+JSON
+
+AUDIT_FINDINGS_PATH="$T3_DIR/a.jsonl" \
+  python3 "$EMIT_SCRIPT" "$T3_INPUT_A" >/dev/null 2>&1
+FP3_A=$(python3 -c "import json,sys; print(json.loads(open('$T3_DIR/a.jsonl').readline())['fingerprint'])")
+
+# Version B: reformatted with extra spaces / expanded string concat
+cat > "$T3_DIR/src/query.py" <<'PYEOF'
+import db
+
+def get_user( name ):
+    return db.execute( "SELECT * FROM users WHERE name=" + name )
+
+def other():
+    pass
+PYEOF
+
+T3_INPUT_B="$T3_DIR/input_b.json"
+cat > "$T3_INPUT_B" <<JSON
+[
+  $(make_finding "src/query.py" 4)
+]
+JSON
+
+AUDIT_FINDINGS_PATH="$T3_DIR/b.jsonl" \
+  python3 "$EMIT_SCRIPT" "$T3_INPUT_B" >/dev/null 2>&1
+FP3_B=$(python3 -c "import json,sys; print(json.loads(open('$T3_DIR/b.jsonl').readline())['fingerprint'])")
+
+if [ "$FP3_A" = "$FP3_B" ]; then
+  pass "t3: fingerprint stable across whitespace reformat"
+else
+  fail "t3: fingerprint stable across whitespace reformat" \
+    "A='$FP3_A' B='$FP3_B'"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: Source-tool fingerprint preserved VERBATIM
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 4: Source-tool fingerprint preserved verbatim ==="
+
+T4_DIR=$(mktemp -d "$TMPDIR_ROOT/t4-XXXXX")
+VERBATIM_FP="gitleaks:abc123def456:1"
+
+T4_INPUT="$T4_DIR/input.json"
+cat > "$T4_INPUT" <<JSON
+[
+  {
+    "check_id": "sq/hardcoded-secret",
+    "rule_id": "secret-001",
+    "severity": "critical",
+    "confidence": "high",
+    "detection": "tool",
+    "source": "tool",
+    "message": "Hardcoded API key detected",
+    "location": { "path": "config.py", "line": 10 },
+    "fingerprint": "$VERBATIM_FP"
+  }
+]
+JSON
+
+AUDIT_FINDINGS_PATH="$T4_DIR/findings.jsonl" \
+  python3 "$EMIT_SCRIPT" "$T4_INPUT" >/dev/null 2>&1
+
+GOT_FP=$(python3 -c "import json,sys; print(json.loads(open('$T4_DIR/findings.jsonl').readline())['fingerprint'])")
+
+if [ "$GOT_FP" = "$VERBATIM_FP" ]; then
+  pass "t4: verbatim source fingerprint preserved"
+else
+  fail "t4: verbatim source fingerprint preserved" \
+    "expected '$VERBATIM_FP', got '$GOT_FP'"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: NO SARIF document produced (gate #30)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 5: Output is line-delimited JSON only — no SARIF ==="
+
+T5_DIR=$(mktemp -d "$TMPDIR_ROOT/t5-XXXXX")
+mkdir -p "$T5_DIR/src"
+echo 'x = 1' > "$T5_DIR/src/main.py"
+
+T5_INPUT="$T5_DIR/input.json"
+cat > "$T5_INPUT" <<JSON
+[
+  $(make_finding "src/main.py" 1)
+]
+JSON
+
+AUDIT_FINDINGS_PATH="$T5_DIR/findings.jsonl" \
+  python3 "$EMIT_SCRIPT" "$T5_INPUT" >/dev/null 2>&1
+
+# SARIF indicators: "runs", "tool", "driver", "$schema" with "sarif"
+SARIF_FOUND=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+
+  # No SARIF wrapper — must NOT have runs[] or tool.driver keys at top level
+  if echo "$line" | python3 -c "
+import json, sys
+obj = json.load(sys.stdin)
+if 'runs' in obj or ('tool' in obj and 'driver' in obj.get('tool', {})):
+    sys.exit(1)
+" 2>/dev/null; then
+    :
+  else
+    fail "t5: no SARIF document structure in output" \
+      "line contains 'runs' or 'tool.driver'"
+    SARIF_FOUND=1
+  fi
+
+  # No \$schema key pointing to SARIF
+  if echo "$line" | python3 -c "
+import json, sys
+obj = json.load(sys.stdin)
+schema = obj.get('\$schema','')
+if 'sarif' in schema.lower():
+    sys.exit(1)
+" 2>/dev/null; then
+    :
+  else
+    fail "t5: no SARIF schema reference in output" \
+      "line contains SARIF \$schema"
+    SARIF_FOUND=1
+  fi
+done < "$T5_DIR/findings.jsonl"
+
+[ "$SARIF_FOUND" -eq 0 ] && pass "t5: output is line-delimited JSON (no SARIF)"
+
+# ---------------------------------------------------------------------------
+# Test 6: Multiple findings — correct count and all valid
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 6: Multiple findings — count and schema ==="
+
+T6_DIR=$(mktemp -d "$TMPDIR_ROOT/t6-XXXXX")
+mkdir -p "$T6_DIR/src"
+cat > "$T6_DIR/src/app.py" <<'PYEOF'
+secret = "hardcoded_token_12345"
+conn.execute("SELECT * FROM t WHERE id=" + user_id)
+eval(user_code)
+PYEOF
+
+T6_INPUT="$T6_DIR/input.json"
+cat > "$T6_INPUT" <<JSON
+[
+  {
+    "check_id": "sq/hardcoded-secret",
+    "rule_id": "secret-001",
+    "severity": "critical",
+    "confidence": "high",
+    "detection": "tool",
+    "source": "tool",
+    "message": "Hardcoded token",
+    "location": { "path": "src/app.py", "line": 1 }
+  },
+  {
+    "check_id": "sq/sql-injection",
+    "rule_id": "sql-001",
+    "severity": "high",
+    "confidence": "medium",
+    "detection": "llm",
+    "source": "llm",
+    "message": "SQL injection risk",
+    "location": { "path": "src/app.py", "line": 2 }
+  },
+  {
+    "check_id": "sq/code-injection",
+    "rule_id": "eval-001",
+    "severity": "critical",
+    "confidence": "high",
+    "detection": "tool",
+    "source": "tool",
+    "message": "eval of user input",
+    "location": { "path": "src/app.py", "line": 3 }
+  }
+]
+JSON
+
+AUDIT_FINDINGS_PATH="$T6_DIR/findings.jsonl" \
+  python3 "$EMIT_SCRIPT" "$T6_INPUT" >/dev/null 2>&1
+
+LINE_COUNT6=$(wc -l < "$T6_DIR/findings.jsonl" | tr -d ' ')
+if [ "$LINE_COUNT6" -eq 3 ]; then
+  pass "t6: 3 findings produce 3 lines"
+else
+  fail "t6: 3 findings produce 3 lines" "got $LINE_COUNT6"
+fi
+
+IDX=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  IDX=$((IDX + 1))
+  ERR=$(validate_against_schema "$line" 2>&1) || true
+  if [ -n "$ERR" ]; then
+    fail "t6: line $IDX schema valid" "$ERR"
+  else
+    pass "t6: line $IDX schema valid"
+  fi
+done < "$T6_DIR/findings.jsonl"
+
+# ---------------------------------------------------------------------------
+# Test 7: Missing file — graceful fallback fingerprint still matches schema
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Test 7: Missing source file — graceful fallback fingerprint ==="
+
+T7_DIR=$(mktemp -d "$TMPDIR_ROOT/t7-XXXXX")
+# Do NOT create the referenced file
+
+T7_INPUT="$T7_DIR/input.json"
+cat > "$T7_INPUT" <<JSON
+[
+  {
+    "check_id": "sq/missing-file",
+    "rule_id": "mf-001",
+    "severity": "low",
+    "confidence": "low",
+    "detection": "tool",
+    "source": "tool",
+    "message": "Finding with a missing source file",
+    "location": { "path": "does/not/exist.py", "line": 42 }
+  }
+]
+JSON
+
+AUDIT_FINDINGS_PATH="$T7_DIR/findings.jsonl" \
+  python3 "$EMIT_SCRIPT" "$T7_INPUT" >/dev/null 2>&1
+
+if [ -f "$T7_DIR/findings.jsonl" ]; then
+  pass "t7: emitter succeeds with missing file"
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    ERR=$(validate_against_schema "$line" 2>&1) || true
+    if [ -n "$ERR" ]; then
+      fail "t7: fallback fingerprint schema valid" "$ERR"
+    else
+      pass "t7: fallback fingerprint schema valid"
+    fi
+  done < "$T7_DIR/findings.jsonl"
+else
+  fail "t7: emitter succeeds with missing file" "findings.jsonl not created"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=================================="
+echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+echo "=================================="
+
+if [ ${#FAILURES[@]} -gt 0 ]; then
+  echo ""
+  echo "Failed tests:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Closes #583

## Summary

- Adds `scripts/emit-findings.py` (python3 stdlib): reads a JSON array of raw findings (stdin or file arg), computes stable fingerprints where absent, validates every object against `finding.schema.json`, and writes `.audit/current/findings.jsonl` (one object per line).
- Fingerprint algorithm (§3.7): `sha256(strip_all_whitespace(lower(primary_line ±2 lines)))[:16] + ":1"`. Source-tool fingerprints are kept VERBATIM.
- Graceful fallback when the referenced file is missing: fingerprint is computed from `path:line:message` so the output is always non-empty and schema-valid.
- Output is controlled by `AUDIT_FINDINGS_PATH` env var; defaults to `.audit/current/findings.jsonl`.
- Registered in `commands-extra/module.json` as `type=script`.
- Adds `tests/test-emit-findings.sh` (shellcheck-clean, self-contained): 15 assertions covering schema validity, fingerprint stability (unrelated insertion + whitespace reformat), verbatim preservation, SARIF gate, multi-finding count, and missing-file fallback.

## Gate #30 compliance

Output is line-delimited JSON only. No `runs[]`, no `tool.driver`, no SARIF `$schema`. Test 5 explicitly asserts this.

## Test plan

- [x] `bash modules/commands-extra/skills/audit/tests/test-emit-findings.sh` → 15 passed, 0 failed
- [x] `shellcheck modules/commands-extra/skills/audit/tests/test-emit-findings.sh` → clean
- [x] `bash tests/test-no-personal-data.sh` → PASS
- [x] `bash tests/test-modules.sh` → 1242 passed, 0 failed