### PR TITLE
#608: Reliability & Error Handling audit pack (Epic 2.2, LLM-detection)

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -342,6 +342,16 @@
       "target": "skills/audit/packs/architecture/checks.md",
       "type": "doc",
       "template": false
+    },
+    "skills/audit/packs/reliability/pack.json": {
+      "target": "skills/audit/packs/reliability/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/reliability/checks.md": {
+      "target": "skills/audit/packs/reliability/checks.md",
+      "type": "doc",
+      "template": false
     }
   },
   "tags": [

--- a/modules/commands-extra/skills/audit/packs/reliability/checks.md
+++ b/modules/commands-extra/skills/audit/packs/reliability/checks.md
@@ -1,0 +1,655 @@
+# checks.md — Reliability & Error Handling Pack
+
+---
+
+## Scope
+
+This pack audits JavaScript and TypeScript source files for async reliability defects: floating promises, misused promise return types, unhandled promise chains, sequential `await` inside loops, HTTP calls without a timeout or abort signal, retry loops without backoff or jitter, and incorrect use of `Promise.all` where partial failures should use `Promise.allSettled`. All checks use LLM detection; the worker agent may run the repo's own `npx eslint` advisory (read-only) but the spine's eslint wrapper (`scripts/spine/wrap-eslint.sh`) runs only `no-eval`/`no-implied-eval`/`no-new-func` via `--no-config-lookup` and cannot cover these rule classes. This pack does NOT cover general code quality (empty catch blocks, style, formatting), security vulnerabilities, TypeScript types, or architectural patterns — those belong in their respective packs.
+
+**Pack ID:** `ccgm/reliability`
+**Applies when:** `language:javascript`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `language:javascript` | All checks target JavaScript/TypeScript async semantics (Promises, async/await, fetch/axios). The registry derives `language:javascript` from the presence of `package.json`; no signal is produced on Go, Python, or other-language repos. |
+
+---
+
+## Scope Note: empty-catch Not Included
+
+The `code-quality/empty-catch-block` check in the `code-quality` pack already covers syntactically empty or comment-only catch blocks across all languages with `detection:llm`. Adding a `reliability/empty-catch` check that targets async error-swallowing would duplicate the same pattern with slightly different framing, producing overlapping findings. The `code-quality/empty-catch-block` LLM instruction already flags catch blocks with only a comment and no actual error handling. To avoid duplicate signal, `reliability/empty-catch` is intentionally omitted from this pack.
+
+---
+
+## Checks
+
+---
+
+### `reliability/floating-promise`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans JavaScript and TypeScript source files for async function calls or Promise-returning expressions whose return value is neither awaited, nor returned, nor assigned, nor explicitly discarded with `void`. These "floating" promises mean rejection errors are silently lost. The spine's eslint wrapper does not run `@typescript-eslint/no-floating-promises`; detection is LLM-owned.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: `@typescript-eslint/no-floating-promises` (advisory; not run by spine)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan JavaScript and TypeScript source files for "floating promises" — async function
+calls or Promise-returning expressions whose result is neither awaited, nor returned,
+nor assigned to a variable, nor explicitly discarded with `void`.
+
+A floating promise means a rejection can go unhandled and the caller has no way to
+know the async operation failed.
+
+Flag as a finding:
+- An async function call used as a statement with no await: someAsyncFn();
+- A method returning a Promise called with no await: obj.save();
+- A Promise constructor result that is not returned or assigned
+
+Do NOT flag:
+- Calls prefixed with `void` to explicitly discard: void someAsyncFn();
+- Promises that are awaited: await someAsyncFn();
+- Promises that are returned: return someAsyncFn();
+- Promises that are assigned: const p = someAsyncFn();
+- Fire-and-forget patterns inside event listeners where documented with a comment
+  explaining the intentional discard
+
+You may run `npx eslint --no-config-lookup` with `@typescript-eslint/no-floating-promises`
+for advisory results if the project has the plugin installed; treat output as one signal.
+
+For each finding report: file:line, the offending expression, and why it is unhandled.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: reliability/floating-promise
+detection: llm
+```
+
+Note: the spine's `wrap-eslint.sh` runs only `no-eval`/`no-implied-eval`/`no-new-func` via
+`--no-config-lookup`. It does NOT run `@typescript-eslint/no-floating-promises` and does NOT
+emit `reliability/floating-promise` IDs. The LLM agent handles this check directly.
+
+#### Severity / Confidence
+
+**Severity rationale:** Floating promises silently swallow rejections. In production, async errors (network failures, DB errors, validation errors) go undetected, causing silent data corruption or stale UI state. High severity: directly causes silent runtime failures.
+
+**Confidence rationale:** LLM pattern matching for unadorned async call statements is reliable in straightforward cases but requires judgment for chained calls and indirect promise returns. Medium confidence accounts for false positives on intentional fire-and-forget.
+
+**Rubric entry:** `reliability/floating-promise`
+
+#### Fixture
+
+**True positive** (`src/handlers/user.ts`):
+
+```ts
+// FINDS: updateProfile() returns a Promise but result is not awaited or returned
+async function handleFormSubmit(data: FormData) {
+  validateForm(data);
+  updateProfile(data);   // <-- floating promise: rejection silently lost
+  showSuccessMessage();
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: updateProfile is awaited
+async function handleFormSubmit(data: FormData) {
+  validateForm(data);
+  await updateProfile(data);
+  showSuccessMessage();
+}
+```
+
+---
+
+### `reliability/misused-promise`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans for Promise-returning functions passed to contexts that expect synchronous boolean or void callbacks — for example, passing an async function to an `if` condition, a `.filter()` callback, or an event handler type that is not declared async-aware. The spine's eslint wrapper does not run `@typescript-eslint/no-misused-promises`; detection is LLM-owned.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: `@typescript-eslint/no-misused-promises` (advisory; not run by spine)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan JavaScript and TypeScript source files for Promise-returning functions used in
+contexts that expect a synchronous result. This causes the async operation to be
+silently ignored because the truthy Promise object is evaluated instead of its resolved
+value.
+
+Flag as a finding:
+- An async function (or one returning a Promise) passed as a .filter() or .find()
+  callback: array.filter(async (x) => ...)
+- An async function passed as a boolean predicate to an if statement or ternary:
+  if (async () => checkCondition())
+- An async function assigned to a DOM event handler that expects synchronous void:
+  button.addEventListener('click', async () => { ... }) — flag ONLY if the handler
+  does work that the caller depends on synchronously
+
+Do NOT flag:
+- async forEach callbacks (these are intentionally fire-and-forget in JS)
+- Promise-returning functions returned from other async functions
+- async map callbacks where the result is Promise.all'd immediately
+
+You may run `npx eslint --no-config-lookup` with `@typescript-eslint/no-misused-promises`
+for advisory results if the project has the plugin installed; treat output as one signal.
+
+For each finding report: file:line, the context where the promise is misused, and the
+expected synchronous type.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: reliability/misused-promise
+detection: llm
+```
+
+Note: the spine's `wrap-eslint.sh` does not run `@typescript-eslint/no-misused-promises`.
+The LLM agent handles this check directly.
+
+#### Severity / Confidence
+
+**Severity rationale:** Passing an async function where a synchronous predicate is expected silently produces wrong results — a filter that always passes, a condition that is always true. These are logic bugs, not style issues. High severity.
+
+**Confidence rationale:** The most egregious cases (async filter callbacks, async if-conditions) are reliably detectable. Edge cases around event handlers require more context. Medium confidence.
+
+**Rubric entry:** `reliability/misused-promise`
+
+#### Fixture
+
+**True positive** (`src/utils/filter.ts`):
+
+```ts
+// FINDS: async callback passed to .filter() — always returns a truthy Promise
+const admins = users.filter(async (u) => await isAdmin(u));
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: results collected with Promise.all, not passed directly to filter
+const adminFlags = await Promise.all(users.map((u) => isAdmin(u)));
+const admins = users.filter((_, i) => adminFlags[i]);
+```
+
+---
+
+### `reliability/unhandled-promise`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans for Promise chains that have no `.catch()` handler, no `await` in a `try/catch`, and no `.finally()` that re-throws. These chains drop rejections silently at runtime. The spine's eslint wrapper does not run `promise/catch-or-return`; detection is LLM-owned.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: `promise/catch-or-return` (advisory; not run by spine)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan JavaScript and TypeScript source files for Promise chains that end without a
+.catch() handler and are not inside a try/catch block. Unhandled rejections produce
+an UnhandledPromiseRejectionWarning (Node) or are silently dropped (browser).
+
+Flag as a finding:
+- A .then() chain with no .catch() at the end: fetch(url).then(process)
+- A Promise constructor call that neither awaits nor attaches .catch()
+- A Promise.all / Promise.race call whose result is not awaited in try/catch and
+  has no .catch() attached
+
+Do NOT flag:
+- Chains that end with .catch(): fetch(url).then(process).catch(handleError)
+- await expressions inside a try/catch block
+- Chains where the final .then() explicitly rethrows: .then(...).catch(e => { throw e; })
+- Chains inside test files using test framework matchers (expect(...).rejects.toThrow)
+
+You may run `npx eslint --no-config-lookup` with `promise/catch-or-return` for advisory
+results if the project has eslint-plugin-promise installed; treat output as one signal.
+
+For each finding report: file:line, the chain expression, and the missing handler type.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: reliability/unhandled-promise
+detection: llm
+```
+
+Note: the spine's `wrap-eslint.sh` does not run `promise/catch-or-return`.
+The LLM agent handles this check directly.
+
+#### Severity / Confidence
+
+**Severity rationale:** Unhandled rejections produce Node.js process crashes (in newer versions) or silent failures in the browser. A network error in an unhanded fetch chain leaves the user in an undefined state with no feedback. High severity.
+
+**Confidence rationale:** Detecting terminal `.then()` calls without `.catch()` is reliable for simple chains. Complex chains and dynamic promise construction require more judgment. Medium confidence.
+
+**Rubric entry:** `reliability/unhandled-promise`
+
+#### Fixture
+
+**True positive** (`src/api/data.ts`):
+
+```ts
+// FINDS: .then() chain with no .catch() — rejection is silently dropped
+fetch('/api/users')
+  .then((res) => res.json())
+  .then((data) => setUsers(data));
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: .catch() is present
+fetch('/api/users')
+  .then((res) => res.json())
+  .then((data) => setUsers(data))
+  .catch((err) => console.error('Failed to load users:', err));
+```
+
+---
+
+### `reliability/await-in-loop`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans for `await` expressions inside `for`, `while`, or `do...while` loop bodies where the iterations are independent and could be parallelised with `Promise.all`. Sequential awaiting inside a loop serialises what could be concurrent work, severely degrading performance. The spine's eslint wrapper does not run `no-await-in-loop`; detection is LLM-owned.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: `no-await-in-loop` (advisory; not run by spine)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan JavaScript and TypeScript source files for `await` expressions inside loop bodies
+(for, for...of, for...in, while, do...while) where each iteration awaits an independent
+async operation that could be parallelised.
+
+Flag as a finding when:
+- A `for` or `while` loop body contains `await` on an independent call (e.g. database
+  lookup, API call, file read) where each iteration does not depend on the result of
+  the previous iteration
+
+Do NOT flag:
+- Loops where each iteration MUST complete before the next starts (sequential processing
+  where order or side-effects matter, e.g. processing items in a queue that must be
+  ordered, migrations run in sequence)
+- Loops where the loop variable itself is mutated by the awaited result
+- Rate-limiting loops that intentionally delay between iterations
+
+For each finding, suggest the `Promise.all(array.map(async (item) => ...))` pattern
+as the fix.
+
+For each finding report: file:line, the loop construct, and the awaited expression.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: reliability/await-in-loop
+detection: llm
+```
+
+Note: the spine's `wrap-eslint.sh` does not run `no-await-in-loop`.
+The LLM agent handles this check directly.
+
+#### Severity / Confidence
+
+**Severity rationale:** Sequential awaiting in a loop over N items makes a task take N × latency instead of 1 × latency. For 100 items at 100ms each, this is 10 seconds vs 100ms. Medium severity: a performance defect that may cause timeouts and degraded UX but does not cause incorrect behavior.
+
+**Confidence rationale:** Most `await` calls inside for-loops are genuinely independent and worth flagging. Dependent loops (where each iteration needs the previous result) require reading the loop body carefully; LLM judgment is needed. Medium confidence.
+
+**Rubric entry:** `reliability/await-in-loop`
+
+#### Fixture
+
+**True positive** (`src/services/email.ts`):
+
+```ts
+// FINDS: each sendEmail call is independent; all could run concurrently
+async function notifyAll(users: User[]) {
+  for (const user of users) {
+    await sendEmail(user.email, 'Welcome!');  // serialised unnecessarily
+  }
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: parallelised with Promise.all
+async function notifyAll(users: User[]) {
+  await Promise.all(users.map((user) => sendEmail(user.email, 'Welcome!')));
+}
+```
+
+---
+
+### `reliability/fetch-without-timeout`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans for `fetch()` and `axios` calls that have no timeout or `AbortController` / `AbortSignal` configured. Without a timeout, a slow or unresponsive server will hold the connection open indefinitely, causing the caller to hang or exhaust connection pools. There is no ESLint rule for this pattern; detection is LLM-owned.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a (no standard ESLint rule exists for this pattern)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan JavaScript and TypeScript source files for HTTP calls using the Fetch API or axios
+that have no timeout or AbortController/AbortSignal configured.
+
+Flag as a finding:
+- fetch(url) or fetch(url, options) where options does not include a `signal` key with
+  an AbortController signal
+- axios.get/post/put/delete/request calls where the config object does not include a
+  `timeout` field or a `signal` field
+- Any wrapper around fetch/axios where the underlying call passes no timeout
+
+Do NOT flag:
+- fetch calls that include a signal: fetch(url, { signal: controller.signal })
+- axios calls that include timeout: axios.get(url, { timeout: 5000 })
+- axios instances created with a baseURL and a timeout in the defaults config (if the
+  call inherits from a configured instance — use judgment based on the instance creation
+  nearby)
+- Test files (*.test.ts, *.spec.ts, *.test.js, __tests__/)
+
+For each finding report: file:line, the fetch/axios call, and the missing timeout/signal.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: reliability/fetch-without-timeout
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** HTTP calls without a timeout can hang indefinitely when a server is slow or unresponsive, exhausting thread pools and causing cascading failures in server-side code, and hanging UIs in browser code. Medium severity: serious reliability risk but not an immediate security issue.
+
+**Confidence rationale:** The pattern is recognisable but requires reading surrounding context (axios instance config, shared abort controllers) to avoid false positives. Medium confidence.
+
+**Rubric entry:** `reliability/fetch-without-timeout`
+
+#### Fixture
+
+**True positive** (`src/api/client.ts`):
+
+```ts
+// FINDS: fetch with no signal — hangs indefinitely if server is unresponsive
+async function getUser(id: string) {
+  const res = await fetch(`/api/users/${id}`);
+  return res.json();
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: AbortController signal provides a timeout
+async function getUser(id: string) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
+  try {
+    const res = await fetch(`/api/users/${id}`, { signal: controller.signal });
+    return res.json();
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+```
+
+---
+
+### `reliability/retry-without-backoff`
+
+**Severity:** `low`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans for retry loops or recursive retry patterns that have no exponential backoff or jitter. Retry storms — many clients retrying at the same fixed interval — can amplify outages. There is no standard ESLint rule for this pattern; detection is LLM-owned.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a (no standard ESLint rule exists for this pattern)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan JavaScript and TypeScript source files for retry loops or recursive retry patterns
+that have no exponential backoff or jitter.
+
+Flag as a finding when:
+- A loop retries an async operation (fetch, axios, DB call) with either no delay at all,
+  or a fixed delay (e.g. sleep(1000) always) and no exponential component
+- A recursive function calls itself on failure with a fixed or zero delay
+- A retry utility is called with a fixed `retryDelay` or `interval` and no backoff factor
+
+Do NOT flag:
+- Retry logic that multiplies the delay by a factor (exponential backoff)
+- Retry logic using a library known to implement backoff (e.g. `retry`, `p-retry`,
+  `axios-retry` with exponentialDelay, `cockatiel`)
+- Polling loops that are not retrying on failure (e.g. status polling every N seconds)
+
+For each finding report: file:line, the retry pattern, and the missing backoff/jitter.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: reliability/retry-without-backoff
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Fixed-interval retries cause thundering-herd problems under load but are a less immediate issue than unhandled rejections or floating promises. Low severity: poor resilience pattern that matters mostly at scale.
+
+**Confidence rationale:** Detecting the absence of a backoff factor requires reading the retry logic carefully. Many patterns exist (loops, recursion, library calls). Medium confidence.
+
+**Rubric entry:** `reliability/retry-without-backoff`
+
+#### Fixture
+
+**True positive** (`src/utils/retry.ts`):
+
+```ts
+// FINDS: retries with a fixed 1-second delay and no backoff factor
+async function fetchWithRetry(url: string, retries = 3): Promise<Response> {
+  try {
+    return await fetch(url);
+  } catch (err) {
+    if (retries > 0) {
+      await sleep(1000);              // fixed delay — no exponential growth
+      return fetchWithRetry(url, retries - 1);
+    }
+    throw err;
+  }
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: delay doubles on each retry (exponential backoff)
+async function fetchWithRetry(url: string, retries = 3, delay = 500): Promise<Response> {
+  try {
+    return await fetch(url);
+  } catch (err) {
+    if (retries > 0) {
+      await sleep(delay);
+      return fetchWithRetry(url, retries - 1, delay * 2);
+    }
+    throw err;
+  }
+}
+```
+
+---
+
+### `reliability/promise-all-vs-allsettled`
+
+**Severity:** `low`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans for `Promise.all()` calls where one rejection causes all results to be lost, and where the calling context suggests that partial success is acceptable or even expected. In such cases `Promise.allSettled()` with per-result error handling is the appropriate API. There is no standard ESLint rule for this pattern; detection is LLM-owned.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a (no standard ESLint rule exists for this pattern)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan JavaScript and TypeScript source files for Promise.all() calls where a single
+rejection would drop all successfully resolved results, and where the context suggests
+partial success would be acceptable.
+
+Flag as a finding when:
+- Promise.all() is called over a collection of independent operations (fetching multiple
+  unrelated resources, sending notifications to multiple users, processing independent
+  items) and the caller has no explicit comment or catch that handles partial failure
+
+Do NOT flag:
+- Promise.all() calls where ALL operations are truly atomic — partial success is not
+  meaningful (e.g. a database transaction where all steps must succeed)
+- Promise.all() calls that are wrapped in .catch() and the caller handles the error
+  in a way that makes the failure explicit
+- Promise.all() inside test files
+
+For each finding, suggest `Promise.allSettled()` with a per-result status check as an
+alternative, and note when Promise.all() is actually correct (atomic operations).
+
+For each finding report: file:line, the Promise.all() call, and why partial success
+appears acceptable in context.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: reliability/promise-all-vs-allsettled
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** `Promise.all` rejecting on the first failure loses all other resolved values; this is often a surprising behavior difference from the developer's intent but is not always a bug. Low severity: a design choice that may or may not reflect intent.
+
+**Confidence rationale:** Distinguishing "atomic, all-or-nothing" from "independent, partial-success-ok" requires reading calling context and business logic. False positives are common. Medium confidence.
+
+**Rubric entry:** `reliability/promise-all-vs-allsettled`
+
+#### Fixture
+
+**True positive** (`src/services/notification.ts`):
+
+```ts
+// FINDS: sending to multiple users is independent; one failure drops all results
+async function notifyUsers(userIds: string[]) {
+  const results = await Promise.all(
+    userIds.map((id) => sendNotification(id))
+  );
+  return results;
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: Promise.allSettled collects each result's status independently
+async function notifyUsers(userIds: string[]) {
+  const results = await Promise.allSettled(
+    userIds.map((id) => sendNotification(id))
+  );
+  const failed = results.filter((r) => r.status === 'rejected');
+  if (failed.length > 0) {
+    logger.warn(`${failed.length} notifications failed`);
+  }
+}
+```
+
+---
+
+## Migration / Scope Notes
+
+### empty-catch Not Included
+
+`reliability/empty-catch` was considered but **dropped** to avoid duplicating `code-quality/empty-catch-block`. The `code-quality` pack already detects syntactically empty or comment-only catch blocks for all languages. Adding a narrower async-scoped version in this pack would generate overlapping findings for the same code. If a future wave warrants distinguishing "catch block that swallows async rejection specifically" from "general empty catch", the two checks should be merged under one pack with a migration mapping.
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/reliability/pack.json
+++ b/modules/commands-extra/skills/audit/packs/reliability/pack.json
@@ -1,0 +1,60 @@
+{
+  "id": "ccgm/reliability",
+  "name": "Reliability & Error Handling",
+  "version": "1.0.0",
+  "applies_when": ["language:javascript"],
+  "tags": ["reliability", "promises", "async", "error-handling"],
+  "severity_floor": "low",
+  "tools": [],
+  "checks": [
+    {
+      "id": "reliability/floating-promise",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "reliability/misused-promise",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "reliability/unhandled-promise",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "reliability/await-in-loop",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "reliability/fetch-without-timeout",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "reliability/retry-without-backoff",
+      "severity": "low",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "reliability/promise-all-vs-allsettled",
+      "severity": "low",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -313,6 +313,41 @@
       "severity": "medium",
       "confidence": "medium",
       "fix_confidence": "low"
+    },
+    "reliability/floating-promise": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/misused-promise": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/unhandled-promise": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/await-in-loop": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/fetch-without-timeout": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/retry-without-backoff": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/promise-all-vs-allsettled": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
     }
   }
 }

--- a/modules/commands-extra/skills/audit/tests/test-pack-reliability.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-reliability.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# test-pack-reliability.sh — Tests for the ccgm/reliability audit pack (issue #608)
+#
+# Tests:
+#   1. pack.json validates against pack.schema.json (stdlib validator via registry.py)
+#   2. severity-rubric.json is valid JSON and contains all reliability/* check ids
+#   3. lint-pack.py passes on the reliability pack with the real rubric
+#   4. checks.md contains required template sections (## Scope, ## applies_when Rationale,
+#      ## Checks, ## Quality Checklist)
+#   5. checks.md documents a TP/TN fixture for each seeded defect class:
+#       floating-promise, unhandled-promise, fetch-without-timeout
+#      Note: reliability/empty-catch was intentionally dropped (overlaps code-quality/
+#      empty-catch-block); the "Scope Note: empty-catch Not Included" section in checks.md
+#      documents this decision.
+#   6. applies_when gates correctly: pack is SELECTED for a JS project (package.json
+#      present), NOT selected for a Go-only project
+#
+# Note: These are LLM-detection checks. We do NOT assert that the LLM finds actual
+# issues in the JS fixture — we only assert structural validity (pack schema, rubric
+# entries, checks.md completeness, and registry selection logic).
+#
+# Exit: 0 if all pass, 1 if any fail.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PACK_DIR="${AUDIT_DIR}/packs/reliability"
+REGISTRY="${AUDIT_DIR}/scripts/registry.py"
+LINTER="${AUDIT_DIR}/scripts/lint-pack.py"
+RUBRIC="${AUDIT_DIR}/schemas/severity-rubric.json"
+
+PASS=0
+FAIL=0
+
+pass() { printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1)); }
+fail() { printf "  FAIL: %s\n" "$1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Test 1: pack.json validates against pack.schema.json
+# ---------------------------------------------------------------------------
+echo "--- Test 1: pack.json validates (stdlib registry.py)"
+
+# Write validator to a temp file to avoid heredoc-in-command-substitution warnings.
+_T1_PY="$(mktemp /tmp/pack_validate_rel_XXXXXX.py)"
+cat > "${_T1_PY}" <<'PYEOF'
+import sys, json, importlib.util, pathlib
+
+registry_py = pathlib.Path(sys.argv[1])
+pack_path   = pathlib.Path(sys.argv[2])
+
+spec = importlib.util.spec_from_file_location("registry", str(registry_py))
+mod  = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+with open(pack_path, encoding="utf-8") as fh:
+    pack = json.load(fh)
+
+try:
+    mod.validate_pack(pack, str(pack_path))
+    print("VALID")
+    sys.exit(0)
+except mod.ValidationError as exc:
+    print("INVALID: " + str(exc))
+    sys.exit(1)
+PYEOF
+# shellcheck disable=SC2064
+trap "rm -f '${_T1_PY}'" EXIT
+
+_T1_RESULT=""
+_T1_EXIT=0
+_T1_RESULT=$(python3 "${_T1_PY}" "${REGISTRY}" "${PACK_DIR}/pack.json" 2>&1) || _T1_EXIT=$?
+
+if [ "${_T1_EXIT}" -eq 0 ] && echo "${_T1_RESULT}" | grep -q "^VALID$"; then
+    pass "reliability/pack.json validates against pack.schema.json"
+else
+    fail "reliability/pack.json failed validation: ${_T1_RESULT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: severity-rubric.json contains all reliability/* check ids
+# ---------------------------------------------------------------------------
+echo "--- Test 2: rubric contains all reliability/* check ids"
+
+EXPECTED_IDS=(
+    "reliability/floating-promise"
+    "reliability/misused-promise"
+    "reliability/unhandled-promise"
+    "reliability/await-in-loop"
+    "reliability/fetch-without-timeout"
+    "reliability/retry-without-backoff"
+    "reliability/promise-all-vs-allsettled"
+)
+
+_T2_MISSING=""
+for check_id in "${EXPECTED_IDS[@]}"; do
+    if ! python3 -c "
+import json, sys
+rubric = json.load(open('${RUBRIC}', encoding='utf-8'))
+checks = rubric.get('checks', {})
+if '${check_id}' not in checks:
+    print('MISSING')
+    sys.exit(1)
+print('FOUND')
+sys.exit(0)
+" 2>/dev/null | grep -q "^FOUND$"; then
+        _T2_MISSING="${_T2_MISSING} ${check_id}"
+    fi
+done
+
+if [ -z "${_T2_MISSING}" ]; then
+    pass "rubric contains all ${#EXPECTED_IDS[@]} reliability/* check ids"
+else
+    fail "rubric missing ids:${_T2_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: lint-pack.py passes on the reliability pack with the real rubric
+# ---------------------------------------------------------------------------
+echo "--- Test 3: lint-pack.py passes on reliability pack"
+
+_T3_OUTPUT=""
+_T3_EXIT=0
+_T3_OUTPUT=$(python3 "${LINTER}" \
+    --packs-dir "${AUDIT_DIR}/packs" \
+    --rubric "${RUBRIC}" 2>&1) || _T3_EXIT=$?
+
+if [ "${_T3_EXIT}" -eq 0 ] && echo "${_T3_OUTPUT}" | grep -q "^PASS: reliability"; then
+    pass "lint-pack.py reports PASS for reliability pack"
+else
+    fail "lint-pack.py did not report PASS for reliability: exit=${_T3_EXIT}, output=${_T3_OUTPUT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: checks.md contains all required template sections
+# ---------------------------------------------------------------------------
+echo "--- Test 4: checks.md has required sections"
+
+CHECKS_MD="${PACK_DIR}/checks.md"
+
+_REQUIRED_SECTIONS=(
+    "^## Scope"
+    "^## applies_when Rationale"
+    "^## Checks"
+    "^## Quality Checklist"
+)
+
+_T4_MISSING=""
+for section in "${_REQUIRED_SECTIONS[@]}"; do
+    if ! grep -qiE "${section}" "${CHECKS_MD}"; then
+        _T4_MISSING="${_T4_MISSING} '${section}'"
+    fi
+done
+
+if [ -z "${_T4_MISSING}" ]; then
+    pass "checks.md contains all required sections"
+else
+    fail "checks.md missing sections:${_T4_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: checks.md documents TP/TN fixtures for seeded defect classes
+#
+# Seeded defect classes to verify:
+#   - floating-promise
+#   - unhandled-promise (covers the unhandled-promise check)
+#   - fetch-without-timeout
+#
+# Note: reliability/empty-catch was intentionally DROPPED (overlaps
+# code-quality/empty-catch-block). The "Scope Note: empty-catch Not Included"
+# section in checks.md documents this decision. We assert that section exists.
+# ---------------------------------------------------------------------------
+echo "--- Test 5: checks.md documents TP/TN fixtures for seeded defect classes"
+
+# Verify True positive and True negative markers for each seeded class
+declare -A SEEDED_CLASSES=(
+    ["floating-promise"]="reliability/floating-promise"
+    ["unhandled-promise"]="reliability/unhandled-promise"
+    ["fetch-without-timeout"]="reliability/fetch-without-timeout"
+)
+
+_T5_ERRORS=""
+
+for class in "${!SEEDED_CLASSES[@]}"; do
+    check_id="${SEEDED_CLASSES[$class]}"
+
+    # check-id appears in checks.md
+    if ! grep -q "${check_id}" "${CHECKS_MD}"; then
+        _T5_ERRORS="${_T5_ERRORS}\n  check-id '${check_id}' not found in checks.md"
+        continue
+    fi
+
+    # Extract the section for this check-id: from the heading to the next ### heading
+    # (or end of file). Use python3 for reliable multi-line extraction.
+    _SECTION=$(python3 - "${CHECKS_MD}" "${check_id}" <<'PYEOF' 2>/dev/null
+import sys, re
+md = open(sys.argv[1], encoding='utf-8').read()
+check_id = sys.argv[2]
+# Find start: the ### line containing the check-id
+pattern = r'(### `' + re.escape(check_id) + r'`.*?)(?=\n### `|\Z)'
+m = re.search(pattern, md, re.DOTALL)
+if m:
+    print(m.group(1))
+PYEOF
+)
+
+    # True positive fixture marker present in section
+    if ! echo "${_SECTION}" | grep -q "True positive\|FINDS:"; then
+        _T5_ERRORS="${_T5_ERRORS}\n  no True positive fixture found for '${check_id}'"
+    fi
+
+    # True negative fixture marker present in section
+    if ! echo "${_SECTION}" | grep -q "True negative\|should produce NO"; then
+        _T5_ERRORS="${_T5_ERRORS}\n  no True negative fixture found for '${check_id}'"
+    fi
+done
+
+# Verify empty-catch decision is documented
+if ! grep -q "empty-catch" "${CHECKS_MD}"; then
+    _T5_ERRORS="${_T5_ERRORS}\n  checks.md does not document the empty-catch omission decision"
+fi
+
+if [ -z "${_T5_ERRORS}" ]; then
+    pass "checks.md documents TP/TN fixtures for all seeded defect classes (floating-promise, unhandled-promise, fetch-without-timeout) and documents empty-catch omission"
+else
+    fail "checks.md fixture coverage issues:$(printf '%b' "${_T5_ERRORS}")"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: applies_when gates correctly via registry.py
+#   6a. JS project (package.json present) → pack INCLUDED
+#   6b. Go-only project (no package.json) → pack EXCLUDED
+# ---------------------------------------------------------------------------
+echo "--- Test 6: applies_when gates correctly"
+
+TMPDIR_PACKS="$(mktemp -d)"
+# shellcheck disable=SC2064
+trap "rm -rf '${TMPDIR_PACKS}'" EXIT
+
+# Set up a temp packs dir with just the reliability pack
+mkdir -p "${TMPDIR_PACKS}/reliability"
+cp "${PACK_DIR}/pack.json" "${TMPDIR_PACKS}/reliability/pack.json"
+
+# Helper: run registry.py with a detector JSON and the temp packs dir
+run_registry() {
+    local detector_json="$1"
+    CCGM_PACKS_DIR="${TMPDIR_PACKS}" python3 "${REGISTRY}" <<< "${detector_json}"
+}
+
+# 6a: JS project → pack INCLUDED
+DETECTOR_JS='{"detected_ecosystems":["javascript"],"project_shape":{},"available_tools":[]}'
+_T6A_RESULT=""
+_T6A_EXIT=0
+_T6A_RESULT=$(run_registry "${DETECTOR_JS}" 2>/dev/null) || _T6A_EXIT=$?
+
+_T6A_INCLUDED=0
+if [ "${_T6A_EXIT}" -eq 0 ]; then
+    if echo "${_T6A_RESULT}" | python3 -c "
+import json, sys
+packs = json.load(sys.stdin)
+ids = [p['id'] for p in packs]
+assert 'ccgm/reliability' in ids, 'ccgm/reliability not in: ' + str(ids)
+" 2>/dev/null; then
+        _T6A_INCLUDED=1
+    fi
+fi
+
+if [ "${_T6A_INCLUDED}" -eq 1 ]; then
+    pass "ccgm/reliability INCLUDED for JS project (language:javascript)"
+else
+    fail "ccgm/reliability should be INCLUDED for JS project but was not. exit=${_T6A_EXIT}, result=${_T6A_RESULT}"
+fi
+
+# 6b: Go-only project → pack EXCLUDED
+DETECTOR_GO='{"detected_ecosystems":["go"],"project_shape":{},"available_tools":[]}'
+_T6B_RESULT=""
+_T6B_EXIT=0
+_T6B_RESULT=$(run_registry "${DETECTOR_GO}" 2>/dev/null) || _T6B_EXIT=$?
+
+_T6B_EXCLUDED=0
+if [ "${_T6B_EXIT}" -eq 0 ]; then
+    if echo "${_T6B_RESULT}" | python3 -c "
+import json, sys
+packs = json.load(sys.stdin)
+ids = [p['id'] for p in packs]
+assert 'ccgm/reliability' not in ids, 'ccgm/reliability should not be in: ' + str(ids)
+" 2>/dev/null; then
+        _T6B_EXCLUDED=1
+    fi
+fi
+
+if [ "${_T6B_EXCLUDED}" -eq 1 ]; then
+    pass "ccgm/reliability EXCLUDED for Go-only project (no language:javascript)"
+else
+    fail "ccgm/reliability should be EXCLUDED for Go project but was not. exit=${_T6B_EXIT}, result=${_T6B_RESULT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Bonus: Validate JS runtime fixture structure (no LLM assertion — static only)
+# Create a minimal JS file with known reliability patterns and verify it exists
+# ---------------------------------------------------------------------------
+echo "--- Bonus: JS runtime fixture creation and static structure"
+
+TMPDIR_FIXTURE="$(mktemp -d)"
+# shellcheck disable=SC2064
+trap "rm -rf '${TMPDIR_FIXTURE}'" EXIT
+
+# floating promise fixture
+cat > "${TMPDIR_FIXTURE}/floating.js" <<'JS'
+// Reliability fixture: floating-promise (TP)
+// updateUser() returns a Promise; result is not awaited (floating)
+async function handleUpdate(user) {
+  validateUser(user);
+  updateUser(user);    // floating promise — rejection silently lost
+  showToast('Saved');
+}
+JS
+
+# fetch-without-timeout fixture
+cat > "${TMPDIR_FIXTURE}/fetch-no-timeout.js" <<'JS'
+// Reliability fixture: fetch-without-timeout (TP)
+// No AbortController signal provided — hangs indefinitely on slow server
+async function loadData(id) {
+  const res = await fetch(`/api/data/${id}`);
+  return res.json();
+}
+JS
+
+# package.json to mark the fixture as a JS project
+cat > "${TMPDIR_FIXTURE}/package.json" <<'JSON'
+{ "name": "reliability-test-fixture", "version": "1.0.0" }
+JSON
+
+if [ -f "${TMPDIR_FIXTURE}/floating.js" ] && \
+   [ -f "${TMPDIR_FIXTURE}/fetch-no-timeout.js" ] && \
+   [ -f "${TMPDIR_FIXTURE}/package.json" ]; then
+    pass "JS runtime fixtures created (floating-promise, fetch-without-timeout, package.json)"
+else
+    fail "JS runtime fixture creation failed"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf "\nResults: %d passed, %d failed\n" "${PASS}" "${FAIL}"
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `ccgm/reliability` audit pack (`packs/reliability/{pack.json,checks.md}`) with 7 LLM-detection checks targeting JavaScript/TypeScript async reliability defects: `floating-promise`, `misused-promise`, `unhandled-promise`, `await-in-loop`, `fetch-without-timeout`, `retry-without-backoff`, `promise-all-vs-allsettled`
- All checks are `detection:llm`; no spine wrappers added, no `run.sh`/`wrap-eslint.sh` edits — consistent with the constraint that the spine's eslint wrapper runs only `no-eval`/`no-implied-eval`/`no-new-func` under `--no-config-lookup` and cannot cover typescript-eslint or promise plugin rules
- Adds 7 `reliability/*` entries to `schemas/severity-rubric.json` (floating/misused/unhandled-promise → high; await-in-loop + fetch-without-timeout → medium; retry-without-backoff + promise-all-vs-allsettled → low; all confidence:medium)
- Registers both pack files as `type:doc` in `modules/commands-extra/module.json`
- Ships `tests/test-pack-reliability.sh` with 8 assertions (schema validation, rubric coverage for all 7 check ids, `lint-pack.py` pass, required checks.md sections, TP/TN fixture documentation, `applies_when` gate selection for JS project and exclusion for Go project)

## empty-catch decision

`reliability/empty-catch` was dropped because `code-quality/empty-catch-block` already covers syntactically empty or comment-only catch blocks for all languages with `detection:llm`. The overlap is documented in the "Scope Note: empty-catch Not Included" section of `checks.md`.

## Test plan

- [ ] `bash modules/commands-extra/skills/audit/tests/test-pack-reliability.sh` → 8 passed, 0 failed
- [ ] `python3 modules/commands-extra/skills/audit/scripts/lint-pack.py` → 10 packs checked, 0 errors
- [ ] `bash modules/commands-extra/skills/audit/tests/test-pack-lint.sh` → 7 passed, 0 failed
- [ ] `bash modules/commands-extra/skills/audit/tests/test-rubric.sh` → 8 passed, 0 failed
- [ ] `bash modules/commands-extra/skills/audit/tests/test-registry.sh` → 8 passed, 0 failed
- [ ] `python3 -m json.tool modules/commands-extra/module.json > /dev/null` → valid
- [ ] `python3 -m json.tool modules/commands-extra/skills/audit/schemas/severity-rubric.json > /dev/null` → valid
- [ ] `bash tests/test-modules.sh` → 1291 passed, 0 failed
- [ ] `bash tests/test-no-personal-data.sh` → PASS

Closes #608