### PR TITLE
#594: spine→LLM triage + merge orchestration (merge-findings.py)

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -108,6 +108,11 @@
       "type": "script",
       "template": false
     },
+    "skills/audit/scripts/merge-findings.py": {
+      "target": "skills/audit/scripts/merge-findings.py",
+      "type": "script",
+      "template": false
+    },
     "skills/audit/schemas/severity-rubric.json": {
       "target": "skills/audit/schemas/severity-rubric.json",
       "type": "doc",

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -1190,13 +1190,13 @@ Workers read their slice from that absolute path. They never access `.audit/curr
 
 For each pack a worker handles:
 
-1. **Triage hybrid candidates**: for every finding in the spine slice with `detection: "hybrid"`, decide `confirmed` or `dismissed` and record a `spine_triage` entry in the results file.
+1. **Triage hybrid candidates**: for every finding in the spine slice with `detection: "hybrid"`, decide `confirmed` or `dismissed` and record a `spine_triage` entry in the results file. A finding is only dropped if ALL workers that named its fingerprint voted `dismissed`; a single `confirmed` vote from any worker overrides any number of `dismissed` votes.
 2. **Add LLM-only findings**: run the pack's LLM/hybrid checks; emit new findings with `source: "llm"`.
 3. **Never invent severity**: workers must NOT set severity, confidence, or fix_confidence from intuition. Use `schemas/severity-rubric.json` only. The merge step enforces this mechanically, but workers should follow it proactively to avoid spurious `agentReportedSeverity` entries.
 
 ### Worker results-file contract
 
-Each worker writes a single JSON file to `.audit/current/results/<worker-id>.json`:
+Each worker writes a single JSON file. The ABSOLUTE path to this file (`.audit/current/results/<worker-id>.json`) is embedded in the worker's task file at the same time as `spine_slice_path`, so workers always receive it as an absolute path and never need to derive it from cwd.
 
 ```json
 {
@@ -1246,8 +1246,11 @@ scripts/merge-findings.py \
   --llm    <ABSOLUTE>/.audit/current/results/worker-1.json \
   ...
   --rubric <ABSOLUTE>/schemas/severity-rubric.json \
+  --repo   <ABSOLUTE repo root> \
   --output <ABSOLUTE>/.audit/current/findings.jsonl
 ```
+
+`--repo` must be the same absolute repo root passed to `scripts/spine/run.sh`. It ensures fingerprints computed for location paths are cwd-independent so baseline comparisons remain stable across invocations from different directories.
 
 The merger:
 

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -1203,7 +1203,7 @@ Each worker writes a single JSON file to `.audit/current/results/<worker-id>.jso
   "findings": [
     {
       "check_id":      "<pack>/<check>",
-      "rule_id":       "<rule>",
+      "rule_id":       "<rule>",   // optional -- defaults to check_id when absent
       "severity":      "critical|high|medium|low|info",
       "confidence":    "high|medium|low",
       "detection":     "tool|llm|hybrid",

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -1155,6 +1155,109 @@ Never block on the network - fall back to offline pattern + metadata analysis.
 
 ---
 
+## Spine Execution Ownership & Merge Contract
+
+**ADV-002. This section is the authoritative spec for Epic 1.7b orchestration.**
+
+### Spine Execution (coordinator responsibility)
+
+The **COORDINATOR** runs the deterministic spine **once per audit run** — never per-worker, never inside a worktree:
+
+```
+scripts/spine/run.sh \
+  --repo  <ABSOLUTE repo root> \
+  --tools <comma-list scoped to the union of the selected packs' tools[]> \
+  --output <ABSOLUTE>/.audit/current/spine/findings.jsonl
+```
+
+- The repo path must be **absolute**. The spine must run against the main checkout, not a worktree.
+- `--tools` must be the union of every `tools[]` array from the packs selected for this run. Do not run spine tools that no pack will consume.
+- The output file is written to `.audit/current/spine/` (under the **main** checkout's `.audit/`, not under any worktree).
+
+### Per-worker spine slices
+
+Workers run in separate git worktrees and **cannot see** a relative `.audit/` under the main checkout. Every path a worker receives must be **absolute**.
+
+At task-file-writing time (Phase M3/M4) the coordinator:
+
+1. Filters the spine output by the pack's check-id namespaces and `tools[]` to produce a per-pack slice.
+2. Writes the slice to `<ABSOLUTE>/.audit/current/spine/<pack-dir>.jsonl`.
+3. Embeds the **absolute** slice path in the worker's task file as `spine_slice_path`.
+
+Workers read their slice from that absolute path. They never access `.audit/current/spine/findings.jsonl` directly.
+
+### Worker duties
+
+For each pack a worker handles:
+
+1. **Triage hybrid candidates**: for every finding in the spine slice with `detection: "hybrid"`, decide `confirmed` or `dismissed` and record a `spine_triage` entry in the results file.
+2. **Add LLM-only findings**: run the pack's LLM/hybrid checks; emit new findings with `source: "llm"`.
+3. **Never invent severity**: workers must NOT set severity, confidence, or fix_confidence from intuition. Use `schemas/severity-rubric.json` only. The merge step enforces this mechanically, but workers should follow it proactively to avoid spurious `agentReportedSeverity` entries.
+
+### Worker results-file contract
+
+Each worker writes a single JSON file to `.audit/current/results/<worker-id>.json`:
+
+```json
+{
+  "findings": [
+    {
+      "check_id":      "<pack>/<check>",
+      "rule_id":       "<rule>",
+      "severity":      "critical|high|medium|low|info",
+      "confidence":    "high|medium|low",
+      "detection":     "tool|llm|hybrid",
+      "source":        "llm",
+      "message":       "<human-readable description>",
+      "location":      {"path": "<repo-relative path>", "line": 1},
+      "fingerprint":   "<optional — kept VERBATIM if present>",
+      "fix_confidence":"high|medium|low",
+      "properties":    {}
+    }
+  ],
+  "spine_triage": [
+    {
+      "fingerprint": "<fingerprint of a spine hybrid candidate>",
+      "verdict":     "confirmed|dismissed",
+      "note":        "<optional explanation>"
+    }
+  ]
+}
+```
+
+`findings` contains only the worker's **new** LLM-detected findings. Spine findings are not re-emitted here; they are carried through by the merge step.
+
+### `--single` mode
+
+In `--single` mode there is no coordinator/worker split. The single session:
+
+1. Runs the spine inline (same invocation as above, before dispatching its read-only subagents).
+2. Dispatches read-only subagents per pack (they receive the absolute spine slice path and produce results files).
+3. Runs the merge itself after all subagents complete.
+
+### Merge invocation
+
+After all workers complete, the coordinator runs:
+
+```
+scripts/merge-findings.py \
+  --spine  <ABSOLUTE>/.audit/current/spine/findings.jsonl \
+  --llm    <ABSOLUTE>/.audit/current/results/worker-0.json \
+  --llm    <ABSOLUTE>/.audit/current/results/worker-1.json \
+  ...
+  --rubric <ABSOLUTE>/schemas/severity-rubric.json \
+  --output <ABSOLUTE>/.audit/current/findings.jsonl
+```
+
+The merger:
+
+- Deduplicates findings by fingerprint (tool source wins over llm source when fingerprints collide).
+- Applies mechanical rubric overwrite: for every `check_id` in the rubric, overwrites `severity`, `confidence`, and `fix_confidence` with the rubric values. When the overwrite changes severity, preserves the original as `properties.agentReportedSeverity` (ADV-007 — calibration disagreements stay visible).
+- Folds coverage-gap records from the spine through to the output (deduped).
+- Validates every output finding against `finding.schema.json`.
+
+---
+
 ## Severity Sourcing
 
 **Agents MUST source severity, confidence, and fix_confidence from `schemas/severity-rubric.json`.** Do NOT invent or guess these values. For every finding whose `check_id` appears in the rubric, copy the rubric's `severity`, `confidence`, and `fix_confidence` verbatim. Preserve the agent-reported value in `properties.agentReportedSeverity` if it differs. For `check_id`s not yet in the rubric, set confidence to `"low"` and flag for rubric expansion.

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -9,6 +9,11 @@
     "fix_confidence": "high|medium|low — safety confidence for auto-fix when applicable"
   },
   "checks": {
+    "secrets/leaked-credential": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
     "security/hardcoded-secret": {
       "severity": "critical",
       "confidence": "medium",

--- a/modules/commands-extra/skills/audit/scripts/merge-findings.py
+++ b/modules/commands-extra/skills/audit/scripts/merge-findings.py
@@ -33,7 +33,7 @@ Each --llm file is a JSON object with two keys:
     "findings": [
       {
         "check_id":      str,   e.g. "security/hardcoded-secret"
-        "rule_id":       str,
+        "rule_id":       str,   Optional for llm findings -- defaults to check_id when absent.
         "severity":      str,   critical|high|medium|low|info
         "confidence":    str,   high|medium|low
         "detection":     str,   tool|llm|hybrid
@@ -94,7 +94,6 @@ Merge semantics (in order)
 import argparse
 import importlib.util
 import json
-import os
 import sys
 from pathlib import Path
 

--- a/modules/commands-extra/skills/audit/scripts/merge-findings.py
+++ b/modules/commands-extra/skills/audit/scripts/merge-findings.py
@@ -8,8 +8,8 @@ rubric mechanically, and streams schema-valid JSONL to stdout (or --output).
 
 Usage
 -----
-  merge-findings.py --spine <spine.jsonl> [--llm <results.json> ...] \
-                    [--rubric <path>] [--output <path>]
+  merge-findings.py --spine <spine.jsonl> [--llm <results.json> ...] \\
+                    [--rubric <path>] [--repo <abs-path>] [--output <path>]
 
 Arguments
 ---------
@@ -18,6 +18,10 @@ Arguments
                      Pass the flag multiple times for multiple workers.
   --rubric  <path>   Path to severity-rubric.json.
                      Default: ../schemas/severity-rubric.json relative to this script.
+  --repo    <path>   Absolute path to the repository root.
+                     Used to resolve location.path when computing fingerprints so
+                     fingerprints are cwd-independent (matching emit-findings.py).
+                     Default: current working directory.
   --output  <path>   Write merged JSONL to this file. Default: stdout.
 
 Exit codes
@@ -56,37 +60,62 @@ Each --llm file is a JSON object with two keys:
   }
 
 Workers produce this file by:
-  1. Reading their spine-slice (ABSOLUTE path in their task file).
+  1. Reading their spine-slice (ABSOLUTE path embedded in their task file as spine_slice_path).
   2. For each finding with detection="hybrid": deciding confirmed/dismissed.
   3. Adding any llm-only findings to "findings".
   4. Never inventing severity -- rubric lookup only (merge-findings enforces it).
+
+Worker trust-boundary invariants (enforced at intake, not just documented):
+  - A results file missing BOTH "findings" and "spine_triage" keys is likely a typo'd
+    key; a warning is printed naming the file so the problem is not silently swallowed.
+  - Workers must claim source="llm". A finding claiming source="tool" is coerced to
+    "llm" with a stderr warning (deterministic-standing masquerade).
+  - Workers must claim detection="llm" or detection="hybrid". A finding claiming
+    detection="tool" is coerced to detection="llm" with a stderr warning (a worker
+    claiming tool-detection would otherwise become non-dismissible).
 
 Merge semantics (in order)
 ---------------------------
 1.  Parse spine JSONL: separate provenance records, note records (type field
     present), and finding records (no type field).
 2.  Parse each LLM results file; collect findings + triage verdicts.
+    - Enforce worker trust-boundary invariants at intake (see above).
+    - Within a single results file, duplicate fingerprints: first entry wins (the
+      second is a worker-side bug; the warning gate in step 4 will flag the triage
+      target).
+    - Across results files, conflicting verdicts for the same fingerprint: KEEP the
+      finding (dismissal requires unanimity across all workers). A warning names the
+      conflicting fingerprint.
 3.  Ensure every finding has a fingerprint: tool-supplied fingerprints kept
     VERBATIM; fingerprints missing get compute_fingerprint() via the imported
     emit-findings logic (same fallback: message+location when file unreadable).
+    Paths are resolved relative to --repo so fingerprints are cwd-independent.
 4.  Triage:
-      - Drop detection="hybrid" findings whose fingerprint has verdict "dismissed".
+      - Drop detection="hybrid" findings whose fingerprint was unanimously
+        "dismissed" across every results file that named that fingerprint.
       - detection="tool" and detection="llm" findings are NOT dismissible.
         If a triage verdict targets a non-hybrid finding, warn to stderr and skip
         the verdict (the finding is kept).
+      - A triage fingerprint that matches no finding: warn to stderr.
+      - An unknown verdict string (not "confirmed" / "dismissed"): warn to stderr,
+        treat as no-op (never honor unknown verdicts).
       - detection="hybrid" with "confirmed" verdict is kept (same as no verdict --
         the default is keep; dismissed is the only active action).
 5.  Dedup by fingerprint: when a tool finding and an LLM finding share a
     fingerprint, keep the tool finding (source=tool; deterministic wins).
+    Within each source group (tool or llm), first-seen fingerprint wins.
     Order output deterministically: sort by location.path, then location.line,
     then check_id.
-6.  Mechanical rubric enforcement for every finding:
+6.  Validate findings BEFORE sort and rubric steps so malformed input (e.g.
+    "line": "7" as a string) exits 1 through the actionable-error channel instead
+    of a bare TypeError traceback from merged.sort().
+7.  Mechanical rubric enforcement for every finding:
       - check_id IN rubric: overwrite severity, confidence, fix_confidence with
         rubric values. If the overwritten severity DIFFERS from what the finding
         carried, preserve the original as properties.agentReportedSeverity (ADV-007).
       - check_id NOT IN rubric: keep reported severity, force confidence="low",
         set properties.unrubriced=True.
-7.  Output: provenance record(s) first, then merged schema-valid findings (one
+8.  Output: provenance record(s) first, then merged schema-valid findings (one
     JSON object per line), then coverage_gap records (deduped by byte-identity).
     Every finding line is validated; invalid findings cause exit 1.
 """
@@ -206,14 +235,24 @@ def _parse_spine(spine_path: str):
 # LLM results file parsing
 # ---------------------------------------------------------------------------
 
+_KNOWN_VERDICTS = frozenset({"confirmed", "dismissed"})
+
+
 def _parse_llm_file(llm_path: str):
     """
     Parse a single LLM results file.
 
+    Enforces worker trust-boundary invariants at intake:
+      - Missing both "findings" and "spine_triage" keys: stderr warning naming the file.
+      - source="tool" on a worker finding: coerced to "llm" with a warning.
+      - detection="tool" on a worker finding: coerced to "llm" with a warning.
+      - Unknown verdict strings: stderr warning, entry skipped (never honored).
+      - First-wins on duplicate fingerprints within this file.
+
     Returns:
-        llm_findings   list of finding dicts
+        llm_findings   list of finding dicts (trust-boundary coercions applied)
         triage_map     dict of fingerprint -> verdict ("confirmed" | "dismissed")
-        triage_notes   dict of fingerprint -> optional note
+                       Only well-known verdicts for non-duplicate fingerprints are included.
     """
     try:
         with open(llm_path, encoding="utf-8") as fh:
@@ -238,8 +277,17 @@ def _parse_llm_file(llm_path: str):
         )
         sys.exit(1)
 
-    llm_findings = raw.get("findings", [])
-    if not isinstance(llm_findings, list):
+    # Fix #1: warn if neither key is present (likely a typo'd key).
+    if "findings" not in raw and "spine_triage" not in raw:
+        print(
+            f"merge-findings: WARNING: LLM results file {llm_path} contains neither "
+            "'findings' nor 'spine_triage' keys -- possible typo'd key; file ignored",
+            file=sys.stderr,
+        )
+        return [], {}
+
+    llm_findings_raw = raw.get("findings", [])
+    if not isinstance(llm_findings_raw, list):
         print(
             f"merge-findings: ERROR: {llm_path}: 'findings' must be an array",
             file=sys.stderr,
@@ -254,30 +302,70 @@ def _parse_llm_file(llm_path: str):
         )
         sys.exit(1)
 
-    triage_map = {}
-    triage_notes = {}
+    # Fix #5: enforce worker trust-boundary coercions on findings.
+    llm_findings = []
+    for f in llm_findings_raw:
+        if not isinstance(f, dict):
+            continue
+        claimed_source = f.get("source", "")
+        if claimed_source == "tool":
+            print(
+                f"merge-findings: WARNING: {llm_path}: worker finding claims "
+                f"source='tool' (deterministic-standing masquerade); coercing to 'llm'",
+                file=sys.stderr,
+            )
+            f = dict(f)
+            f["source"] = "llm"
+        claimed_detection = f.get("detection", "")
+        if claimed_detection == "tool":
+            print(
+                f"merge-findings: WARNING: {llm_path}: worker finding claims "
+                f"detection='tool'; coercing to 'llm' (a worker claiming tool-detection "
+                "would otherwise become non-dismissible)",
+                file=sys.stderr,
+            )
+            f = dict(f)
+            f["detection"] = "llm"
+        llm_findings.append(f)
+
+    # Build triage_map; warn on unknown verdicts; first-wins on duplicate fingerprints
+    # within this file.
+    triage_map: dict = {}
     for entry in triage_list:
         if not isinstance(entry, dict):
             continue
         fp = entry.get("fingerprint", "")
         verdict = entry.get("verdict", "")
-        if fp and verdict in ("confirmed", "dismissed"):
-            triage_map[fp] = verdict
-            if "note" in entry:
-                triage_notes[fp] = entry["note"]
 
-    return llm_findings, triage_map, triage_notes
+        # Fix #2: warn on unknown verdict strings, never honor them.
+        if verdict not in _KNOWN_VERDICTS:
+            print(
+                f"merge-findings: WARNING: {llm_path}: unknown triage verdict "
+                f"'{verdict}' for fingerprint '{fp}'; treating as no-op",
+                file=sys.stderr,
+            )
+            continue
+
+        if not fp:
+            continue
+
+        # First-wins within this file (within-source dedup rule).
+        if fp not in triage_map:
+            triage_map[fp] = verdict
+
+    return llm_findings, triage_map
 
 
 # ---------------------------------------------------------------------------
 # Fingerprint helper
 # ---------------------------------------------------------------------------
 
-def _ensure_fingerprint(finding: dict, emit_mod) -> dict:
+def _ensure_fingerprint(finding: dict, emit_mod, repo_root: Path) -> dict:
     """
     Ensure the finding has a fingerprint.
     Tool-supplied fingerprints are kept VERBATIM.
     Missing fingerprints are computed via emit-findings' compute_fingerprint.
+    Paths are resolved relative to repo_root so fingerprints are cwd-independent.
     """
     if finding.get("fingerprint"):
         return finding
@@ -287,10 +375,51 @@ def _ensure_fingerprint(finding: dict, emit_mod) -> dict:
     line = loc.get("line", 1)
     message = finding.get("message", "")
 
+    # Resolve path relative to repo_root for cwd-independent fingerprints.
+    abs_path = str(repo_root / path) if path and not Path(path).is_absolute() else path
+
     finding["fingerprint"] = emit_mod.compute_fingerprint(
-        path, line, message
+        abs_path, line, message
     )
     return finding
+
+
+# ---------------------------------------------------------------------------
+# Pre-sort validation helper
+# ---------------------------------------------------------------------------
+
+def _validate_before_sort(findings: list, emit_mod) -> list:
+    """
+    Validate findings BEFORE sort and rubric steps (Fix #6).
+
+    Exits 1 with an actionable error message if any finding is malformed
+    (e.g. location.line is a string instead of an int), so the user sees
+    a clear ERROR rather than a bare TypeError traceback from merged.sort().
+
+    Returns validated findings (unchanged list if all pass).
+    """
+    errors = []
+    for idx, f in enumerate(findings):
+        loc = f.get("location", {})
+        line_val = loc.get("line") if isinstance(loc, dict) else None
+        if line_val is not None and not isinstance(line_val, int):
+            errors.append(
+                f"finding[{idx}] ({f.get('check_id','?')}): "
+                f"location.line must be an integer, got {type(line_val).__name__} "
+                f"value {line_val!r}"
+            )
+        # Also run the full validation to catch any other malformed fields early.
+        try:
+            emit_mod.validate_finding(f)
+        except emit_mod.ValidationError as exc:
+            errors.append(f"finding[{idx}] ({f.get('check_id','?')}): {exc}")
+
+    if errors:
+        for err in errors:
+            print(f"merge-findings: VALIDATION ERROR: {err}", file=sys.stderr)
+        sys.exit(1)
+
+    return findings
 
 
 # ---------------------------------------------------------------------------
@@ -363,8 +492,26 @@ def main() -> int:
         default=None,
         help="Path to severity-rubric.json (default: ../schemas/severity-rubric.json)",
     )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        metavar="ABS_PATH",
+        help=(
+            "Absolute path to the repository root. Used to resolve location.path "
+            "when computing fingerprints so fingerprints are cwd-independent "
+            "(matching emit-findings.py). Default: current working directory."
+        ),
+    )
     parser.add_argument("--output", default=None, help="Output path (default: stdout)")
     args = parser.parse_args()
+
+    # ------------------------------------------------------------------
+    # Resolve repo root
+    # ------------------------------------------------------------------
+    if args.repo:
+        repo_root = Path(args.repo).resolve()
+    else:
+        repo_root = Path.cwd()
 
     # ------------------------------------------------------------------
     # Load emit-findings module for fingerprint + validation
@@ -391,30 +538,60 @@ def main() -> int:
     provenance_records, note_records, spine_findings = _parse_spine(args.spine)
 
     # ------------------------------------------------------------------
-    # Step 2: Parse LLM results files
+    # Step 2: Parse LLM results files.
+    # Collect per-file triage maps to detect cross-file conflicts.
+    # Dismissal requires unanimity: a fingerprint is dismissed only if
+    # EVERY file that named it voted "dismissed".
     # ------------------------------------------------------------------
-    all_llm_findings = []
-    merged_triage_map = {}  # fingerprint -> verdict
+    all_llm_findings: list = []
+    # per_file_triage: list of (llm_path, triage_map) for conflict detection
+    per_file_triage: list = []
 
     for llm_path in args.llm:
-        llm_findings, triage_map, _ = _parse_llm_file(llm_path)
+        llm_findings, triage_map = _parse_llm_file(llm_path)
         all_llm_findings.extend(llm_findings)
-        merged_triage_map.update(triage_map)
+        per_file_triage.append((llm_path, triage_map))
+
+    # Build the merged triage map with conflict detection (Fix #4).
+    # For each fingerprint that appears in any file:
+    #   - All votes "dismissed" -> dismissed.
+    #   - Any vote "confirmed" or conflict -> confirmed (kept); warn if conflict.
+    merged_triage_map: dict = {}  # fingerprint -> "dismissed" | "confirmed"
+    fp_votes: dict = {}  # fp -> list of (path, verdict)
+    for llm_path, tmap in per_file_triage:
+        for fp, verdict in tmap.items():
+            fp_votes.setdefault(fp, []).append((llm_path, verdict))
+
+    for fp, votes in fp_votes.items():
+        verdicts = [v for _, v in votes]
+        unique_verdicts = set(verdicts)
+        if len(unique_verdicts) == 1:
+            merged_triage_map[fp] = verdicts[0]
+        else:
+            # Fix #4: conflicting verdicts -> keep + warn.
+            sources = ", ".join(f"'{v}' from {p}" for p, v in votes)
+            print(
+                f"merge-findings: WARNING: conflicting triage verdicts for "
+                f"fingerprint '{fp}' ({sources}); keeping finding "
+                "(dismissal requires unanimity across all workers)",
+                file=sys.stderr,
+            )
+            merged_triage_map[fp] = "confirmed"
 
     # ------------------------------------------------------------------
     # Step 3: Ensure all findings have fingerprints
     # ------------------------------------------------------------------
     for f in spine_findings:
-        _ensure_fingerprint(f, emit_mod)
+        _ensure_fingerprint(f, emit_mod, repo_root)
     for f in all_llm_findings:
-        _ensure_fingerprint(f, emit_mod)
+        _ensure_fingerprint(f, emit_mod, repo_root)
 
     # ------------------------------------------------------------------
     # Step 4: Apply triage verdicts
     # ------------------------------------------------------------------
-    # Validate triage targets: warn if a triage verdict targets a non-hybrid finding
+    # Build fp -> detection map from all findings for triage validation.
     all_findings_for_triage = spine_findings + all_llm_findings
-    fp_to_detection = {}
+    fp_to_detection: dict = {}
     for f in all_findings_for_triage:
         fp = f.get("fingerprint", "")
         if fp:
@@ -430,8 +607,15 @@ def main() -> int:
                     "verdict ignored -- deterministic findings are not dismissible",
                     file=sys.stderr,
                 )
+        else:
+            # Fix #3: triage fingerprint matches no finding -> warn.
+            print(
+                f"merge-findings: WARNING: triage fingerprint '{fp}' (verdict='{verdict}') "
+                "does not match any finding in the spine or LLM results; verdict ignored",
+                file=sys.stderr,
+            )
 
-    # Filter: drop dismissed hybrids
+    # Filter: drop hybrid findings that were unanimously dismissed.
     def _keep_finding(f: dict) -> bool:
         detection = f.get("detection", "tool")
         if detection != "hybrid":
@@ -444,31 +628,45 @@ def main() -> int:
     all_llm_findings = [f for f in all_llm_findings if _keep_finding(f)]
 
     # ------------------------------------------------------------------
-    # Step 5: Dedup by fingerprint -- tool source wins over llm source
+    # Step 5: Dedup by fingerprint -- tool source wins over llm source.
+    # Within each source group, first-seen fingerprint wins.
     # ------------------------------------------------------------------
-    # Build a dict keyed by fingerprint; tool findings win.
     by_fingerprint: dict = {}
 
-    # Insert LLM findings first (lower priority)
+    # Insert LLM findings first (lower priority); first-wins within this group.
     for f in all_llm_findings:
         fp = f.get("fingerprint", "")
         if fp and fp not in by_fingerprint:
             by_fingerprint[fp] = f
 
-    # Insert spine (tool) findings, overwriting any LLM finding with same fp
+    # Insert spine (tool) findings, overwriting any LLM finding with same fp.
+    # First-seen wins within the spine group (spine is already deterministic).
     for f in spine_findings:
         fp = f.get("fingerprint", "")
         if fp:
-            by_fingerprint[fp] = f  # tool always wins
-        else:
-            # No fingerprint (should not happen after step 3): keep as unique
-            import hashlib as _hl
-            sentinel = _hl.sha256(json.dumps(f, sort_keys=True).encode()).hexdigest()[:16]
-            by_fingerprint[sentinel] = f
+            by_fingerprint[fp] = f  # tool always wins over llm
 
     merged = list(by_fingerprint.values())
 
+    # ------------------------------------------------------------------
+    # Step 5b: Ensure all merged findings have required fields for validation.
+    # Spine findings already conform; LLM findings may be missing rule_id
+    # or other fields. We do a best-effort coerce before validation.
+    # ------------------------------------------------------------------
+    for f in merged:
+        if "rule_id" not in f:
+            f["rule_id"] = f.get("check_id", "unknown")
+
+    # ------------------------------------------------------------------
+    # Step 6: Validate findings BEFORE sort and rubric (Fix #6).
+    # Exits 1 with an actionable message on malformed input (e.g. string line)
+    # instead of a bare TypeError traceback from merged.sort().
+    # ------------------------------------------------------------------
+    merged = _validate_before_sort(merged, emit_mod)
+
+    # ------------------------------------------------------------------
     # Deterministic sort: path, line, check_id
+    # ------------------------------------------------------------------
     def _sort_key(f: dict):
         loc = f.get("location", {})
         return (
@@ -480,22 +678,13 @@ def main() -> int:
     merged.sort(key=_sort_key)
 
     # ------------------------------------------------------------------
-    # Step 6: Mechanical rubric enforcement
+    # Step 7: Mechanical rubric enforcement
     # ------------------------------------------------------------------
     for f in merged:
         _apply_rubric(f, rubric)
 
     # ------------------------------------------------------------------
-    # Step 6b: Ensure all merged findings have required fields for validation.
-    # Spine findings already conform; LLM findings may be missing rule_id
-    # or other fields. We do a best-effort coerce before validation.
-    # ------------------------------------------------------------------
-    for f in merged:
-        if "rule_id" not in f:
-            f["rule_id"] = f.get("check_id", "unknown")
-
-    # ------------------------------------------------------------------
-    # Validate each merged finding
+    # Final validation pass (post-rubric)
     # ------------------------------------------------------------------
     errors = []
     valid_findings = []
@@ -512,7 +701,7 @@ def main() -> int:
         return 1
 
     # ------------------------------------------------------------------
-    # Step 7: Build output lines
+    # Step 8: Build output lines
     # ------------------------------------------------------------------
     output_lines = []
 
@@ -525,7 +714,7 @@ def main() -> int:
         output_lines.append(json.dumps(f, separators=(",", ":")))
 
     # Coverage gaps (dedup byte-identical lines)
-    seen_gaps = set()
+    seen_gaps: set = set()
     for rec in note_records:
         if rec.get("type") == "coverage_gap":
             serialized = json.dumps(rec, separators=(",", ":"), sort_keys=True)

--- a/modules/commands-extra/skills/audit/scripts/merge-findings.py
+++ b/modules/commands-extra/skills/audit/scripts/merge-findings.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+"""
+CCGM /audit merge-findings (Epic 1.9) -- spine + LLM results merger.
+
+Merges the deterministic spine JSONL with zero or more LLM results files,
+applies triage verdicts, deduplicates by fingerprint, enforces the severity
+rubric mechanically, and streams schema-valid JSONL to stdout (or --output).
+
+Usage
+-----
+  merge-findings.py --spine <spine.jsonl> [--llm <results.json> ...] \
+                    [--rubric <path>] [--output <path>]
+
+Arguments
+---------
+  --spine   <path>   Required. JSONL produced by scripts/spine/run.sh.
+  --llm     <path>   Zero or more LLM results JSON files (see contract below).
+                     Pass the flag multiple times for multiple workers.
+  --rubric  <path>   Path to severity-rubric.json.
+                     Default: ../schemas/severity-rubric.json relative to this script.
+  --output  <path>   Write merged JSONL to this file. Default: stdout.
+
+Exit codes
+----------
+  0  Success.
+  1  Malformed input or validation error.
+
+LLM results-file contract
+--------------------------
+Each --llm file is a JSON object with two keys:
+
+  {
+    "findings": [
+      {
+        "check_id":      str,   e.g. "security/hardcoded-secret"
+        "rule_id":       str,
+        "severity":      str,   critical|high|medium|low|info
+        "confidence":    str,   high|medium|low
+        "detection":     str,   tool|llm|hybrid
+        "source":        str,   "llm" (worker-produced findings must be "llm")
+        "message":       str,
+        "location":      {"path": str, "line": int},
+        // Optional:
+        "fingerprint":   str,   If present, kept VERBATIM.
+        "fix_confidence":str,
+        "properties":    {}
+      }
+    ],
+    "spine_triage": [
+      {
+        "fingerprint": str,     Fingerprint of a spine hybrid candidate.
+        "verdict":     str,     "confirmed" | "dismissed"
+        "note":        str      Optional human-readable explanation.
+      }
+    ]
+  }
+
+Workers produce this file by:
+  1. Reading their spine-slice (ABSOLUTE path in their task file).
+  2. For each finding with detection="hybrid": deciding confirmed/dismissed.
+  3. Adding any llm-only findings to "findings".
+  4. Never inventing severity -- rubric lookup only (merge-findings enforces it).
+
+Merge semantics (in order)
+---------------------------
+1.  Parse spine JSONL: separate provenance records, note records (type field
+    present), and finding records (no type field).
+2.  Parse each LLM results file; collect findings + triage verdicts.
+3.  Ensure every finding has a fingerprint: tool-supplied fingerprints kept
+    VERBATIM; fingerprints missing get compute_fingerprint() via the imported
+    emit-findings logic (same fallback: message+location when file unreadable).
+4.  Triage:
+      - Drop detection="hybrid" findings whose fingerprint has verdict "dismissed".
+      - detection="tool" and detection="llm" findings are NOT dismissible.
+        If a triage verdict targets a non-hybrid finding, warn to stderr and skip
+        the verdict (the finding is kept).
+      - detection="hybrid" with "confirmed" verdict is kept (same as no verdict --
+        the default is keep; dismissed is the only active action).
+5.  Dedup by fingerprint: when a tool finding and an LLM finding share a
+    fingerprint, keep the tool finding (source=tool; deterministic wins).
+    Order output deterministically: sort by location.path, then location.line,
+    then check_id.
+6.  Mechanical rubric enforcement for every finding:
+      - check_id IN rubric: overwrite severity, confidence, fix_confidence with
+        rubric values. If the overwritten severity DIFFERS from what the finding
+        carried, preserve the original as properties.agentReportedSeverity (ADV-007).
+      - check_id NOT IN rubric: keep reported severity, force confidence="low",
+        set properties.unrubriced=True.
+7.  Output: provenance record(s) first, then merged schema-valid findings (one
+    JSON object per line), then coverage_gap records (deduped by byte-identity).
+    Every finding line is validated; invalid findings cause exit 1.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Import emit-findings.py via importlib (hyphenated filename)
+# Pattern from lint-pack.py's _load_registry helper.
+# ---------------------------------------------------------------------------
+
+def _load_emit_findings(scripts_dir: Path):
+    """Import emit-findings.py and return the module."""
+    emit_path = scripts_dir / "emit-findings.py"
+    if not emit_path.is_file():
+        raise FileNotFoundError(f"emit-findings.py not found at {emit_path}")
+    spec = importlib.util.spec_from_file_location("emit_findings", str(emit_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Rubric loading
+# ---------------------------------------------------------------------------
+
+def _load_rubric(rubric_path: Path) -> dict:
+    """
+    Load severity-rubric.json and return the checks dict.
+    Returns {} if the file is absent or unreadable (non-fatal -- unrubriced
+    path handles missing entries gracefully).
+    """
+    if not rubric_path.exists():
+        print(
+            f"merge-findings: WARNING: rubric not found at {rubric_path}; "
+            "all findings will be treated as unrubriced",
+            file=sys.stderr,
+        )
+        return {}
+    try:
+        with open(rubric_path, encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except json.JSONDecodeError as exc:
+        print(
+            f"merge-findings: WARNING: rubric JSON decode error: {exc}; "
+            "treating all findings as unrubriced",
+            file=sys.stderr,
+        )
+        return {}
+    if isinstance(raw, dict) and "checks" in raw:
+        return raw["checks"]
+    if isinstance(raw, dict):
+        return raw
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Spine JSONL parsing
+# ---------------------------------------------------------------------------
+
+def _parse_spine(spine_path: str):
+    """
+    Parse the spine JSONL file.
+
+    Returns:
+        provenance_records  list of dicts with "type" == "provenance"
+        note_records        list of dicts with any "type" field (skipped, coverage_gap, etc.)
+        findings            list of finding dicts (no "type" field)
+    """
+    provenance_records = []
+    note_records = []
+    findings = []
+
+    try:
+        with open(spine_path, encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except OSError as exc:
+        print(f"merge-findings: ERROR: cannot read spine file: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    for lineno, raw_line in enumerate(lines, 1):
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        try:
+            obj = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            print(
+                f"merge-findings: ERROR: spine line {lineno} is not valid JSON: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        if not isinstance(obj, dict):
+            print(
+                f"merge-findings: ERROR: spine line {lineno} is not a JSON object",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        if "type" in obj:
+            if obj["type"] == "provenance":
+                provenance_records.append(obj)
+            else:
+                note_records.append(obj)
+        else:
+            findings.append(obj)
+
+    return provenance_records, note_records, findings
+
+
+# ---------------------------------------------------------------------------
+# LLM results file parsing
+# ---------------------------------------------------------------------------
+
+def _parse_llm_file(llm_path: str):
+    """
+    Parse a single LLM results file.
+
+    Returns:
+        llm_findings   list of finding dicts
+        triage_map     dict of fingerprint -> verdict ("confirmed" | "dismissed")
+        triage_notes   dict of fingerprint -> optional note
+    """
+    try:
+        with open(llm_path, encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except OSError as exc:
+        print(
+            f"merge-findings: ERROR: cannot read LLM results file {llm_path}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except json.JSONDecodeError as exc:
+        print(
+            f"merge-findings: ERROR: LLM results file {llm_path} is not valid JSON: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if not isinstance(raw, dict):
+        print(
+            f"merge-findings: ERROR: LLM results file {llm_path} must be a JSON object",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    llm_findings = raw.get("findings", [])
+    if not isinstance(llm_findings, list):
+        print(
+            f"merge-findings: ERROR: {llm_path}: 'findings' must be an array",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    triage_list = raw.get("spine_triage", [])
+    if not isinstance(triage_list, list):
+        print(
+            f"merge-findings: ERROR: {llm_path}: 'spine_triage' must be an array",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    triage_map = {}
+    triage_notes = {}
+    for entry in triage_list:
+        if not isinstance(entry, dict):
+            continue
+        fp = entry.get("fingerprint", "")
+        verdict = entry.get("verdict", "")
+        if fp and verdict in ("confirmed", "dismissed"):
+            triage_map[fp] = verdict
+            if "note" in entry:
+                triage_notes[fp] = entry["note"]
+
+    return llm_findings, triage_map, triage_notes
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint helper
+# ---------------------------------------------------------------------------
+
+def _ensure_fingerprint(finding: dict, emit_mod) -> dict:
+    """
+    Ensure the finding has a fingerprint.
+    Tool-supplied fingerprints are kept VERBATIM.
+    Missing fingerprints are computed via emit-findings' compute_fingerprint.
+    """
+    if finding.get("fingerprint"):
+        return finding
+
+    loc = finding.get("location", {})
+    path = loc.get("path", "")
+    line = loc.get("line", 1)
+    message = finding.get("message", "")
+
+    finding["fingerprint"] = emit_mod.compute_fingerprint(
+        path, line, message
+    )
+    return finding
+
+
+# ---------------------------------------------------------------------------
+# Rubric enforcement
+# ---------------------------------------------------------------------------
+
+def _apply_rubric(finding: dict, rubric: dict) -> dict:
+    """
+    Apply mechanical rubric enforcement.
+
+    check_id IN rubric:
+      - Overwrite severity, confidence, fix_confidence with rubric values.
+      - If overwritten severity differs from reported: preserve original in
+        properties.agentReportedSeverity.
+
+    check_id NOT IN rubric:
+      - Keep reported severity.
+      - Force confidence = "low".
+      - Set properties.unrubriced = True.
+    """
+    check_id = finding.get("check_id", "")
+    if check_id in rubric:
+        entry = rubric[check_id]
+        reported_severity = finding.get("severity")
+        rubric_severity = entry.get("severity", reported_severity)
+
+        if rubric_severity != reported_severity:
+            props = finding.get("properties") or {}
+            props["agentReportedSeverity"] = reported_severity
+            finding["properties"] = props
+
+        finding["severity"] = rubric_severity
+        if "confidence" in entry:
+            finding["confidence"] = entry["confidence"]
+        if "fix_confidence" in entry:
+            finding["fix_confidence"] = entry["fix_confidence"]
+    else:
+        finding["confidence"] = "low"
+        props = finding.get("properties") or {}
+        props["unrubriced"] = True
+        finding["properties"] = props
+
+    return finding
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    script_dir = Path(__file__).parent
+
+    # ------------------------------------------------------------------
+    # Argument parsing
+    # ------------------------------------------------------------------
+    parser = argparse.ArgumentParser(
+        description="Merge spine JSONL with LLM results, apply triage + rubric.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--spine", required=True, help="Path to spine.jsonl")
+    parser.add_argument(
+        "--llm",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="LLM results JSON file (may be repeated)",
+    )
+    parser.add_argument(
+        "--rubric",
+        default=None,
+        help="Path to severity-rubric.json (default: ../schemas/severity-rubric.json)",
+    )
+    parser.add_argument("--output", default=None, help="Output path (default: stdout)")
+    args = parser.parse_args()
+
+    # ------------------------------------------------------------------
+    # Load emit-findings module for fingerprint + validation
+    # ------------------------------------------------------------------
+    try:
+        emit_mod = _load_emit_findings(script_dir)
+    except FileNotFoundError as exc:
+        print(f"merge-findings: ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    # ------------------------------------------------------------------
+    # Load rubric
+    # ------------------------------------------------------------------
+    if args.rubric:
+        rubric_path = Path(args.rubric)
+    else:
+        rubric_path = script_dir / ".." / "schemas" / "severity-rubric.json"
+    rubric_path = rubric_path.resolve()
+    rubric = _load_rubric(rubric_path)
+
+    # ------------------------------------------------------------------
+    # Step 1: Parse spine
+    # ------------------------------------------------------------------
+    provenance_records, note_records, spine_findings = _parse_spine(args.spine)
+
+    # ------------------------------------------------------------------
+    # Step 2: Parse LLM results files
+    # ------------------------------------------------------------------
+    all_llm_findings = []
+    merged_triage_map = {}  # fingerprint -> verdict
+
+    for llm_path in args.llm:
+        llm_findings, triage_map, _ = _parse_llm_file(llm_path)
+        all_llm_findings.extend(llm_findings)
+        merged_triage_map.update(triage_map)
+
+    # ------------------------------------------------------------------
+    # Step 3: Ensure all findings have fingerprints
+    # ------------------------------------------------------------------
+    for f in spine_findings:
+        _ensure_fingerprint(f, emit_mod)
+    for f in all_llm_findings:
+        _ensure_fingerprint(f, emit_mod)
+
+    # ------------------------------------------------------------------
+    # Step 4: Apply triage verdicts
+    # ------------------------------------------------------------------
+    # Validate triage targets: warn if a triage verdict targets a non-hybrid finding
+    all_findings_for_triage = spine_findings + all_llm_findings
+    fp_to_detection = {}
+    for f in all_findings_for_triage:
+        fp = f.get("fingerprint", "")
+        if fp:
+            fp_to_detection[fp] = f.get("detection", "tool")
+
+    for fp, verdict in merged_triage_map.items():
+        if fp in fp_to_detection:
+            detection = fp_to_detection[fp]
+            if detection != "hybrid":
+                print(
+                    f"merge-findings: WARNING: triage verdict '{verdict}' targets "
+                    f"a non-hybrid finding (detection='{detection}', fp='{fp}'); "
+                    "verdict ignored -- deterministic findings are not dismissible",
+                    file=sys.stderr,
+                )
+
+    # Filter: drop dismissed hybrids
+    def _keep_finding(f: dict) -> bool:
+        detection = f.get("detection", "tool")
+        if detection != "hybrid":
+            return True
+        fp = f.get("fingerprint", "")
+        verdict = merged_triage_map.get(fp)
+        return verdict != "dismissed"
+
+    spine_findings = [f for f in spine_findings if _keep_finding(f)]
+    all_llm_findings = [f for f in all_llm_findings if _keep_finding(f)]
+
+    # ------------------------------------------------------------------
+    # Step 5: Dedup by fingerprint -- tool source wins over llm source
+    # ------------------------------------------------------------------
+    # Build a dict keyed by fingerprint; tool findings win.
+    by_fingerprint: dict = {}
+
+    # Insert LLM findings first (lower priority)
+    for f in all_llm_findings:
+        fp = f.get("fingerprint", "")
+        if fp and fp not in by_fingerprint:
+            by_fingerprint[fp] = f
+
+    # Insert spine (tool) findings, overwriting any LLM finding with same fp
+    for f in spine_findings:
+        fp = f.get("fingerprint", "")
+        if fp:
+            by_fingerprint[fp] = f  # tool always wins
+        else:
+            # No fingerprint (should not happen after step 3): keep as unique
+            import hashlib as _hl
+            sentinel = _hl.sha256(json.dumps(f, sort_keys=True).encode()).hexdigest()[:16]
+            by_fingerprint[sentinel] = f
+
+    merged = list(by_fingerprint.values())
+
+    # Deterministic sort: path, line, check_id
+    def _sort_key(f: dict):
+        loc = f.get("location", {})
+        return (
+            loc.get("path", ""),
+            loc.get("line", 0),
+            f.get("check_id", ""),
+        )
+
+    merged.sort(key=_sort_key)
+
+    # ------------------------------------------------------------------
+    # Step 6: Mechanical rubric enforcement
+    # ------------------------------------------------------------------
+    for f in merged:
+        _apply_rubric(f, rubric)
+
+    # ------------------------------------------------------------------
+    # Step 6b: Ensure all merged findings have required fields for validation.
+    # Spine findings already conform; LLM findings may be missing rule_id
+    # or other fields. We do a best-effort coerce before validation.
+    # ------------------------------------------------------------------
+    for f in merged:
+        if "rule_id" not in f:
+            f["rule_id"] = f.get("check_id", "unknown")
+
+    # ------------------------------------------------------------------
+    # Validate each merged finding
+    # ------------------------------------------------------------------
+    errors = []
+    valid_findings = []
+    for idx, f in enumerate(merged):
+        try:
+            emit_mod.validate_finding(f)
+            valid_findings.append(f)
+        except emit_mod.ValidationError as exc:
+            errors.append(f"finding[{idx}] ({f.get('check_id','?')}): {exc}")
+
+    if errors:
+        for err in errors:
+            print(f"merge-findings: VALIDATION ERROR: {err}", file=sys.stderr)
+        return 1
+
+    # ------------------------------------------------------------------
+    # Step 7: Build output lines
+    # ------------------------------------------------------------------
+    output_lines = []
+
+    # Provenance first
+    for rec in provenance_records:
+        output_lines.append(json.dumps(rec, separators=(",", ":")))
+
+    # Findings
+    for f in valid_findings:
+        output_lines.append(json.dumps(f, separators=(",", ":")))
+
+    # Coverage gaps (dedup byte-identical lines)
+    seen_gaps = set()
+    for rec in note_records:
+        if rec.get("type") == "coverage_gap":
+            serialized = json.dumps(rec, separators=(",", ":"), sort_keys=True)
+            if serialized not in seen_gaps:
+                seen_gaps.add(serialized)
+                output_lines.append(json.dumps(rec, separators=(",", ":")))
+
+    # ------------------------------------------------------------------
+    # Write output
+    # ------------------------------------------------------------------
+    out_text = "\n".join(output_lines)
+    if output_lines:
+        out_text += "\n"
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            out_path.write_text(out_text, encoding="utf-8")
+        except OSError as exc:
+            print(f"merge-findings: ERROR: cannot write output: {exc}", file=sys.stderr)
+            return 1
+        print(
+            f"merge-findings: wrote {len(valid_findings)} finding(s) + "
+            f"{len(seen_gaps)} coverage-gap(s) to {args.output}",
+            file=sys.stderr,
+        )
+    else:
+        sys.stdout.write(out_text)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/commands-extra/skills/audit/tests/test-merge.sh
+++ b/modules/commands-extra/skills/audit/tests/test-merge.sh
@@ -788,7 +788,8 @@ PYEOF
   # Run merge with real rubric (no LLM files)
   E2E_MERGED="$E2E_DIR/merged.jsonl"
   set +e
-  python3 "$MERGE_SCRIPT" --spine "$E2E_SPINE" --rubric "$RUBRIC_FILE" --output "$E2E_MERGED" 2>/dev/null
+  python3 "$MERGE_SCRIPT" --spine "$E2E_SPINE" --rubric "$RUBRIC_FILE" \
+    --repo "$E2E_DIR/repo" --output "$E2E_MERGED" 2>/dev/null
   MERGE_E2E_EXIT=$?
   set -e
 
@@ -901,7 +902,8 @@ PYEOF
 
   E2E_ACTION_MERGED="$E2E_DIR/merged_action.jsonl"
   set +e
-  python3 "$MERGE_SCRIPT" --spine "$E2E_ACTION_SPINE" --rubric "$RUBRIC_FILE" --output "$E2E_ACTION_MERGED" 2>/dev/null
+  python3 "$MERGE_SCRIPT" --spine "$E2E_ACTION_SPINE" --rubric "$RUBRIC_FILE" \
+    --repo "$E2E_DIR/repo" --output "$E2E_ACTION_MERGED" 2>/dev/null
   ACTION_MERGE_EXIT=$?
   set -e
 
@@ -932,31 +934,310 @@ PYEOF
   if [[ "$E2E_ACTION_GAP_COUNT" -ge 1 ]]; then
     pass "t7: actionlint coverage_gap folds through merge ($E2E_ACTION_GAP_COUNT gap(s))"
   else
-    # actionlint absent: spine emits skipped + coverage_gap records
-    # The merge passes through coverage_gap; check for any note-type records
-    E2E_NOTE_COUNT="$(python3 - "$E2E_ACTION_MERGED" << 'PYEOF'
+    fail "t7: no coverage_gap records in actionlint spine merge output (expected >= 1)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: worker trust-boundary -- dismissed verdict on tool-detection finding
+#   (a) dismissed verdict targeting detection="tool" finding -> warning on stderr
+#       AND the finding is kept (non-hybrid findings are not dismissible)
+# ---------------------------------------------------------------------------
+printf '\nTest 8a: dismissed verdict on tool-detection finding -- warn + keep\n'
+
+T8_DIR="$TESTRUN_DIR/t8"
+mkdir -p "$T8_DIR"
+
+T8_FP_TOOL="334455667788aabb:1"
+
+python3 - "$T8_DIR/spine.jsonl" "$T8_FP_TOOL" << 'PYEOF'
 import json, sys
-count = 0
-with open(sys.argv[1]) as fh:
-    for l in fh:
-        l = l.strip()
-        if not l:
-            continue
-        try:
-            obj = json.loads(l)
-            if obj.get("type") in ("coverage_gap", "skipped"):
-                count += 1
-        except Exception:
-            pass
-print(count)
+spine_file, fp = sys.argv[1], sys.argv[2]
+with open(spine_file, "w") as fh:
+    fh.write(json.dumps({
+        "type": "provenance", "tool": "ccgm-spine", "version": "1.0",
+        "repo": "/tmp/test-repo", "tools_requested": "gitleaks",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }) + "\n")
+    fh.write(json.dumps({
+        "check_id": "security/hardcoded-secret",
+        "rule_id": "gitleaks-rule",
+        "severity": "high",
+        "confidence": "high",
+        "detection": "tool",
+        "source": "tool",
+        "message": "hardcoded secret detected by tool",
+        "location": {"path": "src/config.py", "line": 10},
+        "fingerprint": fp,
+    }) + "\n")
+PYEOF
+
+python3 - "$T8_DIR/llm.json" "$T8_FP_TOOL" << 'PYEOF'
+import json, sys
+out, fp = sys.argv[1], sys.argv[2]
+with open(out, "w") as fh:
+    json.dump({
+      "findings": [],
+      "spine_triage": [
+        {"fingerprint": fp, "verdict": "dismissed", "note": "worker tries to dismiss tool finding"}
+      ]
+    }, fh)
+PYEOF
+
+set +e
+T8A_STDERR="$(python3 "$MERGE_SCRIPT" --spine "$T8_DIR/spine.jsonl" \
+  --llm "$T8_DIR/llm.json" --rubric "$RUBRIC_FILE" 2>&1 >/dev/null)"
+T8A_OUT="$(python3 "$MERGE_SCRIPT" --spine "$T8_DIR/spine.jsonl" \
+  --llm "$T8_DIR/llm.json" --rubric "$RUBRIC_FILE" 2>/dev/null)"
+T8A_EXIT=$?
+set -e
+
+if [[ $T8A_EXIT -eq 0 ]]; then
+  pass "t8a: merge exits 0 (tool finding kept)"
+else
+  fail "t8a: merge exits $T8A_EXIT (expected 0)"
+fi
+
+T8A_PRESENT="$(fp_exists "$T8A_OUT" "$T8_FP_TOOL")"
+if [[ "$T8A_PRESENT" == "yes" ]]; then
+  pass "t8a: tool-detection finding is kept despite dismissed verdict"
+else
+  fail "t8a: tool-detection finding was incorrectly dropped by dismissed verdict"
+fi
+
+if echo "$T8A_STDERR" | grep -q "WARNING.*non-hybrid\|WARNING.*not dismissible"; then
+  pass "t8a: stderr warning emitted for attempted non-hybrid dismissal"
+else
+  fail "t8a: no warning on stderr for attempted non-hybrid dismissal (got: $T8A_STDERR)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8b: invalid finding (string line) -> exit 1 with actionable message
+# ---------------------------------------------------------------------------
+printf '\nTest 8b: invalid finding (string line) -> exit 1 with actionable message\n'
+
+T8B_FP="445566778899bbcc:1"
+
+python3 - "$T8_DIR/llm_badline.json" "$T8B_FP" << 'PYEOF'
+import json, sys
+out, fp = sys.argv[1], sys.argv[2]
+with open(out, "w") as fh:
+    json.dump({
+      "findings": [
+        {
+          "check_id": "code-quality/eslint-violation",
+          "rule_id": "no-unused-vars",
+          "severity": "medium",
+          "confidence": "medium",
+          "detection": "llm",
+          "source": "llm",
+          "message": "eslint violation",
+          # line is a string instead of int -- malformed input
+          "location": {"path": "src/app.js", "line": "7"},
+          "fingerprint": fp
+        }
+      ],
+      "spine_triage": []
+    }, fh)
+PYEOF
+
+write_spine "$T8_DIR/spine_empty.jsonl"
+
+set +e
+T8B_STDERR="$(python3 "$MERGE_SCRIPT" --spine "$T8_DIR/spine_empty.jsonl" \
+  --llm "$T8_DIR/llm_badline.json" --rubric "$RUBRIC_FILE" 2>&1 >/dev/null)"
+T8B_EXIT=$?
+set -e
+
+if [[ $T8B_EXIT -eq 1 ]]; then
+  pass "t8b: merge exits 1 on string-line finding"
+else
+  fail "t8b: merge exits $T8B_EXIT (expected 1 for malformed input)"
+fi
+
+# Assert actionable error message (not a bare traceback)
+if echo "$T8B_STDERR" | grep -q "VALIDATION ERROR\|location.line must be"; then
+  pass "t8b: stderr contains actionable error message (not a traceback)"
+else
+  fail "t8b: stderr does not contain actionable error message (got: $T8B_STDERR)"
+fi
+
+# Assert no traceback leaked
+if echo "$T8B_STDERR" | grep -q "Traceback\|TypeError"; then
+  fail "t8b: bare Python traceback leaked to stderr (got: $T8B_STDERR)"
+else
+  pass "t8b: no bare traceback in stderr"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8c: deterministic ordering -- two runs produce byte-identical output
+# ---------------------------------------------------------------------------
+printf '\nTest 8c: deterministic ordering -- two runs produce byte-identical output\n'
+
+T8C_DIR="$TESTRUN_DIR/t8c"
+mkdir -p "$T8C_DIR"
+
+# Write spine with two findings at different paths/lines
+python3 - "$T8C_DIR/spine.jsonl" << 'PYEOF'
+import json, sys
+with open(sys.argv[1], "w") as fh:
+    fh.write(json.dumps({
+        "type": "provenance", "tool": "ccgm-spine", "version": "1.0",
+        "repo": "/tmp/test-repo", "tools_requested": "gitleaks",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }) + "\n")
+    fh.write(json.dumps({
+        "check_id": "security/hardcoded-secret",
+        "rule_id": "rule-b",
+        "severity": "high", "confidence": "high",
+        "detection": "tool", "source": "tool",
+        "message": "secret at z file",
+        "location": {"path": "z/file.py", "line": 5},
+        "fingerprint": "zz9988776655aabb:1",
+    }) + "\n")
+    fh.write(json.dumps({
+        "check_id": "code-quality/eslint-violation",
+        "rule_id": "rule-a",
+        "severity": "medium", "confidence": "medium",
+        "detection": "tool", "source": "tool",
+        "message": "eslint at a file",
+        "location": {"path": "a/file.py", "line": 1},
+        "fingerprint": "aa1122334455bbcc:1",
+    }) + "\n")
+PYEOF
+
+set +e
+T8C_RUN1="$(python3 "$MERGE_SCRIPT" --spine "$T8C_DIR/spine.jsonl" \
+  --rubric "$RUBRIC_FILE" 2>/dev/null)"
+T8C_RUN2="$(python3 "$MERGE_SCRIPT" --spine "$T8C_DIR/spine.jsonl" \
+  --rubric "$RUBRIC_FILE" 2>/dev/null)"
+set -e
+
+if [[ "$T8C_RUN1" == "$T8C_RUN2" ]]; then
+  pass "t8c: two runs produce byte-identical output (deterministic)"
+else
+  fail "t8c: runs differ -- output is non-deterministic"
+fi
+
+# Also verify that findings are sorted (a/file.py before z/file.py)
+T8C_PATHS="$(python3 - "$T8C_RUN1" << 'PYEOF'
+import json, sys
+paths = []
+for l in sys.argv[1].splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj:
+            paths.append(obj.get("location", {}).get("path", ""))
+    except Exception:
+        pass
+print(",".join(paths))
 PYEOF
 )"
-    if [[ "$E2E_NOTE_COUNT" -ge 1 ]]; then
-      pass "t7: actionlint absence recorded as coverage_gap or skipped note ($E2E_NOTE_COUNT record(s))"
-    else
-      fail "t7: no coverage_gap or note records in actionlint spine merge output"
-    fi
-  fi
+
+if [[ "$T8C_PATHS" == "a/file.py,z/file.py" ]]; then
+  pass "t8c: output is sorted by path (a/file.py before z/file.py)"
+else
+  fail "t8c: output order unexpected: '$T8C_PATHS' (expected 'a/file.py,z/file.py')"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8d: conflicting cross-file verdicts -> finding kept + warning
+# ---------------------------------------------------------------------------
+printf '\nTest 8d: conflicting cross-file verdicts -> finding kept + warning\n'
+
+T8D_DIR="$TESTRUN_DIR/t8d"
+mkdir -p "$T8D_DIR"
+
+T8D_FP="556677889900ccdd:1"
+
+python3 - "$T8D_DIR/spine.jsonl" "$T8D_FP" << 'PYEOF'
+import json, sys
+spine_file, fp = sys.argv[1], sys.argv[2]
+with open(spine_file, "w") as fh:
+    fh.write(json.dumps({
+        "type": "provenance", "tool": "ccgm-spine", "version": "1.0",
+        "repo": "/tmp/test-repo", "tools_requested": "semgrep",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }) + "\n")
+    fh.write(json.dumps({
+        "check_id": "security/hardcoded-secret",
+        "rule_id": "semgrep-rule",
+        "severity": "high", "confidence": "medium",
+        "detection": "hybrid", "source": "tool",
+        "message": "possible secret",
+        "location": {"path": "src/auth.py", "line": 7},
+        "fingerprint": fp,
+    }) + "\n")
+PYEOF
+
+# Worker A says dismissed
+python3 - "$T8D_DIR/worker_a.json" "$T8D_FP" << 'PYEOF'
+import json, sys
+out, fp = sys.argv[1], sys.argv[2]
+with open(out, "w") as fh:
+    json.dump({
+      "findings": [],
+      "spine_triage": [{"fingerprint": fp, "verdict": "dismissed", "note": "worker A says false positive"}]
+    }, fh)
+PYEOF
+
+# Worker B says confirmed
+python3 - "$T8D_DIR/worker_b.json" "$T8D_FP" << 'PYEOF'
+import json, sys
+out, fp = sys.argv[1], sys.argv[2]
+with open(out, "w") as fh:
+    json.dump({
+      "findings": [],
+      "spine_triage": [{"fingerprint": fp, "verdict": "confirmed", "note": "worker B says real"}]
+    }, fh)
+PYEOF
+
+# Test both orderings: A then B, and B then A
+set +e
+T8D_STDERR_AB="$(python3 "$MERGE_SCRIPT" --spine "$T8D_DIR/spine.jsonl" \
+  --llm "$T8D_DIR/worker_a.json" --llm "$T8D_DIR/worker_b.json" \
+  --rubric "$RUBRIC_FILE" 2>&1 >/dev/null)"
+T8D_OUT_AB="$(python3 "$MERGE_SCRIPT" --spine "$T8D_DIR/spine.jsonl" \
+  --llm "$T8D_DIR/worker_a.json" --llm "$T8D_DIR/worker_b.json" \
+  --rubric "$RUBRIC_FILE" 2>/dev/null)"
+T8D_EXIT_AB=$?
+
+T8D_STDERR_BA="$(python3 "$MERGE_SCRIPT" --spine "$T8D_DIR/spine.jsonl" \
+  --llm "$T8D_DIR/worker_b.json" --llm "$T8D_DIR/worker_a.json" \
+  --rubric "$RUBRIC_FILE" 2>&1 >/dev/null)"
+T8D_OUT_BA="$(python3 "$MERGE_SCRIPT" --spine "$T8D_DIR/spine.jsonl" \
+  --llm "$T8D_DIR/worker_b.json" --llm "$T8D_DIR/worker_a.json" \
+  --rubric "$RUBRIC_FILE" 2>/dev/null)"
+T8D_EXIT_BA=$?
+set -e
+
+if [[ $T8D_EXIT_AB -eq 0 && $T8D_EXIT_BA -eq 0 ]]; then
+  pass "t8d: merge exits 0 for both orderings"
+else
+  fail "t8d: merge exits $T8D_EXIT_AB (A+B) / $T8D_EXIT_BA (B+A) (expected 0)"
+fi
+
+T8D_PRESENT_AB="$(fp_exists "$T8D_OUT_AB" "$T8D_FP")"
+T8D_PRESENT_BA="$(fp_exists "$T8D_OUT_BA" "$T8D_FP")"
+
+if [[ "$T8D_PRESENT_AB" == "yes" && "$T8D_PRESENT_BA" == "yes" ]]; then
+  pass "t8d: finding kept in both orderings (dismissal requires unanimity)"
+else
+  fail "t8d: finding unexpectedly dropped -- AB=$T8D_PRESENT_AB, BA=$T8D_PRESENT_BA"
+fi
+
+if echo "$T8D_STDERR_AB" | grep -q "WARNING.*conflict\|WARNING.*unanimity\|WARNING.*dismissal"; then
+  pass "t8d: warning emitted for conflicting verdicts (A+B order)"
+else
+  fail "t8d: no conflict warning in A+B order (stderr: $T8D_STDERR_AB)"
+fi
+
+if echo "$T8D_STDERR_BA" | grep -q "WARNING.*conflict\|WARNING.*unanimity\|WARNING.*dismissal"; then
+  pass "t8d: warning emitted for conflicting verdicts (B+A order)"
+else
+  fail "t8d: no conflict warning in B+A order (stderr: $T8D_STDERR_BA)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/modules/commands-extra/skills/audit/tests/test-merge.sh
+++ b/modules/commands-extra/skills/audit/tests/test-merge.sh
@@ -742,9 +742,11 @@ else
   # ADV-009: the assembled key string is CONSTRUCTED AT RUNTIME from fragments.
   # The prefix "AKIA" and the 16-char suffix "ABCDEFGHIJKLMNOP" are never
   # concatenated in any tracked file -- only at runtime here.
-  # NOTE: "AKIAIOSFODNN7EXAMPLE" is the official AWS docs example and is
-  # allow-listed in gitleaks; we use a different 16-char suffix that
-  # triggers real detection without being a real credential.
+  # NOTE: the AWS docs example key is "AKIA" + "IOSFODNN7EXAMPLE" (fragmented
+  # here per ADV-009 to prevent secret-scanner false positives on this file);
+  # that combined value is allow-listed in gitleaks.  We use a different 16-char
+  # suffix ("ABCDEFGHIJKLMNOP") that triggers real detection without being a
+  # real credential.
   git init "$E2E_DIR/repo" --quiet 2>/dev/null
   git -C "$E2E_DIR/repo" config user.email "test@test.test"
   git -C "$E2E_DIR/repo" config user.name "Test"
@@ -822,7 +824,13 @@ PYEOF
     fail "t7: 0 findings with check_id=secrets/leaked-credential (expected >= 1)"
   fi
 
-  # Assert severity=critical (sourced from rubric, not gitleaks default "high")
+  # Assert severity=critical.
+  # parse-gitleaks.py maps aws-access-token to "critical" in _RULE_SEVERITY, so
+  # the parser severity and the rubric severity coincide for this rule.  The
+  # NON-vacuous proof that rubric enforcement is mechanical (not just passing
+  # through the parser value) is t6: t6 feeds the same check_id with spine
+  # severity="high" and asserts output severity="critical" -- proving the rubric
+  # step fires independently of what the parser emitted.  See t6 above.
   E2E_SEV="$(python3 - "$E2E_MERGED" << 'PYEOF'
 import json, sys
 with open(sys.argv[1]) as fh:
@@ -843,7 +851,7 @@ PYEOF
 )"
 
   if [[ "$E2E_SEV" == "critical" ]]; then
-    pass "t7: severity=critical sourced from rubric (not gitleaks default)"
+    pass "t7: severity=critical enforced by rubric (parser+rubric both map aws-access-token->critical)"
   else
     fail "t7: severity='$E2E_SEV' (expected 'critical' from rubric)"
   fi

--- a/modules/commands-extra/skills/audit/tests/test-merge.sh
+++ b/modules/commands-extra/skills/audit/tests/test-merge.sh
@@ -1,0 +1,969 @@
+#!/usr/bin/env bash
+# CCGM audit -- test-merge.sh
+# Tests for Epic 1.9: merge-findings.py (spine+LLM triage + merge orchestration)
+#
+# Synthetic test cases use mktemp dirs at runtime; the real-tool e2e uses a
+# throwaway git repo.  All tmp dirs are cleaned up via a trap.
+#
+# ADV-009: the fake-secret fixture is CONSTRUCTED AT RUNTIME from fragments;
+# the assembled string never appears in this tracked file.
+#
+# Usage: bash modules/commands-extra/skills/audit/tests/test-merge.sh
+# Exit:  0 = all tests passed, non-zero = at least one failure
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MERGE_SCRIPT="$SCRIPT_DIR/../scripts/merge-findings.py"
+SPINE_SCRIPT="$SCRIPT_DIR/../scripts/spine/run.sh"
+RUBRIC_FILE="$SCRIPT_DIR/../schemas/severity-rubric.json"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+  printf '  [PASS] %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  ERRORS+=("$1")
+  FAIL=$((FAIL + 1))
+}
+
+# Validate a single finding JSON object against finding.schema.json.
+# Returns:
+#   0  valid finding
+#   1  non-finding record (provenance/coverage_gap/skipped) -- caller skips
+#   2  invalid finding
+validate_finding() {
+  local json_line="$1"
+  python3 - "$json_line" << 'PYEOF'
+import json, re, sys
+line = sys.argv[1]
+try:
+    obj = json.loads(line)
+except json.JSONDecodeError:
+    sys.exit(1)
+if not isinstance(obj, dict):
+    sys.exit(1)
+if obj.get("type") in ("skipped", "coverage_gap", "provenance"):
+    sys.exit(1)
+required = {"check_id","rule_id","severity","confidence","location","message","fingerprint","detection","source"}
+missing = required - obj.keys()
+if missing:
+    print("Missing: " + str(sorted(missing)), file=sys.stderr)
+    sys.exit(2)
+if not re.fullmatch(r"[a-z0-9_-]+/[a-z0-9_.-]+", obj["check_id"]):
+    print("Bad check_id: " + obj["check_id"], file=sys.stderr)
+    sys.exit(2)
+if obj["severity"] not in ("critical","high","medium","low","info"):
+    print("Bad severity: " + obj["severity"], file=sys.stderr)
+    sys.exit(2)
+if obj["confidence"] not in ("high","medium","low"):
+    print("Bad confidence: " + obj["confidence"], file=sys.stderr)
+    sys.exit(2)
+if obj["detection"] not in ("tool","llm","hybrid"):
+    print("Bad detection: " + obj["detection"], file=sys.stderr)
+    sys.exit(2)
+if obj["source"] not in ("tool","llm"):
+    print("Bad source: " + obj["source"], file=sys.stderr)
+    sys.exit(2)
+loc = obj.get("location", {})
+if not isinstance(loc, dict) or "path" not in loc or "line" not in loc:
+    print("Bad location", file=sys.stderr)
+    sys.exit(2)
+if not isinstance(loc["line"], int) or loc["line"] < 1:
+    print("Bad line number", file=sys.stderr)
+    sys.exit(2)
+fp = obj.get("fingerprint", "")
+if not re.fullmatch(r"[A-Za-z0-9_.:+/=\-]{8,128}", fp):
+    print("Bad fingerprint: " + fp, file=sys.stderr)
+    sys.exit(2)
+sys.exit(0)
+PYEOF
+}
+
+# Count finding lines in a JSONL string (excludes type= records)
+count_findings() {
+  python3 - "$1" << 'PYEOF'
+import json, sys
+count = 0
+for l in sys.argv[1].splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj:
+            count += 1
+    except Exception:
+        pass
+print(count)
+PYEOF
+}
+
+# Get field from first finding matching fingerprint in a JSONL string
+# Usage: get_finding_field <jsonl_str> <fingerprint> <field>
+get_finding_field() {
+  python3 - "$1" "$2" "$3" << 'PYEOF'
+import json, sys
+output, fp, field = sys.argv[1], sys.argv[2], sys.argv[3]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj and obj.get("fingerprint") == fp:
+            val = obj.get(field)
+            print("" if val is None else str(val))
+            sys.exit(0)
+    except Exception:
+        pass
+print("__not_found__")
+PYEOF
+}
+
+# Get nested field: get_finding_nested_field <jsonl_str> <fp> <parent_field> <child_field>
+get_finding_nested_field() {
+  python3 - "$1" "$2" "$3" "$4" << 'PYEOF'
+import json, sys
+output, fp, parent, child = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj and obj.get("fingerprint") == fp:
+            parent_val = obj.get(parent)
+            if isinstance(parent_val, dict):
+                val = parent_val.get(child)
+                print("" if val is None else str(val))
+            else:
+                print("__no_parent__")
+            sys.exit(0)
+    except Exception:
+        pass
+print("__not_found__")
+PYEOF
+}
+
+# Check if fingerprint exists in output as a finding
+fp_exists() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+output, fp = sys.argv[1], sys.argv[2]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj and obj.get("fingerprint") == fp:
+            print("yes")
+            sys.exit(0)
+    except Exception:
+        pass
+print("no")
+PYEOF
+}
+
+# Count records of a given type in a JSONL string
+count_type() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+output, type_val = sys.argv[1], sys.argv[2]
+count = 0
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if obj.get("type") == type_val:
+            count += 1
+    except Exception:
+        pass
+print(count)
+PYEOF
+}
+
+# Get type of first record in JSONL string
+first_type() {
+  python3 - "$1" << 'PYEOF'
+import json, sys
+for l in sys.argv[1].splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        print(obj.get("type", "finding"))
+        sys.exit(0)
+    except Exception:
+        pass
+print("empty")
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Global temp directory (all subtests use subdirs within it)
+# ---------------------------------------------------------------------------
+TESTRUN_DIR="$(mktemp -d /tmp/ccgm-test-merge-XXXXXX)"
+trap 'rm -rf "$TESTRUN_DIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Helper: write a minimal spine JSONL
+# ---------------------------------------------------------------------------
+write_spine() {
+  # write_spine <out_file> [finding_json] [note_json]
+  local out_file="$1"
+  local finding_json="${2:-}"
+  local note_json="${3:-}"
+  python3 - "$out_file" "$finding_json" "$note_json" << 'PYEOF'
+import json, sys
+out_file = sys.argv[1]
+finding_json = sys.argv[2]
+note_json = sys.argv[3]
+lines = []
+lines.append(json.dumps({
+    "type": "provenance", "tool": "ccgm-spine", "version": "1.0",
+    "repo": "/tmp/test-repo", "tools_requested": "gitleaks",
+    "timestamp": "2026-01-01T00:00:00Z",
+}))
+if finding_json:
+    lines.append(finding_json)
+if note_json:
+    lines.append(note_json)
+with open(out_file, "w") as fh:
+    for l in lines:
+        fh.write(l + "\n")
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: same fingerprint -- tool finding wins over LLM finding
+# ---------------------------------------------------------------------------
+printf '\nTest 1: same fingerprint -- tool wins over llm\n'
+
+T1_DIR="$TESTRUN_DIR/t1"
+mkdir -p "$T1_DIR"
+
+T1_FP="aabbccdd11223344:1"
+
+T1_SPINE_FINDING="$(python3 -c "
+import json
+print(json.dumps({
+  'check_id': 'code-quality/eslint-violation',
+  'rule_id': 'no-console',
+  'severity': 'critical',
+  'confidence': 'high',
+  'detection': 'tool',
+  'source': 'tool',
+  'message': 'console.log usage',
+  'location': {'path': 'src/main.js', 'line': 10},
+  'fingerprint': '${T1_FP}'
+}))
+")"
+
+write_spine "$T1_DIR/spine.jsonl" "$T1_SPINE_FINDING"
+
+python3 - "$T1_DIR/llm.json" "$T1_FP" << 'PYEOF'
+import json, sys
+out, fp = sys.argv[1], sys.argv[2]
+with open(out, "w") as fh:
+    json.dump({
+      "findings": [
+        {
+          "check_id": "code-quality/eslint-violation",
+          "rule_id": "no-console",
+          "severity": "high",
+          "confidence": "medium",
+          "detection": "llm",
+          "source": "llm",
+          "message": "console.log usage detected by llm",
+          "location": {"path": "src/main.js", "line": 10},
+          "fingerprint": fp
+        }
+      ],
+      "spine_triage": []
+    }, fh)
+PYEOF
+
+set +e
+T1_OUT="$(python3 "$MERGE_SCRIPT" --spine "$T1_DIR/spine.jsonl" \
+  --llm "$T1_DIR/llm.json" --rubric "$RUBRIC_FILE" 2>/dev/null)"
+T1_EXIT=$?
+set -e
+
+if [[ $T1_EXIT -eq 0 ]]; then
+  pass "t1: merge-findings exits 0"
+else
+  fail "t1: merge-findings exits $T1_EXIT (expected 0)"
+fi
+
+T1_FINDING_COUNT="$(count_findings "$T1_OUT")"
+if [[ "$T1_FINDING_COUNT" -eq 1 ]]; then
+  pass "t1: exactly one finding survives dedup"
+else
+  fail "t1: expected 1 finding, got $T1_FINDING_COUNT"
+fi
+
+T1_SOURCE="$(get_finding_field "$T1_OUT" "$T1_FP" "source")"
+if [[ "$T1_SOURCE" == "tool" ]]; then
+  pass "t1: surviving finding is source=tool"
+else
+  fail "t1: surviving finding source='$T1_SOURCE' (expected 'tool')"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: hybrid triage -- dismissed absent, confirmed present
+# ---------------------------------------------------------------------------
+printf '\nTest 2: hybrid triage -- dismissed absent, confirmed present\n'
+
+T2_DIR="$TESTRUN_DIR/t2"
+mkdir -p "$T2_DIR"
+
+T2_FP_DISMISSED="bbccddee22334455:1"
+T2_FP_CONFIRMED="ccddee1122334466:1"
+
+python3 - "$T2_DIR/spine.jsonl" "$T2_FP_DISMISSED" "$T2_FP_CONFIRMED" << 'PYEOF'
+import json, sys
+spine_file, fp_dis, fp_con = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = [
+    {"type": "provenance", "tool": "ccgm-spine", "version": "1.0",
+     "repo": "/tmp/test-repo", "tools_requested": "gitleaks",
+     "timestamp": "2026-01-01T00:00:00Z"},
+    {"check_id": "security/hardcoded-secret", "rule_id": "semgrep-rule",
+     "severity": "high", "confidence": "medium",
+     "detection": "hybrid", "source": "tool",
+     "message": "possible hardcoded secret",
+     "location": {"path": "src/config.py", "line": 5},
+     "fingerprint": fp_dis},
+    {"check_id": "security/hardcoded-secret", "rule_id": "semgrep-rule",
+     "severity": "high", "confidence": "medium",
+     "detection": "hybrid", "source": "tool",
+     "message": "another hardcoded secret",
+     "location": {"path": "src/config.py", "line": 20},
+     "fingerprint": fp_con},
+]
+with open(spine_file, "w") as fh:
+    for l in lines:
+        fh.write(json.dumps(l) + "\n")
+PYEOF
+
+python3 - "$T2_DIR/llm.json" "$T2_FP_DISMISSED" "$T2_FP_CONFIRMED" << 'PYEOF'
+import json, sys
+out, fp_dis, fp_con = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(out, "w") as fh:
+    json.dump({
+      "findings": [],
+      "spine_triage": [
+        {"fingerprint": fp_dis, "verdict": "dismissed", "note": "false positive"},
+        {"fingerprint": fp_con, "verdict": "confirmed", "note": "real secret"}
+      ]
+    }, fh)
+PYEOF
+
+set +e
+T2_OUT="$(python3 "$MERGE_SCRIPT" --spine "$T2_DIR/spine.jsonl" \
+  --llm "$T2_DIR/llm.json" --rubric "$RUBRIC_FILE" 2>/dev/null)"
+T2_EXIT=$?
+set -e
+
+if [[ $T2_EXIT -eq 0 ]]; then
+  pass "t2: merge exits 0"
+else
+  fail "t2: merge exits $T2_EXIT (expected 0)"
+fi
+
+DISMISSED_PRESENT="$(fp_exists "$T2_OUT" "$T2_FP_DISMISSED")"
+if [[ "$DISMISSED_PRESENT" == "no" ]]; then
+  pass "t2: dismissed hybrid is absent from output"
+else
+  fail "t2: dismissed hybrid is PRESENT in output (should have been dropped)"
+fi
+
+CONFIRMED_PRESENT="$(fp_exists "$T2_OUT" "$T2_FP_CONFIRMED")"
+if [[ "$CONFIRMED_PRESENT" == "yes" ]]; then
+  pass "t2: confirmed hybrid is present in output"
+else
+  fail "t2: confirmed hybrid is ABSENT from output (should be present)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: rubric overwrite
+#   a) LLM finding check_id=code-quality/eslint-violation carrying
+#      severity="critical" -> output severity="medium" +
+#      properties.agentReportedSeverity == "critical"
+#   b) finding with severity already matching rubric -> NO agentReportedSeverity
+# ---------------------------------------------------------------------------
+printf '\nTest 3: rubric overwrite\n'
+
+T3_DIR="$TESTRUN_DIR/t3"
+mkdir -p "$T3_DIR"
+
+T3_FP_WRONG="ddee11223344aabb:1"
+T3_FP_MATCH="ee11223344aabbcc:1"
+
+write_spine "$T3_DIR/spine.jsonl"
+
+python3 - "$T3_DIR/llm.json" "$T3_FP_WRONG" "$T3_FP_MATCH" << 'PYEOF'
+import json, sys
+out, fp_wrong, fp_match = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(out, "w") as fh:
+    json.dump({
+      "findings": [
+        {
+          "check_id": "code-quality/eslint-violation",
+          "rule_id": "no-unused-vars",
+          "severity": "critical",
+          "confidence": "high",
+          "detection": "llm",
+          "source": "llm",
+          "message": "eslint violation (wrong severity)",
+          "location": {"path": "src/app.js", "line": 3},
+          "fingerprint": fp_wrong
+        },
+        {
+          "check_id": "code-quality/eslint-violation",
+          "rule_id": "no-unused-vars",
+          "severity": "medium",
+          "confidence": "high",
+          "detection": "llm",
+          "source": "llm",
+          "message": "eslint violation (correct severity)",
+          "location": {"path": "src/app.js", "line": 7},
+          "fingerprint": fp_match
+        }
+      ],
+      "spine_triage": []
+    }, fh)
+PYEOF
+
+set +e
+T3_OUT="$(python3 "$MERGE_SCRIPT" --spine "$T3_DIR/spine.jsonl" \
+  --llm "$T3_DIR/llm.json" --rubric "$RUBRIC_FILE" 2>/dev/null)"
+T3_EXIT=$?
+set -e
+
+if [[ $T3_EXIT -eq 0 ]]; then
+  pass "t3: merge exits 0"
+else
+  fail "t3: merge exits $T3_EXIT (expected 0)"
+fi
+
+# Check finding with wrong severity
+T3A_SEV="$(get_finding_field "$T3_OUT" "$T3_FP_WRONG" "severity")"
+if [[ "$T3A_SEV" == "medium" ]]; then
+  pass "t3a: rubric overwrote severity to 'medium'"
+else
+  fail "t3a: severity='$T3A_SEV' (expected 'medium' from rubric)"
+fi
+
+T3A_AGENT_SEV="$(get_finding_nested_field "$T3_OUT" "$T3_FP_WRONG" "properties" "agentReportedSeverity")"
+if [[ "$T3A_AGENT_SEV" == "critical" ]]; then
+  pass "t3a: agentReportedSeverity='critical' preserved in properties"
+else
+  fail "t3a: agentReportedSeverity='$T3A_AGENT_SEV' (expected 'critical')"
+fi
+
+# Check finding with matching severity -- must NOT have agentReportedSeverity
+T3B_AGENT_SEV="$(get_finding_nested_field "$T3_OUT" "$T3_FP_MATCH" "properties" "agentReportedSeverity")"
+if [[ "$T3B_AGENT_SEV" == "__not_found__" || "$T3B_AGENT_SEV" == "__no_parent__" || "$T3B_AGENT_SEV" == "" ]]; then
+  pass "t3b: no agentReportedSeverity when severity matches rubric"
+else
+  fail "t3b: spurious agentReportedSeverity='$T3B_AGENT_SEV' when severity already matched rubric"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: unrubriced check_id -> confidence forced low, unrubriced=true
+# ---------------------------------------------------------------------------
+printf '\nTest 4: unrubriced check_id\n'
+
+T4_DIR="$TESTRUN_DIR/t4"
+mkdir -p "$T4_DIR"
+
+T4_FP="ff11223344aabbcc:1"
+
+write_spine "$T4_DIR/spine.jsonl"
+
+python3 - "$T4_DIR/llm.json" "$T4_FP" << 'PYEOF'
+import json, sys
+out, fp = sys.argv[1], sys.argv[2]
+with open(out, "w") as fh:
+    json.dump({
+      "findings": [
+        {
+          "check_id": "zzz/not-in-rubric",
+          "rule_id": "custom-rule",
+          "severity": "high",
+          "confidence": "high",
+          "detection": "llm",
+          "source": "llm",
+          "message": "custom finding not in rubric",
+          "location": {"path": "src/utils.py", "line": 42},
+          "fingerprint": fp
+        }
+      ],
+      "spine_triage": []
+    }, fh)
+PYEOF
+
+set +e
+T4_OUT="$(python3 "$MERGE_SCRIPT" --spine "$T4_DIR/spine.jsonl" \
+  --llm "$T4_DIR/llm.json" --rubric "$RUBRIC_FILE" 2>/dev/null)"
+T4_EXIT=$?
+set -e
+
+if [[ $T4_EXIT -eq 0 ]]; then
+  pass "t4: merge exits 0"
+else
+  fail "t4: merge exits $T4_EXIT (expected 0)"
+fi
+
+T4_CONF="$(get_finding_field "$T4_OUT" "$T4_FP" "confidence")"
+if [[ "$T4_CONF" == "low" ]]; then
+  pass "t4: unrubriced finding has confidence=low"
+else
+  fail "t4: confidence='$T4_CONF' (expected 'low' for unrubriced)"
+fi
+
+T4_UNRUBRICED="$(get_finding_nested_field "$T4_OUT" "$T4_FP" "properties" "unrubriced")"
+if [[ "$T4_UNRUBRICED" == "True" ]]; then
+  pass "t4: properties.unrubriced=True set"
+else
+  fail "t4: properties.unrubriced='$T4_UNRUBRICED' (expected 'True')"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: coverage-gap folding + provenance passthrough
+# ---------------------------------------------------------------------------
+printf '\nTest 5: coverage-gap folding + provenance passthrough\n'
+
+T5_DIR="$TESTRUN_DIR/t5"
+mkdir -p "$T5_DIR"
+
+T5_GAP="$(python3 -c "import json; print(json.dumps({'type':'coverage_gap','tool':'actionlint','check_id':'ci/invalid-workflow','description':'actionlint not installed'}))")"
+
+write_spine "$T5_DIR/spine.jsonl" "" "$T5_GAP"
+
+python3 - "$T5_DIR/llm.json" << 'PYEOF'
+import json, sys
+with open(sys.argv[1], "w") as fh:
+    json.dump({"findings": [], "spine_triage": []}, fh)
+PYEOF
+
+set +e
+T5_OUT="$(python3 "$MERGE_SCRIPT" --spine "$T5_DIR/spine.jsonl" \
+  --llm "$T5_DIR/llm.json" --rubric "$RUBRIC_FILE" 2>/dev/null)"
+T5_EXIT=$?
+set -e
+
+if [[ $T5_EXIT -eq 0 ]]; then
+  pass "t5: merge exits 0"
+else
+  fail "t5: merge exits $T5_EXIT (expected 0)"
+fi
+
+T5_FIRST="$(first_type "$T5_OUT")"
+if [[ "$T5_FIRST" == "provenance" ]]; then
+  pass "t5: provenance record appears first"
+else
+  fail "t5: first record type='$T5_FIRST' (expected 'provenance')"
+fi
+
+T5_GAP_COUNT="$(count_type "$T5_OUT" "coverage_gap")"
+if [[ "$T5_GAP_COUNT" -ge 1 ]]; then
+  pass "t5: coverage_gap records folded through ($T5_GAP_COUNT found)"
+else
+  fail "t5: no coverage_gap records in output (expected >= 1)"
+fi
+
+# Dedup: write the same gap twice to the spine -> should appear once in output
+python3 - "$T5_DIR/spine_dup.jsonl" "$T5_GAP" << 'PYEOF'
+import json, sys
+spine_file, gap_json = sys.argv[1], sys.argv[2]
+with open(spine_file, "w") as fh:
+    fh.write(json.dumps({
+        "type": "provenance", "tool": "ccgm-spine", "version": "1.0",
+        "repo": "/tmp/test-repo", "tools_requested": "gitleaks",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }) + "\n")
+    # Write the same gap twice
+    fh.write(gap_json + "\n")
+    fh.write(gap_json + "\n")
+PYEOF
+
+set +e
+T5_DUP_OUT="$(python3 "$MERGE_SCRIPT" --spine "$T5_DIR/spine_dup.jsonl" \
+  --llm "$T5_DIR/llm.json" --rubric "$RUBRIC_FILE" 2>/dev/null)"
+set -e
+
+T5_DUP_GAP_COUNT="$(python3 - "$T5_DUP_OUT" "ci/invalid-workflow" << 'PYEOF'
+import json, sys
+output, check_id = sys.argv[1], sys.argv[2]
+count = 0
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if obj.get("type") == "coverage_gap" and obj.get("check_id") == check_id:
+            count += 1
+    except Exception:
+        pass
+print(count)
+PYEOF
+)"
+
+if [[ "$T5_DUP_GAP_COUNT" -eq 1 ]]; then
+  pass "t5: duplicate coverage_gap records deduped to 1"
+else
+  fail "t5: duplicate coverage_gap not deduped (got $T5_DUP_GAP_COUNT, expected 1)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: output validity -- every finding passes schema validation
+# ---------------------------------------------------------------------------
+printf '\nTest 6: output validity -- all findings pass schema validation\n'
+
+T6_DIR="$TESTRUN_DIR/t6"
+mkdir -p "$T6_DIR"
+
+T6_FP_A="112233445566aabb:1"
+T6_FP_B="223344556677bbcc:1"
+
+python3 - "$T6_DIR/spine.jsonl" "$T6_FP_A" << 'PYEOF'
+import json, sys
+spine_file, fp_a = sys.argv[1], sys.argv[2]
+with open(spine_file, "w") as fh:
+    fh.write(json.dumps({
+        "type": "provenance", "tool": "ccgm-spine", "version": "1.0",
+        "repo": "/tmp/test-repo", "tools_requested": "gitleaks",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }) + "\n")
+    fh.write(json.dumps({
+        "check_id": "secrets/leaked-credential",
+        "rule_id": "aws-access-token",
+        "severity": "high",
+        "confidence": "high",
+        "detection": "tool",
+        "source": "tool",
+        "message": "AWS key found AKIA[redacted:len=20]",
+        "location": {"path": "config/env.py", "line": 2},
+        "fingerprint": fp_a,
+        "properties": {"tool": "gitleaks"}
+    }) + "\n")
+PYEOF
+
+python3 - "$T6_DIR/llm.json" "$T6_FP_B" << 'PYEOF'
+import json, sys
+out, fp_b = sys.argv[1], sys.argv[2]
+with open(out, "w") as fh:
+    json.dump({
+      "findings": [
+        {
+          "check_id": "security/sql-injection",
+          "rule_id": "sql-injection-001",
+          "severity": "high",
+          "confidence": "medium",
+          "detection": "llm",
+          "source": "llm",
+          "message": "potential sql injection",
+          "location": {"path": "src/db.py", "line": 15},
+          "fingerprint": fp_b
+        }
+      ],
+      "spine_triage": []
+    }, fh)
+PYEOF
+
+set +e
+T6_OUT="$(python3 "$MERGE_SCRIPT" --spine "$T6_DIR/spine.jsonl" \
+  --llm "$T6_DIR/llm.json" --rubric "$RUBRIC_FILE" 2>/dev/null)"
+T6_EXIT=$?
+set -e
+
+if [[ $T6_EXIT -eq 0 ]]; then
+  pass "t6: merge exits 0"
+else
+  fail "t6: merge exits $T6_EXIT (expected 0)"
+fi
+
+T6_VALID=0
+T6_INVALID=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  V=0
+  validate_finding "$line" || V=$?
+  if [[ $V -eq 0 ]]; then
+    T6_VALID=$((T6_VALID + 1))
+  elif [[ $V -eq 2 ]]; then
+    T6_INVALID=$((T6_INVALID + 1))
+    printf '    SCHEMA FAIL: %s\n' "$line" >&2
+  fi
+done <<< "$T6_OUT"
+
+if [[ $T6_VALID -ge 2 ]]; then
+  pass "t6: $T6_VALID finding(s) validate against finding.schema.json"
+else
+  fail "t6: only $T6_VALID finding(s) valid (expected >= 2)"
+fi
+if [[ $T6_INVALID -eq 0 ]]; then
+  pass "t6: no invalid findings"
+else
+  fail "t6: $T6_INVALID finding(s) failed schema validation"
+fi
+
+# Rubric: secrets/leaked-credential spine finding -> severity should become critical
+T6_LEAKED_SEV="$(get_finding_field "$T6_OUT" "$T6_FP_A" "severity")"
+if [[ "$T6_LEAKED_SEV" == "critical" ]]; then
+  pass "t6: secrets/leaked-credential rubric applied (severity=critical)"
+else
+  fail "t6: secrets/leaked-credential severity='$T6_LEAKED_SEV' (expected 'critical' from rubric)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7 (REAL-TOOL E2E): gitleaks on a throwaway repo + rubric enforcement
+# ---------------------------------------------------------------------------
+printf '\nTest 7 (real-tool e2e): gitleaks integration\n'
+
+if ! command -v gitleaks > /dev/null 2>&1; then
+  printf '  [SKIP] gitleaks not installed -- e2e test skipped\n'
+else
+  E2E_DIR="$(mktemp -d /tmp/ccgm-e2e-XXXXXX)"
+  # Note: outer trap already removes TESTRUN_DIR; add E2E_DIR cleanup
+  trap 'rm -rf "$TESTRUN_DIR" "$E2E_DIR"' EXIT
+
+  # Build a throwaway git repo with a fake AWS key.
+  # ADV-009: the assembled key string is CONSTRUCTED AT RUNTIME from fragments.
+  # The prefix "AKIA" and the 16-char suffix "ABCDEFGHIJKLMNOP" are never
+  # concatenated in any tracked file -- only at runtime here.
+  # NOTE: "AKIAIOSFODNN7EXAMPLE" is the official AWS docs example and is
+  # allow-listed in gitleaks; we use a different 16-char suffix that
+  # triggers real detection without being a real credential.
+  git init "$E2E_DIR/repo" --quiet 2>/dev/null
+  git -C "$E2E_DIR/repo" config user.email "test@test.test"
+  git -C "$E2E_DIR/repo" config user.name "Test"
+  # Disable global hooks for this throwaway repo so the test is self-contained
+  # and does not trigger any project pre-commit infrastructure.
+  git -C "$E2E_DIR/repo" config core.hooksPath /dev/null 2>/dev/null || true
+
+  # Construct the fake key from two separate string fragments (ADV-009)
+  KEY_PART1="AKIA"
+  KEY_PART2="ABCDEFGHIJKLMNOP"
+  FAKE_KEY="${KEY_PART1}${KEY_PART2}"
+
+  # Write a file containing the assembled key (runtime only -- not tracked by CCGM)
+  python3 - "$E2E_DIR/repo/secrets.env" "$FAKE_KEY" << 'PYEOF'
+import sys
+path, key = sys.argv[1], sys.argv[2]
+with open(path, "w") as fh:
+    fh.write("# Test environment\n")
+    fh.write(f"AWS_ACCESS_KEY_ID={key}\n")
+    fh.write("APP_ENV=development\n")
+PYEOF
+
+  git -C "$E2E_DIR/repo" add secrets.env
+  git -C "$E2E_DIR/repo" commit -m "test: add config" --quiet 2>/dev/null
+
+  # Run the real spine (gitleaks only)
+  E2E_SPINE="$E2E_DIR/spine.jsonl"
+  set +e
+  bash "$SPINE_SCRIPT" --repo "$E2E_DIR/repo" --tools gitleaks --output "$E2E_SPINE" 2>/dev/null
+  SPINE_E2E_EXIT=$?
+  set -e
+
+  if [[ $SPINE_E2E_EXIT -eq 0 ]]; then
+    pass "t7: spine (gitleaks) exits 0"
+  else
+    fail "t7: spine (gitleaks) exits $SPINE_E2E_EXIT (expected 0)"
+  fi
+
+  # Run merge with real rubric (no LLM files)
+  E2E_MERGED="$E2E_DIR/merged.jsonl"
+  set +e
+  python3 "$MERGE_SCRIPT" --spine "$E2E_SPINE" --rubric "$RUBRIC_FILE" --output "$E2E_MERGED" 2>/dev/null
+  MERGE_E2E_EXIT=$?
+  set -e
+
+  if [[ $MERGE_E2E_EXIT -eq 0 ]]; then
+    pass "t7: merge-findings exits 0 on real spine output"
+  else
+    fail "t7: merge-findings exits $MERGE_E2E_EXIT (expected 0)"
+  fi
+
+  # Assert >= 1 finding with check_id=secrets/leaked-credential
+  E2E_CRED_COUNT="$(python3 - "$E2E_MERGED" << 'PYEOF'
+import json, sys
+count = 0
+with open(sys.argv[1]) as fh:
+    for l in fh:
+        l = l.strip()
+        if not l:
+            continue
+        try:
+            obj = json.loads(l)
+            if isinstance(obj, dict) and "type" not in obj:
+                if obj.get("check_id") == "secrets/leaked-credential":
+                    count += 1
+        except Exception:
+            pass
+print(count)
+PYEOF
+)"
+
+  if [[ "$E2E_CRED_COUNT" -ge 1 ]]; then
+    pass "t7: >= 1 finding with check_id=secrets/leaked-credential from real gitleaks"
+  else
+    fail "t7: 0 findings with check_id=secrets/leaked-credential (expected >= 1)"
+  fi
+
+  # Assert severity=critical (sourced from rubric, not gitleaks default "high")
+  E2E_SEV="$(python3 - "$E2E_MERGED" << 'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    for l in fh:
+        l = l.strip()
+        if not l:
+            continue
+        try:
+            obj = json.loads(l)
+            if isinstance(obj, dict) and "type" not in obj:
+                if obj.get("check_id") == "secrets/leaked-credential":
+                    print(obj.get("severity", "?"))
+                    sys.exit(0)
+        except Exception:
+            pass
+print("not_found")
+PYEOF
+)"
+
+  if [[ "$E2E_SEV" == "critical" ]]; then
+    pass "t7: severity=critical sourced from rubric (not gitleaks default)"
+  else
+    fail "t7: severity='$E2E_SEV' (expected 'critical' from rubric)"
+  fi
+
+  # Assert valid fingerprint
+  E2E_FP_VALID="$(python3 - "$E2E_MERGED" << 'PYEOF'
+import json, re, sys
+with open(sys.argv[1]) as fh:
+    for l in fh:
+        l = l.strip()
+        if not l:
+            continue
+        try:
+            obj = json.loads(l)
+            if isinstance(obj, dict) and "type" not in obj:
+                if obj.get("check_id") == "secrets/leaked-credential":
+                    fp = obj.get("fingerprint", "")
+                    if re.fullmatch(r"[A-Za-z0-9_.:+/=\-]{8,128}", fp):
+                        print("valid")
+                    else:
+                        print("invalid:" + fp)
+                    sys.exit(0)
+        except Exception:
+            pass
+print("not_found")
+PYEOF
+)"
+
+  if [[ "$E2E_FP_VALID" == "valid" ]]; then
+    pass "t7: finding has valid fingerprint"
+  else
+    fail "t7: fingerprint result='$E2E_FP_VALID' (expected 'valid')"
+  fi
+
+  # Assert the assembled fake key does NOT appear in merged output (redaction held)
+  if grep -qF "$FAKE_KEY" "$E2E_MERGED" 2>/dev/null; then
+    fail "t7: assembled fake key appears in merged output -- redaction failed"
+  else
+    pass "t7: assembled fake key is NOT in merged output -- redaction held"
+  fi
+
+  # Run spine with actionlint (not installed) -> verify coverage_gap folds through merge
+  E2E_ACTION_SPINE="$E2E_DIR/spine_action.jsonl"
+  set +e
+  bash "$SPINE_SCRIPT" --repo "$E2E_DIR/repo" --tools actionlint --output "$E2E_ACTION_SPINE" 2>/dev/null
+  set -e
+
+  E2E_ACTION_MERGED="$E2E_DIR/merged_action.jsonl"
+  set +e
+  python3 "$MERGE_SCRIPT" --spine "$E2E_ACTION_SPINE" --rubric "$RUBRIC_FILE" --output "$E2E_ACTION_MERGED" 2>/dev/null
+  ACTION_MERGE_EXIT=$?
+  set -e
+
+  if [[ $ACTION_MERGE_EXIT -eq 0 ]]; then
+    pass "t7: merge exits 0 on actionlint-only spine"
+  else
+    fail "t7: merge exits $ACTION_MERGE_EXIT on actionlint spine"
+  fi
+
+  E2E_ACTION_GAP_COUNT="$(python3 - "$E2E_ACTION_MERGED" << 'PYEOF'
+import json, sys
+count = 0
+with open(sys.argv[1]) as fh:
+    for l in fh:
+        l = l.strip()
+        if not l:
+            continue
+        try:
+            obj = json.loads(l)
+            if obj.get("type") == "coverage_gap":
+                count += 1
+        except Exception:
+            pass
+print(count)
+PYEOF
+)"
+
+  if [[ "$E2E_ACTION_GAP_COUNT" -ge 1 ]]; then
+    pass "t7: actionlint coverage_gap folds through merge ($E2E_ACTION_GAP_COUNT gap(s))"
+  else
+    # actionlint absent: spine emits skipped + coverage_gap records
+    # The merge passes through coverage_gap; check for any note-type records
+    E2E_NOTE_COUNT="$(python3 - "$E2E_ACTION_MERGED" << 'PYEOF'
+import json, sys
+count = 0
+with open(sys.argv[1]) as fh:
+    for l in fh:
+        l = l.strip()
+        if not l:
+            continue
+        try:
+            obj = json.loads(l)
+            if obj.get("type") in ("coverage_gap", "skipped"):
+                count += 1
+        except Exception:
+            pass
+print(count)
+PYEOF
+)"
+    if [[ "$E2E_NOTE_COUNT" -ge 1 ]]; then
+      pass "t7: actionlint absence recorded as coverage_gap or skipped note ($E2E_NOTE_COUNT record(s))"
+    else
+      fail "t7: no coverage_gap or note records in actionlint spine merge output"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n-------------------------------------------------\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  printf '\nFailed tests:\n'
+  for err in "${ERRORS[@]}"; do
+    printf '  - %s\n' "$err"
+  done
+  exit 1
+fi
+
+printf 'All tests passed.\n'
+exit 0


### PR DESCRIPTION
## Summary

Implements Epic 1.9: the merge layer that combines deterministic spine JSONL with LLM worker results files, applies triage verdicts, deduplicates by fingerprint, enforces the severity rubric mechanically, and streams schema-valid findings JSONL.

Closes #594

## Changes

- **`modules/commands-extra/skills/audit/scripts/merge-findings.py`** — New executable Python3 (stdlib-only) merger. CLI: `--spine`, `--llm` (repeatable), `--rubric`, `--output`. Implements: spine/LLM parsing, fingerprint assignment via imported emit-findings logic, hybrid triage (dismissed/confirmed), tool-wins dedup, rubric overwrite with `agentReportedSeverity` preservation (ADV-007), unrubriced path (confidence forced low + `unrubriced=True`), coverage-gap folding with dedup, schema validation on every output finding.

- **`modules/commands-extra/skills/audit/SKILL.md`** — New section `## Spine Execution Ownership & Merge Contract` inserted immediately before `## Severity Sourcing`. Specifies ADV-002: coordinator runs spine once per run (ABSOLUTE paths only), per-pack slicing to worker task files, worker duties (triage + LLM findings, never invent severity), `--single` mode behaviour, and the merge invocation. Defines the LLM results-file contract (the shape Epic 1.7b will produce).

- **`modules/commands-extra/skills/audit/schemas/severity-rubric.json`** — Added `secrets/leaked-credential` entry (`severity: critical, confidence: high, fix_confidence: low`) grouped with the security/* block. Pre-seeds the Wave-2 secrets pack's check_id and proves the rubric-severity path in the e2e test.

- **`modules/commands-extra/skills/audit/tests/test-merge.sh`** — New bash test suite (29 assertions): synthetic cases for dedup, hybrid triage, rubric overwrite/agentReportedSeverity, unrubriced path, coverage-gap folding/dedup, provenance passthrough, schema validity. Real-tool e2e (ADV-006): builds a throwaway git repo, commits a fake AWS key constructed at runtime from fragments (ADV-009), runs the real gitleaks spine, asserts `secrets/leaked-credential` findings with `severity=critical` from rubric, valid fingerprint, redaction held, and actionlint coverage_gap fold-through.

- **`modules/commands-extra/module.json`** — Registered `merge-findings.py` in the files map.

## LLM Results-File Contract

Workers write a JSON file with this shape:

```json
{
  "findings": [
    {
      "check_id": "<pack>/<check>",
      "rule_id": "<rule>",
      "severity": "critical|high|medium|low|info",
      "confidence": "high|medium|low",
      "detection": "tool|llm|hybrid",
      "source": "llm",
      "message": "<description>",
      "location": {"path": "<repo-relative>", "line": 1},
      "fingerprint": "<optional — kept VERBATIM if present>",
      "fix_confidence": "high|medium|low",
      "properties": {}
    }
  ],
  "spine_triage": [
    {
      "fingerprint": "<fp of a spine hybrid candidate>",
      "verdict": "confirmed|dismissed",
      "note": "<optional>"
    }
  ]
}
```

## Test Plan

- [x] `bash modules/commands-extra/skills/audit/tests/test-merge.sh` — 29/29 PASS (gitleaks e2e ran, not skipped)
- [x] `bash modules/commands-extra/skills/audit/tests/test-spine.sh` — 25/25 PASS
- [x] `bash modules/commands-extra/skills/audit/tests/test-emit-findings.sh` — 15/15 PASS
- [x] `bash modules/commands-extra/skills/audit/tests/test-rubric.sh` — 8/8 PASS
- [x] `bash modules/commands-extra/skills/audit/tests/test-pack-lint.sh` — 7/7 PASS
- [x] `python3 -m json.tool modules/commands-extra/module.json > /dev/null` — OK
- [x] `python3 -m json.tool modules/commands-extra/skills/audit/schemas/severity-rubric.json > /dev/null` — OK
- [x] `bash tests/test-modules.sh` — 1270/1270 PASS
- [x] `bash tests/test-no-personal-data.sh` — PASS