### PR TITLE
#589: harden /audit grep -oP portability guard to ignore comments

### DIFF
--- a/modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh
+++ b/modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh
@@ -20,7 +20,7 @@
 #     "available_tools": [...]
 #   }
 #
-# BSD-safe: no grep -oP; no GNU-only flags.
+# BSD-safe: avoids GNU-only Perl-regex grep flags.
 
 set -euo pipefail
 

--- a/modules/commands-extra/skills/audit/tests/test-detect-defaults.sh
+++ b/modules/commands-extra/skills/audit/tests/test-detect-defaults.sh
@@ -261,7 +261,8 @@ if [ -d "$AUDIT_SKILL_DIR" ]; then
   set +e
   # Exclude this test file itself — it contains the string in comments/checks
   GNU_GREP_HITS=$(grep -rn 'grep -oP' "$AUDIT_SKILL_DIR" 2>/dev/null \
-    | grep -v 'test-detect-defaults.sh' || true)
+    | grep -v 'test-detect-defaults.sh' \
+    | grep -vE ':[0-9]+:[[:space:]]*#' || true)
   set -e
   if [ -z "$GNU_GREP_HITS" ]; then
     pass "no 'grep -oP' (GNU-only) found in audit skill source files"


### PR DESCRIPTION
Wave-1 integration gate caught a cross-epic regression: Epic 0.1's `test-detect-defaults.sh` portability guard greps for `grep -oP` without excluding comments, so Epic 1.3's explanatory comment in `detect-ecosystems.sh` (which says "no grep -oP") false-positived.

- TEST 4 now excludes full-line comments (`grep -vE ':[0-9]+:[[:space:]]*#'`) — matches usage, not mentions.
- Reworded the detector comment to avoid the literal string.

Full audit suite green (9 suites). Closes #589.