### PR TITLE
#607: Epic 2.1 — Data & Migrations audit pack (squawk + sqlfluff spine wrappers)

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -342,6 +342,36 @@
       "target": "skills/audit/packs/architecture/checks.md",
       "type": "doc",
       "template": false
+    },
+    "skills/audit/scripts/spine/wrap-squawk.sh": {
+      "target": "skills/audit/scripts/spine/wrap-squawk.sh",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/scripts/spine/parse-squawk.py": {
+      "target": "skills/audit/scripts/spine/parse-squawk.py",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/scripts/spine/wrap-sqlfluff.sh": {
+      "target": "skills/audit/scripts/spine/wrap-sqlfluff.sh",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/scripts/spine/parse-sqlfluff.py": {
+      "target": "skills/audit/scripts/spine/parse-sqlfluff.py",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/packs/data-migrations/pack.json": {
+      "target": "skills/audit/packs/data-migrations/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/data-migrations/checks.md": {
+      "target": "skills/audit/packs/data-migrations/checks.md",
+      "type": "doc",
+      "template": false
     }
   },
   "tags": [

--- a/modules/commands-extra/skills/audit/packs/data-migrations/checks.md
+++ b/modules/commands-extra/skills/audit/packs/data-migrations/checks.md
@@ -30,21 +30,12 @@ definitions, or non-SQL config files.
 ### `dm/unquoted-reserved-keyword`
 
 **Severity:** `high`
-**Confidence:** `high`
-**Detection:** `hybrid`
+**Confidence:** `medium`
+**Detection:** `llm`
 
 #### Detection
 
-**Tool (detection = hybrid):**
-`squawk`
-
-Rule / rule-id: squawk scans for PostgreSQL reserved keyword misuse; the parser maps
-relevant squawk violations to `dm/unquoted-reserved-keyword`. When squawk is absent, the
-fallback grep/llm instruction below applies.
-
-Fallback when tool absent: `llm` (grep pattern documented in LLM instruction)
-
-**LLM instruction (hybrid fallback):**
+**LLM instruction:**
 
 ```
 Scan every SQL file under the project's migration directories
@@ -77,11 +68,14 @@ the surrounding SQL line.
 
 ```yaml
 check_id: dm/unquoted-reserved-keyword
-detection: hybrid
-tool: squawk
-fallback: llm
-# squawk emits this check_id via parse-squawk.py when it detects reserved
-# keyword violations. The spine namespace is dm/* (not squawk/*).
+detection: llm
+# squawk does NOT emit this check_id. squawk has no built-in rule that maps to
+# dm/unquoted-reserved-keyword; parse-squawk.py only maps
+# "require-concurrent-index-creation" -> dm/index-without-concurrently, and
+# everything else falls to the generic dm/squawk-violation catch-all.
+# This check is detected by LLM+grep against the reserved-keyword list above.
+# squawk findings appear under dm/squawk-violation or dm/index-without-concurrently,
+# not under this check_id.
 ```
 
 #### Severity / Confidence
@@ -91,10 +85,12 @@ that prevents the migration from running, directly breaking deployments. This is
 severity blocker with no runtime fallback — if the migration fails, the deployment rolls
 back or stalls.
 
-**Confidence rationale:** The set of PostgreSQL reserved keywords is finite and well-
-documented. A regex match on an unquoted token is precise; double-quoted identifiers are
-unambiguous. Tool-backed detection (squawk) yields HIGH confidence; LLM fallback is also
-HIGH for this pattern because the keyword list is deterministic.
+**Confidence rationale:** The reserved keyword list is finite and deterministic, which
+makes LLM+grep detection reliable for clear cases. However, LLM analysis can produce
+false positives when a keyword appears in context that looks like an identifier but is
+actually valid SQL syntax. MEDIUM confidence reflects this LLM-inherent uncertainty;
+tool-backed detection (which would yield HIGH) is not available for this specific pattern
+since squawk does not have a dedicated reserved-keyword-as-identifier rule.
 
 **Rubric entry:** `dm/unquoted-reserved-keyword`
 
@@ -481,3 +477,15 @@ $$;
 - [x] Severity / confidence rationale is present for every check
 - [x] `applies_when` rationale table is complete
 - [x] `scripts/lint-pack.py` passes on this pack
+
+## Migration Mapping
+
+| check_id | spine namespace | detection | tool (spine) | notes |
+|----------|----------------|-----------|--------------|-------|
+| `dm/unquoted-reserved-keyword` | `dm/` | `llm` | none | squawk has no rule mapping to this id; detected by LLM+grep against the reserved-keyword list. squawk findings appear as `dm/squawk-violation` or `dm/index-without-concurrently`. |
+| `dm/index-without-concurrently` | `dm/` | `hybrid` | squawk (`require-concurrent-index-creation`) | `parse-squawk.py` maps this rule directly to this check_id. |
+| `dm/missing-rls` | `dm/` | `llm` | none | pure LLM cross-file analysis; no spine tool. |
+| `dm/on-conflict-without-unique` | `dm/` | `llm` | none | pure LLM cross-file analysis; no spine tool. |
+| `dm/security-definer-function` | `dm/` | `hybrid` | sqlfluff (description pattern match) | `parse-sqlfluff.py` maps violations matching `/security[\s_-]*definer/i` to this id. All other sqlfluff violations map to `dm/sqlfluff-violation`. |
+| `dm/squawk-violation` (catch-all) | `dm/` | `tool` | squawk (fallback for all unmapped rules) | emitted by `parse-squawk.py` for any squawk rule not explicitly mapped. NOT a declared pack check; surfaces in findings under its rubric entry. |
+| `dm/sqlfluff-violation` (catch-all) | `dm/` | `tool` | sqlfluff (fallback for non-SECURITY-DEFINER violations) | emitted by `parse-sqlfluff.py` for any sqlfluff violation whose description does not match the SECURITY DEFINER pattern. NOT a declared pack check; surfaces in findings under its rubric entry. |

--- a/modules/commands-extra/skills/audit/packs/data-migrations/checks.md
+++ b/modules/commands-extra/skills/audit/packs/data-migrations/checks.md
@@ -1,0 +1,483 @@
+# Data & Migrations Audit
+
+## Scope
+
+This pack audits SQL migration files for PostgreSQL-specific dangerous patterns. It
+targets files under known migration directories (`supabase/migrations`, `prisma/migrations`,
+`db/migrate`, `db/migrations`, `database/migrations`). Checks cover reserved-keyword
+quoting, locking risks from non-concurrent index creation, missing row-level security on
+new tables, invalid ON CONFLICT usage, and SECURITY DEFINER functions that require
+reviewer attention. This pack does NOT audit application-level query code, ORM model
+definitions, or non-SQL config files.
+
+**Pack ID:** `ccgm/data-migrations`
+**Applies when:** `["has_migrations"]`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `has_migrations` | Pack is only useful when a recognised migration directory exists; running on repos without migrations produces zero signal and wastes tool invocations. |
+
+---
+
+## Checks
+
+---
+
+### `dm/unquoted-reserved-keyword`
+
+**Severity:** `high`
+**Confidence:** `high`
+**Detection:** `hybrid`
+
+#### Detection
+
+**Tool (detection = hybrid):**
+`squawk`
+
+Rule / rule-id: squawk scans for PostgreSQL reserved keyword misuse; the parser maps
+relevant squawk violations to `dm/unquoted-reserved-keyword`. When squawk is absent, the
+fallback grep/llm instruction below applies.
+
+Fallback when tool absent: `llm` (grep pattern documented in LLM instruction)
+
+**LLM instruction (hybrid fallback):**
+
+```
+Scan every SQL file under the project's migration directories
+(supabase/migrations/, prisma/migrations/, db/migrate/, db/migrations/,
+database/migrations/) for PostgreSQL reserved keywords used as unquoted
+column, table, or parameter names.
+
+Reserved keywords to check (per PostgreSQL documentation and the CCGM
+code-quality rule): position, order, user, offset, limit, key, value,
+type, name, check, default, time, index, comment.
+
+Flag each occurrence where the keyword appears as an identifier WITHOUT
+double-quotes. Example bad patterns:
+  ADD COLUMN position INTEGER
+  ADD COLUMN order TEXT
+  CREATE TABLE key (...)
+  ALTER TABLE t ADD COLUMN index INT
+
+Do NOT flag:
+  - Keywords already wrapped in double-quotes: "position", "order", "user"
+  - Keywords appearing inside SQL comments (-- comment or /* comment */)
+  - Keywords appearing inside string literals ('literal value')
+  - Keywords used as SQL syntax (e.g. ORDER in ORDER BY, INDEX in CREATE INDEX)
+
+For each finding report: file path, line number, the unquoted keyword, and
+the surrounding SQL line.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: dm/unquoted-reserved-keyword
+detection: hybrid
+tool: squawk
+fallback: llm
+# squawk emits this check_id via parse-squawk.py when it detects reserved
+# keyword violations. The spine namespace is dm/* (not squawk/*).
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** An unquoted PostgreSQL reserved keyword causes a syntax error
+that prevents the migration from running, directly breaking deployments. This is a HIGH
+severity blocker with no runtime fallback — if the migration fails, the deployment rolls
+back or stalls.
+
+**Confidence rationale:** The set of PostgreSQL reserved keywords is finite and well-
+documented. A regex match on an unquoted token is precise; double-quoted identifiers are
+unambiguous. Tool-backed detection (squawk) yields HIGH confidence; LLM fallback is also
+HIGH for this pattern because the keyword list is deterministic.
+
+**Rubric entry:** `dm/unquoted-reserved-keyword`
+
+#### Fixture
+
+**True positive** (`db/migrations/0001_create_events.sql`):
+
+```sql
+-- FINDS: "position" is a reserved keyword, used unquoted as a column name.
+ALTER TABLE events ADD COLUMN position INTEGER;
+-- FINDS: "order" is reserved, used as column name without quotes.
+ALTER TABLE items ADD COLUMN order TEXT;
+```
+
+**True negative** (should produce NO finding):
+
+```sql
+-- OK: "position" is double-quoted — safe identifier.
+ALTER TABLE events ADD COLUMN "position" INTEGER;
+-- OK: ORDER BY is SQL syntax, not an identifier.
+SELECT * FROM events ORDER BY created_at;
+-- OK: appears only in a comment.
+-- We decided not to use "order" as a column name.
+```
+
+---
+
+### `dm/index-without-concurrently`
+
+**Severity:** `high`
+**Confidence:** `high`
+**Detection:** `hybrid`
+
+#### Detection
+
+**Tool (detection = hybrid):**
+`squawk`
+
+Rule / rule-id: `require-concurrent-index-creation` — squawk's built-in rule for this
+pattern. The parser maps this rule to `dm/index-without-concurrently`.
+
+Fallback when tool absent: `llm`
+
+**LLM instruction (hybrid fallback):**
+
+```
+Scan every SQL file under the project's migration directories for CREATE INDEX
+statements that do NOT use the CONCURRENTLY option.
+
+Flag each occurrence of:
+  CREATE INDEX (without CONCURRENTLY)
+  CREATE UNIQUE INDEX (without CONCURRENTLY)
+
+Do NOT flag:
+  - CREATE INDEX CONCURRENTLY (safe)
+  - CREATE UNIQUE INDEX CONCURRENTLY (safe)
+  - Index creation inside a transaction block BEGIN...COMMIT — CONCURRENTLY
+    is not allowed inside transactions, so this is not a false-positive scenario
+    to suppress; flag it and note that a schema change strategy review is needed.
+  - Commented-out CREATE INDEX lines
+
+For each finding report: file path, line number, and the full CREATE INDEX statement.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: dm/index-without-concurrently
+detection: hybrid
+tool: squawk
+rule: require-concurrent-index-creation
+fallback: llm
+# parse-squawk.py maps squawk rule "require-concurrent-index-creation"
+# -> check_id "dm/index-without-concurrently"
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A non-concurrent index creation on a large table acquires an
+`ACCESS EXCLUSIVE` lock, blocking all reads and writes until the index is built. This
+can cause multi-minute outages on production tables. The risk is HIGH: real downtime,
+not a theoretical vulnerability.
+
+**Confidence rationale:** The squawk rule `require-concurrent-index-creation` has no
+false positives for standard PostgreSQL DDL. HIGH confidence for tool-backed detection;
+HIGH for LLM fallback (pattern is syntactically unambiguous).
+
+**Rubric entry:** `dm/index-without-concurrently`
+
+#### Fixture
+
+**True positive** (`db/migrations/0002_add_email_index.sql`):
+
+```sql
+-- FINDS: CREATE INDEX without CONCURRENTLY locks the table.
+CREATE INDEX idx_users_email ON users(email);
+CREATE UNIQUE INDEX idx_users_username ON users(username);
+```
+
+**True negative** (should produce NO finding):
+
+```sql
+-- OK: CONCURRENTLY keyword is present.
+CREATE INDEX CONCURRENTLY idx_users_email ON users(email);
+CREATE UNIQUE INDEX CONCURRENTLY idx_users_username ON users(username);
+```
+
+---
+
+### `dm/missing-rls`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction:**
+
+```
+Scan every SQL file under the project's migration directories for CREATE TABLE
+statements that create new PostgreSQL tables WITHOUT a corresponding
+ENABLE ROW LEVEL SECURITY (RLS) statement.
+
+For each CREATE TABLE found, check whether the same migration file (or any
+earlier migration file in the same directory) contains:
+  ALTER TABLE <table_name> ENABLE ROW LEVEL SECURITY;
+
+Flag tables where RLS is NOT enabled anywhere in the migration set. Focus on
+Supabase-style projects (supabase/migrations/) where RLS is the primary access
+control mechanism. For non-Supabase projects, still flag but note that RLS may
+be intentionally absent if another access control layer is in use.
+
+Do NOT flag:
+  - System or extension tables (pg_*, information_schema)
+  - Temporary tables (CREATE TEMP TABLE / CREATE TEMPORARY TABLE)
+  - Tables that have ENABLE ROW LEVEL SECURITY in the same or any migration file
+  - Tables where the CREATE TABLE is inside a CREATE SCHEMA or EXTENSION block
+
+For each finding report: the migration file path, the line number of the
+CREATE TABLE statement, the table name, and whether any migration file in the
+set contains ENABLE ROW LEVEL SECURITY for this table (to distinguish new tables
+from inherited ones).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: dm/missing-rls
+detection: llm
+# No spine tool; pure LLM cross-file analysis.
+# The LLM must scan all migration files in the directory to check for
+# ENABLE ROW LEVEL SECURITY statements across the set.
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A table without RLS in a Supabase (or PostgREST-backed) project
+is accessible to any authenticated user with the anon/service role, bypassing all
+application-level access control. This is a HIGH severity data-exposure risk.
+
+**Confidence rationale:** MEDIUM confidence because: (1) the LLM must reason cross-file
+about whether RLS was enabled in a prior migration, which introduces false positives for
+tables where an earlier migration enables RLS; (2) non-Supabase projects may
+intentionally omit RLS. Tool detection is not available for this check.
+
+**Rubric entry:** `dm/missing-rls`
+
+#### Fixture
+
+**True positive** (`supabase/migrations/0003_create_documents.sql`):
+
+```sql
+-- FINDS: table created without ENABLE ROW LEVEL SECURITY anywhere in migrations.
+CREATE TABLE documents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id),
+  content text
+);
+-- No ALTER TABLE documents ENABLE ROW LEVEL SECURITY in any migration file.
+```
+
+**True negative** (should produce NO finding):
+
+```sql
+-- OK: RLS is enabled in the same migration.
+CREATE TABLE documents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id),
+  content text
+);
+ALTER TABLE documents ENABLE ROW LEVEL SECURITY;
+```
+
+---
+
+### `dm/on-conflict-without-unique`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction:**
+
+```
+Scan every SQL file under the project's migration directories for INSERT statements
+or upsert patterns that use ON CONFLICT targeting a specific column or set of
+columns WITHOUT a corresponding UNIQUE constraint or UNIQUE INDEX on those columns.
+
+Patterns to flag:
+  INSERT INTO t (...) VALUES (...) ON CONFLICT (col1) DO UPDATE ...
+  INSERT INTO t (...) VALUES (...) ON CONFLICT (col1, col2) DO UPDATE ...
+
+For each ON CONFLICT clause, check whether the same or any earlier migration file
+defines:
+  - UNIQUE (col1) as a column constraint or table constraint
+  - CREATE UNIQUE INDEX on col1 (or the combined column set)
+
+Do NOT flag:
+  - ON CONFLICT ON CONSTRAINT <constraint_name> — this explicitly names a constraint
+  - ON CONFLICT DO NOTHING without a column list — no constraint required
+  - Cases where a UNIQUE constraint is clearly visible in the same file
+
+For each finding report: the migration file path, the line number of the ON CONFLICT
+clause, the targeted column(s), and a note that a UNIQUE constraint or index is
+needed on those columns for the ON CONFLICT to be valid.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: dm/on-conflict-without-unique
+detection: llm
+# No spine tool; pure LLM cross-file analysis.
+# The LLM must cross-reference ON CONFLICT column lists against
+# UNIQUE constraints and indexes across all migration files.
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** An ON CONFLICT clause without a backing UNIQUE constraint causes
+a runtime PostgreSQL error (`there is no unique or exclusion constraint matching the ON
+CONFLICT specification`) that will fail every INSERT/UPSERT operation, breaking
+application logic. MEDIUM severity because this is a runtime logic error rather than a
+security issue or data-loss risk.
+
+**Confidence rationale:** MEDIUM confidence because: (1) the LLM must reason cross-file
+about whether a UNIQUE constraint is defined in an earlier migration; (2) the pattern
+`ON CONFLICT ON CONSTRAINT <name>` legitimately exists and must be excluded. Tool
+detection is not available for this check.
+
+**Rubric entry:** `dm/on-conflict-without-unique`
+
+#### Fixture
+
+**True positive** (`db/migrations/0004_add_upsert.sql`):
+
+```sql
+-- FINDS: ON CONFLICT (email) but no UNIQUE constraint on email.
+INSERT INTO users (email, name) VALUES ($1, $2)
+ON CONFLICT (email) DO UPDATE SET name = EXCLUDED.name;
+-- (No CREATE UNIQUE INDEX or UNIQUE(email) anywhere in migration files)
+```
+
+**True negative** (should produce NO finding):
+
+```sql
+-- OK: UNIQUE constraint is present in the same migration.
+ALTER TABLE users ADD CONSTRAINT users_email_unique UNIQUE (email);
+INSERT INTO users (email, name) VALUES ($1, $2)
+ON CONFLICT (email) DO UPDATE SET name = EXCLUDED.name;
+```
+
+---
+
+### `dm/security-definer-function`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `hybrid`
+
+#### Detection
+
+**Tool (detection = hybrid):**
+`sqlfluff`
+
+Rule / rule-id: sqlfluff parses SQL files; the parser detects `SECURITY DEFINER` in
+function definitions by matching the description string against a pattern. When sqlfluff
+is absent, the LLM fallback below applies.
+
+Fallback when tool absent: `llm`
+
+**LLM instruction (hybrid fallback):**
+
+```
+Scan every SQL file under the project's migration directories for PostgreSQL
+function or procedure definitions that include the SECURITY DEFINER clause.
+
+Pattern to match (case-insensitive):
+  CREATE [OR REPLACE] FUNCTION ...
+  ...
+  SECURITY DEFINER
+  ...
+
+Flag each SECURITY DEFINER function as requiring explicit reviewer attention.
+SECURITY DEFINER functions run as the function owner (typically a superuser),
+not the calling user. Misuse allows privilege escalation. Every instance should
+be reviewed to confirm:
+  1. The privilege elevation is intentional and necessary.
+  2. The function validates input to prevent SQL injection at the elevated
+     privilege level.
+  3. The function is not callable by untrusted roles without appropriate REVOKE/GRANT.
+
+Do NOT suppress findings — every SECURITY DEFINER function should be flagged
+for review. This is an "always review" check, not a "definitely a bug" check.
+
+For each finding report: the migration file path, the line number of the
+SECURITY DEFINER clause or the CREATE FUNCTION statement, and the function name.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: dm/security-definer-function
+detection: hybrid
+tool: sqlfluff
+fallback: llm
+# parse-sqlfluff.py maps violations whose description matches
+# /security[\s_-]*definer/i -> check_id "dm/security-definer-function"
+# All other sqlfluff violations map to dm/sqlfluff-violation.
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** SECURITY DEFINER functions run as the owning role, typically a
+superuser. An incorrectly scoped or input-validating SECURITY DEFINER function can be
+exploited for privilege escalation. MEDIUM severity because: (1) not every SECURITY
+DEFINER function is a bug — some are intentional; (2) this is a "flag for review" check
+rather than a definitive vulnerability.
+
+**Confidence rationale:** HIGH confidence because the `SECURITY DEFINER` keyword is
+syntactically unambiguous and cannot appear as a false positive in well-formed SQL.
+Both sqlfluff detection and LLM detection are reliable for this pattern.
+
+**Rubric entry:** `dm/security-definer-function`
+
+#### Fixture
+
+**True positive** (`supabase/migrations/0005_add_rpc.sql`):
+
+```sql
+-- FINDS: SECURITY DEFINER function — flagged for review.
+CREATE OR REPLACE FUNCTION admin_get_all_users()
+RETURNS SETOF auth.users
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  SELECT * FROM auth.users;
+$$;
+```
+
+**True negative** (should produce NO finding):
+
+```sql
+-- OK: no SECURITY DEFINER — function runs as caller.
+CREATE OR REPLACE FUNCTION get_my_profile(user_id uuid)
+RETURNS TABLE(id uuid, email text)
+LANGUAGE sql
+AS $$
+  SELECT id, email FROM profiles WHERE id = user_id;
+$$;
+```
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/data-migrations/pack.json
+++ b/modules/commands-extra/skills/audit/packs/data-migrations/pack.json
@@ -10,10 +10,8 @@
     {
       "id": "dm/unquoted-reserved-keyword",
       "severity": "high",
-      "confidence": "high",
-      "detection": "hybrid",
-      "tool": "squawk",
-      "fallback": "llm",
+      "confidence": "medium",
+      "detection": "llm",
       "auto_fixable": true
     },
     {

--- a/modules/commands-extra/skills/audit/packs/data-migrations/pack.json
+++ b/modules/commands-extra/skills/audit/packs/data-migrations/pack.json
@@ -1,0 +1,52 @@
+{
+  "id": "ccgm/data-migrations",
+  "name": "Data & Migrations Audit",
+  "version": "1.0.0",
+  "applies_when": ["has_migrations"],
+  "tags": ["database", "migrations", "postgresql", "sql"],
+  "severity_floor": "medium",
+  "tools": ["squawk", "sqlfluff"],
+  "checks": [
+    {
+      "id": "dm/unquoted-reserved-keyword",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "hybrid",
+      "tool": "squawk",
+      "fallback": "llm",
+      "auto_fixable": true
+    },
+    {
+      "id": "dm/index-without-concurrently",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "hybrid",
+      "tool": "squawk",
+      "fallback": "llm",
+      "auto_fixable": true
+    },
+    {
+      "id": "dm/missing-rls",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "dm/on-conflict-without-unique",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "dm/security-definer-function",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "hybrid",
+      "tool": "sqlfluff",
+      "fallback": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -313,6 +313,31 @@
       "severity": "medium",
       "confidence": "medium",
       "fix_confidence": "low"
+    },
+    "dm/unquoted-reserved-keyword": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dm/index-without-concurrently": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dm/missing-rls": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dm/on-conflict-without-unique": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dm/security-definer-function": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
     }
   }
 }

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -316,7 +316,7 @@
     },
     "dm/unquoted-reserved-keyword": {
       "severity": "high",
-      "confidence": "high",
+      "confidence": "medium",
       "fix_confidence": "high"
     },
     "dm/index-without-concurrently": {
@@ -337,6 +337,16 @@
     "dm/security-definer-function": {
       "severity": "medium",
       "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "dm/squawk-violation": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dm/sqlfluff-violation": {
+      "severity": "low",
+      "confidence": "medium",
       "fix_confidence": "low"
     }
   }

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-sqlfluff.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-sqlfluff.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+CCGM audit spine -- parse sqlfluff JSON output -> finding.schema.json JSONL.
+
+Usage: parse-sqlfluff.py <sqlfluff_json_file> <repo_root>
+
+Assumed sqlfluff lint --format json output shape (documented in wrap-sqlfluff.sh):
+
+  [
+    {
+      "filepath": "db/migrations/0001_create_users.sql",
+      "violations": [
+        {
+          "start_line_no": 5,
+          "start_line_pos": 1,
+          "end_line_no": 5,
+          "end_line_pos": 40,
+          "description": "Found SECURITY DEFINER in function definition.",
+          "name": "ST07",
+          "warning": false,
+          "fixable": false
+        }
+      ]
+    }
+  ]
+
+The top-level is a JSON array of file objects. Each file object has a "violations"
+array. Each violation contains start_line_no (1-based integer), description (string),
+and name (rule code string). The "warning" bool controls severity: false -> medium,
+true -> low.
+
+check_id assignment:
+  - description contains "SECURITY DEFINER" (case-insensitive) -> dm/security-definer-function
+  - all others -> dm/sqlfluff-violation
+
+properties.tool is always set to "sqlfluff".
+"""
+
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import normalize  # noqa: E402
+
+
+# Pattern to detect SECURITY DEFINER descriptions
+_SECURITY_DEFINER_RE = re.compile(r"security[\s_-]*definer", re.IGNORECASE)
+
+
+def main(argv):
+    if len(argv) < 3:
+        sys.stderr.write("Usage: parse-sqlfluff.py <json_file> <repo_root>\n")
+        sys.exit(1)
+
+    json_file = argv[1]
+    repo_root = argv[2].rstrip("/")
+
+    try:
+        with open(json_file, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.stderr.write("Cannot parse {0}: {1}\n".format(json_file, exc))
+        sys.exit(0)
+
+    if not isinstance(data, list):
+        sys.stderr.write("Expected JSON array from sqlfluff lint --format json\n")
+        sys.exit(0)
+
+    for file_entry in data:
+        if not isinstance(file_entry, dict):
+            continue
+
+        file_path = file_entry.get("filepath", "unknown.sql")
+        # Make path repo-relative
+        if file_path.startswith(repo_root + "/"):
+            file_path = file_path[len(repo_root) + 1:]
+
+        violations = file_entry.get("violations", [])
+        if not isinstance(violations, list):
+            continue
+
+        for violation in violations:
+            if not isinstance(violation, dict):
+                continue
+
+            rule_name = violation.get("name", "unknown")
+            description = violation.get("description", "sqlfluff violation")
+            is_warning = bool(violation.get("warning", False))
+            line_no = max(1, int(violation.get("start_line_no", 1)))
+
+            # Determine check_id
+            if _SECURITY_DEFINER_RE.search(description):
+                check_id = "dm/security-definer-function"
+                severity = "medium"
+                confidence = "high"
+            else:
+                check_id = "dm/sqlfluff-violation"
+                severity = "low" if is_warning else "medium"
+                confidence = "high"
+
+            fp = normalize.make_content_fingerprint(
+                "{0}:{1}:{2}".format(file_path, line_no, rule_name)
+            )
+
+            finding = normalize.make_finding(
+                check_id=check_id,
+                rule_id="sqlfluff/{0}".format(rule_name),
+                severity=severity,
+                confidence=confidence,
+                path=file_path,
+                line=line_no,
+                message=description,
+                fingerprint=fp,
+                properties={"tool": "sqlfluff"},
+            )
+            normalize.emit_finding(finding)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-squawk.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-squawk.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+CCGM audit spine -- parse squawk JSON output -> finding.schema.json JSONL.
+
+Usage: parse-squawk.py <squawk_json_file> <repo_root>
+
+Assumed squawk --reporter json output shape (documented in wrap-squawk.sh):
+
+  [
+    {
+      "file": "db/migrations/0001_create_users.sql",
+      "violations": [
+        {
+          "rule": "require-concurrent-index-creation",
+          "level": "Warning",
+          "messages": [
+            {
+              "Note": "Use CONCURRENTLY when creating indexes to avoid locking the table."
+            }
+          ],
+          "position": {
+            "start": { "line": 5, "col": 1 },
+            "end":   { "line": 5, "col": 40 }
+          }
+        }
+      ]
+    }
+  ]
+
+The top-level array has one entry per file. Each entry has a "violations" array.
+Each violation has:
+  - rule:     string — squawk rule name, e.g. "require-concurrent-index-creation"
+  - level:    string — "Warning" | "Error" | "Note"
+  - messages: list of single-key objects, e.g. [{"Note": "..."}, {"Help": "..."}]
+  - position: object with start/end, each containing line (1-based) and col
+
+squawk rule -> dm/* check_id mapping:
+  require-concurrent-index-creation  -> dm/index-without-concurrently
+  ban-drop-database                  -> dm/squawk-violation
+  prefer-robust-stmts                -> dm/squawk-violation
+  add-field-with-default             -> dm/squawk-violation
+  (all others)                       -> dm/squawk-violation
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import normalize  # noqa: E402
+
+
+# Severity mapping from squawk level strings.
+_SEVERITY_MAP = {
+    "error": "high",
+    "warning": "medium",
+    "note": "low",
+}
+
+# Rule-to-check_id mapping; unrecognised rules fall back to dm/squawk-violation.
+_RULE_CHECK_ID = {
+    "require-concurrent-index-creation": "dm/index-without-concurrently",
+}
+_DEFAULT_CHECK_ID = "dm/squawk-violation"
+
+
+def _extract_message(messages):
+    """
+    Extract a human-readable message string from squawk's messages list.
+    Each element is a single-key dict: {"Note": "..."} or {"Help": "..."}.
+    Returns the first Note or Help value found, or "squawk violation" as default.
+    """
+    if not isinstance(messages, list):
+        return "squawk violation"
+    for msg_obj in messages:
+        if not isinstance(msg_obj, dict):
+            continue
+        for key in ("Note", "Help", "Error"):
+            val = msg_obj.get(key)
+            if val:
+                return str(val)
+    return "squawk violation"
+
+
+def main(argv):
+    if len(argv) < 3:
+        sys.stderr.write("Usage: parse-squawk.py <json_file> <repo_root>\n")
+        sys.exit(1)
+
+    json_file = argv[1]
+    repo_root = argv[2].rstrip("/")
+
+    try:
+        with open(json_file, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.stderr.write("Cannot parse {0}: {1}\n".format(json_file, exc))
+        sys.exit(0)
+
+    if not isinstance(data, list):
+        sys.stderr.write("Expected JSON array from squawk --reporter json\n")
+        sys.exit(0)
+
+    for file_entry in data:
+        if not isinstance(file_entry, dict):
+            continue
+
+        file_path = file_entry.get("file", "unknown.sql")
+        # Make path repo-relative
+        if file_path.startswith(repo_root + "/"):
+            file_path = file_path[len(repo_root) + 1:]
+
+        violations = file_entry.get("violations", [])
+        if not isinstance(violations, list):
+            continue
+
+        for violation in violations:
+            if not isinstance(violation, dict):
+                continue
+
+            rule = violation.get("rule", "unknown")
+            level = violation.get("level", "Warning").lower()
+            messages = violation.get("messages", [])
+            position = violation.get("position", {})
+            start = position.get("start", {})
+            line_no = max(1, int(start.get("line", 1)))
+
+            check_id = _RULE_CHECK_ID.get(rule, _DEFAULT_CHECK_ID)
+            severity = _SEVERITY_MAP.get(level, "medium")
+            message = _extract_message(messages)
+            if message == "squawk violation":
+                message = "squawk rule {0}: {1}".format(rule, _extract_message(messages))
+
+            fp = normalize.make_content_fingerprint(
+                "{0}:{1}:{2}".format(file_path, line_no, rule)
+            )
+
+            finding = normalize.make_finding(
+                check_id=check_id,
+                rule_id="squawk/{0}".format(rule),
+                severity=severity,
+                confidence="high",
+                path=file_path,
+                line=line_no,
+                message=message,
+                fingerprint=fp,
+                properties={"tool": "squawk"},
+            )
+            normalize.emit_finding(finding)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-squawk.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-squawk.py
@@ -129,7 +129,7 @@ def main(argv):
             severity = _SEVERITY_MAP.get(level, "medium")
             message = _extract_message(messages)
             if message == "squawk violation":
-                message = "squawk rule {0}: {1}".format(rule, _extract_message(messages))
+                message = "squawk rule {0}".format(rule)
 
             fp = normalize.make_content_fingerprint(
                 "{0}:{1}:{2}".format(file_path, line_no, rule)

--- a/modules/commands-extra/skills/audit/scripts/spine/run.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/run.sh
@@ -11,7 +11,8 @@
 #   --repo  <path>   Absolute path to the repo root (default: cwd)
 #   --tools <list>   Comma-separated subset of tools to run (default: all)
 #                    Valid: gitleaks,semgrep,dep-audit,knip,eslint,
-#                           govulncheck,bandit,hadolint,actionlint,trivy
+#                           govulncheck,bandit,hadolint,actionlint,trivy,
+#                           squawk,sqlfluff
 #   --output <file>  Write aggregated JSONL to this file instead of stdout
 #
 # Output: JSONL -- one JSON object per line, either a finding or a note.
@@ -32,7 +33,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Defaults
 # ---------------------------------------------------------------------------
 REPO_ROOT=""
-REQUESTED_TOOLS="gitleaks,semgrep,dep-audit,knip,eslint,govulncheck,bandit,hadolint,actionlint,trivy"
+REQUESTED_TOOLS="gitleaks,semgrep,dep-audit,knip,eslint,govulncheck,bandit,hadolint,actionlint,trivy,squawk,sqlfluff"
 OUTPUT_FILE=""
 
 # ---------------------------------------------------------------------------
@@ -85,9 +86,11 @@ TOOL_WRAPPERS["bandit"]="$SCRIPT_DIR/wrap-bandit.sh"
 TOOL_WRAPPERS["hadolint"]="$SCRIPT_DIR/wrap-hadolint.sh"
 TOOL_WRAPPERS["actionlint"]="$SCRIPT_DIR/wrap-actionlint.sh"
 TOOL_WRAPPERS["trivy"]="$SCRIPT_DIR/wrap-trivy.sh"
+TOOL_WRAPPERS["squawk"]="$SCRIPT_DIR/wrap-squawk.sh"
+TOOL_WRAPPERS["sqlfluff"]="$SCRIPT_DIR/wrap-sqlfluff.sh"
 
 # Ordered execution list (stable, deterministic)
-TOOL_ORDER=(gitleaks semgrep dep-audit knip eslint govulncheck bandit hadolint actionlint trivy)
+TOOL_ORDER=(gitleaks semgrep dep-audit knip eslint govulncheck bandit hadolint actionlint trivy squawk sqlfluff)
 
 # ---------------------------------------------------------------------------
 # Parse requested tools into a set (using associative array for O(1) lookup)

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-sqlfluff.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-sqlfluff.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# CCGM audit spine -- sqlfluff wrapper
+# Lints SQL migration files using sqlfluff for style, formatting, and
+# dangerous pattern detection (e.g. SECURITY DEFINER).
+#
+# Usage: wrap-sqlfluff.sh <repo_root>
+#
+# Output (stdout): JSONL
+# Exit code: always 0
+#
+# sqlfluff lint --format json output shape:
+#   [
+#     {
+#       "filepath": "db/migrations/0001_create_users.sql",
+#       "violations": [
+#         {
+#           "start_line_no": 5,
+#           "start_line_pos": 1,
+#           "end_line_no": 5,
+#           "end_line_pos": 40,
+#           "description": "Found SECURITY DEFINER in function definition.",
+#           "name": "ST07",
+#           "warning": false,
+#           "fixable": false
+#         }
+#       ]
+#     }
+#   ]
+#
+# The top-level array has one entry per file. Each entry has a "violations" array.
+# Each violation has:
+#   - start_line_no:  integer (1-based)
+#   - start_line_pos: integer (1-based)
+#   - description:    string
+#   - name:           string rule code, e.g. "LT01", "ST07"
+#   - warning:        bool
+#   - fixable:        bool
+#
+# sqlfluff rule -> check_id mapping (in parse-sqlfluff.py):
+#   (all violations)  -> dm/security-definer-function when description matches SECURITY DEFINER
+#   (all others)      -> dm/sqlfluff-violation (generic)
+
+set -euo pipefail
+
+REPO_ROOT="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NORMALIZE_PY="$SCRIPT_DIR/normalize.py"
+PARSE_PY="$SCRIPT_DIR/parse-sqlfluff.py"
+
+if [[ -z "$REPO_ROOT" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip sqlfluff \
+    "dm/security-definer-function:sqlfluff not installed -- SECURITY DEFINER check skipped (llm fallback available)"
+  exit 0
+fi
+
+# Locate migration directories (mirrors detect-ecosystems.sh has_migrations logic)
+MIGRATION_DIRS=()
+for candidate in \
+    "supabase/migrations" \
+    "prisma/migrations" \
+    "db/migrate" \
+    "db/migrations" \
+    "database/migrations"; do
+  if [[ -d "$REPO_ROOT/$candidate" ]]; then
+    MIGRATION_DIRS+=("$REPO_ROOT/$candidate")
+  fi
+done
+
+if [[ ${#MIGRATION_DIRS[@]} -eq 0 ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip sqlfluff \
+    "dm/security-definer-function:no migration directories found -- sqlfluff skipped"
+  exit 0
+fi
+
+if ! command -v sqlfluff > /dev/null 2>&1; then
+  python3 "$NORMALIZE_PY" --emit-skip sqlfluff \
+    "dm/security-definer-function:sqlfluff not installed -- SECURITY DEFINER check skipped (llm fallback available)"
+  exit 0
+fi
+
+# Collect .sql files from migration directories using find + null-delimited output
+mapfile -d '' SQL_FILES < <(
+  for dir in "${MIGRATION_DIRS[@]}"; do
+    find "$dir" \
+      -type f \
+      -name "*.sql" \
+      -not -path "*/.git/*" \
+      -print0
+  done
+)
+
+if [[ ${#SQL_FILES[@]} -eq 0 ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip sqlfluff \
+    "dm/security-definer-function:no .sql files found in migration dirs -- sqlfluff skipped"
+  exit 0
+fi
+
+TMPFILE="$(mktemp /tmp/ccgm-sqlfluff-XXXXXX.json)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+# Run sqlfluff lint with JSON format and no project config (--config /dev/null
+# is not supported; use --nocolor and rely on --format json for isolation).
+# Paths are passed as separate argv elements (injection-safe).
+# sqlfluff exits non-zero when violations are found -- ignore exit code.
+set +e
+sqlfluff lint --format json --nocolor "${SQL_FILES[@]}" > "$TMPFILE" 2>/dev/null || true
+set -e
+
+if [[ ! -s "$TMPFILE" ]]; then
+  exit 0
+fi
+
+python3 "$PARSE_PY" "$TMPFILE" "$REPO_ROOT"

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-squawk.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-squawk.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# CCGM audit spine -- squawk wrapper
+# Lints PostgreSQL migration files for dangerous patterns (missing CONCURRENTLY,
+# unquoted reserved keywords, etc.).
+#
+# Usage: wrap-squawk.sh <repo_root>
+#
+# Output (stdout): JSONL
+# Exit code: always 0
+#
+# squawk JSON output shape (squawk --reporter json <files>):
+#   [
+#     {
+#       "file": "db/migrations/0001_create_users.sql",
+#       "violations": [
+#         {
+#           "rule": "require-concurrent-index-creation",
+#           "level": "Warning",
+#           "messages": [
+#             {
+#               "Note": "..."
+#             }
+#           ],
+#           "position": {
+#             "start": { "line": 5, "col": 1 },
+#             "end":   { "line": 5, "col": 40 }
+#           }
+#         }
+#       ]
+#     }
+#   ]
+#
+# squawk rule -> check_id mapping (in parse-squawk.py):
+#   require-concurrent-index-creation -> dm/index-without-concurrently
+#   (all others)                      -> dm/squawk-violation (generic)
+
+set -euo pipefail
+
+REPO_ROOT="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NORMALIZE_PY="$SCRIPT_DIR/normalize.py"
+PARSE_PY="$SCRIPT_DIR/parse-squawk.py"
+
+if [[ -z "$REPO_ROOT" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip squawk \
+    "dm/index-without-concurrently:squawk not installed -- index-without-CONCURRENTLY check skipped" \
+    "dm/unquoted-reserved-keyword:squawk not installed -- reserved-keyword check skipped (grep/llm fallback available)"
+  exit 0
+fi
+
+# Locate migration directories (mirrors detect-ecosystems.sh has_migrations logic)
+MIGRATION_DIRS=()
+for candidate in \
+    "supabase/migrations" \
+    "prisma/migrations" \
+    "db/migrate" \
+    "db/migrations" \
+    "database/migrations"; do
+  if [[ -d "$REPO_ROOT/$candidate" ]]; then
+    MIGRATION_DIRS+=("$REPO_ROOT/$candidate")
+  fi
+done
+
+if [[ ${#MIGRATION_DIRS[@]} -eq 0 ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip squawk \
+    "dm/index-without-concurrently:no migration directories found -- squawk skipped" \
+    "dm/unquoted-reserved-keyword:no migration directories found -- squawk skipped"
+  exit 0
+fi
+
+if ! command -v squawk > /dev/null 2>&1; then
+  python3 "$NORMALIZE_PY" --emit-skip squawk \
+    "dm/index-without-concurrently:squawk not installed -- index-without-CONCURRENTLY check skipped" \
+    "dm/unquoted-reserved-keyword:squawk not installed -- reserved-keyword check skipped (grep/llm fallback available)"
+  exit 0
+fi
+
+# Collect .sql files from migration directories using find + null-delimited output
+mapfile -d '' SQL_FILES < <(
+  for dir in "${MIGRATION_DIRS[@]}"; do
+    find "$dir" \
+      -type f \
+      -name "*.sql" \
+      -not -path "*/.git/*" \
+      -print0
+  done
+)
+
+if [[ ${#SQL_FILES[@]} -eq 0 ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip squawk \
+    "dm/index-without-concurrently:no .sql files found in migration dirs -- squawk skipped" \
+    "dm/unquoted-reserved-keyword:no .sql files found in migration dirs -- squawk skipped"
+  exit 0
+fi
+
+TMPFILE="$(mktemp /tmp/ccgm-squawk-XXXXXX.json)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+# Run squawk: each SQL file is passed as a separate argv element (injection-safe)
+set +e
+squawk --reporter json "${SQL_FILES[@]}" > "$TMPFILE" 2>/dev/null || true
+set -e
+
+if [[ ! -s "$TMPFILE" ]]; then
+  exit 0
+fi
+
+python3 "$PARSE_PY" "$TMPFILE" "$REPO_ROOT"

--- a/modules/commands-extra/skills/audit/tests/test-pack-data-migrations.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-data-migrations.sh
@@ -344,6 +344,51 @@ else
   fail "parse-squawk.py fingerprint field is missing or invalid"
 fi
 
+# Test: parse-squawk.py empty-messages -> "squawk rule <rule>" (no doubled tail)
+SQUAWK_EMPTY_MSG="$TESTRUN_TMPDIR/squawk-empty-msg.json"
+cat > "$SQUAWK_EMPTY_MSG" <<'JSON'
+[
+  {
+    "file": "/repo/supabase/migrations/0003_test.sql",
+    "violations": [
+      {
+        "rule": "prefer-robust-stmts",
+        "level": "Warning",
+        "messages": [],
+        "position": {
+          "start": {"line": 3, "col": 1},
+          "end":   {"line": 3, "col": 10}
+        }
+      }
+    ]
+  }
+]
+JSON
+
+SQUAWK_EMPTY_OUT="$TESTRUN_TMPDIR/squawk-empty-parsed.jsonl"
+python3 "$PARSE_SQUAWK" "$SQUAWK_EMPTY_MSG" "/repo" > "$SQUAWK_EMPTY_OUT"
+
+if python3 - "$SQUAWK_EMPTY_OUT" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        msg = obj.get("message", "")
+        # Must be exactly "squawk rule <rule>" -- no "squawk violation" tail
+        if msg != "squawk rule prefer-robust-stmts":
+            print("Bad message: {!r}".format(msg), file=sys.stderr)
+            sys.exit(1)
+sys.exit(0)
+PYEOF
+then
+  pass "parse-squawk.py empty-messages yields 'squawk rule <rule>' (no doubled tail)"
+else
+  fail "parse-squawk.py empty-messages: wrong message (expected 'squawk rule prefer-robust-stmts')"
+fi
+
 # ---------------------------------------------------------------------------
 # Synthetic JSON fixtures for parse-sqlfluff.py unit tests
 # ---------------------------------------------------------------------------

--- a/modules/commands-extra/skills/audit/tests/test-pack-data-migrations.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-data-migrations.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+# test-pack-data-migrations.sh
+# Tests for the data-migrations audit pack (Epic 2.1).
+#
+# Tests:
+#   1. pack.json validates against pack.schema.json (registry validate_pack)
+#   2. checks.md has all required template sections (lint-pack.py)
+#   3. severity-rubric.json contains all dm/* check-ids from pack.json
+#   4. lint-pack.py passes on the data-migrations pack against the real rubric
+#   5. Graceful-degradation: wrap-squawk.sh emits coverage_gap when squawk absent
+#   6. Graceful-degradation: wrap-sqlfluff.sh emits coverage_gap when sqlfluff absent
+#   7. Unit test: parse-squawk.py emits valid dm/* findings from synthetic JSON
+#   8. Unit test: parse-sqlfluff.py emits valid dm/* findings from synthetic JSON
+#   9. Unit test: parse-squawk.py sets properties.tool = "squawk"
+#  10. Unit test: parse-sqlfluff.py sets properties.tool = "sqlfluff"
+#  11. Unit test: parse-squawk.py maps require-concurrent-index-creation -> dm/index-without-concurrently
+#  12. Unit test: parse-sqlfluff.py maps SECURITY DEFINER description -> dm/security-definer-function
+#  13. Unit test: parse-squawk.py includes fingerprint field matching expected pattern
+#  14. Fixture repo: graceful-degradation path emits coverage_gap notes (squawk/sqlfluff absent)
+#
+# Exit 0 = all tests passed; exit 1 = one or more failures.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SPINE_DIR="${AUDIT_DIR}/scripts/spine"
+PACK_DIR="${AUDIT_DIR}/packs/data-migrations"
+LINTER="${AUDIT_DIR}/scripts/lint-pack.py"
+RUBRIC="${AUDIT_DIR}/schemas/severity-rubric.json"
+PARSE_SQUAWK="${SPINE_DIR}/parse-squawk.py"
+PARSE_SQLFLUFF="${SPINE_DIR}/parse-sqlfluff.py"
+WRAP_SQUAWK="${SPINE_DIR}/wrap-squawk.sh"
+WRAP_SQLFLUFF="${SPINE_DIR}/wrap-sqlfluff.sh"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+  printf '  [PASS] %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  ERRORS+=("$1")
+  FAIL=$((FAIL + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Temp dir for the whole test run
+# ---------------------------------------------------------------------------
+TESTRUN_TMPDIR="$(mktemp -d /tmp/ccgm-test-dm-XXXXXX)"
+trap 'rm -rf "$TESTRUN_TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Test 1: pack.json validates against pack.schema.json via lint-pack.py
+# ---------------------------------------------------------------------------
+printf '\nTest 1: pack.json validates (lint-pack.py --rubric /dev/null)\n'
+
+if [[ ! -f "$PACK_DIR/pack.json" ]]; then
+  fail "pack.json does not exist at $PACK_DIR/pack.json"
+else
+  # Use lint-pack.py with a nonexistent rubric to test schema validation only
+  OUT="$(python3 "$LINTER" --packs-dir "$(dirname "$PACK_DIR")" --rubric "$TESTRUN_TMPDIR/no-rubric.json" 2>&1 || true)"
+  if echo "$OUT" | grep -q "^PASS: data-migrations"; then
+    pass "pack.json passes schema validation (no rubric)"
+  else
+    fail "pack.json schema validation failed: $OUT"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: checks.md has all required template sections
+# ---------------------------------------------------------------------------
+printf '\nTest 2: checks.md has all required sections\n'
+
+if [[ ! -f "$PACK_DIR/checks.md" ]]; then
+  fail "checks.md does not exist at $PACK_DIR/checks.md"
+else
+  for section_pattern in \
+    "^## Scope" \
+    "^## applies_when Rationale" \
+    "^## Checks" \
+    "^## Quality Checklist"; do
+    if grep -qiE "$section_pattern" "$PACK_DIR/checks.md"; then
+      pass "checks.md contains section matching '$section_pattern'"
+    else
+      fail "checks.md missing section matching '$section_pattern'"
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: severity-rubric.json contains all dm/* check-ids from pack.json
+# ---------------------------------------------------------------------------
+printf '\nTest 3: rubric contains all dm/* check-ids\n'
+
+if [[ ! -f "$RUBRIC" ]]; then
+  fail "severity-rubric.json not found at $RUBRIC"
+else
+  # Extract check ids from pack.json using python3 stdlib
+  PACK_CHECK_IDS="$(python3 - "$PACK_DIR/pack.json" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    pack = json.load(f)
+for c in pack.get("checks", []):
+    print(c["id"])
+PYEOF
+)"
+  while IFS= read -r cid; do
+    [[ -z "$cid" ]] && continue
+    if python3 - "$RUBRIC" "$cid" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    rubric = json.load(f)
+checks = rubric.get("checks", {})
+cid = sys.argv[2]
+sys.exit(0 if cid in checks else 1)
+PYEOF
+    then
+      pass "rubric contains check-id '$cid'"
+    else
+      fail "rubric MISSING check-id '$cid'"
+    fi
+  done <<< "$PACK_CHECK_IDS"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: lint-pack.py passes on data-migrations pack with real rubric
+# ---------------------------------------------------------------------------
+printf '\nTest 4: lint-pack.py PASS on data-migrations pack (real rubric)\n'
+
+OUT="$(python3 "$LINTER" --packs-dir "$(dirname "$PACK_DIR")" --rubric "$RUBRIC" 2>&1 || true)"
+if echo "$OUT" | grep -q "^PASS: data-migrations"; then
+  pass "lint-pack.py reports PASS for data-migrations with real rubric"
+else
+  fail "lint-pack.py did NOT report PASS for data-migrations: $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: wrap-squawk.sh graceful-degradation when squawk absent
+# ---------------------------------------------------------------------------
+printf '\nTest 5: wrap-squawk.sh emits coverage_gap when squawk absent\n'
+
+# Create a minimal migration fixture
+FIXTURE_REPO="$TESTRUN_TMPDIR/fixture-repo"
+mkdir -p "$FIXTURE_REPO/supabase/migrations"
+
+# Seed fixture with all 4 defect types
+cat > "$FIXTURE_REPO/supabase/migrations/0001_defects.sql" <<'SQLEOF'
+-- dm/unquoted-reserved-keyword: "order" column without quotes
+CREATE TABLE items (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    order TEXT,
+    position INTEGER
+);
+
+-- dm/index-without-concurrently: missing CONCURRENTLY
+CREATE INDEX idx_items_order ON items(order);
+
+-- dm/missing-rls: table created without ENABLE ROW LEVEL SECURITY
+CREATE TABLE documents (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid,
+    content text
+);
+
+-- dm/security-definer-function: SECURITY DEFINER present
+CREATE OR REPLACE FUNCTION admin_all_users()
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+AS $$ SELECT 1; $$;
+SQLEOF
+
+# Build a PATH that excludes squawk and sqlfluff
+SYSTEM_BINS=""
+for bin in python3 bash find mktemp rm printf head grep; do
+  BINPATH="$(command -v "$bin" 2>/dev/null || true)"
+  if [[ -n "$BINPATH" ]]; then
+    BINDIR="$(dirname "$BINPATH")"
+    case ":$SYSTEM_BINS:" in
+      *":$BINDIR:"*) ;;
+      *) SYSTEM_BINS="${SYSTEM_BINS:+$SYSTEM_BINS:}$BINDIR" ;;
+    esac
+  fi
+done
+RESTRICTED_PATH="$SYSTEM_BINS:/usr/bin:/bin"
+
+SQUAWK_OUT="$TESTRUN_TMPDIR/squawk-graceful.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "$WRAP_SQUAWK" "$FIXTURE_REPO" > "$SQUAWK_OUT" 2>/dev/null
+SQUAWK_EXIT=$?
+set -e
+
+if [[ $SQUAWK_EXIT -eq 0 ]]; then
+  pass "wrap-squawk.sh exits 0 when squawk absent"
+else
+  fail "wrap-squawk.sh exits $SQUAWK_EXIT (expected 0)"
+fi
+
+# Should have a skipped note or coverage_gap
+if grep -q '"type":"skipped"\|"type":"coverage_gap"' "$SQUAWK_OUT" 2>/dev/null; then
+  pass "wrap-squawk.sh emits skipped/coverage_gap note when squawk absent"
+else
+  fail "wrap-squawk.sh produced no skip/gap notes when squawk absent"
+fi
+
+# All output should be valid JSON
+INVALID_JSON=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID_JSON=$((INVALID_JSON + 1))
+  fi
+done < "$SQUAWK_OUT"
+if [[ $INVALID_JSON -eq 0 ]]; then
+  pass "wrap-squawk.sh output is valid JSONL when squawk absent"
+else
+  fail "wrap-squawk.sh output has $INVALID_JSON invalid JSON lines"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: wrap-sqlfluff.sh graceful-degradation when sqlfluff absent
+# ---------------------------------------------------------------------------
+printf '\nTest 6: wrap-sqlfluff.sh emits coverage_gap when sqlfluff absent\n'
+
+SQLFLUFF_OUT="$TESTRUN_TMPDIR/sqlfluff-graceful.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "$WRAP_SQLFLUFF" "$FIXTURE_REPO" > "$SQLFLUFF_OUT" 2>/dev/null
+SQLFLUFF_EXIT=$?
+set -e
+
+if [[ $SQLFLUFF_EXIT -eq 0 ]]; then
+  pass "wrap-sqlfluff.sh exits 0 when sqlfluff absent"
+else
+  fail "wrap-sqlfluff.sh exits $SQLFLUFF_EXIT (expected 0)"
+fi
+
+if grep -q '"type":"skipped"\|"type":"coverage_gap"' "$SQLFLUFF_OUT" 2>/dev/null; then
+  pass "wrap-sqlfluff.sh emits skipped/coverage_gap note when sqlfluff absent"
+else
+  fail "wrap-sqlfluff.sh produced no skip/gap notes when sqlfluff absent"
+fi
+
+# ---------------------------------------------------------------------------
+# Synthetic JSON fixtures for parse-squawk.py unit tests
+# ---------------------------------------------------------------------------
+printf '\nTest 7-11: parse-squawk.py unit tests against synthetic JSON\n'
+
+SQUAWK_SYNTHETIC="$TESTRUN_TMPDIR/squawk-synthetic.json"
+cat > "$SQUAWK_SYNTHETIC" <<'JSON'
+[
+  {
+    "file": "/repo/supabase/migrations/0001_defects.sql",
+    "violations": [
+      {
+        "rule": "require-concurrent-index-creation",
+        "level": "Warning",
+        "messages": [
+          {"Note": "Use CONCURRENTLY when creating indexes to avoid locking the table during index creation."}
+        ],
+        "position": {
+          "start": {"line": 8, "col": 1},
+          "end":   {"line": 8, "col": 50}
+        }
+      },
+      {
+        "rule": "ban-drop-database",
+        "level": "Error",
+        "messages": [
+          {"Note": "Dropping a database is a destructive and irreversible operation."}
+        ],
+        "position": {
+          "start": {"line": 15, "col": 1},
+          "end":   {"line": 15, "col": 20}
+        }
+      }
+    ]
+  }
+]
+JSON
+
+SQUAWK_PARSE_OUT="$TESTRUN_TMPDIR/squawk-parsed.jsonl"
+python3 "$PARSE_SQUAWK" "$SQUAWK_SYNTHETIC" "/repo" > "$SQUAWK_PARSE_OUT"
+
+# Count findings
+FINDING_COUNT="$(grep -c '"check_id"' "$SQUAWK_PARSE_OUT" 2>/dev/null || printf '0')"
+if [[ "$FINDING_COUNT" -ge 2 ]]; then
+  pass "parse-squawk.py emits $FINDING_COUNT finding(s) from synthetic JSON"
+else
+  fail "parse-squawk.py emitted $FINDING_COUNT finding(s) (expected >= 2)"
+fi
+
+# Test 8: all output is valid JSON
+INVALID=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID=$((INVALID + 1))
+  fi
+done < "$SQUAWK_PARSE_OUT"
+if [[ $INVALID -eq 0 ]]; then
+  pass "parse-squawk.py output is valid JSONL"
+else
+  fail "parse-squawk.py output has $INVALID invalid JSON lines"
+fi
+
+# Test 9: properties.tool = "squawk"
+if grep -q '"tool":"squawk"' "$SQUAWK_PARSE_OUT"; then
+  pass "parse-squawk.py sets properties.tool = squawk"
+else
+  fail "parse-squawk.py missing properties.tool = squawk"
+fi
+
+# Test 11: require-concurrent-index-creation -> dm/index-without-concurrently
+if grep -q '"check_id":"dm/index-without-concurrently"' "$SQUAWK_PARSE_OUT"; then
+  pass "parse-squawk.py maps require-concurrent-index-creation -> dm/index-without-concurrently"
+else
+  fail "parse-squawk.py did NOT map require-concurrent-index-creation -> dm/index-without-concurrently"
+fi
+
+# Test 13: fingerprint field present and non-empty
+if python3 - "$SQUAWK_PARSE_OUT" <<'PYEOF'
+import json, sys, re
+fp_pattern = re.compile(r"[A-Za-z0-9_.:+/=\-]{8,128}")
+with open(sys.argv[1]) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        fp = obj.get("fingerprint", "")
+        if not fp_pattern.fullmatch(fp):
+            print(f"Bad fingerprint: {fp!r}", file=sys.stderr)
+            sys.exit(1)
+sys.exit(0)
+PYEOF
+then
+  pass "parse-squawk.py fingerprint field is present and valid"
+else
+  fail "parse-squawk.py fingerprint field is missing or invalid"
+fi
+
+# ---------------------------------------------------------------------------
+# Synthetic JSON fixtures for parse-sqlfluff.py unit tests
+# ---------------------------------------------------------------------------
+printf '\nTest 8, 10, 12: parse-sqlfluff.py unit tests against synthetic JSON\n'
+
+SQLFLUFF_SYNTHETIC="$TESTRUN_TMPDIR/sqlfluff-synthetic.json"
+cat > "$SQLFLUFF_SYNTHETIC" <<'JSON'
+[
+  {
+    "filepath": "/repo/supabase/migrations/0002_rpc.sql",
+    "violations": [
+      {
+        "start_line_no": 5,
+        "start_line_pos": 1,
+        "end_line_no": 5,
+        "end_line_pos": 20,
+        "description": "Found SECURITY DEFINER in function definition. Review privilege escalation risk.",
+        "name": "ST07",
+        "warning": false,
+        "fixable": false
+      },
+      {
+        "start_line_no": 20,
+        "start_line_pos": 1,
+        "end_line_no": 20,
+        "end_line_pos": 30,
+        "description": "Expected newline at end of file.",
+        "name": "LT12",
+        "warning": true,
+        "fixable": true
+      }
+    ]
+  }
+]
+JSON
+
+SQLFLUFF_PARSE_OUT="$TESTRUN_TMPDIR/sqlfluff-parsed.jsonl"
+python3 "$PARSE_SQLFLUFF" "$SQLFLUFF_SYNTHETIC" "/repo" > "$SQLFLUFF_PARSE_OUT"
+
+# Test 8: output is valid JSONL
+INVALID=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID=$((INVALID + 1))
+  fi
+done < "$SQLFLUFF_PARSE_OUT"
+if [[ $INVALID -eq 0 ]]; then
+  pass "parse-sqlfluff.py output is valid JSONL"
+else
+  fail "parse-sqlfluff.py output has $INVALID invalid JSON lines"
+fi
+
+# Test 10: properties.tool = "sqlfluff"
+if grep -q '"tool":"sqlfluff"' "$SQLFLUFF_PARSE_OUT"; then
+  pass "parse-sqlfluff.py sets properties.tool = sqlfluff"
+else
+  fail "parse-sqlfluff.py missing properties.tool = sqlfluff"
+fi
+
+# Test 12: SECURITY DEFINER description -> dm/security-definer-function
+if grep -q '"check_id":"dm/security-definer-function"' "$SQLFLUFF_PARSE_OUT"; then
+  pass "parse-sqlfluff.py maps SECURITY DEFINER description -> dm/security-definer-function"
+else
+  fail "parse-sqlfluff.py did NOT map SECURITY DEFINER description -> dm/security-definer-function"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 14: Fixture repo graceful-degradation path (squawk/sqlfluff absent)
+#          emits coverage_gap notes for migration directory
+# ---------------------------------------------------------------------------
+printf '\nTest 14: Fixture repo graceful-degradation (tools absent)\n'
+
+SPINE_OUT="$TESTRUN_TMPDIR/spine-dm-graceful.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "${SPINE_DIR}/run.sh" \
+  --repo "$FIXTURE_REPO" \
+  --tools "squawk,sqlfluff" \
+  --output "$SPINE_OUT" \
+  2>/dev/null
+SPINE_EXIT=$?
+set -e
+
+if [[ $SPINE_EXIT -eq 0 ]]; then
+  pass "spine exits 0 for squawk,sqlfluff on fixture repo (tools absent)"
+else
+  fail "spine exits $SPINE_EXIT (expected 0)"
+fi
+
+SKIP_OR_GAP="$(grep -c '"type":"skipped"\|"type":"coverage_gap"' "$SPINE_OUT" 2>/dev/null || printf '0')"
+if [[ "$SKIP_OR_GAP" -gt 0 ]]; then
+  pass "spine emits $SKIP_OR_GAP skip/gap note(s) for absent tools on fixture repo"
+else
+  fail "spine emits no skip/gap notes for absent tools on fixture repo"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n-------------------------------------------------\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  printf '\nFailed tests:\n'
+  for err in "${ERRORS[@]}"; do
+    printf '  - %s\n' "$err"
+  done
+  exit 1
+fi
+
+printf 'All tests passed.\n'
+exit 0

--- a/modules/commands-extra/skills/audit/tests/test-spine.sh
+++ b/modules/commands-extra/skills/audit/tests/test-spine.sh
@@ -438,6 +438,8 @@ if command -v shellcheck > /dev/null 2>&1; then
     "$SPINE_DIR/wrap-hadolint.sh"
     "$SPINE_DIR/wrap-actionlint.sh"
     "$SPINE_DIR/wrap-trivy.sh"
+    "$SPINE_DIR/wrap-squawk.sh"
+    "$SPINE_DIR/wrap-sqlfluff.sh"
   )
 
   for script in "${SHELL_SCRIPTS[@]}"; do


### PR DESCRIPTION
## Summary

- Adds the `ccgm/data-migrations` audit pack (`applies_when: has_migrations`) with 5 checks: `dm/unquoted-reserved-keyword`, `dm/index-without-concurrently`, `dm/missing-rls`, `dm/on-conflict-without-unique`, `dm/security-definer-function`.
- Adds two new spine tool wrappers: `wrap-squawk.sh` / `parse-squawk.py` (squawk — PostgreSQL migration linter) and `wrap-sqlfluff.sh` / `parse-sqlfluff.py` (sqlfluff — SQL linter).
- Registers both tools in `run.sh` (TOOL_WRAPPERS + TOOL_ORDER) and adds their 6 files to `module.json`.
- Adds 5 `dm/*` entries to `severity-rubric.json`.
- Adds `tests/test-pack-data-migrations.sh` with 26 tests covering pack validation, rubric membership, graceful degradation, and parser unit tests against synthetic JSON.

## Assumed tool output shapes (documented in wrappers/parsers)

**squawk `--reporter json`:** Top-level array of file objects, each with `"file"` (string) and `"violations"` (array). Each violation has `"rule"` (string, e.g. `"require-concurrent-index-creation"`), `"level"` (`"Warning"` | `"Error"` | `"Note"`), `"messages"` (array of single-key dicts like `{"Note": "..."}`), and `"position": {"start": {"line": N, "col": N}}`.

**sqlfluff `lint --format json`:** Top-level array of file objects, each with `"filepath"` (string) and `"violations"` (array). Each violation has `"start_line_no"` (int, 1-based), `"description"` (string), `"name"` (rule code string), `"warning"` (bool). The `dm/security-definer-function` check_id is assigned when `description` matches `/security[\s_-]*definer/i`.

## Test plan

- [x] `shellcheck` clean on both new wrappers
- [x] `test-pack-data-migrations.sh` — 26 passed, 0 failed
- [x] `test-spine.sh` — 25 passed, 0 failed (10 skipped notes, confirming squawk + sqlfluff registered)
- [x] `lint-pack.py` — 10 packs, 0 errors (data-migrations: PASS)
- [x] `test-pack-lint.sh` — 7 passed, 0 failed
- [x] `test-rubric.sh` — 8 passed, 0 failed
- [x] `test-registry.sh` — 8 passed, 0 failed
- [x] `module.json` and `severity-rubric.json` valid JSON
- [x] `test-modules.sh` — 1295 passed, 0 failed
- [x] `test-no-personal-data.sh` — PASS

Closes #607