### PR TITLE
#610: correctness/logic pack + eslint spine extension (7 new rules)

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -342,6 +342,16 @@
       "target": "skills/audit/packs/architecture/checks.md",
       "type": "doc",
       "template": false
+    },
+    "skills/audit/packs/correctness/pack.json": {
+      "target": "skills/audit/packs/correctness/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/correctness/checks.md": {
+      "target": "skills/audit/packs/correctness/checks.md",
+      "type": "doc",
+      "template": false
     }
   },
   "tags": [

--- a/modules/commands-extra/skills/audit/packs/correctness/checks.md
+++ b/modules/commands-extra/skills/audit/packs/correctness/checks.md
@@ -1,0 +1,350 @@
+# Correctness / Logic Pack
+
+## Scope
+
+This pack audits JavaScript source files for correctness and logic errors. It covers two layers of detection. First, the deterministic layer: the spine's eslint wrapper (`wrap-eslint.sh`) runs seven core ESLint rules with `--no-config-lookup` and no type information; these rules emit findings under the `lint/*` namespace (e.g. `lint/eqeqeq`, `lint/use-isnan`) and are severitied via the rubric at HIGH confidence. Second, the LLM best-effort layer: three checks (`correctness/off-by-one`, `correctness/float-equality`, `correctness/wrong-branch-logic`) are LLM-only, LOW confidence, with no deterministic backing. This pack does NOT audit security vulnerabilities, dependency health, architectural patterns, performance, TypeScript type safety, or Python/Go/other languages.
+
+**Pack ID:** `ccgm/correctness`
+**Applies when:** `language:javascript`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `language:javascript` | All deterministic checks are ESLint rules targeting JavaScript/TypeScript syntax. The LLM checks also scope to JS/TS logic patterns. Running on non-JS repos produces zero signal and wastes agent time. |
+
+---
+
+## Spine-Namespace Convention
+
+The spine's eslint wrapper (`wrap-eslint.sh`) emits findings with `check_id: lint/<rule-name>` for every ESLint rule it fires. These `lint/*` check-ids are **not** declared in this pack's `checks[]` — they are emitted by the spine's deterministic layer and severitied via rubric entries (`lint/eqeqeq`, `lint/use-isnan`, etc.). The LLM worker triages `lint/*` candidates via `spine_triage` and may escalate them to correctness-layer findings. The check-ids declared in `pack.json` (`correctness/*`) are for the LLM best-effort layer only.
+
+This follows the same convention established in the security pack: spine-namespace findings (`lint/*`, `secrets/*`, `sast/*`) flow through the rubric; pack-namespace check-ids (`correctness/*`, `security/*`) are LLM-originated or LLM-confirmed findings.
+
+**Spine rule → rubric mapping:**
+
+| ESLint rule | Spine check-id | Severity | Confidence |
+|-------------|---------------|----------|------------|
+| `eqeqeq` | `lint/eqeqeq` | medium | high |
+| `use-isnan` | `lint/use-isnan` | high | high |
+| `valid-typeof` | `lint/valid-typeof` | high | high |
+| `no-unreachable` | `lint/no-unreachable` | high | high |
+| `no-constant-condition` | `lint/no-constant-condition` | medium | high |
+| `no-fallthrough` | `lint/no-fallthrough` | medium | high |
+| `default-case` | `lint/default-case` | medium | high |
+
+---
+
+## Checks
+
+---
+
+### `correctness/off-by-one`
+
+**Severity:** `high`
+**Confidence:** `low`
+**Detection:** `llm`
+
+> **LLM best-effort, low-confidence check. No deterministic backing. Expect false positives and false negatives.**
+
+#### Detection
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan JavaScript and TypeScript source files for off-by-one errors in loop bounds,
+array accesses, and index arithmetic.
+
+Look for patterns such as:
+- Loop conditions using `<` vs `<=` or `>` vs `>=` that may skip the first or last
+  element (e.g. `for (let i = 0; i < arr.length - 1; i++)` when the last element
+  should be included)
+- Array accesses at index `arr.length` (out-of-bounds)
+- Slice/substring calls where end index is off by one (e.g. `str.slice(0, n-1)`
+  when the intent is to include the character at `n-1`)
+- Range comparisons where a boundary value is incorrectly included or excluded
+  (e.g. `if (x > 0 && x < 10)` vs `if (x >= 0 && x <= 10)`)
+
+Do NOT flag:
+- Intentional half-open ranges (e.g. `slice(0, n)` where the last element is
+  correctly excluded)
+- Idiomatic patterns where the off-by-one is clearly the intent
+- Loop patterns that are correct for their data structure (e.g. iterating pairs
+  with `i < arr.length - 1`)
+
+For each finding report: file path, line number, the code snippet, and an explanation
+of the suspected off-by-one. Mark auto_fixable: false — correct fix requires
+understanding the intended semantics.
+
+IMPORTANT: This is a low-confidence check. Only flag instances where you have strong
+reason to believe the boundary is wrong, not merely unusual. If uncertain, do not flag.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: correctness/off-by-one
+detection: llm
+```
+
+Note: No spine tool emits `correctness/off-by-one`. Deterministic eslint findings for
+related issues appear under `lint/no-unreachable` (unreachable code that may result from
+logic errors). The LLM handles this check directly.
+
+#### Severity / Confidence
+
+**Severity rationale:** Off-by-one errors produce incorrect results — wrong number of iterations, missed final elements, or out-of-bounds accesses that crash at runtime. HIGH severity because the consequence is data corruption or a runtime exception.
+
+**Confidence rationale:** Off-by-one detection requires understanding the intended semantics of a loop or range, which the LLM must infer from context. The LLM is often right but can misread intent. LOW confidence — flag only high-certainty cases, expect false positives.
+
+**Rubric entry:** `correctness/off-by-one`
+
+#### Fixture
+
+**True positive** (`src/utils/paginate.ts`):
+
+```typescript
+// FINDS: off-by-one — last item excluded when it should be included
+function getPage(items: number[], page: number, size: number): number[] {
+  const start = page * size;
+  const end = start + size - 1;  // off-by-one: should be start + size
+  return items.slice(start, end);
+}
+```
+
+**True negative** (should produce NO finding):
+
+```typescript
+// OK: correct slice semantics — end is exclusive in Array.prototype.slice
+function getPage(items: number[], page: number, size: number): number[] {
+  const start = page * size;
+  const end = start + size;
+  return items.slice(start, end);
+}
+```
+
+---
+
+### `correctness/float-equality`
+
+**Severity:** `medium`
+**Confidence:** `low`
+**Detection:** `llm`
+
+> **LLM best-effort, low-confidence check. No deterministic backing. Expect false positives and false negatives.**
+
+#### Detection
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan JavaScript and TypeScript source files for direct equality comparisons between
+floating-point values using === or == where the values are the result of arithmetic
+operations, trigonometry, or string-to-float conversion.
+
+Look for patterns such as:
+- `someFloat === 0` or `someFloat === 1.0` after arithmetic (e.g. the result of
+  multiplication or division)
+- `a === b` where both a and b are floating-point results of computations
+- Comparisons of currency amounts, percentages, or measurement values using strict
+  equality
+
+Do NOT flag:
+- Comparisons of floats to integer literals where the float is known to be an integer
+  (e.g. `Math.floor(x) === 5`)
+- Comparisons using Number.EPSILON or an explicit tolerance (already correct)
+- Integer comparisons that happen to use float-typed variables
+
+For each finding report: file path, line number, the comparison expression, and the
+recommended fix (compare with an epsilon tolerance instead of strict equality).
+Mark auto_fixable: false.
+
+IMPORTANT: This is a low-confidence check. Only flag instances where floating-point
+precision loss is likely (post-arithmetic comparisons). If uncertain, do not flag.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: correctness/float-equality
+detection: llm
+```
+
+Note: The spine's `lint/use-isnan` (ESLint `use-isnan` rule) catches the specific case of
+comparing a float to `NaN` with `===`; that is a separate, higher-confidence check in the
+`lint/*` namespace. This check covers the broader pattern of float equality after arithmetic.
+
+#### Severity / Confidence
+
+**Severity rationale:** Direct float equality fails silently on values that should be equal but differ by floating-point rounding error, producing subtly wrong results in calculations. MEDIUM because the bug is usually latent rather than immediately crashing.
+
+**Confidence rationale:** Determining whether a comparison involves a float subject to arithmetic error requires tracing the type and origin of the compared values, which the LLM must infer. LOW confidence — many comparisons look float-like but are safe.
+
+**Rubric entry:** `correctness/float-equality`
+
+#### Fixture
+
+**True positive** (`src/billing/tax.ts`):
+
+```typescript
+// FINDS: float equality after arithmetic — precision loss likely
+function applyDiscount(price: number, discount: number): number {
+  const discounted = price * (1 - discount);
+  if (discounted === 0) {  // may never be exactly 0 after multiplication
+    return 0;
+  }
+  return discounted;
+}
+```
+
+**True negative** (should produce NO finding):
+
+```typescript
+// OK: epsilon comparison avoids float precision issues
+function applyDiscount(price: number, discount: number): number {
+  const discounted = price * (1 - discount);
+  if (Math.abs(discounted) < Number.EPSILON) {
+    return 0;
+  }
+  return discounted;
+}
+```
+
+---
+
+### `correctness/wrong-branch-logic`
+
+**Severity:** `high`
+**Confidence:** `low`
+**Detection:** `llm`
+
+> **LLM best-effort, low-confidence check. No deterministic backing. Expect false positives and false negatives.**
+
+#### Detection
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan JavaScript and TypeScript source files for conditional logic that appears to have
+its branches swapped, inverted conditions, or incorrectly composed boolean expressions.
+
+Look for patterns such as:
+- Inverted guard clauses (e.g. `if (isAuthenticated) { throw new Error("Unauthorized") }`
+  when the intent is to throw on the negative case)
+- AND vs OR confusion in compound conditions (e.g. `if (!a || !b)` when the intent is
+  `if (!a && !b)` — De Morgan's law violations)
+- Conditions that contradict function name or comment intent
+  (e.g. a function called `isValid` that returns `false` on success)
+- Negated conditions on the happy-path branch (e.g. early-return on !error when the
+  caller expects error-first)
+
+Do NOT flag:
+- Intentionally inverted logic that is clearly documented
+- Standard error-first callback patterns
+- Negative conditions that correctly model the problem domain
+
+For each finding report: file path, line number, the condition, and an explanation of
+why the branch logic appears incorrect. Mark auto_fixable: false — correct fix requires
+understanding the intended control flow.
+
+IMPORTANT: This is a low-confidence check. Only flag instances where the intent is
+clearly stated (via function name, comment, or context) and contradicts the code.
+If uncertain, do not flag.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: correctness/wrong-branch-logic
+detection: llm
+```
+
+Note: The spine's `lint/no-constant-condition` catches conditions that are always true or
+always false (e.g. `if (true)`, `while (false)`), which is the deterministic subset of this
+class. The broader pattern — inverted or swapped conditions — requires LLM reasoning.
+
+#### Severity / Confidence
+
+**Severity rationale:** Wrong branch logic means the code does the opposite of what was intended — rejecting valid inputs, allowing invalid ones, or executing the wrong path. HIGH severity because the consequences are typically data corruption, security bypass, or user-visible incorrect behavior.
+
+**Confidence rationale:** Determining whether branch logic is wrong requires understanding the intent behind the code, which the LLM must infer from names, comments, and context. LOW confidence — many inverted conditions are intentional.
+
+**Rubric entry:** `correctness/wrong-branch-logic`
+
+#### Fixture
+
+**True positive** (`src/middleware/auth.ts`):
+
+```typescript
+// FINDS: inverted guard — throws when user IS authenticated (should throw when NOT)
+function requireAuth(user: User | null): void {
+  if (user !== null) {
+    throw new Error("Unauthorized: must be logged in");
+  }
+}
+```
+
+**True negative** (should produce NO finding):
+
+```typescript
+// OK: correctly throws when user is NOT authenticated
+function requireAuth(user: User | null): void {
+  if (user === null) {
+    throw new Error("Unauthorized: must be logged in");
+  }
+}
+```
+
+---
+
+## Migration Mapping
+
+Every correctness check category is mapped to its owning check-id or spine namespace:
+
+| Check category | Detection layer | Check-id / namespace |
+|----------------|-----------------|----------------------|
+| Type-unsafe equality (`==` / `!=`) | Deterministic (spine) | `lint/eqeqeq` |
+| Comparison to NaN | Deterministic (spine) | `lint/use-isnan` |
+| Invalid typeof string | Deterministic (spine) | `lint/valid-typeof` |
+| Unreachable code after return/throw | Deterministic (spine) | `lint/no-unreachable` |
+| Always-true/always-false condition | Deterministic (spine) | `lint/no-constant-condition` |
+| Switch case fallthrough | Deterministic (spine) | `lint/no-fallthrough` |
+| Missing default case in switch | Deterministic (spine) | `lint/default-case` |
+| Off-by-one in loops/indices | LLM best-effort (LOW confidence) | `correctness/off-by-one` |
+| Float equality after arithmetic | LLM best-effort (LOW confidence) | `correctness/float-equality` |
+| Inverted / swapped branch logic | LLM best-effort (LOW confidence) | `correctness/wrong-branch-logic` |
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/correctness/pack.json
+++ b/modules/commands-extra/skills/audit/packs/correctness/pack.json
@@ -1,0 +1,32 @@
+{
+  "id": "ccgm/correctness",
+  "name": "Correctness / Logic",
+  "version": "1.0.0",
+  "applies_when": ["language:javascript"],
+  "tags": ["correctness", "logic", "eslint"],
+  "severity_floor": "medium",
+  "tools": ["eslint"],
+  "checks": [
+    {
+      "id": "correctness/off-by-one",
+      "severity": "high",
+      "confidence": "low",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "correctness/float-equality",
+      "severity": "medium",
+      "confidence": "low",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "correctness/wrong-branch-logic",
+      "severity": "high",
+      "confidence": "low",
+      "detection": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -313,6 +313,56 @@
       "severity": "medium",
       "confidence": "medium",
       "fix_confidence": "low"
+    },
+    "lint/eqeqeq": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/use-isnan": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/valid-typeof": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/no-unreachable": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/no-constant-condition": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "lint/no-fallthrough": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/default-case": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "correctness/off-by-one": {
+      "severity": "high",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "correctness/float-equality": {
+      "severity": "medium",
+      "confidence": "low",
+      "fix_confidence": "medium"
+    },
+    "correctness/wrong-branch-logic": {
+      "severity": "high",
+      "confidence": "low",
+      "fix_confidence": "low"
     }
   }
 }

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-eslint.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-eslint.sh
@@ -8,6 +8,13 @@
 #
 # Output (stdout): JSONL
 # Exit code: always 0
+#
+# Active rules (all core ESLint, all config-free, all require no type information):
+#   Security surface (Epic 2.1):
+#     no-eval, no-implied-eval, no-new-func
+#   Correctness/Logic surface (Epic 2.4):
+#     eqeqeq, use-isnan, valid-typeof, no-unreachable,
+#     no-constant-condition, no-fallthrough, default-case
 
 set -euo pipefail
 
@@ -34,16 +41,16 @@ TMPFILE="$(mktemp /tmp/ccgm-eslint-XXXXXX.json)"
 trap 'rm -f "$TMPFILE"' EXIT
 
 # Config isolation: --no-config-lookup is the critical flag.
-# We pass a fixed minimal eval-rule set (no-eval, no-implied-eval, no-new-func)
-# so only the audit spine's known security rules run -- the repo's own lint
-# config is never loaded.  repo_root is passed via cd in subshell, glob is
-# a static pattern.
+# We pass a fixed rule set (10 rules: 3 security + 7 correctness); all are
+# core ESLint rules that run correctly with only --no-config-lookup and no
+# type information.  The repo's own lint config is never loaded.
+# repo_root is passed via cd in subshell, glob is a static pattern.
 set +e
 (
   cd "$REPO_ROOT"
   eslint \
     --no-config-lookup \
-    --rule '{"no-eval":["error"],"no-implied-eval":["error"],"no-new-func":["error"]}' \
+    --rule '{"no-eval":["error"],"no-implied-eval":["error"],"no-new-func":["error"],"eqeqeq":["error","always"],"use-isnan":["error"],"valid-typeof":["error"],"no-unreachable":["error"],"no-constant-condition":["error"],"no-fallthrough":["error"],"default-case":["error"]}' \
     --format json \
     --output-file "$TMPFILE" \
     "$GLOB_PATTERN" \

--- a/modules/commands-extra/skills/audit/tests/test-pack-correctness.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-correctness.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# test-pack-correctness.sh -- Epic 2.4 correctness pack test suite
+#
+# Tests:
+#   (a) parse-eslint.py emits lint/eqeqeq + lint/no-unreachable from synthetic
+#       ESLint JSON output (properties.tool=eslint, valid fingerprint, rubric-known)
+#   (b) wrap-eslint.sh --rule JSON contains all 10 rules; comment lists them
+#   (c) pack.json + rubric validate; lint-pack.py passes on correctness pack
+#   (d) checks.md marks LLM-only checks as LOW confidence, syntactic as HIGH
+#   (e) shellcheck on wrap-eslint.sh
+#
+# Exit code: 0 = all pass, 1 = failure
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SPINE_DIR="${AUDIT_DIR}/scripts/spine"
+SCHEMAS_DIR="${AUDIT_DIR}/schemas"
+RUBRIC="${SCHEMAS_DIR}/severity-rubric.json"
+LINTER="${AUDIT_DIR}/scripts/lint-pack.py"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+  printf '  [PASS] %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  ERRORS+=("$1")
+  FAIL=$((FAIL + 1))
+}
+
+# ---------------------------------------------------------------------------
+# (a) parse-eslint.py unit test against synthetic ESLint JSON output
+# ---------------------------------------------------------------------------
+printf '\n(a) parse-eslint.py: synthetic output with eqeqeq + no-unreachable\n'
+
+SYNTHETIC_INPUT="$(mktemp /tmp/ccgm-eslint-synth-XXXXXX.json)"
+trap 'rm -f "$SYNTHETIC_INPUT"' EXIT
+
+# Construct ESLint-shaped JSON with one eqeqeq violation and one no-unreachable violation
+cat > "$SYNTHETIC_INPUT" << 'SYNTH_EOF'
+[
+  {
+    "filePath": "/repo/src/utils.js",
+    "messages": [
+      {
+        "ruleId": "eqeqeq",
+        "severity": 2,
+        "message": "Expected '===' and instead saw '=='.",
+        "line": 10,
+        "endLine": 10,
+        "column": 14,
+        "endColumn": 18
+      },
+      {
+        "ruleId": "no-unreachable",
+        "severity": 2,
+        "message": "Unreachable code.",
+        "line": 25,
+        "endLine": 25,
+        "column": 3,
+        "endColumn": 20
+      }
+    ]
+  }
+]
+SYNTH_EOF
+
+PARSE_OUTPUT="$(python3 "${SPINE_DIR}/parse-eslint.py" "$SYNTHETIC_INPUT" "/repo" 2>&1)"
+
+# Expect exactly 2 lines of JSON
+LINE_COUNT="$(printf '%s\n' "$PARSE_OUTPUT" | grep -c '^{' || true)"
+if [[ "$LINE_COUNT" -eq 2 ]]; then
+  pass "parse-eslint.py emits 2 findings for 2 synthetic violations"
+else
+  fail "parse-eslint.py emitted $LINE_COUNT finding lines (expected 2)"
+fi
+
+# Check for lint/eqeqeq finding
+if printf '%s\n' "$PARSE_OUTPUT" | grep -q '"lint/eqeqeq"'; then
+  pass "parse-eslint.py emits lint/eqeqeq check_id"
+else
+  fail "parse-eslint.py did not emit lint/eqeqeq check_id"
+fi
+
+# Check for lint/no-unreachable finding
+if printf '%s\n' "$PARSE_OUTPUT" | grep -q '"lint/no-unreachable"'; then
+  pass "parse-eslint.py emits lint/no-unreachable check_id"
+else
+  fail "parse-eslint.py did not emit lint/no-unreachable check_id"
+fi
+
+# Verify properties.tool=eslint in both findings
+TOOL_COUNT="$(printf '%s\n' "$PARSE_OUTPUT" | python3 -c "
+import json, sys
+lines = [l for l in sys.stdin.read().splitlines() if l.strip()]
+count = 0
+for l in lines:
+    try:
+        obj = json.loads(l)
+        if obj.get('properties', {}).get('tool') == 'eslint':
+            count += 1
+    except Exception:
+        pass
+print(count)
+" 2>/dev/null || printf '0')"
+
+if [[ "$TOOL_COUNT" -eq 2 ]]; then
+  pass "both findings have properties.tool=eslint"
+else
+  fail "$TOOL_COUNT/2 findings have properties.tool=eslint (expected 2)"
+fi
+
+# Verify valid fingerprints (non-empty, match the allowed character set)
+FINGERPRINT_OK="$(printf '%s\n' "$PARSE_OUTPUT" | python3 -c "
+import json, re, sys
+lines = [l for l in sys.stdin.read().splitlines() if l.strip()]
+ok = 0
+for l in lines:
+    try:
+        obj = json.loads(l)
+        fp = obj.get('fingerprint', '')
+        if re.fullmatch(r'[A-Za-z0-9_.:+/=\-]{8,128}', fp):
+            ok += 1
+    except Exception:
+        pass
+print(ok)
+" 2>/dev/null || printf '0')"
+
+if [[ "$FINGERPRINT_OK" -eq 2 ]]; then
+  pass "both findings have valid fingerprints"
+else
+  fail "$FINGERPRINT_OK/2 findings have valid fingerprints (expected 2)"
+fi
+
+# Verify all emitted check_ids are in the rubric (rubric-known).
+# Write findings to a temp file to avoid stdin/heredoc conflict.
+PARSE_OUTPUT_FILE="$(mktemp /tmp/ccgm-parse-out-XXXXXX.jsonl)"
+printf '%s\n' "$PARSE_OUTPUT" > "$PARSE_OUTPUT_FILE"
+trap 'rm -f "$SYNTHETIC_INPUT" "$PARSE_OUTPUT_FILE"' EXIT
+
+RUBRIC_OK="$(python3 - "$RUBRIC" "$PARSE_OUTPUT_FILE" << 'PYEOF'
+import json, sys
+
+rubric_path = sys.argv[1]
+findings_path = sys.argv[2]
+with open(rubric_path, encoding="utf-8") as fh:
+    rubric = json.load(fh).get("checks", {})
+
+ok = 0
+with open(findings_path, encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+            cid = obj.get("check_id", "")
+            if cid in rubric:
+                ok += 1
+        except Exception:
+            pass
+print(ok)
+PYEOF
+)"
+
+if [[ "$RUBRIC_OK" -eq 2 ]]; then
+  pass "both emitted check_ids are present in severity-rubric.json (rubric-known)"
+else
+  fail "$RUBRIC_OK/2 emitted check_ids found in rubric (expected 2 -- lint/eqeqeq and lint/no-unreachable)"
+fi
+
+# ---------------------------------------------------------------------------
+# (b) wrap-eslint.sh rule JSON contains all 10 rules; comment lists them
+# ---------------------------------------------------------------------------
+printf '\n(b) wrap-eslint.sh: rule JSON has all 10 rules + comment lists them\n'
+
+WRAP_ESLINT="${SPINE_DIR}/wrap-eslint.sh"
+
+# All 10 expected rules
+EXPECTED_RULES=(
+  "no-eval"
+  "no-implied-eval"
+  "no-new-func"
+  "eqeqeq"
+  "use-isnan"
+  "valid-typeof"
+  "no-unreachable"
+  "no-constant-condition"
+  "no-fallthrough"
+  "default-case"
+)
+
+for rule in "${EXPECTED_RULES[@]}"; do
+  if grep -q "\"${rule}\"" "$WRAP_ESLINT"; then
+    pass "wrap-eslint.sh --rule JSON contains ${rule}"
+  else
+    fail "wrap-eslint.sh --rule JSON missing ${rule}"
+  fi
+done
+
+# Verify the comment block lists the new correctness rules
+for rule in eqeqeq use-isnan valid-typeof no-unreachable no-constant-condition no-fallthrough default-case; do
+  if grep -q "${rule}" "$WRAP_ESLINT"; then
+    # Already covered by the rule JSON check above; just confirm grep works
+    pass "wrap-eslint.sh comment/body references ${rule}"
+  else
+    fail "wrap-eslint.sh does not reference ${rule} at all"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# (c) pack.json + rubric validate; lint-pack.py passes on correctness pack
+# ---------------------------------------------------------------------------
+printf '\n(c) lint-pack.py passes on correctness pack with rubric\n'
+
+PACK_DIR="${AUDIT_DIR}/packs/correctness"
+PACK_JSON="${PACK_DIR}/pack.json"
+
+# Validate pack.json is valid JSON
+if python3 -c "import json; json.load(open('${PACK_JSON}'))" 2>/dev/null; then
+  pass "packs/correctness/pack.json is valid JSON"
+else
+  fail "packs/correctness/pack.json is not valid JSON"
+fi
+
+# Validate rubric is valid JSON after our additions
+if python3 -c "import json; json.load(open('${RUBRIC}'))" 2>/dev/null; then
+  pass "severity-rubric.json is valid JSON after additions"
+else
+  fail "severity-rubric.json is not valid JSON after additions"
+fi
+
+# Lint just the correctness pack against the rubric
+LINT_OUTPUT="$(python3 "${LINTER}" --packs-dir "${AUDIT_DIR}/packs" --rubric "${RUBRIC}" 2>&1)"
+LINT_EXIT=$?
+
+if [[ $LINT_EXIT -eq 0 ]]; then
+  pass "lint-pack.py passes on all packs (including correctness) with rubric"
+else
+  fail "lint-pack.py failed: ${LINT_OUTPUT}"
+fi
+
+# Explicitly check that correctness pack is PASS (not just that there are no errors)
+if printf '%s\n' "$LINT_OUTPUT" | grep -q '^PASS: correctness$'; then
+  pass "lint-pack.py reports PASS: correctness"
+else
+  fail "lint-pack.py did not report PASS: correctness (output: ${LINT_OUTPUT})"
+fi
+
+# ---------------------------------------------------------------------------
+# (d) checks.md marks LLM-only checks LOW confidence, syntactic checks HIGH
+# ---------------------------------------------------------------------------
+printf '\n(d) checks.md: LLM-only checks LOW confidence, syntactic HIGH\n'
+
+CHECKS_MD="${PACK_DIR}/checks.md"
+
+# LLM-only checks should be marked as LOW confidence
+LLM_CHECKS=("off-by-one" "float-equality" "wrong-branch-logic")
+for check in "${LLM_CHECKS[@]}"; do
+  # Look for the check section and verify LOW confidence is mentioned
+  if grep -A 5 "correctness/${check}" "$CHECKS_MD" | grep -qi "low"; then
+    pass "checks.md marks correctness/${check} as low confidence"
+  else
+    fail "checks.md does not mark correctness/${check} as low confidence"
+  fi
+done
+
+# Syntactic (deterministic) checks documented in the spine-namespace table
+SYNTACTIC_RULES=("eqeqeq" "use-isnan" "valid-typeof" "no-unreachable" "no-constant-condition" "no-fallthrough" "default-case")
+for rule in "${SYNTACTIC_RULES[@]}"; do
+  if grep -q "lint/${rule}" "$CHECKS_MD"; then
+    pass "checks.md documents lint/${rule} (deterministic spine check)"
+  else
+    fail "checks.md does not document lint/${rule}"
+  fi
+done
+
+# High confidence is stated for spine checks in the rubric table
+if grep -q "high" "$CHECKS_MD"; then
+  pass "checks.md references high confidence for spine checks"
+else
+  fail "checks.md does not reference high confidence"
+fi
+
+# LLM checks are explicitly marked as LLM best-effort
+if grep -q "LLM best-effort" "$CHECKS_MD"; then
+  pass "checks.md contains 'LLM best-effort' disclaimer"
+else
+  fail "checks.md missing 'LLM best-effort' disclaimer"
+fi
+
+# ---------------------------------------------------------------------------
+# (e) shellcheck on wrap-eslint.sh
+# ---------------------------------------------------------------------------
+printf '\n(e) shellcheck on wrap-eslint.sh\n'
+
+if command -v shellcheck > /dev/null 2>&1; then
+  SC_OUTPUT="$(shellcheck -S warning "${WRAP_ESLINT}" 2>&1 || true)"
+  if [[ -z "$SC_OUTPUT" ]]; then
+    pass "shellcheck clean: wrap-eslint.sh"
+  else
+    fail "shellcheck issues in wrap-eslint.sh:"
+    printf '%s\n' "$SC_OUTPUT" | head -10
+  fi
+else
+  fail "shellcheck not installed -- cannot verify shell safety"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n-------------------------------------------------\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  printf '\nFailed tests:\n'
+  for err in "${ERRORS[@]}"; do
+    printf '  - %s\n' "$err"
+  done
+  exit 1
+fi
+
+printf 'All tests passed.\n'
+exit 0

--- a/modules/commands-extra/skills/audit/tests/test-pack-correctness.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-correctness.sh
@@ -238,8 +238,12 @@ else
 fi
 
 # Lint just the correctness pack against the rubric
+# Use set +e so a non-zero exit from lint-pack.py is captured in LINT_EXIT
+# rather than aborting the whole script under set -euo pipefail.
+set +e
 LINT_OUTPUT="$(python3 "${LINTER}" --packs-dir "${AUDIT_DIR}/packs" --rubric "${RUBRIC}" 2>&1)"
 LINT_EXIT=$?
+set -e
 
 if [[ $LINT_EXIT -eq 0 ]]; then
   pass "lint-pack.py passes on all packs (including correctness) with rubric"


### PR DESCRIPTION
## Summary

- Extends `wrap-eslint.sh` with 7 safe config-free core ESLint rules (`eqeqeq`, `use-isnan`, `valid-typeof`, `no-unreachable`, `no-constant-condition`, `no-fallthrough`, `default-case`) — `--no-config-lookup` preserved, no type info required, config isolation inviolable
- Adds `packs/correctness/` (`ccgm/correctness`, `applies_when: [language:javascript]`) with 3 deterministic spine-surface checks (documented via `lint/*` rubric entries) and 3 LLM best-effort LOW-confidence checks (`off-by-one`, `float-equality`, `wrong-branch-logic`)
- Adds 10 new rubric entries (`lint/*` × 7, `correctness/*` × 3) to `severity-rubric.json`
- Registers pack files in `module.json`
- Adds `tests/test-pack-correctness.sh` (40 tests, all passing)

## Changes

| File | Change |
|------|--------|
| `scripts/spine/wrap-eslint.sh` | Add 7 correctness rules to `--rule` JSON; update comment to list all 10 rules truthfully |
| `schemas/severity-rubric.json` | Add 7 `lint/*` entries + 3 `correctness/*` entries |
| `packs/correctness/pack.json` | New pack: `ccgm/correctness`, LLM-only checks only (spine checks are rubric-severitied under `lint/*`) |
| `packs/correctness/checks.md` | Full pack docs: spine-namespace convention table, LLM best-effort disclaimers, fixtures |
| `modules/commands-extra/module.json` | Register `packs/correctness/{pack.json,checks.md}` |
| `tests/test-pack-correctness.sh` | 40-test suite covering all 5 deliverable gates |

## parse-eslint allowlist finding

`parse-eslint.py` has **no rule allowlist** — line 88 maps any rule generically via `"lint/{0}".format(rule_id.replace("/", "-").replace("@", ""))`. No changes needed to the parser; all 7 new rules emit correct `lint/<rule>` check-ids automatically.

## Spine-namespace convention followed

Same as the security pack: the spine emits `lint/*` check-ids (severitied via rubric entries); the pack's declared `checks[]` are LLM-only. The checks.md documents the `lint/*` → rule mapping in an explicit table and uses the same "Spine-Namespace Note" pattern established in `packs/security/checks.md`.

## Test plan

- `bash tests/test-pack-correctness.sh` — 40/40 PASS
- `bash tests/test-spine.sh` — 25/25 PASS (config-isolation + shellcheck green)
- `bash tests/test-pack-lint.sh` — 7/7 PASS
- `bash tests/test-rubric.sh` — 8/8 PASS
- `bash tests/test-registry.sh` — 8/8 PASS
- `python3 scripts/lint-pack.py` — 10 packs, 0 errors (all pass)
- `python3 -m json.tool module.json` — valid JSON
- `python3 -m json.tool severity-rubric.json` — valid JSON
- `shellcheck -S warning wrap-eslint.sh` — clean
- `bash tests/test-no-personal-data.sh` — PASS

Closes #610