### PR TITLE
#592: migrate code-quality, typescript-react, architecture category prompts to packs

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -242,6 +242,36 @@
       "target": "skills/audit/scripts/spine/parse-trivy.py",
       "type": "script",
       "template": false
+    },
+    "skills/audit/packs/code-quality/pack.json": {
+      "target": "skills/audit/packs/code-quality/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/code-quality/checks.md": {
+      "target": "skills/audit/packs/code-quality/checks.md",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/typescript-react/pack.json": {
+      "target": "skills/audit/packs/typescript-react/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/typescript-react/checks.md": {
+      "target": "skills/audit/packs/typescript-react/checks.md",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/architecture/pack.json": {
+      "target": "skills/audit/packs/architecture/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/architecture/checks.md": {
+      "target": "skills/audit/packs/architecture/checks.md",
+      "type": "doc",
+      "template": false
     }
   },
   "tags": [

--- a/modules/commands-extra/skills/audit/packs/architecture/checks.md
+++ b/modules/commands-extra/skills/audit/packs/architecture/checks.md
@@ -1,0 +1,410 @@
+# checks.md — Architecture Pack
+
+---
+
+## Scope
+
+This pack audits structural and architectural patterns: circular module dependencies, god objects (modules or classes with excessive responsibilities), improper layering (concerns mixed across architectural layers), and wrong-layer imports (a layer importing from a layer it should not depend on). All checks apply to any codebase regardless of language, since these structural antipatterns are language-agnostic. This pack does NOT cover code quality smells (line lengths, linting), TypeScript-specific type patterns, security vulnerabilities, or dependency health — those belong in their respective packs.
+
+**Pack ID:** `ccgm/architecture`
+**Applies when:** `always`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `always` | Circular dependencies, god objects, improper layering, and wrong-layer imports are structural smells detectable in any codebase regardless of language. The LLM can reason about module dependency graphs and layer separation in Python, Go, TypeScript, Ruby, or any other language. Running on all repos is appropriate. |
+
+---
+
+## Checks
+
+---
+
+### `architecture/circular-dependency`
+
+**Severity:** `high`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent traces import/require graphs looking for cycles between modules.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/architecture.md
+Use the structural antipattern indicators, dependency detection patterns, and severity
+guidelines from that file to guide every check below. Do not rely on memory — open and
+apply the file.
+
+Detect circular dependencies between modules. A circular dependency exists when module A
+imports from module B, and module B (directly or transitively) imports from module A.
+
+Steps:
+1. For JavaScript/TypeScript projects, run: npx madge --circular --extensions ts,tsx,js,jsx src/
+   (if madge is available). Parse the output for cycles.
+2. If madge is not available, or for other languages, manually trace the top-level import
+   graph of the most-imported modules (focus on shared utilities, services, and core
+   modules where cycles are most common).
+3. For Python projects, scan import statements looking for mutual imports between modules
+   in the same package.
+
+For each circular dependency found, report:
+- The full cycle path (e.g. A → B → C → A)
+- File paths for each node in the cycle
+- Assessment of which import is most likely the wrong direction
+
+Mark auto_fixable: false — breaking a circular dependency requires restructuring modules,
+extracting shared interfaces, or inverting the dependency, all of which require human
+architectural judgment.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: architecture/circular-dependency
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Circular dependencies prevent clean module initialization, can cause undefined references at runtime (especially in CommonJS), impede tree shaking, and make it impossible to reason about module load order. High severity.
+
+**Confidence rationale:** Tracing import chains to find cycles is a deterministic graph traversal. When madge is available, confidence is very high. LLM-based tracing on the most-connected modules is also reliable. High confidence overall.
+
+**Rubric entry:** `architecture/circular-dependency`
+
+#### Fixture
+
+**True positive** (`src/services/auth.ts` and `src/services/user.ts`):
+
+```ts
+// src/services/auth.ts
+import { getUserById } from './user';   // imports from user
+
+// src/services/user.ts
+import { verifyToken } from './auth';   // imports from auth → CIRCULAR: auth → user → auth
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// src/services/auth.ts
+import { hashPassword } from '../utils/crypto';  // one-directional: auth → utils
+
+// src/utils/crypto.ts
+// (no imports from auth or user)
+```
+
+---
+
+### `architecture/god-object`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent identifies modules or classes that have accumulated too many responsibilities.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/architecture.md
+Use the structural antipattern indicators, dependency detection patterns, and severity
+guidelines from that file to guide every check below. Do not rely on memory — open and
+apply the file.
+
+Identify god objects: modules or classes that have accumulated so many responsibilities
+that they have become a central hub that everything depends on, or that handle concerns
+that should be separated into distinct modules.
+
+Indicators of a god object:
+- A class or module with more than 10 public methods spanning unrelated concerns
+- A "utils" or "helpers" module that has grown to contain business logic, data access,
+  and presentation concerns mixed together
+- A single file or module that is imported by more than 30% of other modules in the
+  project
+- A class that has both data access (database queries), business logic, AND presentation
+  logic
+
+Steps:
+1. Check file sizes — large files (>300 lines) are candidates
+2. Count the number of imports/dependents for key modules (grep -r "from './utils'" src/ | wc -l)
+3. For candidate files, assess whether the exported functions/classes span multiple
+   unrelated concerns
+
+For each finding report: file path, the number of responsibilities observed, a brief
+description of the mixed concerns, and which modules depend on it. Mark auto_fixable:
+false (requires human-driven decomposition).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: architecture/god-object
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** God objects create tight coupling throughout a codebase — every change to the god object risks breaking its many dependents, and testing becomes difficult because the module cannot be imported without bringing in all its unrelated concerns. High severity.
+
+**Confidence rationale:** Assessing whether a module has too many responsibilities requires judgment about what constitutes a "concern," making this inherently more subjective than structural checks. Medium confidence.
+
+**Rubric entry:** `architecture/god-object`
+
+#### Fixture
+
+**True positive** (`src/utils/helpers.ts` with 25 exported functions spanning auth, DB, formatting, and UI):
+
+```ts
+// FINDS: single module handles authentication, database, formatting, and UI concerns
+export function hashPassword(pw: string) { ... }      // auth concern
+export function executeQuery(sql: string) { ... }     // database concern
+export function formatCurrency(n: number) { ... }     // formatting concern
+export function renderModal(content: string) { ... }  // UI concern
+// ... 21 more unrelated functions
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: module has a single clear responsibility (string formatting utilities)
+export function formatCurrency(n: number): string { ... }
+export function formatDate(d: Date): string { ... }
+export function formatPhoneNumber(p: string): string { ... }
+```
+
+---
+
+### `architecture/improper-layering`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent infers the project's layered architecture and identifies where concerns have leaked across layers.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/architecture.md
+Use the structural antipattern indicators, dependency detection patterns, and severity
+guidelines from that file to guide every check below. Do not rely on memory — open and
+apply the file.
+
+Audit the project's layered architecture for improper layer mixing. First, infer the
+project's intended architecture by examining directory structure, naming conventions,
+and import patterns. Common layer structures:
+
+- Frontend: components/ → hooks/ → services/ → api/
+- Backend: controllers/ (or routes/) → services/ → repositories/ (or models/) → db/
+- Full-stack: pages/ → components/ → hooks/ → services/ → api/
+
+Improper layering occurs when:
+- A data layer module (repository, model) contains presentation logic (string formatting,
+  HTML generation, UI state)
+- A presentation layer module (component, view) contains direct database calls or raw
+  SQL
+- A service module calls a controller/route handler directly (inverted layer dependency)
+- Business logic is embedded in route handlers or controllers instead of service modules
+
+For each finding report: file path, the layer it belongs to, the type of concern that
+has leaked in from another layer, and the lines where the mixing occurs. Mark
+auto_fixable: false (requires human-driven restructuring).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: architecture/improper-layering
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Improper layering makes the codebase harder to test (can't test a layer in isolation), harder to maintain (changes to one concern ripple across layers), and harder to understand (the role of each module is unclear). Medium severity: the code functions but the structure degrades over time.
+
+**Confidence rationale:** Inferring the intended architecture from directory structure is reliable for well-organized projects but requires judgment. Medium confidence.
+
+**Rubric entry:** `architecture/improper-layering`
+
+#### Fixture
+
+**True positive** (`src/repositories/UserRepository.ts`):
+
+```ts
+// FINDS: data repository layer contains presentation logic (formatting for display)
+export class UserRepository {
+  async findById(id: string): Promise<string> {
+    const user = await db.query('SELECT * FROM users WHERE id = $1', [id]);
+    // Presentation concern leaked into data layer:
+    return `<div class="user-card">${user.name}</div>`;
+  }
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: repository only handles data access and returns plain data objects
+export class UserRepository {
+  async findById(id: string): Promise<User | null> {
+    const row = await db.query('SELECT * FROM users WHERE id = $1', [id]);
+    return row ? mapRowToUser(row) : null;
+  }
+}
+```
+
+---
+
+### `architecture/wrong-layer-import`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans import statements to find imports that cross layer boundaries in the wrong direction.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/architecture.md
+Use the structural antipattern indicators, dependency detection patterns, and severity
+guidelines from that file to guide every check below. Do not rely on memory — open and
+apply the file.
+
+Detect imports from the wrong layer. In a well-layered architecture, dependencies flow
+in one direction (outer layers depend on inner layers, not the reverse).
+
+First infer the project's intended layer order from the directory structure. Then look for
+imports that violate the expected direction:
+
+- A service importing from a route/controller (inner layer importing outer)
+- A shared utility (utils/, lib/) importing from a feature module (feature imports from
+  shared are fine; shared importing from features is wrong)
+- A lower-level module (models/, entities/) importing from a higher-level module
+  (controllers/, views/)
+- A shared data module importing from an application-specific business logic module
+
+Approach: scan import statements in modules that are candidates for being "inner" layers
+and check whether they import from "outer" layer directories.
+
+Run: grep -r "from '../controllers" src/services/ or similar targeted greps for your
+discovered layer structure.
+
+For each finding report: file path, line number, the import statement, which layer it
+belongs to, and which layer it is incorrectly importing from. Mark auto_fixable: false
+when confident the dependency direction is clearly wrong; mark auto_fixable: true (with
+medium confidence) when the fix is mechanical (moving the import to an appropriate
+abstraction) — but flag for human verification.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: architecture/wrong-layer-import
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Wrong-direction imports create tight coupling between layers that should be independent. They make it impossible to swap out an implementation, test layers in isolation, or reason about the dependency graph. Medium severity.
+
+**Confidence rationale:** Determining whether an import crosses a layer boundary in the wrong direction requires inferring the intended architecture — this requires judgment and may have false positives in projects with non-standard structures. Medium confidence.
+
+**Rubric entry:** `architecture/wrong-layer-import`
+
+#### Fixture
+
+**True positive** (`src/services/EmailService.ts`):
+
+```ts
+// FINDS: service layer imports from route/controller layer (wrong direction)
+import { handleWebhookRequest } from '../routes/webhooks';  // outer layer imported by inner
+
+export class EmailService {
+  async sendConfirmation(userId: string) {
+    // ...uses handleWebhookRequest...
+  }
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: service imports from a shared utility (correct direction)
+import { formatEmailAddress } from '../utils/email';
+
+export class EmailService {
+  async sendConfirmation(userId: string) {
+    const addr = formatEmailAddress(userId);
+    // ...
+  }
+}
+```
+
+---
+
+## Migration Mapping
+
+Maps every bullet from the original Agent 4 category prompt to the check that owns it.
+
+| Original Agent 4 Bullet | Check ID |
+|-------------------------|----------|
+| Circular dependencies (NOT auto-fixable) | `architecture/circular-dependency` |
+| God objects (NOT auto-fixable) | `architecture/god-object` |
+| Improper layering (NOT auto-fixable) | `architecture/improper-layering` |
+| Import from wrong layer (MAYBE auto-fixable with verification) | `architecture/wrong-layer-import` |
+
+All 4 bullets accounted for. No checks dropped.
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/architecture/checks.md
+++ b/modules/commands-extra/skills/audit/packs/architecture/checks.md
@@ -138,17 +138,12 @@ Identify god objects: modules or classes that have accumulated so many responsib
 that they have become a central hub that everything depends on, or that handle concerns
 that should be separated into distinct modules.
 
-Indicators of a god object:
-- A class or module with more than 10 public methods spanning unrelated concerns
-- A "utils" or "helpers" module that has grown to contain business logic, data access,
-  and presentation concerns mixed together
-- A single file or module that is imported by more than 30% of other modules in the
-  project
-- A class that has both data access (database queries), business logic, AND presentation
-  logic
+Use the indicators defined in architecture.md (God Object / Blob section) — including
+file size thresholds, method count thresholds, and import-percentage thresholds — as the
+authoritative criteria. Do not substitute your own numeric thresholds.
 
 Steps:
-1. Check file sizes — large files (>300 lines) are candidates
+1. Apply the size and export-count indicators from architecture.md to find candidates
 2. Count the number of imports/dependents for key modules (grep -r "from './utils'" src/ | wc -l)
 3. For candidate files, assess whether the exported functions/classes span multiple
    unrelated concerns

--- a/modules/commands-extra/skills/audit/packs/architecture/pack.json
+++ b/modules/commands-extra/skills/audit/packs/architecture/pack.json
@@ -1,0 +1,39 @@
+{
+  "id": "ccgm/architecture",
+  "name": "Architecture",
+  "version": "1.0.0",
+  "applies_when": ["always"],
+  "tags": ["architecture", "structure", "dependencies", "layering"],
+  "severity_floor": "medium",
+  "tools": [],
+  "checks": [
+    {
+      "id": "architecture/circular-dependency",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "architecture/god-object",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "architecture/improper-layering",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "architecture/wrong-layer-import",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/packs/architecture/pack.json
+++ b/modules/commands-extra/skills/audit/packs/architecture/pack.json
@@ -33,7 +33,7 @@
       "severity": "medium",
       "confidence": "medium",
       "detection": "llm",
-      "auto_fixable": false
+      "auto_fixable": true
     }
   ]
 }

--- a/modules/commands-extra/skills/audit/packs/code-quality/checks.md
+++ b/modules/commands-extra/skills/audit/packs/code-quality/checks.md
@@ -535,7 +535,7 @@ Maps every bullet from the original Agent 3 category prompt to the check that ow
 |-------------------------|----------|
 | ESLint violations (auto-fixable: eslint --fix) | `code-quality/eslint-violation` |
 | Prettier violations (auto-fixable: prettier --write) | `code-quality/prettier-violation` |
-| Unused imports/variables (auto-fixable: eslint --fix) | `code-quality/unused-import` |
+| Unused imports/variables (auto-fixable: eslint --fix) | `code-quality/unused-import` (split: unused **imports** → `code-quality/unused-import`; unused **variables** → `code-quality/eslint-violation` via `no-unused-vars`, with llm fallback when eslint is absent) |
 | Long methods >50 lines (NOT auto-fixable - needs refactor) | `code-quality/long-method` |
 | Large files >500 lines (NOT auto-fixable - needs split) | `code-quality/large-file` |
 | Empty catch blocks (NOT auto-fixable - needs error handling) | `code-quality/empty-catch-block` |

--- a/modules/commands-extra/skills/audit/packs/code-quality/checks.md
+++ b/modules/commands-extra/skills/audit/packs/code-quality/checks.md
@@ -1,0 +1,555 @@
+# checks.md — Code Quality Pack
+
+---
+
+## Scope
+
+This pack audits source code for common quality issues: linting violations, formatting drift, unused imports, oversized methods and files, and unhandled error paths (empty catch blocks). It covers all languages for the language-agnostic checks (long-method, large-file, empty-catch-block) and JavaScript/TypeScript projects for the ESLint-backed checks; the ESLint checks degrade gracefully on non-JS repos (the tool is simply absent and the llm fallback runs). This pack does NOT cover security vulnerabilities, dependency health, architectural patterns, or TypeScript/React-specific type checks — those belong in their respective packs.
+
+**Pack ID:** `ccgm/code-quality`
+**Applies when:** `always`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `always` | Long-method, large-file, and empty-catch-block are language-agnostic structural smells detectable by the LLM in any codebase. The ESLint-backed checks (eslint-violation, unused-import) only run when ESLint is present; they degrade gracefully to llm fallback on non-JS repos, so running on all repos produces no false noise. |
+
+---
+
+## Checks
+
+---
+
+### `code-quality/eslint-violation`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `tool`
+
+#### Detection
+
+ESLint is invoked by the spine against the repository root. Any rule violation reported at error or warning level is a finding.
+
+**Tool (if detection = tool or hybrid):**
+`eslint`
+
+Rule / rule-id: `(all enabled rules in the project's ESLint config)`
+
+Fallback when tool absent: `llm`
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/code-quality.md
+Use the code smell categories, thresholds, and severity guidelines from that file to inform
+your checks. Do not rely on memory — open and apply the file.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
+each finding. Do not rely on memory — open and apply the file.
+
+The ESLint spine tool was not available. Scan JavaScript and TypeScript source files for
+common ESLint rule violations that are statically detectable:
+- no-unused-vars: variables declared but never referenced
+- no-console: console.log/warn/error left in production code
+- eqeqeq: == or != used instead of === or !==
+- no-var: var declarations instead of let/const
+- prefer-const: let declarations that are never reassigned
+
+For each finding report: file path, line number, the rule name, and the offending code
+snippet. Mark auto_fixable: true (eslint --fix resolves these mechanically).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: code-quality/eslint-violation
+detection: tool
+tool: eslint
+fallback: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** ESLint violations indicate code that breaks project-defined quality rules. Medium severity: violations create maintenance debt and can mask bugs, but do not typically cause immediate runtime failures on their own.
+
+**Confidence rationale:** ESLint is deterministic — it parses the AST and applies rules exactly. When the tool runs, confidence is high. The llm fallback covers only common rule patterns and has the same high confidence for those patterns.
+
+**Rubric entry:** `code-quality/eslint-violation`
+
+#### Fixture
+
+**True positive** (`src/utils/format.js`):
+
+```js
+// FINDS: == used instead of === (eqeqeq violation)
+function isAdmin(role) {
+  return role == 'admin';
+}
+```
+
+**True negative** (should produce NO finding):
+
+```js
+// OK: strict equality used
+function isAdmin(role) {
+  return role === 'admin';
+}
+```
+
+---
+
+### `code-quality/prettier-violation`
+
+**Severity:** `low`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent checks for formatting inconsistencies against the project's Prettier configuration or common defaults.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/code-quality.md
+Use the code smell categories and formatting guidelines from that file to inform your checks.
+Do not rely on memory — open and apply the file.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
+each finding. Do not rely on memory — open and apply the file.
+
+Check JavaScript and TypeScript files for Prettier formatting violations. If a
+.prettierrc, prettier.config.js, or "prettier" key in package.json exists, use that
+configuration; otherwise assume Prettier defaults (2-space indent, double quotes,
+trailing commas in ES5 positions, 80-char print width).
+
+Look for:
+- Inconsistent indentation (tabs vs spaces, wrong indent width)
+- Lines exceeding the configured print width
+- Missing or extra trailing commas
+- Inconsistent quote style (single vs double)
+- Inconsistent semicolon usage
+
+Run: npx prettier --check . (if prettier is installed locally)
+If Prettier is not available, flag the most egregious formatting inconsistencies found by
+visual inspection of representative files.
+
+For each finding report: file path, line number or range, and description of the
+formatting violation. Mark auto_fixable: true (prettier --write resolves these).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: code-quality/prettier-violation
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Formatting violations are purely cosmetic and do not affect runtime behavior. Low severity: they create diff noise and review friction but pose no functional risk.
+
+**Confidence rationale:** Prettier's rules are deterministic given a config. When the LLM evaluates against explicit Prettier config, matches are precise. High confidence.
+
+**Rubric entry:** `code-quality/prettier-violation`
+
+#### Fixture
+
+**True positive** (`src/components/Button.tsx`):
+
+```tsx
+// FINDS: inconsistent indentation (tabs used, project uses spaces)
+function Button({label}) {
+	return <button>{label}</button>
+}
+```
+
+**True negative** (should produce NO finding):
+
+```tsx
+// OK: consistent 2-space indentation, double quotes, no missing semicolons
+function Button({ label }: { label: string }) {
+  return <button>{label}</button>;
+}
+```
+
+---
+
+### `code-quality/unused-import`
+
+**Severity:** `low`
+**Confidence:** `high`
+**Detection:** `hybrid`
+
+#### Detection
+
+ESLint's `no-unused-vars` / `@typescript-eslint/no-unused-vars` rule detects unused imports when the spine tool runs. LLM fallback scans import statements against usages in the file body.
+
+**Tool (if detection = tool or hybrid):**
+`eslint`
+
+Rule / rule-id: `no-unused-vars` / `@typescript-eslint/no-unused-vars`
+
+Fallback when tool absent: `llm`
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/code-quality.md
+Use the code smell categories and severity guidelines from that file to inform your checks.
+Do not rely on memory — open and apply the file.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
+each finding. Do not rely on memory — open and apply the file.
+
+ESLint was not available. Scan JavaScript and TypeScript source files for import or require
+statements where the imported binding is never referenced in the file body. This includes:
+- Named imports: import { Foo } from './foo' where Foo is never used
+- Default imports: import Bar from './bar' where Bar is never used
+- Namespace imports: import * as Baz from './baz' where Baz is never used
+- CommonJS: const { x } = require('./x') where x is never used
+
+Do NOT flag:
+- Type-only imports used only as type annotations (import type { ... })
+- Re-exports: export { Foo } from './foo'
+- Imports used in JSX (e.g. React import in older React)
+
+For each finding report: file path, line number, the unused binding name, and the import
+statement. Mark auto_fixable: true (eslint --fix removes these).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: code-quality/unused-import
+detection: hybrid
+tool: eslint
+rule: no-unused-vars
+fallback: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Unused imports are dead code that inflate bundle size and create confusion about what a file depends on. Low severity: they add noise but do not cause runtime errors in most cases.
+
+**Confidence rationale:** Static analysis of import/use pairs is deterministic. Both ESLint and LLM-based scanning produce precise results for this pattern. High confidence.
+
+**Rubric entry:** `code-quality/unused-import`
+
+#### Fixture
+
+**True positive** (`src/pages/Dashboard.tsx`):
+
+```tsx
+// FINDS: Spinner is imported but never referenced below
+import React from 'react';
+import { Spinner } from '../components/Spinner';
+
+export function Dashboard() {
+  return <div>Dashboard</div>;
+}
+```
+
+**True negative** (should produce NO finding):
+
+```tsx
+// OK: all imports are used
+import React from 'react';
+import { Spinner } from '../components/Spinner';
+
+export function Dashboard({ loading }: { loading: boolean }) {
+  return loading ? <Spinner /> : <div>Dashboard</div>;
+}
+```
+
+---
+
+### `code-quality/long-method`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent counts function/method body lines and flags any exceeding the threshold.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/code-quality.md
+Use the code smell categories, thresholds, and severity guidelines from that file to inform
+your checks. Do not rely on memory — open and apply the file.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
+each finding. Do not rely on memory — open and apply the file.
+
+Scan source files for functions or methods longer than 50 lines. Count lines from the
+opening brace (or colon for Python) to the closing brace, inclusive, excluding blank
+lines and comment-only lines from the line count only when doing so would not affect the
+threshold determination — in practice, count all lines for simplicity.
+
+Flag every function/method body that exceeds 50 lines as a finding.
+
+Do NOT flag:
+- Generated code files (*.generated.ts, *.pb.go, etc.)
+- Minified files
+
+For each finding report: file path, start line, end line, function/method name, and
+actual line count. Mark auto_fixable: false (requires human refactoring).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: code-quality/long-method
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Functions exceeding 50 lines are difficult to test, review, and maintain. They often encode multiple responsibilities, making them a source of bugs and future regressions. Medium severity.
+
+**Confidence rationale:** Line counting is deterministic. The LLM can count lines reliably. High confidence.
+
+**Rubric entry:** `code-quality/long-method`
+
+#### Fixture
+
+**True positive** (`src/services/auth.ts`):
+
+```ts
+// FINDS: handleLogin is 55 lines (exceeds 50-line threshold)
+async function handleLogin(req, res) {
+  // ... 55 lines of login logic ...
+  // line 1
+  // line 2
+  // ... (55 lines total)
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: handleLogout is only 8 lines
+async function handleLogout(req, res) {
+  await destroySession(req.session);
+  res.clearCookie('auth');
+  res.redirect('/login');
+}
+```
+
+---
+
+### `code-quality/large-file`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent checks total line counts for source files and flags any exceeding the threshold.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/code-quality.md
+Use the code smell categories, thresholds, and severity guidelines from that file to inform
+your checks. Do not rely on memory — open and apply the file.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
+each finding. Do not rely on memory — open and apply the file.
+
+Identify source files with more than 500 lines. Use: find . -name "*.ts" -o -name "*.tsx"
+-o -name "*.js" -o -name "*.jsx" -o -name "*.py" -o -name "*.go" -o -name "*.rb" | head -200
+then check line counts with wc -l on the discovered files.
+
+Do NOT flag:
+- Auto-generated files (*.generated.*, *.pb.go, *.min.js, dist/, build/, node_modules/)
+- Vendored third-party files
+- Lock files (package-lock.json, yarn.lock, etc.)
+
+For each finding report: file path and line count. Mark auto_fixable: false (requires
+human-driven file splitting and module reorganization).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: code-quality/large-file
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Files exceeding 500 lines typically contain multiple concerns that should be separated into distinct modules. Large files impede code review, increase merge conflict risk, and make reasoning about the code harder. Medium severity.
+
+**Confidence rationale:** Line counting is deterministic. High confidence.
+
+**Rubric entry:** `code-quality/large-file`
+
+#### Fixture
+
+**True positive** (`src/components/Dashboard.tsx` with 620 lines):
+
+```
+$ wc -l src/components/Dashboard.tsx
+     620 src/components/Dashboard.tsx
+# FINDS: 620 lines exceeds 500-line threshold
+```
+
+**True negative** (should produce NO finding):
+
+```
+$ wc -l src/components/Button.tsx
+      42 src/components/Button.tsx
+# OK: 42 lines is well under threshold
+```
+
+---
+
+### `code-quality/empty-catch-block`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans try/catch blocks for empty or effectively empty catch bodies that silently swallow errors.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/code-quality.md
+Use the code smell categories and severity guidelines from that file to inform your checks.
+Do not rely on memory — open and apply the file.
+
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
+each finding. Do not rely on memory — open and apply the file.
+
+Scan source files for catch blocks that are empty or that only contain a comment with no
+actual error handling. These silently swallow errors and make debugging extremely difficult.
+
+Flag as a finding:
+- catch blocks with no statements at all: catch (e) {}
+- catch blocks with only a comment: catch (e) { // TODO }
+- catch blocks that only re-assign to a variable without rethrowing or logging
+
+Do NOT flag:
+- catch blocks that log the error (console.error, logger.error, etc.)
+- catch blocks that rethrow (throw e, throw new Error(...))
+- catch blocks that set state / return a fallback value AND document why
+
+For each finding report: file path, line number of the catch keyword, and the catch block
+content. Mark auto_fixable: false (requires human decision about correct error handling).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: code-quality/empty-catch-block
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Empty catch blocks silently discard errors, making runtime failures invisible and extremely difficult to debug. They indicate an unresolved error handling decision. Medium severity: not an immediate vulnerability but a reliability risk.
+
+**Confidence rationale:** Detecting syntactically empty or comment-only catch blocks is straightforward pattern matching. High confidence.
+
+**Rubric entry:** `code-quality/empty-catch-block`
+
+#### Fixture
+
+**True positive** (`src/api/client.ts`):
+
+```ts
+// FINDS: catch block is empty — error is silently discarded
+try {
+  const data = await fetchUser(id);
+  return data;
+} catch (e) {
+  // TODO: handle this
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: error is logged and rethrown
+try {
+  const data = await fetchUser(id);
+  return data;
+} catch (e) {
+  console.error('fetchUser failed:', e);
+  throw e;
+}
+```
+
+---
+
+## Migration Mapping
+
+Maps every bullet from the original Agent 3 category prompt to the check that owns it.
+
+| Original Agent 3 Bullet | Check ID |
+|-------------------------|----------|
+| ESLint violations (auto-fixable: eslint --fix) | `code-quality/eslint-violation` |
+| Prettier violations (auto-fixable: prettier --write) | `code-quality/prettier-violation` |
+| Unused imports/variables (auto-fixable: eslint --fix) | `code-quality/unused-import` |
+| Long methods >50 lines (NOT auto-fixable - needs refactor) | `code-quality/long-method` |
+| Large files >500 lines (NOT auto-fixable - needs split) | `code-quality/large-file` |
+| Empty catch blocks (NOT auto-fixable - needs error handling) | `code-quality/empty-catch-block` |
+
+All 6 bullets accounted for. No checks dropped.
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/code-quality/checks.md
+++ b/modules/commands-extra/skills/audit/packs/code-quality/checks.md
@@ -4,7 +4,7 @@
 
 ## Scope
 
-This pack audits source code for common quality issues: linting violations, formatting drift, unused imports, oversized methods and files, and unhandled error paths (empty catch blocks). It covers all languages for the language-agnostic checks (long-method, large-file, empty-catch-block) and JavaScript/TypeScript projects for the ESLint-backed checks; the ESLint checks degrade gracefully on non-JS repos (the tool is simply absent and the llm fallback runs). This pack does NOT cover security vulnerabilities, dependency health, architectural patterns, or TypeScript/React-specific type checks — those belong in their respective packs.
+This pack audits source code for common quality issues: linting violations, formatting drift, unused imports, oversized methods and files, and unhandled error paths (empty catch blocks). It covers all languages for the language-agnostic checks (long-method, large-file, empty-catch-block) and JavaScript/TypeScript projects for the ESLint-based checks. The ESLint-based checks (eslint-violation, unused-import) use LLM detection; the worker agent may run `npx eslint` for advisory results, but does not rely on the spine's eslint wrapper (which is config-isolated to a fixed eval-rule surface under the `lint/*` namespace). This pack does NOT cover security vulnerabilities, dependency health, architectural patterns, or TypeScript/React-specific type checks — those belong in their respective packs.
 
 **Pack ID:** `ccgm/code-quality`
 **Applies when:** `always`
@@ -15,7 +15,7 @@ This pack audits source code for common quality issues: linting violations, form
 
 | Condition | Reason |
 |-----------|--------|
-| `always` | Long-method, large-file, and empty-catch-block are language-agnostic structural smells detectable by the LLM in any codebase. The ESLint-backed checks (eslint-violation, unused-import) only run when ESLint is present; they degrade gracefully to llm fallback on non-JS repos, so running on all repos produces no false noise. |
+| `always` | Long-method, large-file, and empty-catch-block are language-agnostic structural smells detectable by the LLM in any codebase. The ESLint-based checks (eslint-violation, unused-import) use LLM detection and the worker agent scopes its eslint invocations to JS/TS files only, so running on all repos produces no false noise on non-JS codebases. |
 
 ---
 
@@ -27,18 +27,18 @@ This pack audits source code for common quality issues: linting violations, form
 
 **Severity:** `medium`
 **Confidence:** `high`
-**Detection:** `tool`
+**Detection:** `llm`
 
 #### Detection
 
-ESLint is invoked by the spine against the repository root. Any rule violation reported at error or warning level is a finding.
+The LLM agent scans JavaScript and TypeScript source files for common ESLint rule violations. The worker agent may run `npx eslint` (read-only, results advisory) on JS/TS files exactly as the original category prompt's agent did; however, the spine's eslint wrapper (`scripts/spine/wrap-eslint.sh`) is config-isolated via `--no-config-lookup` and runs only a narrow hardcoded eval-rule surface (`no-eval`, `no-implied-eval`, `no-new-func`), emitting findings under the `lint/*` namespace — it does NOT run these rule classes and does NOT emit `code-quality/eslint-violation` check IDs. Detection is therefore LLM-owned.
 
 **Tool (if detection = tool or hybrid):**
-`eslint`
+n/a
 
-Rule / rule-id: `(all enabled rules in the project's ESLint config)`
+Rule / rule-id: n/a
 
-Fallback when tool absent: `llm`
+Fallback when tool absent: n/a (detection is always llm)
 
 **LLM instruction (if detection = llm or hybrid):**
 
@@ -51,9 +51,13 @@ READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
 Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
 each finding. Do not rely on memory — open and apply the file.
 
-The ESLint spine tool was not available. Scan JavaScript and TypeScript source files for
-common ESLint rule violations that are statically detectable:
-- no-unused-vars: variables declared but never referenced
+Scan JavaScript and TypeScript source files for common ESLint rule violations that are
+statically detectable. You may run `npx eslint` on JS/TS files for advisory results if
+the project has ESLint installed; treat its output as one signal among several.
+
+Rule classes to check (via LLM inspection of source files):
+- no-unused-vars: variables declared but never referenced (note: unused IMPORTS are
+  reported separately under code-quality/unused-import)
 - no-console: console.log/warn/error left in production code
 - eqeqeq: == or != used instead of === or !==
 - no-var: var declarations instead of let/const
@@ -67,16 +71,19 @@ snippet. Mark auto_fixable: true (eslint --fix resolves these mechanically).
 
 ```yaml
 check_id: code-quality/eslint-violation
-detection: tool
-tool: eslint
-fallback: llm
+detection: llm
 ```
+
+Note: the spine's `wrap-eslint.sh` runs only `no-eval` / `no-implied-eval` / `no-new-func` with
+`--no-config-lookup`, emitting findings under the `lint/*` namespace. It does NOT run the rule
+classes above and does NOT emit `code-quality/eslint-violation` IDs. Wave 2's reliability pack
+will wire eslint rules to the spine properly.
 
 #### Severity / Confidence
 
 **Severity rationale:** ESLint violations indicate code that breaks project-defined quality rules. Medium severity: violations create maintenance debt and can mask bugs, but do not typically cause immediate runtime failures on their own.
 
-**Confidence rationale:** ESLint is deterministic — it parses the AST and applies rules exactly. When the tool runs, confidence is high. The llm fallback covers only common rule patterns and has the same high confidence for those patterns.
+**Confidence rationale:** The LLM covers common statically-detectable rule patterns (eqeqeq, no-var, prefer-const, no-console, no-unused-vars) with high reliability. High confidence.
 
 **Rubric entry:** `code-quality/eslint-violation`
 
@@ -191,18 +198,18 @@ function Button({ label }: { label: string }) {
 
 **Severity:** `low`
 **Confidence:** `high`
-**Detection:** `hybrid`
+**Detection:** `llm`
 
 #### Detection
 
-ESLint's `no-unused-vars` / `@typescript-eslint/no-unused-vars` rule detects unused imports when the spine tool runs. LLM fallback scans import statements against usages in the file body.
+The LLM agent scans JavaScript and TypeScript source files for import or require statements where the imported binding is never referenced in the file body. The spine's eslint wrapper accepts no per-pack rules; `no-unused-vars` never runs in the spine's eslint surface. Detection is therefore LLM-owned.
 
 **Tool (if detection = tool or hybrid):**
-`eslint`
+n/a
 
-Rule / rule-id: `no-unused-vars` / `@typescript-eslint/no-unused-vars`
+Rule / rule-id: n/a
 
-Fallback when tool absent: `llm`
+Fallback when tool absent: n/a (detection is always llm)
 
 **LLM instruction (if detection = llm or hybrid):**
 
@@ -215,8 +222,8 @@ READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
 Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
 each finding. Do not rely on memory — open and apply the file.
 
-ESLint was not available. Scan JavaScript and TypeScript source files for import or require
-statements where the imported binding is never referenced in the file body. This includes:
+Scan JavaScript and TypeScript source files for import or require statements where the
+imported binding is never referenced in the file body. This includes:
 - Named imports: import { Foo } from './foo' where Foo is never used
 - Default imports: import Bar from './bar' where Bar is never used
 - Namespace imports: import * as Baz from './baz' where Baz is never used
@@ -235,17 +242,17 @@ statement. Mark auto_fixable: true (eslint --fix removes these).
 
 ```yaml
 check_id: code-quality/unused-import
-detection: hybrid
-tool: eslint
-rule: no-unused-vars
-fallback: llm
+detection: llm
 ```
+
+Note: the spine's `wrap-eslint.sh` accepts no per-pack rule configuration; `no-unused-vars`
+never runs in the spine's eslint surface. The LLM agent handles this check directly.
 
 #### Severity / Confidence
 
 **Severity rationale:** Unused imports are dead code that inflate bundle size and create confusion about what a file depends on. Low severity: they add noise but do not cause runtime errors in most cases.
 
-**Confidence rationale:** Static analysis of import/use pairs is deterministic. Both ESLint and LLM-based scanning produce precise results for this pattern. High confidence.
+**Confidence rationale:** Static analysis of import/use pairs is straightforward. LLM-based scanning produces precise results for this pattern. High confidence.
 
 **Rubric entry:** `code-quality/unused-import`
 
@@ -305,10 +312,10 @@ READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
 Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
 each finding. Do not rely on memory — open and apply the file.
 
-Scan source files for functions or methods longer than 50 lines. Count lines from the
-opening brace (or colon for Python) to the closing brace, inclusive, excluding blank
-lines and comment-only lines from the line count only when doing so would not affect the
-threshold determination — in practice, count all lines for simplicity.
+Scan source files for functions or methods longer than 50 lines. Count ALL lines between
+the function's opening delimiter (opening brace for C-like languages, colon for Python)
+and its closing delimiter, inclusive. Blank lines and comment-only lines are included in
+the count.
 
 Flag every function/method body that exceeds 50 lines as a finding.
 
@@ -390,9 +397,10 @@ READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
 Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
 each finding. Do not rely on memory — open and apply the file.
 
-Identify source files with more than 500 lines. Use: find . -name "*.ts" -o -name "*.tsx"
--o -name "*.js" -o -name "*.jsx" -o -name "*.py" -o -name "*.go" -o -name "*.rb" | head -200
-then check line counts with wc -l on the discovered files.
+Identify source files with more than 500 lines. Use:
+  git ls-files '*.ts' '*.tsx' '*.js' '*.jsx' '*.py' '*.go' '*.rb'
+This respects .gitignore and excludes node_modules, dist, and other generated directories
+automatically. Then check line counts with wc -l on the discovered files.
 
 Do NOT flag:
 - Auto-generated files (*.generated.*, *.pb.go, *.min.js, dist/, build/, node_modules/)
@@ -535,7 +543,7 @@ Maps every bullet from the original Agent 3 category prompt to the check that ow
 |-------------------------|----------|
 | ESLint violations (auto-fixable: eslint --fix) | `code-quality/eslint-violation` |
 | Prettier violations (auto-fixable: prettier --write) | `code-quality/prettier-violation` |
-| Unused imports/variables (auto-fixable: eslint --fix) | `code-quality/unused-import` (split: unused **imports** → `code-quality/unused-import`; unused **variables** → `code-quality/eslint-violation` via `no-unused-vars`, with llm fallback when eslint is absent) |
+| Unused imports/variables (auto-fixable: eslint --fix) | `code-quality/unused-import` (split: unused **imports** → `code-quality/unused-import`; unused **variables** → `code-quality/eslint-violation` via the `no-unused-vars` rule class in its LLM instruction) |
 | Long methods >50 lines (NOT auto-fixable - needs refactor) | `code-quality/long-method` |
 | Large files >500 lines (NOT auto-fixable - needs split) | `code-quality/large-file` |
 | Empty catch blocks (NOT auto-fixable - needs error handling) | `code-quality/empty-catch-block` |

--- a/modules/commands-extra/skills/audit/packs/code-quality/pack.json
+++ b/modules/commands-extra/skills/audit/packs/code-quality/pack.json
@@ -1,0 +1,56 @@
+{
+  "id": "ccgm/code-quality",
+  "name": "Code Quality",
+  "version": "1.0.0",
+  "applies_when": ["always"],
+  "tags": ["code-quality", "eslint", "prettier", "style"],
+  "severity_floor": "low",
+  "tools": ["eslint"],
+  "checks": [
+    {
+      "id": "code-quality/eslint-violation",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "tool",
+      "tool": "eslint",
+      "auto_fixable": true
+    },
+    {
+      "id": "code-quality/prettier-violation",
+      "severity": "low",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": true
+    },
+    {
+      "id": "code-quality/unused-import",
+      "severity": "low",
+      "confidence": "high",
+      "detection": "hybrid",
+      "tool": "eslint",
+      "fallback": "llm",
+      "auto_fixable": true
+    },
+    {
+      "id": "code-quality/long-method",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "code-quality/large-file",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "code-quality/empty-catch-block",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/packs/code-quality/pack.json
+++ b/modules/commands-extra/skills/audit/packs/code-quality/pack.json
@@ -13,6 +13,7 @@
       "confidence": "high",
       "detection": "tool",
       "tool": "eslint",
+      "fallback": "llm",
       "auto_fixable": true
     },
     {

--- a/modules/commands-extra/skills/audit/packs/code-quality/pack.json
+++ b/modules/commands-extra/skills/audit/packs/code-quality/pack.json
@@ -3,17 +3,15 @@
   "name": "Code Quality",
   "version": "1.0.0",
   "applies_when": ["always"],
-  "tags": ["code-quality", "eslint", "prettier", "style"],
+  "tags": ["code-quality", "prettier", "style"],
   "severity_floor": "low",
-  "tools": ["eslint"],
+  "tools": [],
   "checks": [
     {
       "id": "code-quality/eslint-violation",
       "severity": "medium",
       "confidence": "high",
-      "detection": "tool",
-      "tool": "eslint",
-      "fallback": "llm",
+      "detection": "llm",
       "auto_fixable": true
     },
     {
@@ -27,9 +25,7 @@
       "id": "code-quality/unused-import",
       "severity": "low",
       "confidence": "high",
-      "detection": "hybrid",
-      "tool": "eslint",
-      "fallback": "llm",
+      "detection": "llm",
       "auto_fixable": true
     },
     {

--- a/modules/commands-extra/skills/audit/packs/typescript-react/checks.md
+++ b/modules/commands-extra/skills/audit/packs/typescript-react/checks.md
@@ -15,7 +15,7 @@ This pack audits TypeScript and React-specific patterns: overuse of the `any` es
 
 | Condition | Reason |
 |-----------|--------|
-| `language:javascript` | The ecosystem detector emits the `javascript` ecosystem for any repository that has a `package.json`; TypeScript repos additionally emit `typescript`. The registry derives condition tokens as `language:javascript` and `language:typescript` respectively. Because `applies_when` is AND-semantics, using `language:javascript` is the broadest honest gate: it covers both plain-JS React projects and TypeScript React projects (all TS repos also satisfy `language:javascript` since both ecosystems are detected). Using `language:typescript` would exclude plain-JS React repos; using `always` would incorrectly fire on Go, Python, and other non-JS repos where none of these patterns apply. |
+| `language:javascript` | The ecosystem detector emits the `javascript` ecosystem for any repository that has a `package.json`; TypeScript repos additionally emit `typescript`. The registry derives condition tokens as `language:javascript` and `language:typescript` respectively. Because `applies_when` is AND-semantics, using `language:javascript` is the broadest honest gate: it covers both plain-JS React projects and TypeScript React projects (TS repos with a `package.json` satisfy both ecosystems; a `package.json`-less TS repo — e.g. Deno-style — would not be gated in, which is acceptable since React projects in practice always carry a `package.json`). Using `language:typescript` would exclude plain-JS React repos; using `always` would incorrectly fire on Go, Python, and other non-JS repos where none of these patterns apply. |
 
 ---
 

--- a/modules/commands-extra/skills/audit/packs/typescript-react/checks.md
+++ b/modules/commands-extra/skills/audit/packs/typescript-react/checks.md
@@ -7,7 +7,7 @@
 This pack audits TypeScript and React-specific patterns: overuse of the `any` escape hatch, missing function return type annotations, React Hooks Rules violations, React Fast Refresh violations (mixed component/non-component exports), and missing `key` props in list renders. It applies to any repository that uses JavaScript or TypeScript (detected by the presence of a `package.json`), which includes plain-JS React projects and TypeScript projects alike. This pack does NOT cover general code quality smells, architecture patterns, security issues, or dependency health — those belong in their respective packs.
 
 **Pack ID:** `ccgm/typescript-react`
-**Applies when:** `language:js`
+**Applies when:** `language:javascript`
 
 ---
 
@@ -15,7 +15,7 @@ This pack audits TypeScript and React-specific patterns: overuse of the `any` es
 
 | Condition | Reason |
 |-----------|--------|
-| `language:js` | The ecosystem detector emits `language:js` for any repository that has a `package.json`, including TypeScript projects (TypeScript compiles to JS and shares the same ecosystem). This is the broadest honest gate: plain-JS React projects keep full coverage, and TypeScript projects are included automatically. Running on repos without a `package.json` (pure Go, Python, etc.) would produce zero signal since none of these patterns apply outside the JS/TS ecosystem. |
+| `language:javascript` | The ecosystem detector emits the `javascript` ecosystem for any repository that has a `package.json`; TypeScript repos additionally emit `typescript`. The registry derives condition tokens as `language:javascript` and `language:typescript` respectively. Because `applies_when` is AND-semantics, using `language:javascript` is the broadest honest gate: it covers both plain-JS React projects and TypeScript React projects (all TS repos also satisfy `language:javascript` since both ecosystems are detected). Using `language:typescript` would exclude plain-JS React repos; using `always` would incorrectly fire on Go, Python, and other non-JS repos where none of these patterns apply. |
 
 ---
 
@@ -142,7 +142,7 @@ Do NOT flag:
 - Functions with `void` return (callbacks, event handlers where return is irrelevant)
 - Private/unexported helper functions (lower priority)
 - Arrow functions used as inline callbacks
-- Functions where the return type is immediately obvious from a one-line body
+- Functions whose body is a single return statement returning a literal (string, number, boolean, or template literal)
 
 For each finding: mark auto_fixable: true when the inferred type is clear and unambiguous
 (TypeScript would infer it correctly); mark auto_fixable: false when the return type
@@ -219,6 +219,10 @@ Scan React component files (.tsx, .jsx) for violations of the Rules of Hooks:
    React component or custom hook function
 4. Hooks called outside React components or custom hooks: hook calls in plain helper
    functions, class methods, or event handlers that are not themselves hooks
+5. Hooks called after a conditional early return: a hook call that appears AFTER an
+   `if (!x) return null;` (or similar guard) near the top of a component — the hook
+   runs on some renders but not others, violating the unconditional-call rule. Example:
+   `if (!user) return null;` followed by `const [count, setCount] = useState(0);`
 
 Custom hooks start with `use` by convention — treat them as valid hook call sites.
 

--- a/modules/commands-extra/skills/audit/packs/typescript-react/checks.md
+++ b/modules/commands-extra/skills/audit/packs/typescript-react/checks.md
@@ -1,0 +1,481 @@
+# checks.md — TypeScript / React Pack
+
+---
+
+## Scope
+
+This pack audits TypeScript and React-specific patterns: overuse of the `any` escape hatch, missing function return type annotations, React Hooks Rules violations, React Fast Refresh violations (mixed component/non-component exports), and missing `key` props in list renders. It applies to any repository that uses JavaScript or TypeScript (detected by the presence of a `package.json`), which includes plain-JS React projects and TypeScript projects alike. This pack does NOT cover general code quality smells, architecture patterns, security issues, or dependency health — those belong in their respective packs.
+
+**Pack ID:** `ccgm/typescript-react`
+**Applies when:** `language:js`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `language:js` | The ecosystem detector emits `language:js` for any repository that has a `package.json`, including TypeScript projects (TypeScript compiles to JS and shares the same ecosystem). This is the broadest honest gate: plain-JS React projects keep full coverage, and TypeScript projects are included automatically. Running on repos without a `package.json` (pure Go, Python, etc.) would produce zero signal since none of these patterns apply outside the JS/TS ecosystem. |
+
+---
+
+## Checks
+
+---
+
+### `typescript/excessive-any`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans TypeScript source files for `any` type annotations and evaluates whether a more specific type is inferable.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
+each finding. Do not rely on memory — open and apply the file.
+
+Scan TypeScript source files (.ts, .tsx) for excessive use of the `any` type. Flag
+occurrences where a more specific type is clearly inferable from context:
+- Function parameters typed as `any` when the call sites reveal the actual shape
+- Return types annotated as `any` when the return value is a concrete type
+- Variables declared as `any` when immediately assigned a typed value
+- Generic type parameters defaulted to `any` when a concrete type is available
+
+Do NOT flag:
+- `any` in type-guard functions (x: unknown guards) where `any` is genuinely necessary
+- Explicitly suppressed instances with a comment explaining why `any` is appropriate
+- Auto-generated or vendored files
+
+For each finding: mark auto_fixable: true when the correct type is clearly inferable from
+the surrounding code (e.g. the function is always called with a string); mark
+auto_fixable: false when the correct type requires broader context or design decisions.
+
+Report: file path, line number, the `any` usage, and the inferred type suggestion if
+available.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: typescript/excessive-any
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Excessive `any` undermines TypeScript's type safety guarantees, allowing type errors to escape the compiler and surface at runtime. Medium severity: not immediately harmful but erodes the value of using TypeScript.
+
+**Confidence rationale:** Identifying `any` annotations is a direct textual match. Whether a better type is inferable requires more judgment, but the LLM can assess this reliably from surrounding code. High confidence.
+
+**Rubric entry:** `typescript/excessive-any`
+
+#### Fixture
+
+**True positive** (`src/api/users.ts`):
+
+```ts
+// FINDS: parameter typed as `any` when string is clearly intended
+async function getUserById(id: any): Promise<User> {
+  return fetch(`/api/users/${id}`).then(r => r.json());
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: explicit string type
+async function getUserById(id: string): Promise<User> {
+  return fetch(`/api/users/${id}`).then(r => r.json());
+}
+```
+
+---
+
+### `typescript/missing-return-type`
+
+**Severity:** `low`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans exported TypeScript functions and methods for missing explicit return type annotations.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
+each finding. Do not rely on memory — open and apply the file.
+
+Scan TypeScript source files (.ts, .tsx) for exported functions and methods that are
+missing explicit return type annotations. Focus on public API surface: exported functions,
+exported class methods, and React component render functions (which return JSX.Element or
+ReactNode).
+
+Flag when:
+- An exported function has no return type annotation and the return type is not `void`
+- An async function returns a Promise without the resolved type specified (e.g. missing
+  Promise<User> annotation)
+
+Do NOT flag:
+- Functions with `void` return (callbacks, event handlers where return is irrelevant)
+- Private/unexported helper functions (lower priority)
+- Arrow functions used as inline callbacks
+- Functions where the return type is immediately obvious from a one-line body
+
+For each finding: mark auto_fixable: true when the inferred type is clear and unambiguous
+(TypeScript would infer it correctly); mark auto_fixable: false when the return type
+depends on conditional branches or complex logic.
+
+Report: file path, line number, and the inferred return type suggestion.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: typescript/missing-return-type
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Missing return type annotations reduce TypeScript's ability to catch bugs at call sites and make refactoring riskier. Low severity: TypeScript infers most return types correctly, so the immediate risk is low, but explicit annotations serve as documentation and catch inference drift over time.
+
+**Confidence rationale:** Identifying missing annotations on exported functions is a straightforward structural scan. High confidence.
+
+**Rubric entry:** `typescript/missing-return-type`
+
+#### Fixture
+
+**True positive** (`src/utils/format.ts`):
+
+```ts
+// FINDS: exported function missing return type annotation
+export function formatCurrency(amount: number) {
+  return `$${amount.toFixed(2)}`;
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: explicit return type present
+export function formatCurrency(amount: number): string {
+  return `$${amount.toFixed(2)}`;
+}
+```
+
+---
+
+### `typescript/react-hooks-violation`
+
+**Severity:** `high`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent reviews React component code for violations of the Rules of Hooks.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
+each finding. Do not rely on memory — open and apply the file.
+
+Scan React component files (.tsx, .jsx) for violations of the Rules of Hooks:
+1. Hooks called inside loops: for/while loops containing useState, useEffect, etc.
+2. Hooks called inside conditionals: if/else/ternary/switch containing hook calls
+3. Hooks called inside nested functions: hook calls that are not at the top level of a
+   React component or custom hook function
+4. Hooks called outside React components or custom hooks: hook calls in plain helper
+   functions, class methods, or event handlers that are not themselves hooks
+
+Custom hooks start with `use` by convention — treat them as valid hook call sites.
+
+For each finding report: file path, line number, the hook being called incorrectly, and
+the type of violation. Mark auto_fixable: false (fixing requires restructuring the
+component logic, which requires human judgment).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: typescript/react-hooks-violation
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Rules of Hooks violations cause React to behave unpredictably — state associated with the wrong render, infinite re-render loops, or hooks silently not running. These are runtime bugs that are difficult to diagnose. High severity.
+
+**Confidence rationale:** Identifying hook calls in conditional or loop contexts is a structural scan with clear rules. High confidence.
+
+**Rubric entry:** `typescript/react-hooks-violation`
+
+#### Fixture
+
+**True positive** (`src/components/UserList.tsx`):
+
+```tsx
+// FINDS: hook called inside a conditional
+function UserList({ isAdmin }: { isAdmin: boolean }) {
+  if (isAdmin) {
+    const [filter, setFilter] = useState('');  // Rules of Hooks violation
+  }
+  return <div />;
+}
+```
+
+**True negative** (should produce NO finding):
+
+```tsx
+// OK: hooks called unconditionally at the top level of the component
+function UserList({ isAdmin }: { isAdmin: boolean }) {
+  const [filter, setFilter] = useState('');
+  return isAdmin ? <div>{filter}</div> : <div />;
+}
+```
+
+---
+
+### `typescript/fast-refresh-violation`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans module files for mixed exports of React components and non-component values, which breaks React Fast Refresh.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
+each finding. Do not rely on memory — open and apply the file.
+
+Scan React source files (.tsx, .jsx) for Fast Refresh violations. React Fast Refresh
+requires that files either export ONLY React components, or ONLY non-component values —
+mixing both in the same file disables Fast Refresh for that file.
+
+A React component is a function whose name starts with a capital letter and returns JSX
+(JSX.Element, ReactElement, ReactNode, or null).
+
+Flag files that export BOTH:
+- One or more React components (capital-letter function names returning JSX), AND
+- One or more non-component values (hooks, utility functions, constants, types, etc.)
+
+Do NOT flag:
+- Files that export ONLY components (no non-component exports)
+- Files that export ONLY non-component values (hooks, utils, constants)
+- Type-only exports (export type { ... }) — these do not affect Fast Refresh
+- The special case of a default-export component + a named export of the component's
+  PropTypes or displayName (common React pattern that does not break Fast Refresh)
+
+For each finding report: file path, the component export(s), and the non-component
+export(s) that are mixed together. Mark auto_fixable: false (requires splitting the
+file, which involves human judgment about module organization).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: typescript/fast-refresh-violation
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Fast Refresh violations silently disable hot-reloading for the affected file, degrading the development experience. In Vite projects, ESLint's react-refresh plugin will also report these as errors, blocking the build. Medium severity.
+
+**Confidence rationale:** Identifying mixed exports is a structural scan with clear rules. High confidence.
+
+**Rubric entry:** `typescript/fast-refresh-violation`
+
+#### Fixture
+
+**True positive** (`src/components/UserCard.tsx`):
+
+```tsx
+// FINDS: mixes component export with utility function export
+export function UserCard({ name }: { name: string }) {
+  return <div>{name}</div>;
+}
+
+// Non-component export in the same file — breaks Fast Refresh
+export function formatUserName(name: string): string {
+  return name.trim().toLowerCase();
+}
+```
+
+**True negative** (should produce NO finding):
+
+```tsx
+// OK: only component exports in this file
+export function UserCard({ name }: { name: string }) {
+  return <div>{name}</div>;
+}
+
+export function UserAvatar({ url }: { url: string }) {
+  return <img src={url} alt="avatar" />;
+}
+```
+
+---
+
+### `typescript/missing-key-prop`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans JSX list renders for missing `key` props and flags array index usage as an anti-pattern.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: llm
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Use the Fix Type Reference table from that file to assign fix_type and fix_confidence to
+each finding. Do not rely on memory — open and apply the file.
+
+Scan React source files (.tsx, .jsx) for list renders missing `key` props, or using
+array index as the key (an anti-pattern).
+
+Flag as findings:
+1. Array.map() calls that return JSX elements without a `key` prop
+2. Array.map() calls where `key={index}` or `key={i}` uses the array index — this is
+   an anti-pattern because array indices are unstable when items are reordered or
+   filtered, causing React to incorrectly reuse DOM nodes. Flag for human review to
+   supply a stable, unique identifier (e.g. item.id, item.slug) as the key.
+
+Do NOT flag:
+- Static JSX lists (not produced by .map or iteration) — keys are not required
+- Fragments with key props that have keys correctly set
+
+For each finding report: file path, line number, the mapped expression, and whether the
+issue is a missing key or an index-as-key anti-pattern. Mark auto_fixable: false (array
+index as key is an anti-pattern; requires a stable, unique identifier — flag for human
+review to supply the correct key).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: typescript/missing-key-prop
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Missing key props cause React reconciliation bugs: incorrect DOM reuse, broken animations, wrong component state after reorders. Using array index as key causes the same class of bugs when the list order changes. Medium severity.
+
+**Confidence rationale:** Detecting `.map()` calls that return JSX without a key prop is a structural scan. High confidence for the missing-key case; also high for index-as-key since `key={index}` or `key={i}` is a recognizable pattern.
+
+**Rubric entry:** `typescript/missing-key-prop`
+
+#### Fixture
+
+**True positive** (`src/components/ItemList.tsx`):
+
+```tsx
+// FINDS: missing key prop on mapped elements
+function ItemList({ items }: { items: string[] }) {
+  return (
+    <ul>
+      {items.map(item => (
+        <li>{item}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+**True negative** (should produce NO finding):
+
+```tsx
+// OK: stable unique key provided
+function ItemList({ items }: { items: { id: string; label: string }[] }) {
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>{item.label}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+---
+
+## Migration Mapping
+
+Maps every bullet from the original Agent 5 category prompt to the check that owns it.
+
+| Original Agent 5 Bullet | Check ID |
+|-------------------------|----------|
+| Excessive `any` types (auto-fixable if type is inferable) | `typescript/excessive-any` |
+| Missing return types (auto-fixable: add inferred type) | `typescript/missing-return-type` |
+| React hooks violations (NOT auto-fixable) | `typescript/react-hooks-violation` |
+| Fast Refresh violations (NOT auto-fixable) | `typescript/fast-refresh-violation` |
+| Missing key props (NOT auto-fixable: array index as key is an anti-pattern; requires a stable, unique identifier — flag for human review to supply the correct key) | `typescript/missing-key-prop` |
+
+All 5 bullets accounted for. No checks dropped.
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/typescript-react/pack.json
+++ b/modules/commands-extra/skills/audit/packs/typescript-react/pack.json
@@ -1,0 +1,46 @@
+{
+  "id": "ccgm/typescript-react",
+  "name": "TypeScript / React",
+  "version": "1.0.0",
+  "applies_when": ["language:js"],
+  "tags": ["typescript", "react", "hooks", "fast-refresh"],
+  "severity_floor": "low",
+  "tools": [],
+  "checks": [
+    {
+      "id": "typescript/excessive-any",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": true
+    },
+    {
+      "id": "typescript/missing-return-type",
+      "severity": "low",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": true
+    },
+    {
+      "id": "typescript/react-hooks-violation",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "typescript/fast-refresh-violation",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "typescript/missing-key-prop",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/packs/typescript-react/pack.json
+++ b/modules/commands-extra/skills/audit/packs/typescript-react/pack.json
@@ -2,7 +2,7 @@
   "id": "ccgm/typescript-react",
   "name": "TypeScript / React",
   "version": "1.0.0",
-  "applies_when": ["language:js"],
+  "applies_when": ["language:javascript"],
   "tags": ["typescript", "react", "hooks", "fast-refresh"],
   "severity_floor": "low",
   "tools": [],

--- a/modules/commands-extra/skills/audit/scripts/lint-pack.py
+++ b/modules/commands-extra/skills/audit/scripts/lint-pack.py
@@ -74,9 +74,12 @@ def _load_rubric(rubric_path: Path):
     if isinstance(raw, list):
         rubric = {entry["id"]: entry for entry in raw if isinstance(entry, dict) and "id" in entry}
     elif isinstance(raw, dict):
-        # Could be {"checks": [...]} envelope or a flat {id: entry} map.
+        # Could be {"checks": [...]} envelope, {"checks": {id: entry}} envelope,
+        # or a flat {id: entry} map.
         if "checks" in raw and isinstance(raw["checks"], list):
             rubric = {e["id"]: e for e in raw["checks"] if isinstance(e, dict) and "id" in e}
+        elif "checks" in raw and isinstance(raw["checks"], dict):
+            rubric = raw["checks"]
         else:
             rubric = raw
     else:


### PR DESCRIPTION
## Summary

- Adds three /audit registry packs (Epic 1.7a batch 2/3): `code-quality`, `typescript-react`, and `architecture`
- All 15 checks use existing rubric IDs with severity/confidence copied verbatim from `severity-rubric.json`
- Each `checks.md` includes a Migration Mapping table proving every Agent 3/4/5 category prompt bullet is accounted for (6 + 5 + 4 = 15 total, none dropped)
- Fixes a pre-existing bug in `lint-pack.py` `_load_rubric`: dict-envelope rubric with dict checks was not correctly loaded, causing all rubric membership checks to fail (required to satisfy the mandatory `lint-pack.py` verification)

## Packs

| Pack | Pack ID | applies_when | Checks |
|------|---------|-------------|--------|
| `packs/code-quality` | `ccgm/code-quality` | `always` | eslint-violation (tool/eslint), prettier-violation (llm), unused-import (hybrid/eslint), long-method (llm), large-file (llm), empty-catch-block (llm) |
| `packs/typescript-react` | `ccgm/typescript-react` | `language:js` | excessive-any, missing-return-type, react-hooks-violation, fast-refresh-violation, missing-key-prop (all llm) |
| `packs/architecture` | `ccgm/architecture` | `always` | circular-dependency, god-object, improper-layering, wrong-layer-import (all llm) |

## Files changed

- `modules/commands-extra/skills/audit/packs/code-quality/pack.json` (new)
- `modules/commands-extra/skills/audit/packs/code-quality/checks.md` (new)
- `modules/commands-extra/skills/audit/packs/typescript-react/pack.json` (new)
- `modules/commands-extra/skills/audit/packs/typescript-react/checks.md` (new)
- `modules/commands-extra/skills/audit/packs/architecture/pack.json` (new)
- `modules/commands-extra/skills/audit/packs/architecture/checks.md` (new)
- `modules/commands-extra/module.json` — 6 new file entries added
- `modules/commands-extra/skills/audit/scripts/lint-pack.py` — bugfix: handle `{"checks": {id: entry}}` dict-envelope rubric format

## Test plan

- [x] `python3 modules/commands-extra/skills/audit/scripts/lint-pack.py` — 3 packs checked, 0 errors
- [x] `bash modules/commands-extra/skills/audit/tests/test-pack-lint.sh` — 7 passed, 0 failed
- [x] `bash modules/commands-extra/skills/audit/tests/test-rubric.sh` — 8 passed, 0 failed
- [x] `bash modules/commands-extra/skills/audit/tests/test-registry.sh` — 8 passed, 0 failed
- [x] `python3 -m json.tool modules/commands-extra/module.json > /dev/null` — valid JSON
- [x] `bash tests/test-modules.sh` — 1275 passed, 0 failed
- [x] `bash tests/test-no-personal-data.sh` — PASS

Closes #592