### PR TITLE
#603: diff-scoped audit mode (--diff / --staged) + four ride-along fixes

### DIFF
--- a/modules/commands-extra/commands/audit.md
+++ b/modules/commands-extra/commands/audit.md
@@ -20,7 +20,7 @@ Run a comprehensive codebase audit across 9 categories. See the full skill for a
 /audit --max-fixes 10     # Limit number of auto-fixes (only with --fix)
 /audit --diff             # Audit only files changed vs the detected base branch
 /audit --diff main        # Audit only files changed vs a specific ref
-/audit --staged           # Audit only files currently staged for commit
+/audit --staged           # Audit only files currently staged for commit (always read-only; --fix ignored)
 /audit [PATH]             # Audit a specific path instead of the entire repo
 ```
 

--- a/modules/commands-extra/commands/audit.md
+++ b/modules/commands-extra/commands/audit.md
@@ -18,6 +18,9 @@ Run a comprehensive codebase audit across 9 categories. See the full skill for a
 /audit --collect          # Compile results + create issues (after workers complete)
 /audit --collect --force  # Collect even if some agents haven't completed
 /audit --max-fixes 10     # Limit number of auto-fixes (only with --fix)
+/audit --diff             # Audit only files changed vs the detected base branch
+/audit --diff main        # Audit only files changed vs a specific ref
+/audit --staged           # Audit only files currently staged for commit
 /audit [PATH]             # Audit a specific path instead of the entire repo
 ```
 

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -24,16 +24,21 @@ Comprehensive codebase audit. Produces a findings document and creates GitHub is
 ```
 
 > **Note on `--diff` and `--staged`**: These flags scope the audit to changed files only.
-> They are composable with `--single` (read-only), `--fix` (where fix mode already applies),
-> and with parallel-worktrees or multi-clone strategies. The deterministic spine still runs
-> against the full repo root; its findings are filtered to the changed-file set before
-> slicing and merging. LLM workers receive the changed-file list and are instructed to audit
-> only those files (except repo-wide checks whose subject file is in the changed set).
+> `--diff` is composable with `--fix` and all execution strategies. `--staged` is always
+> read-only — `--fix` is ignored with a printed note when combined with `--staged`.
+> The deterministic spine still runs against the full repo root; its findings are filtered
+> to the changed-file set before slicing and merging. LLM workers receive the changed-file
+> list and are instructed to audit only those files (except repo-wide checks whose subject
+> file is in the changed set).
 
 > **Note on `--single` and `--fix`**: `--single` is always read-only. It never applies
 > fixes even if `--fix` is also passed. If you invoke `/audit --single --fix`, the `--fix`
 > flag is silently ignored and a note is printed:
 > `Note: --single is read-only; --fix ignored. Use parallel-worktrees strategy for auto-fix.`
+
+> **Note on `--staged` and `--fix`**: `--staged` is always read-only. If you invoke
+> `/audit --staged --fix`, the `--fix` flag is ignored and a note is printed:
+> `Note: --staged is read-only; --fix ignored. Staged-only audits do not apply fixes.`
 
 ### Interactive Configuration
 
@@ -78,7 +83,7 @@ This ensures the user always knows exactly what the audit will do before it star
 - `--max-fixes N` -> sets MAX_FIXES=N (only with --fix)
 - `--manual` -> Coordinator-Only Mode (Phases M1-M4 + output launch commands)
 - `--diff [ref]` -> sets DIFF_MODE=true; changed files computed via `git diff -z <ref>...HEAD` (ref defaults to BASE_BRANCH). Composable with `--single`, `--fix`, and all execution strategies.
-- `--staged` -> sets STAGED_MODE=true; changed files computed via `git diff -z --staged`. Composable with `--single` and all execution strategies (no `--fix` with `--staged` — staged-only runs are always read-only).
+- `--staged` -> sets STAGED_MODE=true; changed files computed via `git diff -z --staged`. Composable with `--single` and all execution strategies. `--fix` is ignored with a printed note when combined with `--staged` — staged-only runs are always read-only.
 - Remaining argument is the target path (default: entire repo)
 
 **If NO flags are passed, prompt the user with `AskUserQuestion` to configure the audit:**
@@ -214,7 +219,10 @@ Write `config.json`:
 
 **Skip this phase entirely for full-repo audits.** Only execute when `--diff` or `--staged` is set.
 
-1. **Compute the changed-file set once** and write it to the coordination directory:
+1. **Compute the changed-file set once** and write it to the coordination directory.
+
+   `changed-files.z` is canonical for machine consumers; `changed-files.txt` is a lossy
+   human-readable view for LLM scoping (filenames containing newlines render ambiguously there).
 
    ```bash
    # --diff mode: changed files vs <ref>...HEAD
@@ -222,33 +230,42 @@ Write `config.json`:
      DIFF_REF="${DIFF_REF:-$BASE_BRANCH}"
      git -C "$REPO_DIR" diff --name-only -z "${DIFF_REF}...HEAD" \
        > "$AUDIT_DIR/current/changed-files.z"
+     if [ $? -ne 0 ]; then
+       echo "ERROR: git diff failed for ref '${DIFF_REF}' — does it exist?" >&2
+       echo "  Verify with: git rev-parse --verify '${DIFF_REF}'" >&2
+       exit 1
+     fi
    fi
 
    # --staged mode: staged files only
    if [ "${STAGED_MODE:-false}" = "true" ]; then
      git -C "$REPO_DIR" diff --name-only -z --staged \
        > "$AUDIT_DIR/current/changed-files.z"
+     if [ $? -ne 0 ]; then
+       echo "ERROR: git diff --staged failed" >&2
+       exit 1
+     fi
    fi
 
    # Generate the human-readable version FROM the -z file using python3.
    # Never split on shell word boundaries — filenames may contain spaces,
    # semicolons, or other metacharacters; they must remain inert data.
-   python3 - "$AUDIT_DIR/current/changed-files.z" \
-             "$AUDIT_DIR/current/changed-files.txt" << 'PYEOF'
-   import sys
-   with open(sys.argv[1], "rb") as fh:
-       data = fh.read()
-   # Null-delimited; strip trailing null before splitting
-   paths = [p.decode("utf-8", errors="surrogateescape")
-            for p in data.rstrip(b"\x00").split(b"\x00") if p]
-   with open(sys.argv[2], "w", encoding="utf-8") as out:
-       for p in paths:
-           out.write(p + "\n")
-   print(f"diff scope: {len(paths)} changed file(s)", file=__import__('sys').stderr)
-   PYEOF
+python3 - "$AUDIT_DIR/current/changed-files.z" \
+          "$AUDIT_DIR/current/changed-files.txt" << 'PYEOF'
+import sys
+with open(sys.argv[1], "rb") as fh:
+    data = fh.read()
+# Null-delimited; strip trailing null before splitting
+paths = [p.decode("utf-8", errors="surrogateescape")
+         for p in data.rstrip(b"\x00").split(b"\x00") if p]
+with open(sys.argv[2], "w", encoding="utf-8") as out:
+    for p in paths:
+        out.write(p + "\n")
+print(f"diff scope: {len(paths)} changed file(s)", file=sys.stderr)
+PYEOF
    ```
 
-2. **Empty-set guard**: if `changed-files.z` is empty (zero bytes or contains only null bytes), print a message and exit cleanly — no spine, no workers, no report:
+2. **Empty-set guard**: if `changed-files.z` is empty (zero bytes or contains only null bytes), clean up the current directory so the next invocation does not hit the resume prompt for a no-op run (config.json would otherwise still claim full-repo scope), then exit cleanly — no spine, no workers, no report:
 
    ```bash
    CHANGED_COUNT=$(python3 -c "
@@ -260,6 +277,7 @@ Write `config.json`:
 
    if [ "${CHANGED_COUNT:-0}" -eq 0 ]; then
      echo "no changed files — nothing to audit"
+     rm -rf "$AUDIT_DIR/current/"
      exit 0
    fi
    ```
@@ -278,49 +296,49 @@ Write `config.json`:
    - **Spine post-filter**: after the spine runs (Phase M4), filter its findings before slicing:
 
    ```bash
-   python3 - \
-     "$AUDIT_DIR/current/spine/findings.jsonl" \
-     "$AUDIT_DIR/current/changed-files.z" \
-     "$AUDIT_DIR/current/spine/findings-diff-filtered.jsonl" << 'PYEOF'
-   import json, sys
+python3 - \
+  "$AUDIT_DIR/current/spine/findings.jsonl" \
+  "$AUDIT_DIR/current/changed-files.z" \
+  "$AUDIT_DIR/current/spine/findings-diff-filtered.jsonl" << 'PYEOF'
+import json, sys
 
-   spine_file, changed_z, out_file = sys.argv[1], sys.argv[2], sys.argv[3]
+spine_file, changed_z, out_file = sys.argv[1], sys.argv[2], sys.argv[3]
 
-   # Read changed paths null-delimited — no shell interpolation anywhere.
-   with open(changed_z, "rb") as fh:
-       data = fh.read()
-   changed_set = set(
-       p.decode("utf-8", errors="surrogateescape")
-       for p in data.rstrip(b"\x00").split(b"\x00") if p
-   )
+# Read changed paths null-delimited — no shell interpolation anywhere.
+with open(changed_z, "rb") as fh:
+    data = fh.read()
+changed_set = set(
+    p.decode("utf-8", errors="surrogateescape")
+    for p in data.rstrip(b"\x00").split(b"\x00") if p
+)
 
-   kept = 0
-   skipped = 0
-   with open(spine_file, encoding="utf-8") as fin, \
-        open(out_file, "w", encoding="utf-8") as fout:
-       for raw in fin:
-           raw = raw.strip()
-           if not raw:
-               continue
-           try:
-               rec = json.loads(raw)
-           except json.JSONDecodeError:
-               continue
-           # coverage_gap and provenance records always pass through.
-           if "type" in rec:
-               fout.write(raw + "\n")
-               continue
-           # Finding records: keep only if location.path is in the changed set.
-           path = rec.get("location", {}).get("path", "")
-           if path in changed_set:
-               fout.write(raw + "\n")
-               kept += 1
-           else:
-               skipped += 1
+kept = 0
+skipped = 0
+with open(spine_file, encoding="utf-8") as fin, \
+     open(out_file, "w", encoding="utf-8") as fout:
+    for raw in fin:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            rec = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        # coverage_gap and provenance records always pass through.
+        if "type" in rec:
+            fout.write(raw + "\n")
+            continue
+        # Finding records: keep only if location.path is in the changed set.
+        path = rec.get("location", {}).get("path", "")
+        if path in changed_set:
+            fout.write(raw + "\n")
+            kept += 1
+        else:
+            skipped += 1
 
-   print(f"diff-filter: kept {kept} finding(s), skipped {skipped} (not in changed set)",
-         file=__import__('sys').stderr)
-   PYEOF
+print(f"diff-filter: kept {kept} finding(s), skipped {skipped} (not in changed set)",
+      file=sys.stderr)
+PYEOF
 
    # Replace the spine findings file with the filtered version for downstream phases.
    mv "$AUDIT_DIR/current/spine/findings-diff-filtered.jsonl" \
@@ -461,6 +479,44 @@ else
     --repo  "$REPO_DIR" \
     --tools "$SPINE_TOOLS" \
     --output "$AUDIT_DIR/current/spine/findings.jsonl"
+fi
+
+# Diff mode: apply the Phase M2.1 post-filter to the spine findings NOW, before slicing.
+if [ "${DIFF_MODE:-false}" = "true" ] || [ "${STAGED_MODE:-false}" = "true" ]; then
+  python3 - \
+    "$AUDIT_DIR/current/spine/findings.jsonl" \
+    "$AUDIT_DIR/current/changed-files.z" \
+    "$AUDIT_DIR/current/spine/findings-diff-filtered.jsonl" << 'PYEOF'
+import json, sys
+spine_file, changed_z, out_file = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(changed_z, "rb") as fh:
+    data = fh.read()
+changed_set = set(
+    p.decode("utf-8", errors="surrogateescape")
+    for p in data.rstrip(b"\x00").split(b"\x00") if p
+)
+kept = 0; skipped = 0
+with open(spine_file, encoding="utf-8") as fin, \
+     open(out_file, "w", encoding="utf-8") as fout:
+    for raw in fin:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            rec = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if "type" in rec:
+            fout.write(raw + "\n"); continue
+        path = rec.get("location", {}).get("path", "")
+        if path in changed_set:
+            fout.write(raw + "\n"); kept += 1
+        else:
+            skipped += 1
+print(f"diff-filter (M4): kept {kept}, skipped {skipped}", file=sys.stderr)
+PYEOF
+  mv "$AUDIT_DIR/current/spine/findings-diff-filtered.jsonl" \
+     "$AUDIT_DIR/current/spine/findings.jsonl"
 fi
 ```
 
@@ -1253,9 +1309,12 @@ grep -qxF '.audit/' .gitignore 2>/dev/null || echo '.audit/' >> .gitignore
 Same mechanics as Phase M2.1 in Autonomous Mode: compute the changed-file set once, write
 `$AUDIT_DIR/current/changed-files.z` (null-delimited) and `changed-files.txt` (one path per
 line, generated by python3 from the -z file — never by shell string-splitting), guard on empty
-set, and update config.json. All python3 parsing is null-delimited end-to-end; filenames
-containing spaces, semicolons, or newlines are inert data and are never interpolated into a shell
-string.
+set, and write `.audit/current/config.json` recording the diff scope (create it; single-session
+mode has none yet). All python3 parsing is null-delimited end-to-end; filenames containing
+spaces, semicolons, or newlines are inert data and are never interpolated into a shell string.
+
+**Bad-ref halt**: if the `git diff` command exits nonzero (nonexistent ref), HALT immediately
+with the git error — do not fall through to the empty-set path.
 
 **Spine post-filter (single-session)**: after the spine runs in Phase 3, apply the same
 documented python3 filter step against `changed-files.z` before producing per-pack slices.
@@ -1311,6 +1370,44 @@ else
     --repo  "$REPO_DIR" \
     --tools "$SPINE_TOOLS" \
     --output "$AUDIT_DIR/current/spine/findings.jsonl"
+fi
+
+# Diff mode: apply the Phase 1.5 post-filter to the spine findings NOW, before slicing.
+if [ "${DIFF_MODE:-false}" = "true" ] || [ "${STAGED_MODE:-false}" = "true" ]; then
+  python3 - \
+    "$AUDIT_DIR/current/spine/findings.jsonl" \
+    "$AUDIT_DIR/current/changed-files.z" \
+    "$AUDIT_DIR/current/spine/findings-diff-filtered.jsonl" << 'PYEOF'
+import json, sys
+spine_file, changed_z, out_file = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(changed_z, "rb") as fh:
+    data = fh.read()
+changed_set = set(
+    p.decode("utf-8", errors="surrogateescape")
+    for p in data.rstrip(b"\x00").split(b"\x00") if p
+)
+kept = 0; skipped = 0
+with open(spine_file, encoding="utf-8") as fin, \
+     open(out_file, "w", encoding="utf-8") as fout:
+    for raw in fin:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            rec = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if "type" in rec:
+            fout.write(raw + "\n"); continue
+        path = rec.get("location", {}).get("path", "")
+        if path in changed_set:
+            fout.write(raw + "\n"); kept += 1
+        else:
+            skipped += 1
+print(f"diff-filter (Phase 3): kept {kept}, skipped {skipped}", file=sys.stderr)
+PYEOF
+  mv "$AUDIT_DIR/current/spine/findings-diff-filtered.jsonl" \
+     "$AUDIT_DIR/current/spine/findings.jsonl"
 fi
 ```
 
@@ -1426,6 +1523,7 @@ flag on the specific check. A check is eligible for autonomous fix only when:
 | Task agent times out | Collect proceeds with completed workers, reports incomplete ones. |
 | All Task agents fail | Report failure, suggest `--manual` mode. |
 | `--single` with `--fix` | Print note: `--single is read-only; --fix ignored`. Proceed read-only. |
+| `--staged` with `--fix` | Print note: `--staged is read-only; --fix ignored`. Proceed read-only. |
 
 ---
 

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -16,7 +16,19 @@ Comprehensive codebase audit. Produces a findings document and creates GitHub is
 /audit --collect          # Compile results + create issues (after workers complete)
 /audit --collect --force  # Collect even if some agents haven't completed
 /audit --max-fixes 10     # Limit number of auto-fixes (only with --fix)
+
+# Diff-scoped audit (limit findings to changed files only)
+/audit --diff             # Audit only files changed vs the detected base branch (git diff)
+/audit --diff main        # Audit only files changed vs a specific ref
+/audit --staged           # Audit only files currently staged for commit
 ```
+
+> **Note on `--diff` and `--staged`**: These flags scope the audit to changed files only.
+> They are composable with `--single` (read-only), `--fix` (where fix mode already applies),
+> and with parallel-worktrees or multi-clone strategies. The deterministic spine still runs
+> against the full repo root; its findings are filtered to the changed-file set before
+> slicing and merging. LLM workers receive the changed-file list and are instructed to audit
+> only those files (except repo-wide checks whose subject file is in the changed set).
 
 > **Note on `--single` and `--fix`**: `--single` is always read-only. It never applies
 > fixes even if `--fix` is also passed. If you invoke `/audit --single --fix`, the `--fix`
@@ -65,6 +77,8 @@ This ensures the user always knows exactly what the audit will do before it star
 - `--fix` -> sets FIX_MODE=true (ignored silently when combined with --single)
 - `--max-fixes N` -> sets MAX_FIXES=N (only with --fix)
 - `--manual` -> Coordinator-Only Mode (Phases M1-M4 + output launch commands)
+- `--diff [ref]` -> sets DIFF_MODE=true; changed files computed via `git diff -z <ref>...HEAD` (ref defaults to BASE_BRANCH). Composable with `--single`, `--fix`, and all execution strategies.
+- `--staged` -> sets STAGED_MODE=true; changed files computed via `git diff -z --staged`. Composable with `--single` and all execution strategies (no `--fix` with `--staged` — staged-only runs are always read-only).
 - Remaining argument is the target path (default: entire repo)
 
 **If NO flags are passed, prompt the user with `AskUserQuestion` to configure the audit:**
@@ -195,6 +209,127 @@ Write `config.json`:
   "epic_issue": null
 }
 ```
+
+### Phase M2.1: Diff Scope (--diff / --staged only)
+
+**Skip this phase entirely for full-repo audits.** Only execute when `--diff` or `--staged` is set.
+
+1. **Compute the changed-file set once** and write it to the coordination directory:
+
+   ```bash
+   # --diff mode: changed files vs <ref>...HEAD
+   if [ "${DIFF_MODE:-false}" = "true" ]; then
+     DIFF_REF="${DIFF_REF:-$BASE_BRANCH}"
+     git -C "$REPO_DIR" diff --name-only -z "${DIFF_REF}...HEAD" \
+       > "$AUDIT_DIR/current/changed-files.z"
+   fi
+
+   # --staged mode: staged files only
+   if [ "${STAGED_MODE:-false}" = "true" ]; then
+     git -C "$REPO_DIR" diff --name-only -z --staged \
+       > "$AUDIT_DIR/current/changed-files.z"
+   fi
+
+   # Generate the human-readable version FROM the -z file using python3.
+   # Never split on shell word boundaries — filenames may contain spaces,
+   # semicolons, or other metacharacters; they must remain inert data.
+   python3 - "$AUDIT_DIR/current/changed-files.z" \
+             "$AUDIT_DIR/current/changed-files.txt" << 'PYEOF'
+   import sys
+   with open(sys.argv[1], "rb") as fh:
+       data = fh.read()
+   # Null-delimited; strip trailing null before splitting
+   paths = [p.decode("utf-8", errors="surrogateescape")
+            for p in data.rstrip(b"\x00").split(b"\x00") if p]
+   with open(sys.argv[2], "w", encoding="utf-8") as out:
+       for p in paths:
+           out.write(p + "\n")
+   print(f"diff scope: {len(paths)} changed file(s)", file=__import__('sys').stderr)
+   PYEOF
+   ```
+
+2. **Empty-set guard**: if `changed-files.z` is empty (zero bytes or contains only null bytes), print a message and exit cleanly — no spine, no workers, no report:
+
+   ```bash
+   CHANGED_COUNT=$(python3 -c "
+   import sys
+   data = open(sys.argv[1], 'rb').read()
+   paths = [p for p in data.rstrip(b'\x00').split(b'\x00') if p]
+   print(len(paths))
+   " "$AUDIT_DIR/current/changed-files.z")
+
+   if [ "${CHANGED_COUNT:-0}" -eq 0 ]; then
+     echo "no changed files — nothing to audit"
+     exit 0
+   fi
+   ```
+
+3. **Update config.json** with diff scope metadata:
+   ```json
+   {
+     "scope": "diff",
+     "diff_ref": "<ref or 'staged'>",
+     "changed_files": <count>
+   }
+   ```
+
+4. The rest of the M-phase pipeline runs unchanged. The diff scope is enforced in two ways:
+   - **LLM scoping**: task files written in Phase M4 include the absolute path to `changed-files.txt` and the instruction: "Audit ONLY files listed in changed-files.txt. Checks whose subject is repo-wide (dependency manifests, ToS surfaces) run only if their subject file is in that list."
+   - **Spine post-filter**: after the spine runs (Phase M4), filter its findings before slicing:
+
+   ```bash
+   python3 - \
+     "$AUDIT_DIR/current/spine/findings.jsonl" \
+     "$AUDIT_DIR/current/changed-files.z" \
+     "$AUDIT_DIR/current/spine/findings-diff-filtered.jsonl" << 'PYEOF'
+   import json, sys
+
+   spine_file, changed_z, out_file = sys.argv[1], sys.argv[2], sys.argv[3]
+
+   # Read changed paths null-delimited — no shell interpolation anywhere.
+   with open(changed_z, "rb") as fh:
+       data = fh.read()
+   changed_set = set(
+       p.decode("utf-8", errors="surrogateescape")
+       for p in data.rstrip(b"\x00").split(b"\x00") if p
+   )
+
+   kept = 0
+   skipped = 0
+   with open(spine_file, encoding="utf-8") as fin, \
+        open(out_file, "w", encoding="utf-8") as fout:
+       for raw in fin:
+           raw = raw.strip()
+           if not raw:
+               continue
+           try:
+               rec = json.loads(raw)
+           except json.JSONDecodeError:
+               continue
+           # coverage_gap and provenance records always pass through.
+           if "type" in rec:
+               fout.write(raw + "\n")
+               continue
+           # Finding records: keep only if location.path is in the changed set.
+           path = rec.get("location", {}).get("path", "")
+           if path in changed_set:
+               fout.write(raw + "\n")
+               kept += 1
+           else:
+               skipped += 1
+
+   print(f"diff-filter: kept {kept} finding(s), skipped {skipped} (not in changed set)",
+         file=__import__('sys').stderr)
+   PYEOF
+
+   # Replace the spine findings file with the filtered version for downstream phases.
+   mv "$AUDIT_DIR/current/spine/findings-diff-filtered.jsonl" \
+      "$AUDIT_DIR/current/spine/findings.jsonl"
+   ```
+
+5. **Report header**: the audit report compiled in Phase M6 includes:
+   > `Diff scope: N changed files (ref: <ref or "staged">)`.
+   > Deterministic tools scanned the full repository root; findings are scoped to the changed-file set.
 
 ### Phase M2.5: Create Epic Issue
 
@@ -996,7 +1131,10 @@ Merge from `origin/audit/agent-$i-$AUDIT_DATE`.
    done
 
    if [ "${USE_CLONES:-false}" = "true" ]; then
-     # Multi-clone: branches were pushed to origin — merge from origin refs
+     # Multi-clone: branches were pushed to origin — fetch first so the
+     # coordinator sees them (coordinator may not have fetched since workers pushed).
+     git fetch origin
+     # Merge from origin refs
      for i in 0 1 2 3; do
        BRANCH="origin/audit/agent-$i-$AUDIT_DATE"
        git rev-parse --verify --quiet "origin/audit/agent-$i-$AUDIT_DATE" 2>/dev/null || continue
@@ -1056,8 +1194,9 @@ EOF
      echo "  Expected branches:" >&2
      for b in "${EXPECTED_BRANCHES[@]}"; do echo "    $b" >&2; done
      echo "  No combined branch was pushed and no PR was created." >&2
-     echo "  Possible causes: workers did not commit, wrong AUDIT_DATE, or branches" >&2
-     echo "  were removed before M6-fix ran." >&2
+     echo "  Possible causes: workers did not commit, wrong AUDIT_DATE, branches" >&2
+     echo "  were removed before M6-fix ran, or (multi-clone) coordinator has not" >&2
+     echo "  fetched since workers pushed (run 'git fetch origin' and retry)." >&2
      exit 1
    fi
    ```
@@ -1106,6 +1245,28 @@ mkdir -p "$AUDIT_DIR/current/spine"
 mkdir -p "$AUDIT_DIR/current/results"
 grep -qxF '.audit/' .gitignore 2>/dev/null || echo '.audit/' >> .gitignore
 ```
+
+### Phase 1.5: Diff Scope (--diff / --staged only, single-session)
+
+**Skip this phase entirely for full-repo audits.** Only execute when `--diff` or `--staged` is set.
+
+Same mechanics as Phase M2.1 in Autonomous Mode: compute the changed-file set once, write
+`$AUDIT_DIR/current/changed-files.z` (null-delimited) and `changed-files.txt` (one path per
+line, generated by python3 from the -z file — never by shell string-splitting), guard on empty
+set, and update config.json. All python3 parsing is null-delimited end-to-end; filenames
+containing spaces, semicolons, or newlines are inert data and are never interpolated into a shell
+string.
+
+**Spine post-filter (single-session)**: after the spine runs in Phase 3, apply the same
+documented python3 filter step against `changed-files.z` before producing per-pack slices.
+Filter spine findings whose `location.path` is NOT in the changed set; pass through all
+`coverage_gap` and `provenance` records unfiltered.
+
+**LLM scoping**: each pack subagent's prompt in Phase 4 includes the absolute path to
+`changed-files.txt` and the rule: "Audit ONLY files listed in changed-files.txt. Checks
+whose subject is repo-wide run only if their subject file is in that list."
+
+**Report header**: same as M-phase — note diff scope and changed-file count.
 
 ### Phase 2: Ecosystem Detection + Pack Selection
 

--- a/modules/commands-extra/skills/audit/scripts/emit-findings.py
+++ b/modules/commands-extra/skills/audit/scripts/emit-findings.py
@@ -171,7 +171,7 @@ def validate_finding(obj: dict) -> None:
     if not _RE_FINGERPRINT.match(obj["fingerprint"]):
         raise ValidationError(
             f"fingerprint '{obj['fingerprint']}' does not match "
-            "^[A-Za-z0-9_.:+/=-]{{8,128}}$"
+            "^[A-Za-z0-9_.:+/=-]{8,128}$"
         )
 
 

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-dep-audit.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-dep-audit.py
@@ -88,7 +88,8 @@ def process_npm_pnpm(data, pm):
             message=message,
             fingerprint=fp,
             properties={
-                "tool": pm,
+                "tool": "dep-audit",
+                "package_manager": pm,
                 "package": pkg_name,
             },
         )
@@ -144,7 +145,8 @@ def process_yarn(data):
             message=message,
             fingerprint=fp,
             properties={
-                "tool": "yarn",
+                "tool": "dep-audit",
+                "package_manager": "yarn",
                 "package": pkg,
             },
         )

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-eslint.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-eslint.sh
@@ -34,10 +34,10 @@ TMPFILE="$(mktemp /tmp/ccgm-eslint-XXXXXX.json)"
 trap 'rm -f "$TMPFILE"' EXIT
 
 # Config isolation: --no-config-lookup is the critical flag.
-# We pass --rule '{}' so no rules run by default -- this is intentional:
-# the audit spine is for security/quality rules from known packs, not
-# running the repo's own lint config against itself.
-# repo_root is passed via cd in subshell, glob is a static pattern.
+# We pass a fixed minimal eval-rule set (no-eval, no-implied-eval, no-new-func)
+# so only the audit spine's known security rules run -- the repo's own lint
+# config is never loaded.  repo_root is passed via cd in subshell, glob is
+# a static pattern.
 set +e
 (
   cd "$REPO_ROOT"

--- a/modules/commands-extra/skills/audit/tests/test-diff-mode.sh
+++ b/modules/commands-extra/skills/audit/tests/test-diff-mode.sh
@@ -127,7 +127,7 @@ with open(spine_file, encoding="utf-8") as fin, \
         else:
             skipped += 1
 
-print(f"diff-filter: kept {kept} finding(s), skipped {skipped}", file=__import__('sys').stderr)
+print(f"diff-filter: kept {kept} finding(s), skipped {skipped}", file=sys.stderr)
 PYEOF
 }
 
@@ -173,10 +173,8 @@ git -C "$REPO1" commit -q -m "base"
 
 BASE_SHA=$(git -C "$REPO1" rev-parse HEAD)
 
-# Second commit: doesn't change anything (we need HEAD~1 to be the "base")
-# Actually: make "base" the base ref and modify modified.js AFTER commit
-# so git diff BASE_SHA...HEAD shows nothing (same commit).
-# Better: make a real second commit to HEAD so we can diff HEAD~1...HEAD.
+# Two-commit fixture: HEAD~1 is the base, HEAD introduces the change to modified.js.
+# git diff HEAD~1...HEAD therefore lists only modified.js, leaving clean.js unchanged.
 printf 'const y = 3;  // changed\n' > "$REPO1/modified.js"
 git -C "$REPO1" add modified.js
 git -C "$REPO1" commit -q -m "change modified.js"
@@ -553,8 +551,34 @@ with open(sys.argv[2], 'w', encoding='utf-8') as out:
     for p in paths:
         out.write(p + '\n')
 PYEOF
-# .txt view is known-lossy for newline-embedded names; only .z is canonical.
-pass "newline-named file: .txt view is known-lossy for embedded newlines (documented); .z is canonical"
+# Assert the divergence that motivated using -z: naive line-splitting of changed-files.txt
+# does NOT reproduce the python3 -z parse for a newline-embedded filename.
+# The .z file holds exactly 1 null-delimited path; the .txt file (newline-delimited) splits
+# the embedded newline and produces 2 lines -- proving .z is the correct canonical form.
+DIVERGE_RESULT=$(python3 - "$NEWLINE_Z" "$NEWLINE_TXT" << 'PYEOF'
+import sys
+z_file, txt_file = sys.argv[1], sys.argv[2]
+# z parse: canonical, 1 path
+with open(z_file, "rb") as fh:
+    data = fh.read()
+z_paths = [p.decode("utf-8", errors="surrogateescape")
+           for p in data.rstrip(b"\x00").split(b"\x00") if p]
+# txt parse: naive line-split, lossy for embedded newlines
+with open(txt_file, "r", encoding="utf-8") as fh:
+    txt_lines = [l.rstrip("\n") for l in fh.readlines() if l.rstrip("\n")]
+z_count = len(z_paths)
+txt_count = len(txt_lines)
+if z_count == 1 and txt_count == 2:
+    print("DIVERGE_OK")
+else:
+    print(f"UNEXPECTED: z_count={z_count} txt_count={txt_count}")
+PYEOF
+)
+if [ "$DIVERGE_RESULT" = "DIVERGE_OK" ]; then
+  pass "newline-named file: .txt line-split gives 2 lines vs .z path count 1 (lossy .txt confirmed; .z is canonical)"
+else
+  fail "newline-named file: expected .txt line count 2 vs .z path count 1 (got: $DIVERGE_RESULT)"
+fi
 
 # Apply diff filter: the newline-named file IS in the changed set and must survive.
 NL_SYNTH_SPINE=$(make_tmp)/nl-synth.jsonl
@@ -743,6 +767,37 @@ PYEOF
     pass "spine post-filter: spine found >= 1 finding before filter (both files have secrets)"
   else
     fail "spine post-filter: expected >= 1 finding before filter (gitleaks should detect fake key)"
+  fi
+
+  # Precondition: pre-filter spine MUST contain a finding for unchanged.js.
+  # This makes the exclusion assert below non-vacuous — if the spine never found
+  # unchanged.js, the "excluded" assert would pass trivially even if the filter broke.
+  # Dependency: wrap-gitleaks.sh scans the working tree (--no-git mode); if it ever
+  # switches to history-scan, unchanged.js would not be scanned and this precondition
+  # would fail loudly, surfacing the gap.
+  PRECOND_UNCHANGED=$(python3 - "$SPINE3_OUT" << 'PYEOF'
+import json, sys
+for raw in open(sys.argv[1]):
+    raw = raw.strip()
+    if not raw:
+        continue
+    try:
+        rec = json.loads(raw)
+    except Exception:
+        continue
+    if "type" in rec:
+        continue
+    path = rec.get("location", {}).get("path", "")
+    if "unchanged.js" in path:
+        print("FOUND")
+        import sys; sys.exit(0)
+print("NOT_FOUND")
+PYEOF
+)
+  if [ "$PRECOND_UNCHANGED" = "FOUND" ]; then
+    pass "spine post-filter precondition: pre-filter spine contains finding for 'unchanged.js'"
+  else
+    fail "spine post-filter precondition: pre-filter spine must contain finding for 'unchanged.js' (non-vacuous exclusion check)"
   fi
 
   # Apply diff filter
@@ -1006,6 +1061,45 @@ if [ "${SPINE_SINGLE:-0}" -ge 1 ]; then
   pass "SKILL.md --single Phase 3: spine/run.sh invocation is still present"
 else
   fail "SKILL.md --single Phase 3: spine/run.sh must still be invoked for full-repo mode"
+fi
+
+# 5f. --staged x --fix contract: documented in Error Handling table and mode detection
+set +e
+ERR_SECTION=$(awk '/^## Error Handling/,/^---/' "$SKILL_MD" 2>/dev/null || true)
+STAGED_FIX_ERR=$(echo "$ERR_SECTION" | grep -c "staged.*fix\|--staged.*--fix\|--staged.*read-only" 2>/dev/null || true)
+STAGED_FIX_MD=$(echo "$MD_SECTION" | grep -c "staged.*fix\|--staged.*ignored\|--staged.*read-only" 2>/dev/null || true)
+set -e
+
+if [ "${STAGED_FIX_ERR:-0}" -ge 1 ]; then
+  pass "SKILL.md Error Handling: --staged x --fix contract documented"
+else
+  fail "SKILL.md Error Handling: must document --staged with --fix (read-only; --fix ignored)"
+fi
+
+if [ "${STAGED_FIX_MD:-0}" -ge 1 ]; then
+  pass "SKILL.md Mode Detection: --staged x --fix contract documented"
+else
+  fail "SKILL.md Mode Detection: --staged must note --fix is ignored"
+fi
+
+# 5g. Diff-mode filter-ordering at M4 and Phase 3 execution sites
+set +e
+M4_SECTION_FULL=$(awk '/^### Phase M4/,/^### Phase M5/' "$SKILL_MD" 2>/dev/null || true)
+PHASE3_FULL=$(awk '/^### Phase 3: Run the Spine/,/^### Phase 4/' "$SKILL_MD" 2>/dev/null || true)
+M4_FILTER=$(echo "$M4_SECTION_FULL" | grep -c "Diff mode.*post-filter\|diff-filter.*M4\|post-filter.*before slicing" 2>/dev/null || true)
+P3_FILTER=$(echo "$PHASE3_FULL" | grep -c "Diff mode.*post-filter\|diff-filter.*Phase 3\|post-filter.*before slicing" 2>/dev/null || true)
+set -e
+
+if [ "${M4_FILTER:-0}" -ge 1 ]; then
+  pass "SKILL.md M4: diff-mode post-filter applied before slicing is documented"
+else
+  fail "SKILL.md M4: diff-mode post-filter must be documented at the M4 execution site"
+fi
+
+if [ "${P3_FILTER:-0}" -ge 1 ]; then
+  pass "SKILL.md --single Phase 3: diff-mode post-filter applied before slicing is documented"
+else
+  fail "SKILL.md --single Phase 3: diff-mode post-filter must be documented at Phase 3 execution site"
 fi
 
 # ---------------------------------------------------------------------------

--- a/modules/commands-extra/skills/audit/tests/test-diff-mode.sh
+++ b/modules/commands-extra/skills/audit/tests/test-diff-mode.sh
@@ -1,0 +1,831 @@
+#!/usr/bin/env bash
+# test-diff-mode.sh
+# Tests for Epic 1.8: --diff / --staged diff-scoped audit mode.
+#
+# Test groups:
+#   1. Changed-set computation: --diff and --staged commands + -z file contents
+#   2. Hostile filename: "evil; touch PWNED.js" is inert data throughout
+#   3. Spine post-filter: finding from changed file survives; unchanged file finding excluded;
+#      coverage_gap/provenance records pass through unfiltered
+#   4. Empty diff: exits cleanly with message, no artifacts beyond changed-files.z
+#   5. Consistency: SKILL.md documents --diff/--staged in Usage + mode detection + both paths;
+#      spine-once step is unconditional for non-diff mode (no regression)
+#
+# All fixtures are constructed at runtime in mktemp dirs; none are tracked.
+#
+# ADV-009: fake secret assembled from fragments at runtime -- never appears whole in source.
+#
+# Usage: bash modules/commands-extra/skills/audit/tests/test-diff-mode.sh
+# Exit:  0 = all pass, non-zero = at least one failure
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SPINE_SCRIPT="${AUDIT_DIR}/scripts/spine/run.sh"
+SKILL_MD="${AUDIT_DIR}/SKILL.md"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+pass() {
+  printf '  [PASS] %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  ERRORS+=("$1")
+  FAIL=$((FAIL + 1))
+}
+
+TMPDIRS=()
+cleanup() {
+  for d in "${TMPDIRS[@]:-}"; do
+    rm -rf "$d" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+make_tmp() {
+  local d
+  d=$(mktemp -d)
+  TMPDIRS+=("$d")
+  echo "$d"
+}
+
+# Create a git fixture repo with hooks disabled (prevents global pre-commit
+# hooks from firing on deliberate test-secret commits).
+make_repo() {
+  local d
+  d=$(make_tmp)
+  git -C "$d" init -q
+  git -C "$d" config user.email "test@example.com"
+  git -C "$d" config user.name "Test"
+  # Override global hooksPath so no pre-commit hook fires in fixture repos.
+  local empty_hooks
+  empty_hooks=$(make_tmp)
+  git -C "$d" config core.hooksPath "$empty_hooks"
+  echo "$d"
+}
+
+# Parse null-delimited changed-files.z -> list of paths using python3
+read_z_file() {
+  local z_file="$1"
+  python3 - "$z_file" << 'PYEOF'
+import sys
+with open(sys.argv[1], "rb") as fh:
+    data = fh.read()
+paths = [p.decode("utf-8", errors="surrogateescape")
+         for p in data.rstrip(b"\x00").split(b"\x00") if p]
+for p in paths:
+    print(p)
+PYEOF
+}
+
+# Apply the documented diff filter step to spine JSONL.
+# Reads null-delimited changed-files.z; outputs filtered JSONL.
+apply_diff_filter() {
+  local spine_file="$1"
+  local changed_z="$2"
+  local out_file="$3"
+  python3 - "$spine_file" "$changed_z" "$out_file" << 'PYEOF'
+import json, sys
+
+spine_file, changed_z, out_file = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(changed_z, "rb") as fh:
+    data = fh.read()
+changed_set = set(
+    p.decode("utf-8", errors="surrogateescape")
+    for p in data.rstrip(b"\x00").split(b"\x00") if p
+)
+
+kept = 0
+skipped = 0
+with open(spine_file, encoding="utf-8") as fin, \
+     open(out_file, "w", encoding="utf-8") as fout:
+    for raw in fin:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            rec = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if "type" in rec:
+            fout.write(raw + "\n")
+            continue
+        path = rec.get("location", {}).get("path", "")
+        if path in changed_set:
+            fout.write(raw + "\n")
+            kept += 1
+        else:
+            skipped += 1
+
+print(f"diff-filter: kept {kept} finding(s), skipped {skipped}", file=__import__('sys').stderr)
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== test-diff-mode.sh (Epic 1.8) ==="
+echo ""
+
+for tool in python3 git; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "ERROR: required tool '$tool' not found" >&2
+    exit 1
+  fi
+done
+
+for f in "$SPINE_SCRIPT" "$SKILL_MD"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: required file not found: $f" >&2
+    exit 1
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# GROUP 1: Changed-set computation
+# ---------------------------------------------------------------------------
+echo "--- [1] Changed-set computation: --diff and --staged ---"
+echo ""
+
+# Build a fixture git repo with two files:
+#   clean.js   -- committed in the base commit
+#   modified.js -- committed in the base commit, then modified (working tree)
+# and a staged variant: staged.js added to the index but not committed.
+
+REPO1=$(make_repo)
+
+# Base commit: clean.js
+printf 'const x = 1;\n' > "$REPO1/clean.js"
+printf 'const y = 2;\n' > "$REPO1/modified.js"
+git -C "$REPO1" add -A
+git -C "$REPO1" commit -q -m "base"
+
+BASE_SHA=$(git -C "$REPO1" rev-parse HEAD)
+
+# Second commit: doesn't change anything (we need HEAD~1 to be the "base")
+# Actually: make "base" the base ref and modify modified.js AFTER commit
+# so git diff BASE_SHA...HEAD shows nothing (same commit).
+# Better: make a real second commit to HEAD so we can diff HEAD~1...HEAD.
+printf 'const y = 3;  // changed\n' > "$REPO1/modified.js"
+git -C "$REPO1" add modified.js
+git -C "$REPO1" commit -q -m "change modified.js"
+
+# Compute changed files via --diff (HEAD~1...HEAD)
+CHANGES_Z1=$(make_tmp)/changed1.z
+git -C "$REPO1" diff --name-only -z "HEAD~1...HEAD" > "$CHANGES_Z1"
+
+PATHS1=$(read_z_file "$CHANGES_Z1")
+
+if echo "$PATHS1" | grep -qxF "modified.js"; then
+  pass "git diff --name-only -z HEAD~1...HEAD includes 'modified.js'"
+else
+  fail "git diff --name-only -z HEAD~1...HEAD should include 'modified.js' (got: $PATHS1)"
+fi
+
+if ! echo "$PATHS1" | grep -qxF "clean.js"; then
+  pass "git diff --name-only -z HEAD~1...HEAD does NOT include 'clean.js' (unchanged)"
+else
+  fail "git diff --name-only -z HEAD~1...HEAD should NOT include 'clean.js'"
+fi
+
+# Generate changed-files.txt from the -z file using python3 (documented step)
+CHANGES_TXT1=$(make_tmp)/changed1.txt
+python3 - "$CHANGES_Z1" "$CHANGES_TXT1" << 'PYEOF'
+import sys
+with open(sys.argv[1], "rb") as fh:
+    data = fh.read()
+paths = [p.decode("utf-8", errors="surrogateescape")
+         for p in data.rstrip(b"\x00").split(b"\x00") if p]
+with open(sys.argv[2], "w", encoding="utf-8") as out:
+    for p in paths:
+        out.write(p + "\n")
+PYEOF
+
+TXT1_CONTENT=$(cat "$CHANGES_TXT1")
+if echo "$TXT1_CONTENT" | grep -qxF "modified.js"; then
+  pass "changed-files.txt (from python3 -z parse) contains 'modified.js'"
+else
+  fail "changed-files.txt should contain 'modified.js'"
+fi
+
+# Verify byte-exact round-trip: reading back the -z file should produce the same paths
+Z_PATHS=$(read_z_file "$CHANGES_Z1")
+TXT_PATHS=$(cat "$CHANGES_TXT1" | tr '\n' '|' | sed 's/|$//')
+Z_PATHS_PIPE=$(echo "$Z_PATHS" | tr '\n' '|' | sed 's/|$//')
+
+if [ "$Z_PATHS_PIPE" = "$TXT_PATHS" ]; then
+  pass "python3 -z parse: paths round-trip byte-exact between .z and .txt"
+else
+  fail "python3 -z parse: paths differ between .z and .txt (z='$Z_PATHS_PIPE' txt='$TXT_PATHS')"
+fi
+
+# Test --staged: stage a new file and verify git diff --staged detects it
+printf 'const z = 4;\n' > "$REPO1/staged.js"
+git -C "$REPO1" add staged.js
+
+STAGED_Z1=$(make_tmp)/staged1.z
+git -C "$REPO1" diff --name-only -z --staged > "$STAGED_Z1"
+
+STAGED_PATHS=$(read_z_file "$STAGED_Z1")
+
+if echo "$STAGED_PATHS" | grep -qxF "staged.js"; then
+  pass "git diff --name-only -z --staged includes 'staged.js'"
+else
+  fail "git diff --name-only -z --staged should include 'staged.js' (got: $STAGED_PATHS)"
+fi
+
+if ! echo "$STAGED_PATHS" | grep -qxF "modified.js"; then
+  pass "git diff --name-only -z --staged does NOT include committed 'modified.js'"
+else
+  fail "git diff --name-only -z --staged should NOT include already-committed 'modified.js'"
+fi
+
+# ---------------------------------------------------------------------------
+# GROUP 2: Hostile filename
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- [2] Hostile filename: inert through changed-set computation and filter ---"
+echo ""
+
+REPO2=$(make_repo)
+
+# Base commit with clean.js
+printf 'const safe = 1;\n' > "$REPO2/clean.js"
+git -C "$REPO2" add clean.js
+git -C "$REPO2" commit -q -m "base"
+
+# Add a file with a hostile name (semicolon + space in name)
+EVIL_NAME='evil; touch PWNED.js'
+printf 'const evil = 1;\n' > "$REPO2/$EVIL_NAME"
+git -C "$REPO2" add -- "$EVIL_NAME"
+git -C "$REPO2" commit -q -m "add hostile-named file"
+
+# Compute changed set
+EVIL_Z=$(make_tmp)/evil-changed.z
+git -C "$REPO2" diff --name-only -z "HEAD~1...HEAD" > "$EVIL_Z"
+
+EVIL_PATHS=$(read_z_file "$EVIL_Z")
+
+# The hostile file should appear as inert data
+if echo "$EVIL_PATHS" | grep -qF "$EVIL_NAME"; then
+  pass "hostile filename '$EVIL_NAME' appears in changed-set as inert data"
+else
+  fail "hostile filename '$EVIL_NAME' missing from changed-set (got: $EVIL_PATHS)"
+fi
+
+# Critical: no PWNED file created during changed-set computation
+rm -f "$REPO2/PWNED.js" "$(pwd)/PWNED.js" "/tmp/PWNED.js" 2>/dev/null || true
+PWNED_FOUND=0
+for PWNED_PATH in "$REPO2/PWNED.js" "$(pwd)/PWNED.js" "/tmp/PWNED.js"; do
+  if [ -f "$PWNED_PATH" ]; then
+    PWNED_FOUND=$((PWNED_FOUND + 1))
+    echo "  PWNED found at: $PWNED_PATH" >&2
+  fi
+done
+if [ "$PWNED_FOUND" -eq 0 ]; then
+  pass "hostile filename: no PWNED.js created during changed-set computation"
+else
+  fail "hostile filename: PWNED.js was created -- shell injection succeeded (CRITICAL)"
+fi
+
+# Now apply the diff filter: create a synthetic spine JSONL with findings for both
+# the hostile file and a safe file.  The hostile file is "changed"; safe is not.
+SYNTH_SPINE=$(make_tmp)/synth.jsonl
+# Build a finding for the hostile filename (in changed set) and one for clean.js (not)
+python3 - "$SYNTH_SPINE" "$EVIL_NAME" << 'PYEOF'
+import json, sys
+spine_file, evil_name = sys.argv[1], sys.argv[2]
+lines = []
+# Finding for hostile-named file (should SURVIVE filter)
+lines.append(json.dumps({
+    "check_id": "security/leaked-credential",
+    "rule_id": "test-rule",
+    "severity": "high",
+    "confidence": "high",
+    "detection": "tool",
+    "source": "tool",
+    "message": "test finding in hostile-named file",
+    "location": {"path": evil_name, "line": 1},
+    "fingerprint": "AbCdEf1234567890AbCdEf1234567890AbCdEf12",
+}))
+# Finding for clean.js (should be EXCLUDED by filter)
+lines.append(json.dumps({
+    "check_id": "security/leaked-credential",
+    "rule_id": "test-rule",
+    "severity": "high",
+    "confidence": "high",
+    "detection": "tool",
+    "source": "tool",
+    "message": "test finding in clean.js",
+    "location": {"path": "clean.js", "line": 1},
+    "fingerprint": "BbCcDd1234567890BbCcDd1234567890BbCcDd12",
+}))
+# coverage_gap record (should PASS THROUGH unconditionally)
+lines.append(json.dumps({
+    "type": "coverage_gap",
+    "tool": "semgrep",
+    "check_id": "spine/wrapper-error",
+    "description": "semgrep not installed",
+}))
+# provenance record (should PASS THROUGH unconditionally)
+lines.append(json.dumps({
+    "type": "provenance",
+    "tool": "ccgm-spine",
+    "version": "1.0",
+    "repo": "/tmp/test",
+    "tools_requested": "gitleaks",
+    "timestamp": "2026-01-01T00:00:00Z",
+}))
+with open(spine_file, "w") as fh:
+    for l in lines:
+        fh.write(l + "\n")
+PYEOF
+
+EVIL_FILTER_OUT=$(make_tmp)/evil-filtered.jsonl
+apply_diff_filter "$SYNTH_SPINE" "$EVIL_Z" "$EVIL_FILTER_OUT"
+
+# Verify: hostile-named finding SURVIVES
+EVIL_FINDING_FOUND=$(python3 - "$EVIL_FILTER_OUT" "$EVIL_NAME" << 'PYEOF'
+import json, sys
+out_file, evil_name = sys.argv[1], sys.argv[2]
+for raw in open(out_file):
+    raw = raw.strip()
+    if not raw:
+        continue
+    try:
+        rec = json.loads(raw)
+    except Exception:
+        continue
+    if "type" in rec:
+        continue
+    if rec.get("location", {}).get("path") == evil_name:
+        print("FOUND")
+        import sys; sys.exit(0)
+print("NOT_FOUND")
+PYEOF
+)
+
+if [ "$EVIL_FINDING_FOUND" = "FOUND" ]; then
+  pass "hostile filename: finding for '$EVIL_NAME' SURVIVES diff filter (in changed set)"
+else
+  fail "hostile filename: finding for '$EVIL_NAME' should survive diff filter (in changed set)"
+fi
+
+# Verify: clean.js finding is EXCLUDED
+CLEAN_FINDING_FOUND=$(python3 - "$EVIL_FILTER_OUT" << 'PYEOF'
+import json, sys
+for raw in open(sys.argv[1]):
+    raw = raw.strip()
+    if not raw:
+        continue
+    try:
+        rec = json.loads(raw)
+    except Exception:
+        continue
+    if "type" in rec:
+        continue
+    if rec.get("location", {}).get("path") == "clean.js":
+        print("FOUND")
+        import sys; sys.exit(0)
+print("NOT_FOUND")
+PYEOF
+)
+
+if [ "$CLEAN_FINDING_FOUND" = "NOT_FOUND" ]; then
+  pass "hostile filename: finding for 'clean.js' EXCLUDED by diff filter (not in changed set)"
+else
+  fail "hostile filename: finding for 'clean.js' should be excluded (not in changed set)"
+fi
+
+# Verify: coverage_gap and provenance pass through
+COVGAP_FOUND=$(python3 - "$EVIL_FILTER_OUT" << 'PYEOF'
+import json, sys
+for raw in open(sys.argv[1]):
+    raw = raw.strip()
+    if not raw:
+        continue
+    try:
+        rec = json.loads(raw)
+    except Exception:
+        continue
+    if rec.get("type") == "coverage_gap":
+        print("FOUND")
+        import sys; sys.exit(0)
+print("NOT_FOUND")
+PYEOF
+)
+if [ "$COVGAP_FOUND" = "FOUND" ]; then
+  pass "hostile filename: coverage_gap record passes through diff filter"
+else
+  fail "hostile filename: coverage_gap record should pass through diff filter unconditionally"
+fi
+
+PROV_FOUND=$(python3 - "$EVIL_FILTER_OUT" << 'PYEOF'
+import json, sys
+for raw in open(sys.argv[1]):
+    raw = raw.strip()
+    if not raw:
+        continue
+    try:
+        rec = json.loads(raw)
+    except Exception:
+        continue
+    if rec.get("type") == "provenance":
+        print("FOUND")
+        import sys; sys.exit(0)
+print("NOT_FOUND")
+PYEOF
+)
+if [ "$PROV_FOUND" = "FOUND" ]; then
+  pass "hostile filename: provenance record passes through diff filter"
+else
+  fail "hostile filename: provenance record should pass through diff filter unconditionally"
+fi
+
+# Critical: path round-trips byte-exact through .z and back
+EVIL_Z_ROUNDTRIP=$(read_z_file "$EVIL_Z" | head -1)
+if [ "$EVIL_Z_ROUNDTRIP" = "$EVIL_NAME" ]; then
+  pass "hostile filename: path round-trips byte-exact through null-delimited .z file"
+else
+  fail "hostile filename: path did not round-trip byte-exact (got '$EVIL_Z_ROUNDTRIP' expected '$EVIL_NAME')"
+fi
+
+# ---------------------------------------------------------------------------
+# GROUP 3: Spine post-filter with real gitleaks (if available)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- [3] Spine post-filter: changed-file finding survives; unchanged excluded ---"
+echo ""
+
+if command -v gitleaks >/dev/null 2>&1; then
+  REPO3=$(make_repo)
+
+  # Base commit: clean files (no secrets)
+  printf 'const x = 1;\n' > "$REPO3/unchanged.js"
+  printf 'const y = 2;\n' > "$REPO3/changed.js"
+  git -C "$REPO3" add -A
+  git -C "$REPO3" commit -q -m "base"
+
+  # Modify changed.js: inject a fake AWS key (ADV-009 pattern)
+  KEY_PREFIX3="AKIAZ12345"
+  KEY_SUFFIX3="6789ABCDEFGH"
+  FAKE_KEY3="${KEY_PREFIX3}${KEY_SUFFIX3}"
+  printf '// This file intentionally contains a test secret for scanner validation\nconst AWS_KEY = "%s";\n' "$FAKE_KEY3" \
+    > "$REPO3/changed.js"
+
+  # Also inject the same fake key into unchanged.js (to test filtering)
+  printf '// This file intentionally contains a test secret for scanner validation\nconst AWS_KEY2 = "%s";\n' "$FAKE_KEY3" \
+    > "$REPO3/unchanged.js"
+
+  git -C "$REPO3" add changed.js
+  git -C "$REPO3" commit -q -m "add secret to changed.js"
+
+  # Compute the changed set (only changed.js -- unchanged.js was not committed after base)
+  CHANGES_Z3=$(make_tmp)/changed3.z
+  git -C "$REPO3" diff --name-only -z "HEAD~1...HEAD" > "$CHANGES_Z3"
+
+  CHANGED_PATHS3=$(read_z_file "$CHANGES_Z3")
+
+  if echo "$CHANGED_PATHS3" | grep -qxF "changed.js"; then
+    pass "spine post-filter fixture: 'changed.js' in changed set"
+  else
+    fail "spine post-filter fixture: 'changed.js' should be in changed set (got: $CHANGED_PATHS3)"
+  fi
+
+  if ! echo "$CHANGED_PATHS3" | grep -qxF "unchanged.js"; then
+    pass "spine post-filter fixture: 'unchanged.js' NOT in changed set"
+  else
+    fail "spine post-filter fixture: 'unchanged.js' should NOT be in changed set"
+  fi
+
+  # Run real spine against the fixture repo
+  SPINE3_OUT=$(make_tmp)/spine3.jsonl
+  set +e
+  bash "$SPINE_SCRIPT" \
+    --repo  "$REPO3" \
+    --tools "gitleaks" \
+    --output "$SPINE3_OUT" 2>/dev/null
+  SPINE3_EC=$?
+  set -e
+
+  if [ "$SPINE3_EC" -eq 0 ] && [ -f "$SPINE3_OUT" ]; then
+    pass "spine post-filter: spine ran successfully (exit 0)"
+  else
+    fail "spine post-filter: spine failed (exit $SPINE3_EC) or output missing"
+  fi
+
+  # Count findings before filter (both changed.js and unchanged.js should have secrets)
+  BEFORE_COUNT=$(python3 - "$SPINE3_OUT" << 'PYEOF'
+import json, sys
+count = 0
+for raw in open(sys.argv[1]):
+    raw = raw.strip()
+    if not raw:
+        continue
+    try:
+        rec = json.loads(raw)
+    except Exception:
+        continue
+    if "type" not in rec:
+        count += 1
+print(count)
+PYEOF
+)
+  if [ "${BEFORE_COUNT:-0}" -ge 1 ]; then
+    pass "spine post-filter: spine found >= 1 finding before filter (both files have secrets)"
+  else
+    fail "spine post-filter: expected >= 1 finding before filter (gitleaks should detect fake key)"
+  fi
+
+  # Apply diff filter
+  FILTERED3_OUT=$(make_tmp)/filtered3.jsonl
+  apply_diff_filter "$SPINE3_OUT" "$CHANGES_Z3" "$FILTERED3_OUT"
+
+  # Assert: finding for changed.js SURVIVES
+  CHANGED_SURVIVED=$(python3 - "$FILTERED3_OUT" << 'PYEOF'
+import json, sys
+for raw in open(sys.argv[1]):
+    raw = raw.strip()
+    if not raw:
+        continue
+    try:
+        rec = json.loads(raw)
+    except Exception:
+        continue
+    if "type" in rec:
+        continue
+    path = rec.get("location", {}).get("path", "")
+    if "changed.js" in path:
+        print("FOUND")
+        import sys; sys.exit(0)
+print("NOT_FOUND")
+PYEOF
+)
+  if [ "$CHANGED_SURVIVED" = "FOUND" ]; then
+    pass "spine post-filter: changed.js finding SURVIVES diff filter"
+  else
+    fail "spine post-filter: changed.js finding should survive (in changed set)"
+  fi
+
+  # Assert: finding for unchanged.js is EXCLUDED
+  UNCHANGED_EXCLUDED=$(python3 - "$FILTERED3_OUT" << 'PYEOF'
+import json, sys
+for raw in open(sys.argv[1]):
+    raw = raw.strip()
+    if not raw:
+        continue
+    try:
+        rec = json.loads(raw)
+    except Exception:
+        continue
+    if "type" in rec:
+        continue
+    path = rec.get("location", {}).get("path", "")
+    if "unchanged.js" in path:
+        print("FOUND")
+        import sys; sys.exit(0)
+print("NOT_FOUND")
+PYEOF
+)
+  if [ "$UNCHANGED_EXCLUDED" = "NOT_FOUND" ]; then
+    pass "spine post-filter: unchanged.js finding EXCLUDED by diff filter"
+  else
+    fail "spine post-filter: unchanged.js finding should be excluded (not in changed set)"
+  fi
+
+  # Assert: coverage_gap/provenance records pass through filter
+  META_PASS=$(python3 - "$FILTERED3_OUT" << 'PYEOF'
+import json, sys
+found_provenance = False
+for raw in open(sys.argv[1]):
+    raw = raw.strip()
+    if not raw:
+        continue
+    try:
+        rec = json.loads(raw)
+    except Exception:
+        continue
+    if rec.get("type") == "provenance":
+        found_provenance = True
+print("FOUND" if found_provenance else "NOT_FOUND")
+PYEOF
+)
+  if [ "$META_PASS" = "FOUND" ]; then
+    pass "spine post-filter: provenance record passes through filter"
+  else
+    fail "spine post-filter: provenance record should pass through diff filter unconditionally"
+  fi
+
+else
+  echo "  gitleaks not installed -- skipping spine post-filter e2e (SKIP, not FAIL)"
+  echo "  SKIP: spine post-filter: changed.js finding survives"
+  echo "  SKIP: spine post-filter: unchanged.js finding excluded"
+  echo "  SKIP: spine post-filter: meta records pass through"
+fi
+
+# ---------------------------------------------------------------------------
+# GROUP 4: Empty diff -> clean exit with message, no artifacts
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- [4] Empty diff -> clean exit, no spine/worker artifacts ---"
+echo ""
+
+REPO4=$(make_repo)
+
+printf 'const x = 1;\n' > "$REPO4/a.js"
+git -C "$REPO4" add -A
+git -C "$REPO4" commit -q -m "init"
+
+# No changes since HEAD -- diff is empty
+EMPTY_Z=$(make_tmp)/empty.z
+git -C "$REPO4" diff --name-only -z "HEAD...HEAD" > "$EMPTY_Z"
+
+EMPTY_COUNT=$(python3 - "$EMPTY_Z" << 'PYEOF'
+import sys
+data = open(sys.argv[1], "rb").read()
+paths = [p for p in data.rstrip(b"\x00").split(b"\x00") if p]
+print(len(paths))
+PYEOF
+)
+
+if [ "${EMPTY_COUNT:-0}" -eq 0 ]; then
+  pass "empty diff: changed-files.z contains zero paths"
+else
+  fail "empty diff: expected zero paths in changed-files.z, got $EMPTY_COUNT"
+fi
+
+# The documented guard: if count == 0, print message and exit 0 (no spine/workers/report)
+EMPTY_OUTPUT=$(python3 - "$EMPTY_Z" << 'PYEOF'
+import sys
+data = open(sys.argv[1], "rb").read()
+paths = [p for p in data.rstrip(b"\x00").split(b"\x00") if p]
+if len(paths) == 0:
+    print("no changed files -- nothing to audit")
+    sys.exit(0)
+print(f"would proceed with {len(paths)} files")
+sys.exit(1)
+PYEOF
+)
+
+if echo "$EMPTY_OUTPUT" | grep -q "no changed files"; then
+  pass "empty diff: documented exit message 'no changed files -- nothing to audit' emitted"
+else
+  fail "empty diff: expected 'no changed files' message from empty-set guard"
+fi
+
+# Staged empty diff
+EMPTY_STAGED_Z=$(make_tmp)/empty-staged.z
+git -C "$REPO4" diff --name-only -z --staged > "$EMPTY_STAGED_Z"
+
+EMPTY_STAGED_COUNT=$(python3 - "$EMPTY_STAGED_Z" << 'PYEOF'
+import sys
+data = open(sys.argv[1], "rb").read()
+paths = [p for p in data.rstrip(b"\x00").split(b"\x00") if p]
+print(len(paths))
+PYEOF
+)
+
+if [ "${EMPTY_STAGED_COUNT:-0}" -eq 0 ]; then
+  pass "empty staged diff: changed-files.z contains zero paths (no staged files)"
+else
+  fail "empty staged diff: expected zero paths, got $EMPTY_STAGED_COUNT"
+fi
+
+# ---------------------------------------------------------------------------
+# GROUP 5: SKILL.md consistency checks
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- [5] SKILL.md consistency: --diff/--staged documented in both paths ---"
+echo ""
+
+# 5a. --diff and --staged appear in the Usage section
+# Use state-tracking awk to avoid the same-line open/close trap.
+set +e
+DIFF_IN_USAGE=$(awk 'found && /^## /{exit} /^## Usage$/{found=1} found' "$SKILL_MD" \
+  | grep -c "\-\-diff" 2>/dev/null || true)
+STAGED_IN_USAGE=$(awk 'found && /^## /{exit} /^## Usage$/{found=1} found' "$SKILL_MD" \
+  | grep -c "\-\-staged" 2>/dev/null || true)
+set -e
+
+if [ "${DIFF_IN_USAGE:-0}" -ge 1 ]; then
+  pass "SKILL.md Usage: --diff is documented"
+else
+  fail "SKILL.md Usage: --diff must be documented in the Usage section"
+fi
+
+if [ "${STAGED_IN_USAGE:-0}" -ge 1 ]; then
+  pass "SKILL.md Usage: --staged is documented"
+else
+  fail "SKILL.md Usage: --staged must be documented in the Usage section"
+fi
+
+# 5b. --diff and --staged appear in Mode Detection
+set +e
+MD_SECTION=$(awk '/^### Mode Detection/,/^\*\*If NO flags/' "$SKILL_MD" 2>/dev/null || true)
+DIFF_IN_MD=$(echo "$MD_SECTION" | grep -c "\-\-diff" 2>/dev/null || true)
+STAGED_IN_MD=$(echo "$MD_SECTION" | grep -c "\-\-staged" 2>/dev/null || true)
+set -e
+
+if [ "${DIFF_IN_MD:-0}" -ge 1 ]; then
+  pass "SKILL.md Mode Detection: --diff is listed"
+else
+  fail "SKILL.md Mode Detection: --diff must be listed in mode detection flags"
+fi
+
+if [ "${STAGED_IN_MD:-0}" -ge 1 ]; then
+  pass "SKILL.md Mode Detection: --staged is listed"
+else
+  fail "SKILL.md Mode Detection: --staged must be listed in mode detection flags"
+fi
+
+# 5c. changed-files.z artifact is documented in BOTH M-phase and --single sections
+set +e
+M_SECTION=$(awk '/^### Phase M2\.1/,/^### Phase M2\.5/' "$SKILL_MD" 2>/dev/null || true)
+SINGLE_SECTION=$(awk '/^### Phase 1\.5/,/^### Phase 2/' "$SKILL_MD" 2>/dev/null || true)
+set -e
+
+if echo "$M_SECTION" | grep -q "changed-files.z"; then
+  pass "SKILL.md M-phase: changed-files.z artifact is documented"
+else
+  fail "SKILL.md M-phase: Phase M2.1 must document the changed-files.z artifact"
+fi
+
+if echo "$SINGLE_SECTION" | grep -q "changed-files.z"; then
+  pass "SKILL.md --single path: changed-files.z artifact is documented"
+else
+  fail "SKILL.md --single path: Phase 1.5 must document the changed-files.z artifact"
+fi
+
+# 5d. The diff-filter step (post-filter model) appears in BOTH paths
+if echo "$M_SECTION" | grep -q "diff.filter\|diff_filter\|filter.*spine\|spine.*filter"; then
+  pass "SKILL.md M-phase: spine post-filter step is documented"
+else
+  fail "SKILL.md M-phase: Phase M2.1 must document the spine post-filter step"
+fi
+
+if echo "$SINGLE_SECTION" | grep -q "diff.filter\|diff_filter\|filter.*spine\|spine.*filter\|post.filter\|postfilter"; then
+  pass "SKILL.md --single path: spine post-filter step is documented"
+else
+  fail "SKILL.md --single path: Phase 1.5 must document the spine post-filter step"
+fi
+
+# 5e. Full-repo spine-once step is UNCONDITIONAL (no --diff guard around it)
+# The documented form is:
+#   bash "$SKILL_ROOT/scripts/spine/run.sh" \
+#     --repo  "$REPO_DIR" \
+#     --tools "$SPINE_TOOLS" \
+#     --output "$AUDIT_DIR/current/spine/findings.jsonl"
+# This should appear without an outer if/else diff guard.
+# We just check the spine invocation still exists in the M4 section.
+set +e
+M4_SECTION=$(awk '/^### Phase M4/,/^### Phase M5/' "$SKILL_MD" 2>/dev/null || true)
+SPINE_ONCE=$(echo "$M4_SECTION" | grep -c "scripts/spine/run.sh" 2>/dev/null || true)
+set -e
+
+if [ "${SPINE_ONCE:-0}" -ge 1 ]; then
+  pass "SKILL.md M4: spine/run.sh invocation is still present (full-repo path unchanged)"
+else
+  fail "SKILL.md M4: spine/run.sh must still be invoked in Phase M4 for full-repo mode"
+fi
+
+# Also verify in --single Phase 3
+set +e
+PHASE3_SECTION=$(awk '/^### Phase 3: Run the Spine/,/^### Phase 4/' "$SKILL_MD" 2>/dev/null || true)
+SPINE_SINGLE=$(echo "$PHASE3_SECTION" | grep -c "scripts/spine/run.sh\|spine/run.sh" 2>/dev/null || true)
+set -e
+
+if [ "${SPINE_SINGLE:-0}" -ge 1 ]; then
+  pass "SKILL.md --single Phase 3: spine/run.sh invocation is still present"
+else
+  fail "SKILL.md --single Phase 3: spine/run.sh must still be invoked for full-repo mode"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "${#ERRORS[@]}" -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for e in "${ERRORS[@]}"; do
+    echo "  - $e"
+  done
+  echo ""
+  exit 1
+fi
+
+echo ""
+exit 0

--- a/modules/commands-extra/skills/audit/tests/test-diff-mode.sh
+++ b/modules/commands-extra/skills/audit/tests/test-diff-mode.sh
@@ -271,6 +271,11 @@ printf 'const evil = 1;\n' > "$REPO2/$EVIL_NAME"
 git -C "$REPO2" add -- "$EVIL_NAME"
 git -C "$REPO2" commit -q -m "add hostile-named file"
 
+# Critical: pre-clean any PWNED artifacts BEFORE the changed-set computation
+# so the existence check below is non-vacuous (any PWNED file found here was
+# created by the computation itself, not left over from a prior test step).
+rm -f "$REPO2/PWNED.js" "$(pwd)/PWNED.js" "/tmp/PWNED.js" 2>/dev/null || true
+
 # Compute changed set
 EVIL_Z=$(make_tmp)/evil-changed.z
 git -C "$REPO2" diff --name-only -z "HEAD~1...HEAD" > "$EVIL_Z"
@@ -284,8 +289,9 @@ else
   fail "hostile filename '$EVIL_NAME' missing from changed-set (got: $EVIL_PATHS)"
 fi
 
-# Critical: no PWNED file created during changed-set computation
-rm -f "$REPO2/PWNED.js" "$(pwd)/PWNED.js" "/tmp/PWNED.js" 2>/dev/null || true
+# Critical: no PWNED file created during changed-set computation.
+# (pre-clean ran before the computation above, so any PWNED file here was
+# created by it -- shell injection evidence that must fail loudly.)
 PWNED_FOUND=0
 for PWNED_PATH in "$REPO2/PWNED.js" "$(pwd)/PWNED.js" "/tmp/PWNED.js"; do
   if [ -f "$PWNED_PATH" ]; then
@@ -354,6 +360,21 @@ PYEOF
 
 EVIL_FILTER_OUT=$(make_tmp)/evil-filtered.jsonl
 apply_diff_filter "$SYNTH_SPINE" "$EVIL_Z" "$EVIL_FILTER_OUT"
+
+# Critical: apply_diff_filter must NOT have created any PWNED artifacts
+# (guards the python filter path, not just the shell computation above).
+PWNED_FOUND_POST=0
+for PWNED_PATH in "$REPO2/PWNED.js" "$(pwd)/PWNED.js" "/tmp/PWNED.js"; do
+  if [ -f "$PWNED_PATH" ]; then
+    PWNED_FOUND_POST=$((PWNED_FOUND_POST + 1))
+    echo "  PWNED found at: $PWNED_PATH" >&2
+  fi
+done
+if [ "$PWNED_FOUND_POST" -eq 0 ]; then
+  pass "hostile filename: no PWNED.js created during apply_diff_filter (python filter path)"
+else
+  fail "hostile filename: PWNED.js created by apply_diff_filter -- injection in filter path (CRITICAL)"
+fi
 
 # Verify: hostile-named finding SURVIVES
 EVIL_FINDING_FOUND=$(python3 - "$EVIL_FILTER_OUT" "$EVIL_NAME" << 'PYEOF'
@@ -459,6 +480,182 @@ if [ "$EVIL_Z_ROUNDTRIP" = "$EVIL_NAME" ]; then
   pass "hostile filename: path round-trips byte-exact through null-delimited .z file"
 else
   fail "hostile filename: path did not round-trip byte-exact (got '$EVIL_Z_ROUNDTRIP' expected '$EVIL_NAME')"
+fi
+
+# ---------------------------------------------------------------------------
+# GROUP 2b: Newline-named hostile file
+# A file whose name contains a literal newline exercises the case where
+# null-delimiting (-z) genuinely differs from line-splitting.  A plain
+# `git diff --name-only` (without -z) would split the name across two
+# lines, corrupting adjacent entries.  With -z the name is preserved as
+# a single opaque token in the binary stream.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- [2b] Newline-named hostile file: null-delimited .z handles embedded newline ---"
+echo ""
+
+REPO2B=$(make_repo)
+
+# Build the newline-embedded filename using printf into a variable;
+# never interpolate the raw name into an unquoted shell string.
+NEWLINE_NAME="$(printf 'evil\nname.js')"
+
+printf 'const safe = 1;\n' > "$REPO2B/clean.js"
+git -C "$REPO2B" add clean.js
+git -C "$REPO2B" commit -q -m "base"
+
+# Create the newline-named file; address it via the variable, not an inline name.
+printf 'const evil = 1;\n' > "$REPO2B/$NEWLINE_NAME"
+git -C "$REPO2B" add -- "$REPO2B/$NEWLINE_NAME"
+git -C "$REPO2B" commit -q -m "add newline-named file"
+
+# Compute changed set with -z (null-delimited)
+NEWLINE_Z=$(make_tmp)/newline-changed.z
+git -C "$REPO2B" diff --name-only -z "HEAD~1...HEAD" > "$NEWLINE_Z"
+
+# Round-trip: parse the .z file with python3; must produce the exact
+# embedded-newline name as a single opaque token.
+NEWLINE_ROUNDTRIP=$(python3 - "$NEWLINE_Z" "$NEWLINE_NAME" << 'PYEOF'
+import sys
+with open(sys.argv[1], 'rb') as fh:
+    data = fh.read()
+names = [p.decode('utf-8', errors='surrogateescape')
+         for p in data.rstrip(b'\x00').split(b'\x00') if p]
+expected = sys.argv[2]
+if expected in names:
+    print('FOUND')
+else:
+    print('NOT_FOUND: ' + repr(names))
+PYEOF
+)
+
+if [ "$NEWLINE_ROUNDTRIP" = "FOUND" ]; then
+  pass "newline-named file: path round-trips byte-exact through null-delimited .z file"
+else
+  fail "newline-named file: .z round-trip failed ($NEWLINE_ROUNDTRIP)"
+fi
+
+# The .z file is canonical for machine consumers.  The .txt (newline-delimited)
+# view is intentionally lossy for names that contain newlines -- the embedded
+# newline renders as a line break that looks like a path boundary in the txt.
+# We document this but assert only on the canonical .z parse.
+NEWLINE_TXT=$(make_tmp)/newline-changed.txt
+python3 - "$NEWLINE_Z" "$NEWLINE_TXT" << 'PYEOF'
+import sys
+with open(sys.argv[1], 'rb') as fh:
+    data = fh.read()
+paths = [p.decode('utf-8', errors='surrogateescape')
+         for p in data.rstrip(b'\x00').split(b'\x00') if p]
+# Note: writing a newline-embedded path to a newline-delimited .txt is
+# intentionally lossy -- the embedded newline becomes a line separator.
+# This is the known-lossy human-readable view; the .z file is canonical.
+with open(sys.argv[2], 'w', encoding='utf-8') as out:
+    for p in paths:
+        out.write(p + '\n')
+PYEOF
+# .txt view is known-lossy for newline-embedded names; only .z is canonical.
+pass "newline-named file: .txt view is known-lossy for embedded newlines (documented); .z is canonical"
+
+# Apply diff filter: the newline-named file IS in the changed set and must survive.
+NL_SYNTH_SPINE=$(make_tmp)/nl-synth.jsonl
+python3 - "$NL_SYNTH_SPINE" "$NEWLINE_NAME" << 'PYEOF'
+import json, sys
+spine_file, nl_name = sys.argv[1], sys.argv[2]
+lines = []
+lines.append(json.dumps({
+    'check_id': 'security/leaked-credential',
+    'rule_id': 'test-rule',
+    'severity': 'high',
+    'confidence': 'high',
+    'detection': 'tool',
+    'source': 'tool',
+    'message': 'test finding in newline-named file',
+    'location': {'path': nl_name, 'line': 1},
+    'fingerprint': 'CcDdEe1234567890CcDdEe1234567890CcDdEe12',
+}))
+# Finding for clean.js -- should be excluded (not in changed set)
+lines.append(json.dumps({
+    'check_id': 'security/leaked-credential',
+    'rule_id': 'test-rule',
+    'severity': 'high',
+    'confidence': 'high',
+    'detection': 'tool',
+    'source': 'tool',
+    'message': 'test finding in clean.js',
+    'location': {'path': 'clean.js', 'line': 1},
+    'fingerprint': 'DdEeFf1234567890DdEeFf1234567890DdEeFf12',
+}))
+with open(spine_file, 'w') as fh:
+    for l in lines:
+        fh.write(l + '\n')
+PYEOF
+
+NL_FILTER_OUT=$(make_tmp)/nl-filtered.jsonl
+apply_diff_filter "$NL_SYNTH_SPINE" "$NEWLINE_Z" "$NL_FILTER_OUT"
+
+# Assert: newline-named finding SURVIVES (path is in changed set)
+NL_FINDING=$(python3 - "$NL_FILTER_OUT" "$NEWLINE_NAME" << 'PYEOF'
+import json, sys
+out_file, nl_name = sys.argv[1], sys.argv[2]
+for raw in open(out_file):
+    raw = raw.strip()
+    if not raw:
+        continue
+    try:
+        rec = json.loads(raw)
+    except Exception:
+        continue
+    if 'type' in rec:
+        continue
+    if rec.get('location', {}).get('path') == nl_name:
+        print('FOUND')
+        import sys; sys.exit(0)
+print('NOT_FOUND')
+PYEOF
+)
+if [ "$NL_FINDING" = "FOUND" ]; then
+  pass "newline-named file: finding SURVIVES apply_diff_filter (path in changed set)"
+else
+  fail "newline-named file: finding should survive apply_diff_filter"
+fi
+
+# Assert: clean.js finding EXCLUDED (not in changed set)
+NL_CLEAN_FINDING=$(python3 - "$NL_FILTER_OUT" << 'PYEOF'
+import json, sys
+for raw in open(sys.argv[1]):
+    raw = raw.strip()
+    if not raw:
+        continue
+    try:
+        rec = json.loads(raw)
+    except Exception:
+        continue
+    if 'type' in rec:
+        continue
+    if rec.get('location', {}).get('path') == 'clean.js':
+        print('FOUND')
+        import sys; sys.exit(0)
+print('NOT_FOUND')
+PYEOF
+)
+if [ "$NL_CLEAN_FINDING" = "NOT_FOUND" ]; then
+  pass "newline-named file: clean.js finding EXCLUDED by apply_diff_filter (not in changed set)"
+else
+  fail "newline-named file: clean.js finding should be excluded by apply_diff_filter"
+fi
+
+# Assert: no PWNED artifacts created during newline-named file operations
+PWNED_FOUND_NL=0
+for PWNED_PATH in "$REPO2B/PWNED.js" "$(pwd)/PWNED.js" "/tmp/PWNED.js"; do
+  if [ -f "$PWNED_PATH" ]; then
+    PWNED_FOUND_NL=$((PWNED_FOUND_NL + 1))
+    echo "  PWNED found at: $PWNED_PATH" >&2
+  fi
+done
+if [ "$PWNED_FOUND_NL" -eq 0 ]; then
+  pass "newline-named file: no PWNED.js created during any operation"
+else
+  fail "newline-named file: PWNED.js was created -- injection succeeded (CRITICAL)"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Deliverable 1 (diff-scoped audit):** adds `--diff [ref]` and `--staged` flags to the `/audit` skill. The spine always runs full-repo; a `python3` post-filter trims findings to the changed set using a null-delimited `changed-files.z` file (filenames are inert data, never shell-interpolated). Documented in new Phase M2.1 (M-phase) and Phase 1.5 (`--single`) in `SKILL.md`, plus Mode Detection flag table and Usage block. `audit.md` updated for parity.
- **Deliverable 2 (test suite):** `tests/test-diff-mode.sh` — 33 tests across 5 groups: changed-set computation, hostile filename (ADV-009, fragment assembly), spine post-filter with gitleaks, empty diff guard, SKILL.md consistency.
- **Fix #599 (wrap-eslint.sh):** comment now truthfully describes the minimal eval-rule set instead of claiming zero rules run.
- **Fix #602.1 (SKILL.md M6-fix):** adds `git fetch origin` before multi-clone rev-parse checks; adds stale-fetch to zero-merge causes list.
- **Fix #602.2 (parse-dep-audit.py):** dep-audit findings now emit `properties: {tool: "dep-audit", package_manager: <pm>}` (was `tool: <pm>`), enabling correct routing to the dependencies pack.
- **Fix #602.3 (emit-findings.py):** removes doubled-brace f-string escaping bug in fingerprint validation error message (`{{8,128}}` → `{8,128}`).

## Test plan

- [x] `test-diff-mode.sh`: 33 passed, 0 failed
- [x] `test-orchestration.sh`: 34 passed, 0 failed
- [x] `test-reference-wiring.sh`: 41 passed, 0 failed
- [x] `test-command-skill-parity.sh`: 26 passed, 0 failed
- [x] `test-merge.sh`: 41 passed, 0 failed
- [x] `test-spine.sh`: 25 passed, 0 failed
- [x] `test-packs-migration.sh`: 40 passed, 0 failed (migration gate: PASS)
- [x] `test-registry.sh`: 8 passed, 0 failed
- [x] `test-rubric.sh`: 8 passed, 0 failed
- [x] `test-pack-lint.sh`: 7 passed, 0 failed
- [x] `test-detect-ecosystems.sh`: 47 passed, 0 failed
- [x] `test-detect-defaults.sh`: 20 passed, 0 failed
- [x] `test-emit-findings.sh`: 15 passed, 0 failed
- [x] Contract section extract-diff vs origin/main: EMPTY
- [x] `tests/test-modules.sh`: 1289 passed, 0 failed
- [x] `tests/test-no-personal-data.sh`: PASS
- [x] `python3 -m json.tool modules/commands-extra/module.json`: valid JSON

Closes #603