### PR TITLE
#593: migrate testing, documentation, performance category prompts to packs

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -133,6 +133,36 @@
       "type": "doc",
       "template": false
     },
+    "skills/audit/packs/testing/pack.json": {
+      "target": "skills/audit/packs/testing/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/testing/checks.md": {
+      "target": "skills/audit/packs/testing/checks.md",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/documentation/pack.json": {
+      "target": "skills/audit/packs/documentation/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/documentation/checks.md": {
+      "target": "skills/audit/packs/documentation/checks.md",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/performance/pack.json": {
+      "target": "skills/audit/packs/performance/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/performance/checks.md": {
+      "target": "skills/audit/packs/performance/checks.md",
+      "type": "doc",
+      "template": false
+    },
     "skills/audit/scripts/spine/run.sh": {
       "target": "skills/audit/scripts/spine/run.sh",
       "type": "script",

--- a/modules/commands-extra/skills/audit/packs/documentation/checks.md
+++ b/modules/commands-extra/skills/audit/packs/documentation/checks.md
@@ -1,0 +1,338 @@
+# Documentation Audit Pack
+
+**Pack ID:** `ccgm/documentation`
+**Applies when:** `always`
+
+---
+
+## Scope
+
+This pack audits the quality and completeness of inline code documentation and project-level
+documentation. It checks for exported symbols missing JSDoc, code comments that no longer
+accurately describe the code they annotate (stale comments), and README files that are
+incomplete or missing key sections. It does NOT audit auto-generated API docs, test
+documentation, or changelog formatting. All three checks are NOT auto-fixable: generated
+documentation stubs do not substitute for meaningful human-authored documentation.
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `always` | Documentation gaps are relevant in every project regardless of ecosystem; language-specific nuances (e.g. JSDoc on TypeScript files) simply produce no findings on non-matching repos. |
+
+---
+
+## Checks
+
+---
+
+### `documentation/missing-jsdoc`
+
+**Severity:** `low`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Audit documentation.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file when classifying findings. In particular:
+the `documentation` fix_type is NOT auto-fixable (auto-fixable = No) — generated stubs
+do not substitute for meaningful documentation and require human authorship.
+Do not rely on memory — open and apply the file.
+
+Check for missing JSDoc on exports:
+- Enumerate all exported functions, classes, interfaces, and type aliases in TypeScript or
+  JavaScript source files.
+- For each exported symbol, check whether a JSDoc comment block (/** ... */) is present
+  immediately above the declaration.
+- Flag exported symbols that lack a JSDoc comment.
+- Do NOT flag internal (non-exported) symbols.
+- Do NOT flag symbols in generated files (e.g. *.generated.ts, *.d.ts).
+- Do NOT flag test files.
+
+Report each finding with: file path, line number, symbol name, severity LOW,
+and auto_fixable=false (documentation fix_type requires human-authored documentation,
+not generated stubs).
+```
+
+#### Spine Wiring
+
+This check is LLM-only. No spine tool is involved.
+
+```yaml
+check_id: documentation/missing-jsdoc
+detection: llm
+tool: ~
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Missing JSDoc on exports reduces discoverability and usability of
+public APIs, but the code remains functional. Low severity reflects that this is a quality
+and maintainability concern rather than a correctness or security issue.
+
+**Confidence rationale:** The presence or absence of a JSDoc block above an exported symbol
+is syntactically detectable; the LLM can enumerate exports reliably, making false positives
+unlikely for well-structured TypeScript/JavaScript codebases.
+
+**Rubric entry:** `documentation/missing-jsdoc`
+
+#### Fixture
+
+**True positive** (`src/utils/format.ts` exports `formatDate` without JSDoc):
+
+```typescript
+// src/utils/format.ts
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+```
+
+Finding: `src/utils/format.ts:2` — exported `formatDate` has no JSDoc comment.
+
+**True negative** (should produce NO finding):
+
+```typescript
+// src/utils/format.ts
+
+/**
+ * Formats a Date to a human-readable string.
+ * @param date - The date to format.
+ * @returns A formatted string like "Jan 1, 2024".
+ */
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+```
+
+No finding: JSDoc block is present above the exported function.
+
+---
+
+### `documentation/stale-comment`
+
+**Severity:** `low`
+**Confidence:** `low`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Audit documentation.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file when classifying findings. In particular:
+the `documentation` fix_type is NOT auto-fixable (auto-fixable = No) — generated stubs
+do not substitute for meaningful documentation and require human authorship.
+Do not rely on memory — open and apply the file.
+
+Check for stale comments:
+- Scan source files for inline comments (// and /* ... */) and JSDoc blocks.
+- Flag comments that appear to describe code that has changed such that the comment is now
+  inaccurate. Common signs of staleness:
+    - A comment references a function, variable, or parameter name that no longer exists.
+    - A comment describes a behavior (e.g. "returns null on error") that the code no longer
+      implements.
+    - A comment contains a TODO or FIXME that refers to a fix that appears to have already
+      been applied.
+    - A comment references a version, date, or external ticket in a way that is clearly
+      outdated.
+- Be conservative: only flag when the mismatch between comment and code is clear from
+  static reading. Do NOT flag comments that are vague or aspirational but not provably wrong.
+- Do NOT flag auto-generated comment blocks or lint-suppression comments.
+
+Report each finding with: file path, line number, the stale comment text (truncated to 80
+chars), severity LOW, and auto_fixable=false.
+```
+
+#### Spine Wiring
+
+This check is LLM-only. No spine tool is involved.
+
+```yaml
+check_id: documentation/stale-comment
+detection: llm
+tool: ~
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A stale comment misleads future readers about the code's behavior,
+increasing maintenance burden and risk of introducing bugs. Low severity reflects that the
+code itself is correct; only the documentation is wrong.
+
+**Confidence rationale:** Determining whether a comment is stale requires semantic comparison
+between the comment's claims and the actual code behavior, which the LLM can reason about
+but may get wrong for ambiguous or context-dependent comments, yielding low confidence.
+
+**Rubric entry:** `documentation/stale-comment`
+
+#### Fixture
+
+**True positive** (`src/auth/session.ts` comment describes removed `null` return):
+
+```typescript
+// src/auth/session.ts
+
+/**
+ * Returns the current user, or null if not authenticated.
+ */
+export function getCurrentUser(): User {
+  // Throws if not authenticated (changed from returning null in v2.0)
+  if (!store.user) throw new AuthError('Not authenticated');
+  return store.user;
+}
+```
+
+Finding: `src/auth/session.ts:3` — comment says "returns null if not authenticated" but the
+function now throws; comment is stale.
+
+**True negative** (should produce NO finding):
+
+```typescript
+// src/auth/session.ts
+
+/**
+ * Returns the current user, or throws AuthError if not authenticated.
+ */
+export function getCurrentUser(): User {
+  if (!store.user) throw new AuthError('Not authenticated');
+  return store.user;
+}
+```
+
+No finding: comment accurately describes the throwing behavior.
+
+---
+
+### `documentation/incomplete-readme`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Audit documentation.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file when classifying findings. In particular:
+the `documentation` fix_type is NOT auto-fixable (auto-fixable = No) — generated stubs
+do not substitute for meaningful documentation and require human authorship.
+Do not rely on memory — open and apply the file.
+
+Check for README completeness:
+- Look for a README.md (or README.rst, README.txt) in the repository root and in major
+  package directories.
+- Flag a README as incomplete if it is missing one or more of the following sections that
+  are appropriate for this project type:
+    - Project description / purpose (what does this project do?)
+    - Installation or setup instructions
+    - Usage examples or quickstart
+    - Configuration reference (if the project has non-trivial configuration)
+    - Contributing or development guide (for libraries and open-source projects)
+- Flag if no README exists at all at the repo root.
+- Be proportional: a small utility library has different README expectations than a full
+  application. Use the project's apparent type and complexity to calibrate.
+- Do NOT flag missing sections for content that is genuinely not applicable (e.g. a
+  private internal tool does not need a Contributing guide).
+
+Report each finding with: file path of the README (or "README.md missing"), the missing
+section name, severity MEDIUM, and auto_fixable=false.
+```
+
+#### Spine Wiring
+
+This check is LLM-only. No spine tool is involved.
+
+```yaml
+check_id: documentation/incomplete-readme
+detection: llm
+tool: ~
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** An incomplete README increases onboarding friction and the risk that
+new contributors misuse or misconfigure the project. Medium severity reflects that this
+directly affects the project's usability and accessibility to contributors.
+
+**Confidence rationale:** Determining whether a README section is "present and sufficient"
+requires understanding the project's type and the reader's needs; the LLM can assess this
+reasonably but may disagree on threshold, yielding medium confidence.
+
+**Rubric entry:** `documentation/incomplete-readme`
+
+#### Fixture
+
+**True positive** (`README.md` missing installation instructions):
+
+```markdown
+# MyApp
+
+A web application for tracking habits.
+
+## Contributing
+
+Submit a PR.
+```
+
+Finding: `README.md` — missing "Installation" and "Usage" sections.
+
+**True negative** (should produce NO finding):
+
+```markdown
+# MyApp
+
+A web application for tracking habits.
+
+## Installation
+
+```bash
+npm install
+npm run dev
+```
+
+## Usage
+
+Visit http://localhost:3000 and create your first habit.
+```
+
+No finding: README contains description, installation, and usage.
+
+---
+
+## Migration Mapping
+
+The following table maps every bullet of the original Agent 7 category prompt to the check-id
+that now owns it, proving no check was dropped.
+
+| Original Agent 7 Bullet | Check ID |
+|--------------------------|----------|
+| Missing JSDoc on exports (NOT auto-fixable: requires human-authored documentation) | `documentation/missing-jsdoc` |
+| Stale comments (NOT auto-fixable) | `documentation/stale-comment` |
+| README completeness (NOT auto-fixable) | `documentation/incomplete-readme` |
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/documentation/checks.md
+++ b/modules/commands-extra/skills/audit/packs/documentation/checks.md
@@ -279,7 +279,7 @@ reasonably but may disagree on threshold, yielding medium confidence.
 
 **True positive** (`README.md` missing installation instructions):
 
-```markdown
+````markdown
 # MyApp
 
 A web application for tracking habits.
@@ -287,13 +287,13 @@ A web application for tracking habits.
 ## Contributing
 
 Submit a PR.
-```
+````
 
 Finding: `README.md` — missing "Installation" and "Usage" sections.
 
 **True negative** (should produce NO finding):
 
-```markdown
+````markdown
 # MyApp
 
 A web application for tracking habits.
@@ -308,7 +308,7 @@ npm run dev
 ## Usage
 
 Visit http://localhost:3000 and create your first habit.
-```
+````
 
 No finding: README contains description, installation, and usage.
 

--- a/modules/commands-extra/skills/audit/packs/documentation/pack.json
+++ b/modules/commands-extra/skills/audit/packs/documentation/pack.json
@@ -1,0 +1,32 @@
+{
+  "id": "ccgm/documentation",
+  "name": "Documentation Audit",
+  "version": "1.0.0",
+  "applies_when": ["always"],
+  "tags": ["documentation", "jsdoc", "readme", "quality"],
+  "severity_floor": "low",
+  "tools": [],
+  "checks": [
+    {
+      "id": "documentation/missing-jsdoc",
+      "severity": "low",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "documentation/stale-comment",
+      "severity": "low",
+      "confidence": "low",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "documentation/incomplete-readme",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/packs/performance/checks.md
+++ b/modules/commands-extra/skills/audit/packs/performance/checks.md
@@ -153,7 +153,8 @@ Check for missing React.memo:
 - Do NOT flag components that use context or internal state, as memo does not prevent
   re-renders caused by context changes.
 
-Report each finding with: file path, component name, severity LOW,
+Report each finding with: file path, line number (the component's declaration line),
+component name, severity LOW,
 and auto_fixable=true at medium confidence (add memo wrapper per fix-patterns.md).
 ```
 
@@ -197,7 +198,7 @@ export function UserCard({ userId, name }: UserCardProps) {
 // Parent re-renders on every keystroke via useState; UserCard props are stable.
 ```
 
-Finding: `src/components/UserCard.tsx` — `UserCard` receives stable props but is not wrapped
+Finding: `src/components/UserCard.tsx:6` — `UserCard` receives stable props but is not wrapped
 in `React.memo`; auto_fixable=true (add `export default React.memo(UserCard)`).
 
 **True negative** (should produce NO finding):

--- a/modules/commands-extra/skills/audit/packs/performance/checks.md
+++ b/modules/commands-extra/skills/audit/packs/performance/checks.md
@@ -1,0 +1,330 @@
+# Performance Audit Pack
+
+**Pack ID:** `ccgm/performance`
+**Applies when:** `always`
+
+---
+
+## Scope
+
+This pack audits common performance anti-patterns in application code. It checks for N+1
+query patterns (a data-fetching loop that issues one query per item rather than batching),
+React components that re-render unnecessarily due to missing `React.memo`, and large
+library imports that pull in entire packages when only a small subset is needed. It does NOT
+audit server infrastructure, network latency, database index design, or build pipeline
+performance. React-specific checks (missing-react-memo) produce no findings on non-React
+repositories.
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `always` | N+1 query and large-bundle-import checks apply to any stack; missing-react-memo is React-specific but produces no findings on non-React repos, making `always` the correct gate (same behavior as today's Agent 8 category prompt). |
+
+---
+
+## Checks
+
+---
+
+### `performance/n-plus-one-query`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Audit performance patterns. Most findings need human review.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table and confidence levels from that file when classifying findings.
+Do not rely on memory — open and apply the file.
+
+Check for N+1 query patterns:
+- Scan data access code (ORM calls, raw SQL, Supabase/Prisma/TypeORM/Mongoose queries,
+  fetch calls to internal APIs, etc.) for patterns where a query or fetch is issued
+  inside a loop or array map.
+- Flag code where:
+    - A `.findMany()`, `.select()`, `.query()`, or equivalent is called inside a
+      `for`, `while`, `forEach`, `map`, `reduce`, or `flatMap` over a result set.
+    - Each iteration fetches related data that could be obtained via a JOIN or
+      batch query (e.g. fetching a user for each order in a list of orders).
+- Do NOT flag cases where the loop body is performing non-database work (calculations,
+  transformations) and the DB call is outside the loop.
+- Do NOT flag intentional per-item operations where batching is not possible or
+  where the set size is bounded to 1.
+
+Report each finding with: file path, line number, a brief description of the pattern
+(e.g. "fetches user inside orders loop"), severity HIGH, and auto_fixable=false (requires
+a refactor to batch queries or use eager loading).
+```
+
+#### Spine Wiring
+
+This check is LLM-only. No spine tool is involved.
+
+```yaml
+check_id: performance/n-plus-one-query
+detection: llm
+tool: ~
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** N+1 query patterns cause quadratic or worse database load as
+dataset size grows, directly degrading response times and database resource usage.
+High severity reflects the production impact when these patterns hit real data volumes.
+
+**Confidence rationale:** Identifying a query inside a loop requires understanding the
+semantics of the called function and the loop's purpose, which the LLM can reason about
+but may misidentify in complex or abstracted code, yielding medium confidence.
+
+**Rubric entry:** `performance/n-plus-one-query`
+
+#### Fixture
+
+**True positive** (`src/api/orders.ts` fetches user inside orders loop):
+
+```typescript
+// src/api/orders.ts
+async function getOrdersWithUsers(orderIds: string[]) {
+  const orders = await db.orders.findMany({ where: { id: { in: orderIds } } });
+  // N+1: one user query per order
+  return Promise.all(orders.map(async (order) => {
+    const user = await db.users.findUnique({ where: { id: order.userId } });
+    return { ...order, user };
+  }));
+}
+```
+
+Finding: `src/api/orders.ts:5` — `db.users.findUnique` called inside `map` over orders list;
+batch with `findMany` and join in memory.
+
+**True negative** (should produce NO finding):
+
+```typescript
+// src/api/orders.ts
+async function getOrdersWithUsers(orderIds: string[]) {
+  const orders = await db.orders.findMany({
+    where: { id: { in: orderIds } },
+    include: { user: true },   // eager-loaded in single query
+  });
+  return orders;
+}
+```
+
+No finding: user is loaded via `include` in a single batched query.
+
+---
+
+### `performance/missing-react-memo`
+
+**Severity:** `low`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Audit performance patterns. Most findings need human review.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table and confidence levels from that file when classifying findings.
+Do not rely on memory — open and apply the file.
+
+Check for missing React.memo:
+- Scan React component files (*.tsx, *.jsx) for functional components that:
+    - Accept props (not zero-prop components).
+    - Are re-exported or used as children of other components.
+    - Have a parent component that re-renders frequently (e.g. contains state that
+      changes on user interaction) where the child's props do not change.
+- Flag components where wrapping in React.memo would prevent unnecessary re-renders.
+- Be conservative: only flag when there is evidence the parent re-renders on state
+  change and the child's props are stable (primitives, stable references via useMemo/
+  useCallback). Do NOT flag every component — only those where memo would have clear value.
+- Do NOT flag components that use context or internal state, as memo does not prevent
+  re-renders caused by context changes.
+
+Report each finding with: file path, component name, severity LOW,
+and auto_fixable=true at medium confidence (add memo wrapper per fix-patterns.md).
+```
+
+#### Spine Wiring
+
+This check is LLM-only. No spine tool is involved.
+
+```yaml
+check_id: performance/missing-react-memo
+detection: llm
+tool: ~
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A component re-rendering unnecessarily wastes CPU and can cause
+cascading child re-renders, but the UI remains correct. Low severity reflects that this
+is a performance optimization opportunity rather than a correctness defect.
+
+**Confidence rationale:** Determining whether `React.memo` would have net benefit requires
+understanding both parent rendering frequency and prop stability; this analysis is
+context-dependent and may be incorrect for complex component trees, yielding medium confidence.
+
+**Rubric entry:** `performance/missing-react-memo`
+
+#### Fixture
+
+**True positive** (`src/components/UserCard.tsx` not memoized, parent re-renders on typing):
+
+```tsx
+// src/components/UserCard.tsx
+interface UserCardProps {
+  userId: string;
+  name: string;
+}
+
+export function UserCard({ userId, name }: UserCardProps) {
+  return <div className="card">{name}</div>;
+}
+
+// Parent re-renders on every keystroke via useState; UserCard props are stable.
+```
+
+Finding: `src/components/UserCard.tsx` — `UserCard` receives stable props but is not wrapped
+in `React.memo`; auto_fixable=true (add `export default React.memo(UserCard)`).
+
+**True negative** (should produce NO finding):
+
+```tsx
+// src/components/UserCard.tsx
+import { memo } from 'react';
+
+export const UserCard = memo(function UserCard({ userId, name }: UserCardProps) {
+  return <div className="card">{name}</div>;
+});
+```
+
+No finding: component is already memoized.
+
+---
+
+### `performance/large-bundle-import`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Audit performance patterns. Most findings need human review.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table and confidence levels from that file when classifying findings.
+Do not rely on memory — open and apply the file.
+
+Check for large bundle imports (needs tree shaking):
+- Scan import statements for patterns that import an entire library when only specific
+  members are needed, preventing the bundler from tree-shaking unused code. Examples:
+    - `import _ from 'lodash'` instead of `import { debounce } from 'lodash-es'` or
+      `import debounce from 'lodash/debounce'`
+    - `import * as Icons from '@heroicons/react'` instead of named imports
+    - `import moment from 'moment'` (moment does not support tree shaking at all)
+    - `import { everything } from 'some-large-library'` where only one item is used
+  - Check for libraries known to be non-tree-shakeable or commonly misimported (lodash,
+    moment, date-fns default, antd, material-ui top-level, rxjs/Rx).
+- Flag imports that are likely to add significant bundle weight unnecessarily.
+- Do NOT flag imports of small libraries or where the full module is genuinely needed.
+- Do NOT flag server-side code (Node.js scripts, API routes) where bundle size is
+  not a concern.
+
+Report each finding with: file path, line number, the import statement, a suggested
+tree-shakeable alternative, severity MEDIUM, and auto_fixable=false (needs tree shaking
+refactor and possibly a dependency change).
+```
+
+#### Spine Wiring
+
+This check is LLM-only. No spine tool is involved.
+
+```yaml
+check_id: performance/large-bundle-import
+detection: llm
+tool: ~
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Importing entire large libraries when only a fraction is used
+inflates the client bundle, directly increasing initial load time and time-to-interactive.
+Medium severity reflects measurable user-facing impact in web applications.
+
+**Confidence rationale:** Identifying commonly misimported libraries (lodash, moment) is
+reliable, but assessing whether a given import is "large" and unused code is "significant"
+requires bundler knowledge and project context, yielding medium confidence.
+
+**Rubric entry:** `performance/large-bundle-import`
+
+#### Fixture
+
+**True positive** (`src/utils/time.ts` imports full lodash):
+
+```typescript
+// src/utils/time.ts
+import _ from 'lodash';
+
+export function debounceSearch(fn: () => void) {
+  return _.debounce(fn, 300);
+}
+```
+
+Finding: `src/utils/time.ts:2` — full lodash imported; replace with
+`import debounce from 'lodash/debounce'` or `import { debounce } from 'lodash-es'`
+for tree shaking.
+
+**True negative** (should produce NO finding):
+
+```typescript
+// src/utils/time.ts
+import debounce from 'lodash/debounce';
+
+export function debounceSearch(fn: () => void) {
+  return debounce(fn, 300);
+}
+```
+
+No finding: per-method import enables tree shaking.
+
+---
+
+## Migration Mapping
+
+The following table maps every bullet of the original Agent 8 category prompt to the check-id
+that now owns it, proving no check was dropped.
+
+| Original Agent 8 Bullet | Check ID |
+|--------------------------|----------|
+| N+1 query patterns (NOT auto-fixable) | `performance/n-plus-one-query` |
+| Missing React.memo (auto-fixable: add memo wrapper — medium confidence per fix-patterns.md) | `performance/missing-react-memo` |
+| Large bundle imports (NOT auto-fixable - needs tree shaking) | `performance/large-bundle-import` |
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/performance/pack.json
+++ b/modules/commands-extra/skills/audit/packs/performance/pack.json
@@ -1,0 +1,32 @@
+{
+  "id": "ccgm/performance",
+  "name": "Performance Audit",
+  "version": "1.0.0",
+  "applies_when": ["always"],
+  "tags": ["performance", "react", "bundle", "database", "quality"],
+  "severity_floor": "low",
+  "tools": [],
+  "checks": [
+    {
+      "id": "performance/n-plus-one-query",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "performance/missing-react-memo",
+      "severity": "low",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": true
+    },
+    {
+      "id": "performance/large-bundle-import",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/packs/testing/checks.md
+++ b/modules/commands-extra/skills/audit/packs/testing/checks.md
@@ -1,0 +1,314 @@
+# Testing Audit Pack
+
+**Pack ID:** `ccgm/testing`
+**Applies when:** `always`
+
+---
+
+## Scope
+
+This pack audits test coverage and test quality across the codebase. It checks for source files
+that lack corresponding test files, test files that contain no assertions (and therefore prove
+nothing), and test files that omit edge-case scenarios (empty inputs, boundary values, error
+paths). It does NOT audit test runtime performance, mock strategy, or test framework setup.
+All three checks require human-authored fixes; generated test stubs do not substitute for
+meaningful test logic.
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `always` | Testing gaps are relevant in every project regardless of language or ecosystem; React-specific or language-specific nuances simply produce no findings on non-matching repos. |
+
+---
+
+## Checks
+
+---
+
+### `testing/missing-test-file`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Audit test coverage and quality. Most findings need human review.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file when classifying findings (in particular,
+`test_implementation` fix_type is NOT auto-fixable). Do not rely on memory — open and apply the file.
+
+Check for missing test files for components:
+- Enumerate source files (components, utilities, services, hooks) under src/ or equivalent.
+- For each source file, look for a corresponding test file (e.g. Foo.test.ts, Foo.spec.ts,
+  __tests__/Foo.ts, or a test directory mirroring the source structure).
+- Flag source files that have no associated test file as findings.
+- Do NOT flag test helper/fixture files, generated files, or files that are trivial re-exports
+  with no logic.
+- Do NOT flag files that are already covered by an integration or e2e test suite if that
+  coverage is documented in the project.
+
+Report each finding with: file path of the untested source file, severity MEDIUM,
+and auto_fixable=false (test_implementation fix_type requires human authorship).
+```
+
+#### Spine Wiring
+
+This check is LLM-only. No spine tool is involved.
+
+```yaml
+check_id: testing/missing-test-file
+detection: llm
+tool: ~
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Source files without any test coverage create a gap where regressions go
+undetected on changes. Medium severity because the absence of a test does not cause an immediate
+failure but degrades long-term maintainability and confidence in changes.
+
+**Confidence rationale:** The presence or absence of a test file for a given source file is a
+deterministic structural check; the LLM can enumerate files reliably, making false positives
+unlikely for well-structured projects.
+
+**Rubric entry:** `testing/missing-test-file`
+
+#### Fixture
+
+**True positive** (`src/components/UserCard.tsx` has no test file):
+
+```
+src/
+  components/
+    UserCard.tsx   ← source file
+    Avatar.tsx
+    Avatar.test.tsx
+```
+
+Finding: `src/components/UserCard.tsx` — no corresponding test file found.
+
+**True negative** (should produce NO finding):
+
+```
+src/
+  components/
+    UserCard.tsx
+    UserCard.test.tsx   ← test file present
+```
+
+No finding: `UserCard.test.tsx` covers `UserCard.tsx`.
+
+---
+
+### `testing/no-assertions`
+
+**Severity:** `high`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Audit test coverage and quality. Most findings need human review.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file when classifying findings (in particular,
+`test_implementation` fix_type is NOT auto-fixable). Do not rely on memory — open and apply the file.
+
+Check for test files without assertions:
+- Enumerate all test files (*.test.ts, *.spec.ts, *.test.tsx, *.spec.tsx, **/__tests__/**,
+  or equivalent in the project's test framework).
+- For each test file, scan for assertion calls: expect(...), assert(...), should(...),
+  assertEquals(...), or framework-specific assertion APIs.
+- Flag test files that contain zero assertion calls — these tests can never fail and prove nothing.
+- Flag individual `it()`/`test()` blocks that contain no assertions even if other blocks in the
+  same file do contain assertions.
+- Do NOT flag test files that use expectation-based framework APIs that appear assertion-free
+  (e.g. jest.fn() with .toHaveBeenCalled()) — those are valid assertions.
+- Do NOT flag setup/teardown files (beforeAll, afterAll, etc.) that are not themselves test blocks.
+
+Report each finding with: file path and block name, severity HIGH,
+and auto_fixable=false (test_implementation fix_type requires human authorship).
+```
+
+#### Spine Wiring
+
+This check is LLM-only. No spine tool is involved.
+
+```yaml
+check_id: testing/no-assertions
+detection: llm
+tool: ~
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A test file with no assertions passes unconditionally and provides
+zero regression protection. This is a high-severity gap because the developer may believe
+coverage exists when it does not, masking bugs that would otherwise be caught.
+
+**Confidence rationale:** The presence of assertion calls is syntactically detectable by
+pattern matching on well-known assertion APIs; false positive rate is low for common frameworks.
+
+**Rubric entry:** `testing/no-assertions`
+
+#### Fixture
+
+**True positive** (`src/utils/format.test.ts` contains no assertions):
+
+```typescript
+// src/utils/format.test.ts
+import { formatDate } from './format';
+
+describe('formatDate', () => {
+  it('formats a date', () => {
+    const result = formatDate(new Date('2024-01-01'));
+    // TODO: add assertion
+  });
+});
+```
+
+Finding: `src/utils/format.test.ts` — test block "formats a date" contains no assertions.
+
+**True negative** (should produce NO finding):
+
+```typescript
+// src/utils/format.test.ts
+import { formatDate } from './format';
+
+describe('formatDate', () => {
+  it('formats a date', () => {
+    expect(formatDate(new Date('2024-01-01'))).toBe('Jan 1, 2024');
+  });
+});
+```
+
+No finding: assertion `expect(...).toBe(...)` is present.
+
+---
+
+### `testing/missing-edge-cases`
+
+**Severity:** `low`
+**Confidence:** `low`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Audit test coverage and quality. Most findings need human review.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file when classifying findings (in particular,
+`test_implementation` fix_type is NOT auto-fixable). Do not rely on memory — open and apply the file.
+
+Check for missing edge case tests:
+- For each test file, examine the source file it covers (if identifiable).
+- Review the source function signatures and logic branches.
+- Flag test files that appear to test only the happy path and omit clearly important edge
+  cases such as: null/undefined inputs, empty arrays/strings, boundary values (0, -1, MAX),
+  error/exception paths, and async rejection handling.
+- Be conservative: only flag when the missing edge case is clearly important given the
+  function's documented or inferred behavior. Do NOT generate speculative findings for
+  hypothetical inputs that are unreachable or explicitly excluded.
+- Do NOT flag edge cases that are already covered elsewhere in the test suite.
+
+Report each finding with: file path, the specific edge case missing, severity LOW,
+and auto_fixable=false (test_implementation fix_type requires human authorship).
+```
+
+#### Spine Wiring
+
+This check is LLM-only. No spine tool is involved.
+
+```yaml
+check_id: testing/missing-edge-cases
+detection: llm
+tool: ~
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Missing edge cases leave specific code paths unprotected against
+regression, but the immediate impact is lower than a fully untested file or a test that
+never fails; it is a quality gap rather than a complete absence of protection.
+
+**Confidence rationale:** Determining which edge cases are "important" requires semantic
+understanding of the function's contract; the LLM can reason about this but may miss
+project-specific invariants or incorrectly model expected behavior, so confidence is low.
+
+**Rubric entry:** `testing/missing-edge-cases`
+
+#### Fixture
+
+**True positive** (`src/utils/divide.test.ts` omits division-by-zero test):
+
+```typescript
+// src/utils/divide.ts
+export function divide(a: number, b: number): number {
+  if (b === 0) throw new Error('Division by zero');
+  return a / b;
+}
+
+// src/utils/divide.test.ts
+describe('divide', () => {
+  it('divides two numbers', () => {
+    expect(divide(10, 2)).toBe(5);
+  });
+});
+```
+
+Finding: `src/utils/divide.test.ts` — no test for division-by-zero error path.
+
+**True negative** (should produce NO finding):
+
+```typescript
+// src/utils/divide.test.ts
+describe('divide', () => {
+  it('divides two numbers', () => {
+    expect(divide(10, 2)).toBe(5);
+  });
+  it('throws on division by zero', () => {
+    expect(() => divide(10, 0)).toThrow('Division by zero');
+  });
+});
+```
+
+No finding: edge case (division by zero) is covered.
+
+---
+
+## Migration Mapping
+
+The following table maps every bullet of the original Agent 6 category prompt to the check-id
+that now owns it, proving no check was dropped.
+
+| Original Agent 6 Bullet | Check ID |
+|--------------------------|----------|
+| Missing test files for components (NOT auto-fixable) | `testing/missing-test-file` |
+| Test files without assertions (NOT auto-fixable) | `testing/no-assertions` |
+| Missing edge case tests (NOT auto-fixable) | `testing/missing-edge-cases` |
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/testing/checks.md
+++ b/modules/commands-extra/skills/audit/packs/testing/checks.md
@@ -133,8 +133,9 @@ Check for test files without assertions:
 - Flag test files that contain zero assertion calls — these tests can never fail and prove nothing.
 - Flag individual `it()`/`test()` blocks that contain no assertions even if other blocks in the
   same file do contain assertions.
-- Do NOT flag test files that use expectation-based framework APIs that appear assertion-free
-  (e.g. jest.fn() with .toHaveBeenCalled()) — those are valid assertions.
+- Count mock-verification calls as valid assertions (e.g. `expect(fn).toHaveBeenCalled()`,
+  `expect(fn).toHaveBeenCalledWith(...)` are assertions); only flag files that have NO
+  assertion forms whatsoever.
 - Do NOT flag setup/teardown files (beforeAll, afterAll, etc.) that are not themselves test blocks.
 
 Report each finding with: file path and block name, severity HIGH,

--- a/modules/commands-extra/skills/audit/packs/testing/pack.json
+++ b/modules/commands-extra/skills/audit/packs/testing/pack.json
@@ -1,0 +1,32 @@
+{
+  "id": "ccgm/testing",
+  "name": "Testing Audit",
+  "version": "1.0.0",
+  "applies_when": ["always"],
+  "tags": ["testing", "coverage", "quality"],
+  "severity_floor": "low",
+  "tools": [],
+  "checks": [
+    {
+      "id": "testing/missing-test-file",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "testing/no-assertions",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "testing/missing-edge-cases",
+      "severity": "low",
+      "confidence": "low",
+      "detection": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/scripts/lint-pack.py
+++ b/modules/commands-extra/skills/audit/scripts/lint-pack.py
@@ -74,9 +74,12 @@ def _load_rubric(rubric_path: Path):
     if isinstance(raw, list):
         rubric = {entry["id"]: entry for entry in raw if isinstance(entry, dict) and "id" in entry}
     elif isinstance(raw, dict):
-        # Could be {"checks": [...]} envelope or a flat {id: entry} map.
+        # Could be {"checks": [...]} envelope, {"checks": {id: entry, ...}} envelope,
+        # or a flat {id: entry} map. Accept all three.
         if "checks" in raw and isinstance(raw["checks"], list):
             rubric = {e["id"]: e for e in raw["checks"] if isinstance(e, dict) and "id" in e}
+        elif "checks" in raw and isinstance(raw["checks"], dict):
+            rubric = raw["checks"]
         else:
             rubric = raw
     else:

--- a/modules/commands-extra/skills/audit/tests/test-pack-lint.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-lint.sh
@@ -302,11 +302,10 @@ trap "rm -rf '${_T5_DIR}'" EXIT
 
 make_valid_pack "${_T5_DIR}/test-covered"
 
-# Write a rubric that DOES contain "tv/check-one"
+# Write a rubric in dict-envelope form ({"checks": {<id>: {...}}}) that DOES contain "tv/check-one".
+# This pins the dict-envelope branch added to lint-pack.py so reverting it would break this test.
 cat > "${_T5_DIR}/rubric.json" <<'JSON'
-[
-  {"id": "tv/check-one", "severity": "high", "confidence": "high"}
-]
+{"checks": {"tv/check-one": {"severity": "high", "confidence": "high"}}}
 JSON
 
 output=""


### PR DESCRIPTION
## Summary

Implements Epic 1.7a batch 3/3: migrates the Agent 6 (Testing), Agent 7 (Documentation), and Agent 8 (Performance) category prompts from SKILL.md into registry packs.

- **packs/testing** (`ccgm/testing`): `missing-test-file` (medium/high), `no-assertions` (high/high), `missing-edge-cases` (low/low) — all `detection: llm`, none auto-fixable.
- **packs/documentation** (`ccgm/documentation`): `missing-jsdoc` (low/high), `stale-comment` (low/low), `incomplete-readme` (medium/medium) — all `detection: llm`, none auto-fixable. Documentation fix_type is NOT auto-fixable per fix-patterns.md (generated stubs don't substitute for human authorship).
- **packs/performance** (`ccgm/performance`): `n-plus-one-query` (high/medium), `missing-react-memo` (low/medium, auto-fixable), `large-bundle-import` (medium/medium) — all `detection: llm`. `missing-react-memo` is auto-fixable at medium fix_confidence per fix-patterns.md.

All 9 check-ids sourced directly from the rubric (no new rubric entries). Each pack uses `applies_when: ["always"]` — React-specific checks produce no findings on non-React repos, matching today's behavior. Each `checks.md` includes a Migration Mapping table proving every original bullet is covered.

Also includes a one-line bug fix in `lint-pack.py`: the rubric parser did not unwrap a dict-shaped `checks` envelope (the shape used by the real `severity-rubric.json`), causing every pack check-id to appear as an orphan. The fix adds an `elif` branch for `isinstance(raw["checks"], dict)` before the fallback `rubric = raw` path.

## Test plan

- [x] `python3 modules/commands-extra/skills/audit/scripts/lint-pack.py` → 3 packs checked, 0 errors
- [x] `bash modules/commands-extra/skills/audit/tests/test-pack-lint.sh` → 7 passed, 0 failed
- [x] `bash modules/commands-extra/skills/audit/tests/test-rubric.sh` → 8 passed, 0 failed
- [x] `bash modules/commands-extra/skills/audit/tests/test-registry.sh` → 8 passed, 0 failed
- [x] `python3 -m json.tool modules/commands-extra/module.json` → valid JSON
- [x] `bash tests/test-modules.sh` → 1275 passed, 0 failed
- [x] `bash tests/test-no-personal-data.sh` → PASS

Closes #593