### PR TITLE
#611: Epic 2.5 CI/CD Hardening audit pack

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -313,6 +313,36 @@
       "type": "script",
       "template": false
     },
+    "skills/audit/scripts/spine/wrap-zizmor.sh": {
+      "target": "skills/audit/scripts/spine/wrap-zizmor.sh",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/scripts/spine/parse-zizmor.py": {
+      "target": "skills/audit/scripts/spine/parse-zizmor.py",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/scripts/spine/wrap-pinact.sh": {
+      "target": "skills/audit/scripts/spine/wrap-pinact.sh",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/scripts/spine/parse-pinact.py": {
+      "target": "skills/audit/scripts/spine/parse-pinact.py",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/packs/ci-cd/pack.json": {
+      "target": "skills/audit/packs/ci-cd/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/ci-cd/checks.md": {
+      "target": "skills/audit/packs/ci-cd/checks.md",
+      "type": "doc",
+      "template": false
+    },
     "skills/audit/packs/code-quality/pack.json": {
       "target": "skills/audit/packs/code-quality/pack.json",
       "type": "doc",

--- a/modules/commands-extra/skills/audit/packs/ci-cd/checks.md
+++ b/modules/commands-extra/skills/audit/packs/ci-cd/checks.md
@@ -1,0 +1,426 @@
+# CI/CD Hardening Pack
+
+## Scope
+
+This pack audits GitHub Actions workflow files for supply-chain and security issues:
+unpinned third-party actions, dangerous trigger configurations, overbroad GITHUB_TOKEN
+permissions, expression-injection vulnerabilities, and actionlint syntax/usage errors.
+It does NOT audit application source code, Docker images, or non-GitHub CI systems
+(e.g. CircleCI, Jenkins). It operates exclusively on files under `.github/workflows/`.
+
+**Pack ID:** `ccgm/ci-cd`
+**Applies when:** `has_workflows`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `has_workflows` | The pack audits `.github/workflows/` files exclusively; a repo without that directory has zero workflow files to scan, making all five checks vacuous. |
+
+---
+
+## Checks
+
+---
+
+### `cicd/unpinned-action`
+
+**Severity:** `high`
+**Confidence:** `high`
+**Detection:** `hybrid`
+
+#### Detection
+
+**Tool (hybrid):**
+`pinact`
+
+Rule / rule-id: `pinact/unpinned-uses`
+
+Fallback when tool absent: `llm`
+
+**LLM instruction (hybrid fallback when pinact absent):**
+
+```
+Scan every workflow file under .github/workflows/ for third-party actions
+referenced by a mutable tag or branch instead of a full 40-character commit SHA.
+
+A third-party action is any `uses:` line where the owner is not the repo itself
+(i.e., not `./`). First-party actions (`uses: ./.github/actions/...`) are out
+of scope.
+
+Flag each occurrence where the ref after `@` is NOT a 40-char lowercase hex
+string (e.g. `@v4`, `@main`, `@master`, `@latest` are all mutable and must be
+flagged).
+
+Do NOT flag pinned actions such as `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683`.
+Do NOT flag Docker images in `image:` keys.
+
+For each finding report: file path, line number, the full `uses:` value,
+and a one-sentence explanation of the supply-chain risk.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: cicd/unpinned-action
+detection: hybrid
+tool: pinact
+rule: pinact/unpinned-uses
+fallback: llm
+```
+
+The spine calls `wrap-pinact.sh <repo_root>` which runs
+`pinact run --check <workflow_files...>` and pipes output through
+`parse-pinact.py`. The parser normalizes each unpinned-action line into a
+`cicd/unpinned-action` finding with `properties.tool = "pinact"`.
+
+#### Severity / Confidence
+
+**Severity rationale:** A mutable action ref (tag, branch) can be hijacked via
+a tag-swap or branch-force-push attack; a compromised action runs in the CI
+environment with access to secrets and the GITHUB_TOKEN. This is a direct
+supply-chain risk rated HIGH by GitHub's security hardening guide.
+
+**Confidence rationale:** The check is deterministic — an action ref that is
+not a 40-char hex SHA is factually mutable; there are no false positives from
+pinact's analysis.
+
+**Rubric entry:** `cicd/unpinned-action`
+
+#### Fixture
+
+**True positive** (`.github/workflows/ci.yml`):
+
+```yaml
+# FINDS: actions/checkout@v4 is a mutable tag, not a pinned SHA.
+- uses: actions/checkout@v4
+```
+
+**True negative** (should produce NO finding):
+
+```yaml
+# OK: full 40-char commit SHA — pinned and reproducible.
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+```
+
+---
+
+### `cicd/dangerous-trigger`
+
+**Severity:** `critical`
+**Confidence:** `high`
+**Detection:** `hybrid`
+
+#### Detection
+
+**Tool (hybrid):**
+`zizmor`
+
+Rule / rule-id: `zizmor/dangerous-triggers` / `zizmor/pull-request-target`
+
+Fallback when tool absent: `llm`
+
+**LLM instruction (hybrid fallback when zizmor absent):**
+
+```
+Scan every workflow file under .github/workflows/ for the dangerous
+`pull_request_target` trigger combined with a checkout step that fetches
+untrusted code.
+
+A workflow is dangerous when ALL of the following are true:
+  1. It uses `on: pull_request_target` (or includes it in a list of triggers).
+  2. It contains a `uses: actions/checkout` step that checks out the PR head
+     (i.e., `ref: ${{ github.event.pull_request.head.sha }}` or similar), OR
+     it does not pass `persist-credentials: false`.
+
+Flag the `on:` line and any corresponding checkout step as findings.
+Do NOT flag `pull_request_target` when there is no checkout of external code
+(e.g., a workflow that only posts a comment using a static token).
+Do NOT flag `on: pull_request` (without `_target`) — it runs in a sandboxed
+context and is not affected by this class of vulnerability.
+
+For each finding report: file path, line number of the `on:` declaration,
+and a one-sentence explanation of the pwn-request risk.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: cicd/dangerous-trigger
+detection: hybrid
+tool: zizmor
+rule: zizmor/dangerous-triggers
+fallback: llm
+```
+
+The spine calls `wrap-zizmor.sh <repo_root>` which runs
+`zizmor --format sarif <workflow_files...>` and pipes output through
+`parse-zizmor.py`. The parser maps zizmor rule IDs containing
+`dangerous-trigger` or `pull-request-target` to `cicd/dangerous-trigger`.
+
+#### Severity / Confidence
+
+**Severity rationale:** `pull_request_target` with an untrusted checkout gives
+attacker-controlled code access to secrets and write permissions on the target
+repo — the canonical "pwn-request" vulnerability class, rated CRITICAL by the
+GitHub security advisory team and GHSL researchers.
+
+**Confidence rationale:** zizmor performs static analysis that tracks both the
+trigger type and checkout patterns; the combined signal is precise and
+well-documented. Rated HIGH confidence.
+
+**Rubric entry:** `cicd/dangerous-trigger`
+
+#### Fixture
+
+**True positive** (`.github/workflows/pr-target.yml`):
+
+```yaml
+# FINDS: pull_request_target + checkout of PR head = pwn-request
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+```
+
+**True negative** (should produce NO finding):
+
+```yaml
+# OK: pull_request (not pull_request_target) — runs in a sandbox.
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+```
+
+---
+
+### `cicd/excessive-permissions`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `tool`
+
+#### Detection
+
+**Tool:**
+`zizmor`
+
+Rule / rule-id: `zizmor/excessive-permissions` / `zizmor/artipacked`
+
+Fallback when tool absent: none — skip check
+
+**LLM instruction (if detection = llm or hybrid):**
+
+n/a — detection is `tool` only.
+
+#### Spine Wiring
+
+```yaml
+check_id: cicd/excessive-permissions
+detection: tool
+tool: zizmor
+rule: zizmor/excessive-permissions
+```
+
+The spine calls `wrap-zizmor.sh <repo_root>`. The parser maps zizmor rule IDs
+containing `excessive-permissions` or `artipacked` to
+`cicd/excessive-permissions` with `properties.tool = "zizmor"`.
+
+#### Severity / Confidence
+
+**Severity rationale:** Overbroad `GITHUB_TOKEN` permissions (e.g. `write-all`
+at the workflow or job level) grant more access than needed; a compromised step
+can push code, approve PRs, or modify releases. MEDIUM severity because
+over-permission is a risk multiplier rather than a direct exploit path.
+
+**Confidence rationale:** zizmor reads the `permissions:` key statically and
+flags write-all or explicitly broad write grants; the check is deterministic
+with high precision.
+
+**Rubric entry:** `cicd/excessive-permissions`
+
+#### Fixture
+
+**True positive** (`.github/workflows/deploy.yml`):
+
+```yaml
+# FINDS: write-all grants unnecessary write permissions across all scopes.
+permissions: write-all
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "deploying"
+```
+
+**True negative** (should produce NO finding):
+
+```yaml
+# OK: minimal permissions declared explicitly.
+permissions:
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "deploying"
+```
+
+---
+
+### `cicd/script-injection`
+
+**Severity:** `high`
+**Confidence:** `high`
+**Detection:** `tool`
+
+#### Detection
+
+**Tool:**
+`zizmor`
+
+Rule / rule-id: `zizmor/template-injection` / `zizmor/expression-injection`
+
+Fallback when tool absent: none — skip check
+
+**LLM instruction (if detection = llm or hybrid):**
+
+n/a — detection is `tool` only.
+
+#### Spine Wiring
+
+```yaml
+check_id: cicd/script-injection
+detection: tool
+tool: zizmor
+rule: zizmor/template-injection
+```
+
+The spine calls `wrap-zizmor.sh <repo_root>`. The parser maps zizmor rule IDs
+containing `template-injection` or `expression-injection` to
+`cicd/script-injection` with `properties.tool = "zizmor"`.
+
+#### Severity / Confidence
+
+**Severity rationale:** Interpolating `${{ github.event.* }}` expressions
+directly into a `run:` shell script allows a PR author to inject arbitrary
+shell commands that execute with the workflow's permissions and token. This is
+a well-known attack vector (e.g. CVE-2021-29476 class) rated HIGH.
+
+**Confidence rationale:** zizmor statically traces expression usage into
+`run:` scripts; the analysis is taint-based and has low false-positive rates
+on the injection patterns it covers.
+
+**Rubric entry:** `cicd/script-injection`
+
+#### Fixture
+
+**True positive** (`.github/workflows/comment.yml`):
+
+```yaml
+# FINDS: ${{ github.event.pull_request.title }} interpolated into run: script.
+- name: Echo title
+  run: echo "${{ github.event.pull_request.title }}"
+```
+
+**True negative** (should produce NO finding):
+
+```yaml
+# OK: value assigned to env var, not directly interpolated into shell.
+- name: Echo title
+  env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: echo "$PR_TITLE"
+```
+
+---
+
+### `cicd/actionlint-error`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `tool`
+
+#### Detection
+
+**Tool:**
+`actionlint`
+
+Rule / rule-id: `actionlint/<kind>` (the kind field from actionlint JSON output)
+
+Fallback when tool absent: none — skip check
+
+**LLM instruction (if detection = llm or hybrid):**
+
+n/a — detection is `tool` only.
+
+#### Spine Wiring
+
+```yaml
+check_id: cicd/actionlint-error
+detection: tool
+tool: actionlint
+rule: actionlint/<kind>
+```
+
+**Namespace note:** actionlint findings are produced by the pre-existing
+`wrap-actionlint.sh` + `parse-actionlint.py` wrapper pair; they are emitted
+under `check_id = "ci/workflow-issue"` (not `cicd/actionlint-error`). The
+`cicd/actionlint-error` check in this pack is a logical reference to that
+surface: the same actionlint wrapper runs as part of the CI/CD pack, and its
+findings appear in the output stream under the `ci/workflow-issue` namespace.
+When aggregating pack findings, consumers should treat `ci/workflow-issue`
+findings with `properties.tool = "actionlint"` as satisfying
+`cicd/actionlint-error`.
+
+#### Severity / Confidence
+
+**Severity rationale:** actionlint catches type errors, undefined contexts,
+invalid event names, and shell-script issues in workflows; such errors cause
+CI failures or silent misbehavior. MEDIUM severity because these are
+correctness errors, not direct security exploits.
+
+**Confidence rationale:** actionlint is a static analysis tool with
+well-defined grammar for GitHub Actions; its error reports are precise and
+have very low false-positive rates.
+
+**Rubric entry:** `cicd/actionlint-error`
+
+#### Fixture
+
+**True positive** (`.github/workflows/broken.yml`):
+
+```yaml
+# FINDS: undefined context "github.nonexistent_field"
+- name: Broken step
+  run: echo ${{ github.nonexistent_field }}
+```
+
+**True negative** (should produce NO finding):
+
+```yaml
+# OK: valid expression context.
+- name: OK step
+  run: echo ${{ github.sha }}
+```
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/ci-cd/pack.json
+++ b/modules/commands-extra/skills/audit/packs/ci-cd/pack.json
@@ -1,0 +1,53 @@
+{
+  "id": "ccgm/ci-cd",
+  "name": "CI/CD Hardening",
+  "version": "1.0.0",
+  "applies_when": ["has_workflows"],
+  "tags": ["ci", "github-actions", "supply-chain", "security"],
+  "severity_floor": "medium",
+  "tools": ["actionlint", "zizmor", "pinact"],
+  "checks": [
+    {
+      "id": "cicd/unpinned-action",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "hybrid",
+      "tool": "pinact",
+      "fallback": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "cicd/dangerous-trigger",
+      "severity": "critical",
+      "confidence": "high",
+      "detection": "hybrid",
+      "tool": "zizmor",
+      "fallback": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "cicd/excessive-permissions",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "tool",
+      "tool": "zizmor",
+      "auto_fixable": false
+    },
+    {
+      "id": "cicd/script-injection",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "tool",
+      "tool": "zizmor",
+      "auto_fixable": false
+    },
+    {
+      "id": "cicd/actionlint-error",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "tool",
+      "tool": "actionlint",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -313,6 +313,31 @@
       "severity": "medium",
       "confidence": "medium",
       "fix_confidence": "low"
+    },
+    "cicd/unpinned-action": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "cicd/dangerous-trigger": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "cicd/excessive-permissions": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "cicd/script-injection": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "cicd/actionlint-error": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
     }
   }
 }

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -338,6 +338,11 @@
       "severity": "medium",
       "confidence": "high",
       "fix_confidence": "low"
+    },
+    "cicd/workflow-security-issue": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
     }
   }
 }

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-pinact.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-pinact.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+CCGM audit spine -- parse pinact output -> finding.schema.json JSONL.
+
+Usage: parse-pinact.py <pinact_output_file> <repo_root>
+
+# -------------------------------------------------------------------------
+# Assumed pinact output shape (documented; not installed locally)
+#
+# pinact run --check emits a diff-like text to stdout.
+# Each unpinned action produces a block like:
+#
+#   .github/workflows/ci.yml
+#     uses: actions/checkout@v4
+#   ->
+#     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+#
+# Alternatively, pinact may emit one line per finding in a more structured form:
+#
+#   .github/workflows/ci.yml:12: actions/checkout@v4 -> actions/checkout@<sha> # v4
+#
+# We handle BOTH formats:
+#   1. "file:line: action@ref" lines (structured single-line format).
+#   2. Multi-line diff blocks starting with a bare filename followed by "uses:" lines.
+#
+# For format 1, a line matches the pattern:
+#   ^<filepath>:[0-9]+: <owner>/<repo>@<ref> ->
+#
+# For format 2, a diff block looks like:
+#   ^<filepath>$              (bare filename, no colon-number)
+#   ^  uses: <owner>/<repo>@<ref>$   (the unpinned reference)
+#   ^->$                              (arrow separator)
+#   ^  uses: <owner>/<repo>@<sha>    (the pinned suggestion)
+#
+# In both cases we extract: filepath, line number (if present, else 1),
+# action reference (e.g. "actions/checkout@v4"), and emit one
+# cicd/unpinned-action finding per action.
+#
+# A third fallback: any "uses:" line containing an action ref that does NOT
+# look like a 40-char hex SHA is treated as a finding. This handles output
+# formats we haven't seen but that still contain "uses:" lines.
+# -------------------------------------------------------------------------
+"""
+
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import normalize  # noqa: E402
+
+
+# Regex: structured single-line format
+# e.g. ".github/workflows/ci.yml:12: actions/checkout@v4 ->"
+_STRUCTURED_RE = re.compile(
+    r"^(?P<path>[^\s:][^\s]*\.ya?ml):(?P<line>\d+):\s+"
+    r"(?P<action>[^\s@]+@[^\s]+)"
+    r"\s+->"
+)
+
+# Regex: "uses:" line inside a diff block
+# e.g. "  uses: actions/checkout@v4" or "- uses: actions/checkout@v4"
+_USES_RE = re.compile(
+    r"^\s*(?:[-+])?\s*uses:\s+(?P<action>[^\s@]+@(?P<ref>[^\s#]+))"
+)
+
+# A fully-pinned ref is a 40-char hex SHA (optionally followed by comment)
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+
+
+def _is_sha(ref):
+    return bool(_SHA_RE.match(ref.split()[0].strip()))
+
+
+def process_pinact(text, repo_root):
+    """Parse pinact output text and emit normalized findings."""
+    lines = text.splitlines()
+    emitted = set()  # deduplicate by (path, action)
+
+    # Pass 1: structured single-line format
+    for raw in lines:
+        m = _STRUCTURED_RE.match(raw)
+        if m:
+            file_path = m.group("path")
+            if file_path.startswith(repo_root + "/"):
+                file_path = file_path[len(repo_root) + 1:]
+            line_no = max(1, int(m.group("line")))
+            action = m.group("action")
+            key = (file_path, action)
+            if key in emitted:
+                continue
+            emitted.add(key)
+            _emit_unpinned(file_path, line_no, action, repo_root)
+        # Track the current file from bare filename lines for pass 2
+    # Pass 2: diff-block / "uses:" line format
+    # Walk lines; when we see a "uses:" line that is unpinned, emit a finding.
+    # We track the current file from preceding bare filename lines.
+    current_file = None
+    current_line = 0
+
+    for raw in lines:
+        stripped = raw.strip()
+
+        # Bare filename line (no line number suffix, ends with .yml/.yaml)
+        if re.match(r"^[^\s:]+\.ya?ml$", stripped) and not stripped.startswith("-"):
+            candidate = stripped
+            if candidate.startswith(repo_root + "/"):
+                candidate = candidate[len(repo_root) + 1:]
+            current_file = candidate
+            current_line = 0
+            continue
+
+        # "uses:" line
+        m = _USES_RE.match(raw)
+        if m:
+            action = m.group("action")
+            ref = m.group("ref").rstrip()
+            if not _is_sha(ref):
+                file_path = current_file or ".github/workflows/unknown.yml"
+                line_no = max(1, current_line)
+                key = (file_path, action)
+                if key not in emitted:
+                    emitted.add(key)
+                    _emit_unpinned(file_path, line_no, action, repo_root)
+            continue
+
+        # Line-number tracking: look for ":<number>:" patterns embedded in lines
+        lno_m = re.search(r":(\d+):", raw)
+        if lno_m and current_file:
+            current_line = int(lno_m.group(1))
+
+
+def _emit_unpinned(file_path, line_no, action, _repo_root):
+    """Emit one cicd/unpinned-action finding."""
+    # action is e.g. "actions/checkout@v4"
+    message = "Unpinned action: {0} (use a full commit SHA instead of a mutable ref)".format(action)
+    fp = normalize.make_content_fingerprint(
+        "{0}:{1}:{2}".format(file_path, line_no, action)
+    )
+    finding = normalize.make_finding(
+        check_id="cicd/unpinned-action",
+        rule_id="pinact/unpinned-uses",
+        severity="high",
+        confidence="high",
+        path=file_path,
+        line=line_no,
+        message=message,
+        fingerprint=fp,
+        properties={"tool": "pinact", "action_ref": action},
+    )
+    normalize.emit_finding(finding)
+
+
+def main(argv):
+    if len(argv) < 3:
+        sys.stderr.write("Usage: parse-pinact.py <pinact_output_file> <repo_root>\n")
+        sys.exit(1)
+
+    output_file = argv[1]
+    repo_root = argv[2].rstrip("/")
+
+    if not os.path.isfile(output_file) or os.path.getsize(output_file) == 0:
+        # No output from pinact (no unpinned actions found) -- emit nothing
+        return
+
+    try:
+        with open(output_file, "r", encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+        process_pinact(text, repo_root)
+    except OSError as exc:
+        sys.stderr.write("Cannot read pinact output: {0}\n".format(exc))
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-zizmor.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-zizmor.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+CCGM audit spine -- parse zizmor SARIF JSON -> finding.schema.json JSONL.
+
+Usage: parse-zizmor.py <zizmor_sarif_json> <repo_root>
+
+# -------------------------------------------------------------------------
+# Assumed zizmor --format sarif output shape (documented; not installed locally)
+#
+# zizmor emits a SARIF 2.1.0 document.  Representative structure:
+#
+#   {
+#     "$schema": "https://...",
+#     "version": "2.1.0",
+#     "runs": [
+#       {
+#         "tool": {
+#           "driver": {
+#             "name": "zizmor",
+#             "rules": [
+#               {
+#                 "id": "excessive-permissions",
+#                 "name": "excessive-permissions",
+#                 "shortDescription": { "text": "Overbroad GITHUB_TOKEN permissions" },
+#                 "defaultConfiguration": { "level": "warning" }
+#               }
+#             ]
+#           }
+#         },
+#         "results": [
+#           {
+#             "ruleId": "excessive-permissions",
+#             "level": "warning",
+#             "message": { "text": "Job 'build' has excessive permissions: write-all" },
+#             "locations": [
+#               {
+#                 "physicalLocation": {
+#                   "artifactLocation": { "uri": ".github/workflows/ci.yml", "uriBaseId": "%SRCROOT%" },
+#                   "region": { "startLine": 12, "startColumn": 1 }
+#                 }
+#               }
+#             ],
+#             "partialFingerprints": {
+#               "primaryLocationLineHash": "abc123def456"
+#             }
+#           }
+#         ]
+#       }
+#     ]
+#   }
+#
+# Known zizmor rule IDs (from source / docs as of 2024-2025):
+#   - dangerous-triggers          -> cicd/dangerous-trigger (critical/high)
+#   - excessive-permissions       -> cicd/excessive-permissions (medium/high)
+#   - template-injection          -> cicd/script-injection (high)
+#   - expression-injection        -> cicd/script-injection (high)
+#   - artipacked                  -> cicd/excessive-permissions (medium)
+#   - pull-request-target         -> cicd/dangerous-trigger (critical)
+#   - unpinned-uses               -> cicd/unpinned-action (high)
+#   - (any other)                 -> cicd/dangerous-trigger (medium, fallback)
+#
+# Level mapping:  error -> high, warning -> medium, note/none -> low
+# -------------------------------------------------------------------------
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import normalize  # noqa: E402
+
+
+# Mapping from zizmor rule-id (lower-case) to (check_id, severity).
+# Matched by prefix/substring so "template-injection" and "expression-injection"
+# both land on cicd/script-injection.
+_RULE_MAP = {
+    "dangerous-trigger":    ("cicd/dangerous-trigger",    "critical"),
+    "pull-request-target":  ("cicd/dangerous-trigger",    "critical"),
+    "template-injection":   ("cicd/script-injection",     "high"),
+    "expression-injection": ("cicd/script-injection",     "high"),
+    "excessive-permissions":("cicd/excessive-permissions", "medium"),
+    "artipacked":           ("cicd/excessive-permissions", "medium"),
+    "unpinned-uses":        ("cicd/unpinned-action",       "high"),
+}
+
+_LEVEL_TO_SEVERITY = {
+    "error":   "high",
+    "warning": "medium",
+    "note":    "low",
+    "none":    "low",
+}
+
+
+def _map_rule(rule_id_raw):
+    """Return (check_id, severity) for a raw zizmor rule ID."""
+    rule_lower = rule_id_raw.lower()
+    for key, val in _RULE_MAP.items():
+        if key in rule_lower:
+            return val
+    return ("cicd/dangerous-trigger", "medium")
+
+
+def process_zizmor_sarif(data, repo_root):
+    """
+    Parse a SARIF document emitted by 'zizmor --format sarif' and emit
+    normalized findings to stdout.
+    """
+    if not isinstance(data, dict):
+        return
+
+    for run in data.get("runs", []):
+        if not isinstance(run, dict):
+            continue
+
+        for result in run.get("results", []):
+            if not isinstance(result, dict):
+                continue
+
+            rule_id_raw = result.get("ruleId", "unknown")
+            check_id, default_severity = _map_rule(rule_id_raw)
+
+            # Level may override the default severity mapping
+            level = result.get("level", "warning").lower()
+            severity = _LEVEL_TO_SEVERITY.get(level, "medium")
+            # critical is not a SARIF level; only override when not already critical
+            if default_severity == "critical":
+                severity = "critical"
+            elif default_severity == "high" and severity == "medium":
+                severity = "high"
+
+            message_obj = result.get("message", {})
+            if isinstance(message_obj, dict):
+                message = message_obj.get("text", "zizmor finding")
+            else:
+                message = str(message_obj) if message_obj else "zizmor finding"
+
+            locations = result.get("locations", [{}])
+            loc = locations[0] if locations else {}
+            pl = loc.get("physicalLocation", {})
+            art = pl.get("artifactLocation", {})
+            region = pl.get("region", {})
+
+            file_path = art.get("uri", ".github/workflows/unknown.yml")
+            # Strip uriBaseId markers like "%SRCROOT%/" that SARIF tools emit
+            if file_path.startswith("%SRCROOT%/"):
+                file_path = file_path[len("%SRCROOT%/"):]
+            # Strip absolute repo prefix if present
+            if file_path.startswith(repo_root + "/"):
+                file_path = file_path[len(repo_root) + 1:]
+
+            line_no = max(1, int(region.get("startLine", 1)))
+
+            # Prefer tool-supplied fingerprint
+            fps = result.get("partialFingerprints", {})
+            tool_fp = fps.get("primaryLocationLineHash", "")
+            if tool_fp:
+                fp = normalize.fingerprint_from_tool(tool_fp)
+            else:
+                fp = normalize.make_content_fingerprint(
+                    "{0}:{1}:{2}".format(file_path, line_no, rule_id_raw)
+                )
+
+            finding = normalize.make_finding(
+                check_id=check_id,
+                rule_id="zizmor/{0}".format(rule_id_raw),
+                severity=severity,
+                confidence="high",
+                path=file_path,
+                line=line_no,
+                message=message,
+                fingerprint=fp,
+                properties={"tool": "zizmor"},
+            )
+            normalize.emit_finding(finding)
+
+
+def main(argv):
+    if len(argv) < 3:
+        sys.stderr.write("Usage: parse-zizmor.py <zizmor_sarif_json> <repo_root>\n")
+        sys.exit(1)
+
+    sarif_file = argv[1]
+    repo_root = argv[2].rstrip("/")
+
+    if not os.path.isfile(sarif_file) or os.path.getsize(sarif_file) == 0:
+        # No output from zizmor (no findings) -- emit nothing
+        return
+
+    try:
+        with open(sarif_file, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        process_zizmor_sarif(data, repo_root)
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.stderr.write("Cannot parse zizmor output: {0}\n".format(exc))
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-zizmor.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-zizmor.py
@@ -57,7 +57,7 @@ Usage: parse-zizmor.py <zizmor_sarif_json> <repo_root>
 #   - artipacked                  -> cicd/excessive-permissions (medium)
 #   - pull-request-target         -> cicd/dangerous-trigger (critical)
 #   - unpinned-uses               -> cicd/unpinned-action (high)
-#   - (any other)                 -> cicd/dangerous-trigger (medium, fallback)
+#   - (any other)                 -> cicd/workflow-security-issue (medium, fallback)
 #
 # Level mapping:  error -> high, warning -> medium, note/none -> low
 # -------------------------------------------------------------------------
@@ -75,7 +75,7 @@ import normalize  # noqa: E402
 # Matched by prefix/substring so "template-injection" and "expression-injection"
 # both land on cicd/script-injection.
 _RULE_MAP = {
-    "dangerous-trigger":    ("cicd/dangerous-trigger",    "critical"),
+    "dangerous-triggers":   ("cicd/dangerous-trigger",    "critical"),
     "pull-request-target":  ("cicd/dangerous-trigger",    "critical"),
     "template-injection":   ("cicd/script-injection",     "high"),
     "expression-injection": ("cicd/script-injection",     "high"),
@@ -98,7 +98,7 @@ def _map_rule(rule_id_raw):
     for key, val in _RULE_MAP.items():
         if key in rule_lower:
             return val
-    return ("cicd/dangerous-trigger", "medium")
+    return ("cicd/workflow-security-issue", "medium")
 
 
 def process_zizmor_sarif(data, repo_root):

--- a/modules/commands-extra/skills/audit/scripts/spine/run.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/run.sh
@@ -11,7 +11,8 @@
 #   --repo  <path>   Absolute path to the repo root (default: cwd)
 #   --tools <list>   Comma-separated subset of tools to run (default: all)
 #                    Valid: gitleaks,semgrep,dep-audit,knip,eslint,
-#                           govulncheck,bandit,hadolint,actionlint,trivy
+#                           govulncheck,bandit,hadolint,actionlint,trivy,
+#                           zizmor,pinact
 #   --output <file>  Write aggregated JSONL to this file instead of stdout
 #
 # Output: JSONL -- one JSON object per line, either a finding or a note.
@@ -32,7 +33,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Defaults
 # ---------------------------------------------------------------------------
 REPO_ROOT=""
-REQUESTED_TOOLS="gitleaks,semgrep,dep-audit,knip,eslint,govulncheck,bandit,hadolint,actionlint,trivy"
+REQUESTED_TOOLS="gitleaks,semgrep,dep-audit,knip,eslint,govulncheck,bandit,hadolint,actionlint,trivy,zizmor,pinact"
 OUTPUT_FILE=""
 
 # ---------------------------------------------------------------------------
@@ -85,9 +86,11 @@ TOOL_WRAPPERS["bandit"]="$SCRIPT_DIR/wrap-bandit.sh"
 TOOL_WRAPPERS["hadolint"]="$SCRIPT_DIR/wrap-hadolint.sh"
 TOOL_WRAPPERS["actionlint"]="$SCRIPT_DIR/wrap-actionlint.sh"
 TOOL_WRAPPERS["trivy"]="$SCRIPT_DIR/wrap-trivy.sh"
+TOOL_WRAPPERS["zizmor"]="$SCRIPT_DIR/wrap-zizmor.sh"
+TOOL_WRAPPERS["pinact"]="$SCRIPT_DIR/wrap-pinact.sh"
 
 # Ordered execution list (stable, deterministic)
-TOOL_ORDER=(gitleaks semgrep dep-audit knip eslint govulncheck bandit hadolint actionlint trivy)
+TOOL_ORDER=(gitleaks semgrep dep-audit knip eslint govulncheck bandit hadolint actionlint trivy zizmor pinact)
 
 # ---------------------------------------------------------------------------
 # Parse requested tools into a set (using associative array for O(1) lookup)

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-pinact.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-pinact.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# CCGM audit spine -- pinact wrapper
+# Checks GitHub Actions workflows for unpinned third-party actions
+# (actions referenced by mutable tag or branch instead of a full commit SHA).
+#
+# Usage: wrap-pinact.sh <repo_root>
+#
+# Output (stdout): JSONL
+# Exit code: always 0
+
+set -euo pipefail
+
+REPO_ROOT="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NORMALIZE_PY="$SCRIPT_DIR/normalize.py"
+PARSE_PY="$SCRIPT_DIR/parse-pinact.py"
+
+if [[ -z "$REPO_ROOT" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip pinact \
+    "cicd/unpinned-action:no repo_root argument supplied"
+  exit 0
+fi
+
+# Only run if workflow files exist
+WORKFLOWS_DIR="$REPO_ROOT/.github/workflows"
+if [[ ! -d "$WORKFLOWS_DIR" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip pinact \
+    "cicd/unpinned-action:no .github/workflows directory -- pinact skipped"
+  exit 0
+fi
+
+# Collect workflow files safely
+mapfile -d '' WORKFLOW_FILES < <(
+  find "$WORKFLOWS_DIR" \
+    -maxdepth 1 \
+    -type f \
+    \( -name "*.yml" -o -name "*.yaml" \) \
+    -print0
+)
+
+if [[ ${#WORKFLOW_FILES[@]} -eq 0 ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip pinact \
+    "cicd/unpinned-action:no workflow YAML files found -- pinact skipped"
+  exit 0
+fi
+
+if ! command -v pinact > /dev/null 2>&1; then
+  python3 "$NORMALIZE_PY" --emit-skip pinact \
+    "cicd/unpinned-action:pinact not installed -- action-pinning check skipped"
+  exit 0
+fi
+
+TMPFILE="$(mktemp /tmp/ccgm-pinact-XXXXXX.txt)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+# pinact run --check: exits non-zero if unpinned actions are found.
+# Output is a diff-like text showing which actions need pinning.
+# Pass workflow files as argv (never interpolated into a shell string).
+set +e
+pinact run --check "${WORKFLOW_FILES[@]}" > "$TMPFILE" 2>&1
+set -e
+
+python3 "$PARSE_PY" "$TMPFILE" "$REPO_ROOT"

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-zizmor.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-zizmor.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# CCGM audit spine -- zizmor wrapper
+# Audits GitHub Actions workflow files for security issues:
+#   - pull_request_target misuse (dangerous triggers)
+#   - excessive GITHUB_TOKEN permissions
+#   - expression injection via ${{ github.event.* }}
+#
+# Usage: wrap-zizmor.sh <repo_root>
+#
+# Output (stdout): JSONL
+# Exit code: always 0
+
+set -euo pipefail
+
+REPO_ROOT="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NORMALIZE_PY="$SCRIPT_DIR/normalize.py"
+PARSE_PY="$SCRIPT_DIR/parse-zizmor.py"
+
+if [[ -z "$REPO_ROOT" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip zizmor \
+    "cicd/dangerous-trigger:no repo_root argument supplied" \
+    "cicd/excessive-permissions:no repo_root argument supplied" \
+    "cicd/script-injection:no repo_root argument supplied"
+  exit 0
+fi
+
+# Only run if workflow files exist
+WORKFLOWS_DIR="$REPO_ROOT/.github/workflows"
+if [[ ! -d "$WORKFLOWS_DIR" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip zizmor \
+    "cicd/dangerous-trigger:no .github/workflows directory -- zizmor skipped" \
+    "cicd/excessive-permissions:no .github/workflows directory -- zizmor skipped" \
+    "cicd/script-injection:no .github/workflows directory -- zizmor skipped"
+  exit 0
+fi
+
+# Collect workflow files safely
+mapfile -d '' WORKFLOW_FILES < <(
+  find "$WORKFLOWS_DIR" \
+    -maxdepth 1 \
+    -type f \
+    \( -name "*.yml" -o -name "*.yaml" \) \
+    -print0
+)
+
+if [[ ${#WORKFLOW_FILES[@]} -eq 0 ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip zizmor \
+    "cicd/dangerous-trigger:no workflow YAML files found -- zizmor skipped" \
+    "cicd/excessive-permissions:no workflow YAML files found -- zizmor skipped" \
+    "cicd/script-injection:no workflow YAML files found -- zizmor skipped"
+  exit 0
+fi
+
+if ! command -v zizmor > /dev/null 2>&1; then
+  python3 "$NORMALIZE_PY" --emit-skip zizmor \
+    "cicd/dangerous-trigger:zizmor not installed -- dangerous trigger check skipped" \
+    "cicd/excessive-permissions:zizmor not installed -- permissions check skipped" \
+    "cicd/script-injection:zizmor not installed -- script injection check skipped"
+  exit 0
+fi
+
+TMPFILE="$(mktemp /tmp/ccgm-zizmor-XXXXXX.json)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+# zizmor --format sarif: emits SARIF JSON
+# Pass workflow files as argv (never interpolated into a shell string).
+# zizmor exits non-zero when findings exist; always exit 0 in the wrapper.
+set +e
+zizmor --format sarif "${WORKFLOW_FILES[@]}" > "$TMPFILE" 2>/dev/null
+set -e
+
+python3 "$PARSE_PY" "$TMPFILE" "$REPO_ROOT"

--- a/modules/commands-extra/skills/audit/tests/test-pack-ci-cd.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-ci-cd.sh
@@ -1,0 +1,631 @@
+#!/usr/bin/env bash
+# test-pack-ci-cd.sh -- CI/CD Hardening pack test suite (Epic 2.5)
+#
+# Tests:
+#   1. pack.json + checks.md validate (lint-pack passes; rubric covers all check-ids)
+#   2. parse-zizmor.py: synthetic SARIF -> valid cicd/* findings, properties.tool="zizmor"
+#   3. parse-pinact.py: synthetic pinact output (structured + diff-block) -> valid findings
+#   4. wrap-zizmor.sh: graceful skip when zizmor absent (coverage_gap entries)
+#   5. wrap-pinact.sh: graceful skip when pinact absent (coverage_gap entries)
+#   6. Registry gating: pack selected when has_workflows=true, excluded when false
+#   7. shellcheck on wrap-zizmor.sh + wrap-pinact.sh
+#
+# Exit code: 0 = all tests passed, 1 = failure
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SPINE_DIR="${AUDIT_DIR}/scripts/spine"
+PACK_DIR="${AUDIT_DIR}/packs/ci-cd"
+SCRIPTS_DIR="${AUDIT_DIR}/scripts"
+RUBRIC="${AUDIT_DIR}/schemas/severity-rubric.json"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() { printf '  [PASS] %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  ERRORS+=("$1")
+  FAIL=$((FAIL + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Validate a single finding JSON line against finding.schema.json constraints.
+# Returns: 0 = valid finding, 1 = non-finding record (skip), 2 = invalid
+# ---------------------------------------------------------------------------
+validate_finding() {
+  local json_line="$1"
+  python3 - "$json_line" << 'PYEOF'
+import json, re, sys
+
+line = sys.argv[1]
+try:
+    obj = json.loads(line)
+except json.JSONDecodeError:
+    sys.exit(2)
+
+if not isinstance(obj, dict):
+    sys.exit(2)
+
+if obj.get("type") in ("skipped", "coverage_gap", "provenance"):
+    sys.exit(1)
+
+required = {"check_id", "rule_id", "severity", "confidence", "location",
+            "message", "fingerprint", "detection", "source"}
+missing = required - obj.keys()
+if missing:
+    print("Missing: " + str(sorted(missing)), file=sys.stderr)
+    sys.exit(2)
+
+if not re.fullmatch(r"[a-z0-9_-]+/[a-z0-9_.-]+", obj["check_id"]):
+    print("Bad check_id: " + obj["check_id"], file=sys.stderr)
+    sys.exit(2)
+
+if obj["severity"] not in ("critical", "high", "medium", "low", "info"):
+    print("Bad severity: " + obj["severity"], file=sys.stderr)
+    sys.exit(2)
+
+if obj["confidence"] not in ("high", "medium", "low"):
+    print("Bad confidence: " + obj["confidence"], file=sys.stderr)
+    sys.exit(2)
+
+if obj["detection"] not in ("tool", "llm", "hybrid"):
+    print("Bad detection: " + obj["detection"], file=sys.stderr)
+    sys.exit(2)
+
+if obj["source"] not in ("tool", "llm"):
+    print("Bad source: " + obj["source"], file=sys.stderr)
+    sys.exit(2)
+
+loc = obj.get("location", {})
+if not isinstance(loc, dict) or "path" not in loc or "line" not in loc:
+    print("Bad location", file=sys.stderr)
+    sys.exit(2)
+if not isinstance(loc["line"], int) or loc["line"] < 1:
+    print("Bad line number", file=sys.stderr)
+    sys.exit(2)
+
+fp = obj.get("fingerprint", "")
+if not re.fullmatch(r"[A-Za-z0-9_.:+/=\-]{8,128}", fp):
+    print("Bad fingerprint: " + fp, file=sys.stderr)
+    sys.exit(2)
+
+sys.exit(0)
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Temp dir for test run
+# ---------------------------------------------------------------------------
+TESTRUN_TMPDIR="$(mktemp -d /tmp/ccgm-test-ci-cd-XXXXXX)"
+trap 'rm -rf "$TESTRUN_TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Test 1: lint-pack passes on ci-cd pack (with rubric)
+# ---------------------------------------------------------------------------
+printf '\nTest 1: lint-pack passes on ci-cd pack\n'
+
+LINT_OUTPUT=""
+LINT_EXIT=0
+LINT_OUTPUT="$(python3 "${SCRIPTS_DIR}/lint-pack.py" \
+  --packs-dir "${AUDIT_DIR}/packs" \
+  --rubric "${RUBRIC}" 2>&1)" || LINT_EXIT=$?
+
+if echo "$LINT_OUTPUT" | grep -q "^PASS: ci-cd"; then
+  pass "lint-pack.py PASS for ci-cd pack"
+elif echo "$LINT_OUTPUT" | grep -q "^FAIL: ci-cd"; then
+  fail "lint-pack.py FAIL for ci-cd pack: ${LINT_OUTPUT}"
+else
+  # lint-pack may print a NOTE and still pass overall
+  if [[ $LINT_EXIT -eq 0 ]]; then
+    pass "lint-pack.py exited 0 (ci-cd pack OK)"
+  else
+    fail "lint-pack.py failed (exit ${LINT_EXIT}): ${LINT_OUTPUT}"
+  fi
+fi
+
+# Rubric covers all cicd/* check-ids
+for CID in cicd/unpinned-action cicd/dangerous-trigger cicd/excessive-permissions cicd/script-injection cicd/actionlint-error; do
+  if python3 -c "
+import json, sys
+with open('${RUBRIC}') as f:
+    r = json.load(f)
+checks = r.get('checks', {})
+sys.exit(0 if '${CID}' in checks else 1)
+  " 2>/dev/null; then
+    pass "rubric covers ${CID}"
+  else
+    fail "rubric missing ${CID}"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Test 2: parse-zizmor.py -- synthetic SARIF -> valid cicd/* findings
+# ---------------------------------------------------------------------------
+printf '\nTest 2: parse-zizmor.py parses synthetic SARIF\n'
+
+SARIF_FILE="${TESTRUN_TMPDIR}/zizmor-sarif.json"
+cat > "$SARIF_FILE" << 'JSON'
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "zizmor",
+          "rules": [
+            {"id": "dangerous-triggers", "name": "dangerous-triggers"},
+            {"id": "excessive-permissions", "name": "excessive-permissions"},
+            {"id": "template-injection", "name": "template-injection"},
+            {"id": "pull-request-target", "name": "pull-request-target"}
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "dangerous-triggers",
+          "level": "error",
+          "message": {"text": "Workflow uses pull_request_target with checkout"},
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {"uri": ".github/workflows/ci.yml"},
+                "region": {"startLine": 3}
+              }
+            }
+          ],
+          "partialFingerprints": {"primaryLocationLineHash": "abc123def456abcd"}
+        },
+        {
+          "ruleId": "excessive-permissions",
+          "level": "warning",
+          "message": {"text": "Job has write-all permissions"},
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {"uri": ".github/workflows/deploy.yml"},
+                "region": {"startLine": 7}
+              }
+            }
+          ],
+          "partialFingerprints": {}
+        },
+        {
+          "ruleId": "template-injection",
+          "level": "error",
+          "message": {"text": "github.event.pull_request.title interpolated into run:"},
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {"uri": ".github/workflows/comment.yml"},
+                "region": {"startLine": 15}
+              }
+            }
+          ],
+          "partialFingerprints": {}
+        },
+        {
+          "ruleId": "pull-request-target",
+          "level": "error",
+          "message": {"text": "Dangerous pull_request_target usage"},
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {"uri": ".github/workflows/pr.yml"},
+                "region": {"startLine": 2}
+              }
+            }
+          ],
+          "partialFingerprints": {}
+        }
+      ]
+    }
+  ]
+}
+JSON
+
+ZI_OUT="${TESTRUN_TMPDIR}/zizmor-findings.jsonl"
+python3 "${SPINE_DIR}/parse-zizmor.py" "$SARIF_FILE" "/repo" > "$ZI_OUT"
+
+VALID_FINDINGS=0
+INVALID_FINDINGS=0
+WRONG_TOOL=0
+
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  V_EXIT=0
+  validate_finding "$line" || V_EXIT=$?
+  if [[ $V_EXIT -eq 0 ]]; then
+    VALID_FINDINGS=$((VALID_FINDINGS + 1))
+    # Check properties.tool = "zizmor"
+    TOOL="$(python3 -c "
+import json, sys
+obj = json.loads(sys.argv[1])
+print(obj.get('properties', {}).get('tool', ''))
+" "$line" 2>/dev/null || true)"
+    if [[ "$TOOL" != "zizmor" ]]; then
+      WRONG_TOOL=$((WRONG_TOOL + 1))
+    fi
+  elif [[ $V_EXIT -eq 2 ]]; then
+    INVALID_FINDINGS=$((INVALID_FINDINGS + 1))
+  fi
+done < "$ZI_OUT"
+
+if [[ $VALID_FINDINGS -ge 4 ]]; then
+  pass "parse-zizmor.py produced $VALID_FINDINGS valid finding(s) from synthetic SARIF"
+else
+  fail "parse-zizmor.py produced $VALID_FINDINGS valid findings (expected >= 4)"
+fi
+
+if [[ $INVALID_FINDINGS -eq 0 ]]; then
+  pass "no invalid findings from parse-zizmor.py"
+else
+  fail "$INVALID_FINDINGS invalid findings from parse-zizmor.py"
+fi
+
+if [[ $WRONG_TOOL -eq 0 ]]; then
+  pass "all zizmor findings have properties.tool=zizmor"
+else
+  fail "$WRONG_TOOL finding(s) missing properties.tool=zizmor"
+fi
+
+# Verify check_id mapping
+CHECKS="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    lines = [l.strip() for l in f if l.strip()]
+ids = [json.loads(l).get('check_id','') for l in lines]
+print(' '.join(sorted(set(ids))))
+" "$ZI_OUT" 2>/dev/null || true)"
+
+for EXPECTED_CID in cicd/dangerous-trigger cicd/excessive-permissions cicd/script-injection; do
+  if echo "$CHECKS" | grep -q "$EXPECTED_CID"; then
+    pass "parse-zizmor.py emits $EXPECTED_CID"
+  else
+    fail "parse-zizmor.py did not emit $EXPECTED_CID (got: $CHECKS)"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Test 3: parse-pinact.py -- structured + diff-block formats
+# ---------------------------------------------------------------------------
+printf '\nTest 3: parse-pinact.py parses synthetic output\n'
+
+# Structured single-line format
+PINACT_STRUCTURED="${TESTRUN_TMPDIR}/pinact-structured.txt"
+cat > "$PINACT_STRUCTURED" << 'TEXT'
+.github/workflows/ci.yml:12: actions/checkout@v4 -> actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+.github/workflows/ci.yml:18: actions/setup-node@v3 -> actions/setup-node@1a4442cacd436585916779262731d1f068594b6a # v3
+TEXT
+
+PI_OUT1="${TESTRUN_TMPDIR}/pinact-findings-1.jsonl"
+python3 "${SPINE_DIR}/parse-pinact.py" "$PINACT_STRUCTURED" "/repo" > "$PI_OUT1"
+
+PINACT_VALID1=0
+PINACT_WRONG_TOOL=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  V_EXIT=0
+  validate_finding "$line" || V_EXIT=$?
+  if [[ $V_EXIT -eq 0 ]]; then
+    PINACT_VALID1=$((PINACT_VALID1 + 1))
+    TOOL="$(python3 -c "
+import json, sys
+obj = json.loads(sys.argv[1])
+print(obj.get('properties', {}).get('tool', ''))
+" "$line" 2>/dev/null || true)"
+    if [[ "$TOOL" != "pinact" ]]; then
+      PINACT_WRONG_TOOL=$((PINACT_WRONG_TOOL + 1))
+    fi
+    # Verify check_id
+    CID="$(python3 -c "
+import json, sys
+print(json.loads(sys.argv[1]).get('check_id',''))
+" "$line" 2>/dev/null || true)"
+    if [[ "$CID" != "cicd/unpinned-action" ]]; then
+      fail "pinact finding has wrong check_id: $CID (expected cicd/unpinned-action)"
+    fi
+  fi
+done < "$PI_OUT1"
+
+if [[ $PINACT_VALID1 -ge 2 ]]; then
+  pass "parse-pinact.py (structured format) produced $PINACT_VALID1 valid finding(s)"
+else
+  fail "parse-pinact.py (structured format) produced $PINACT_VALID1 valid findings (expected >= 2)"
+fi
+if [[ $PINACT_WRONG_TOOL -eq 0 ]]; then
+  pass "all pinact findings have properties.tool=pinact"
+else
+  fail "$PINACT_WRONG_TOOL finding(s) missing properties.tool=pinact"
+fi
+
+# Diff-block format
+PINACT_DIFFBLOCK="${TESTRUN_TMPDIR}/pinact-diffblock.txt"
+cat > "$PINACT_DIFFBLOCK" << 'TEXT'
+.github/workflows/release.yml
+  uses: actions/upload-artifact@v3
+->
+  uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6 # v3
+TEXT
+
+PI_OUT2="${TESTRUN_TMPDIR}/pinact-findings-2.jsonl"
+python3 "${SPINE_DIR}/parse-pinact.py" "$PINACT_DIFFBLOCK" "/repo" > "$PI_OUT2"
+
+PINACT_VALID2=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  V_EXIT=0
+  validate_finding "$line" || V_EXIT=$?
+  if [[ $V_EXIT -eq 0 ]]; then
+    PINACT_VALID2=$((PINACT_VALID2 + 1))
+  fi
+done < "$PI_OUT2"
+
+if [[ $PINACT_VALID2 -ge 1 ]]; then
+  pass "parse-pinact.py (diff-block format) produced $PINACT_VALID2 valid finding(s)"
+else
+  fail "parse-pinact.py (diff-block format) produced 0 valid findings (expected >= 1)"
+fi
+
+# Empty output = no findings emitted
+PINACT_EMPTY="${TESTRUN_TMPDIR}/pinact-empty.txt"
+printf '' > "$PINACT_EMPTY"
+PI_OUT3="${TESTRUN_TMPDIR}/pinact-findings-3.jsonl"
+python3 "${SPINE_DIR}/parse-pinact.py" "$PINACT_EMPTY" "/repo" > "$PI_OUT3"
+LINES3="$(wc -l < "$PI_OUT3" | tr -d ' ')"
+if [[ "$LINES3" -eq 0 ]]; then
+  pass "parse-pinact.py emits nothing for empty input"
+else
+  fail "parse-pinact.py emitted $LINES3 line(s) for empty input (expected 0)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: wrap-zizmor.sh -- graceful skip when zizmor absent
+# ---------------------------------------------------------------------------
+printf '\nTest 4: wrap-zizmor.sh graceful skip when zizmor absent\n'
+
+# Build a minimal repo with a workflows dir
+WRAP_REPO="${TESTRUN_TMPDIR}/repo-with-workflows"
+mkdir -p "${WRAP_REPO}/.github/workflows"
+cat > "${WRAP_REPO}/.github/workflows/ci.yml" << 'YAML'
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+YAML
+
+# Restricted PATH (no zizmor)
+SYSTEM_BINS=""
+for bin in python3 bash find date mktemp cp rm mv printf head grep; do
+  BINPATH="$(command -v "$bin" 2>/dev/null || true)"
+  if [[ -n "$BINPATH" ]]; then
+    BINDIR="$(dirname "$BINPATH")"
+    case ":$SYSTEM_BINS:" in
+      *":$BINDIR:"*) ;;
+      *) SYSTEM_BINS="${SYSTEM_BINS:+$SYSTEM_BINS:}$BINDIR" ;;
+    esac
+  fi
+done
+RESTRICTED_PATH="$SYSTEM_BINS:/usr/bin:/bin"
+
+ZI_SKIP_OUT="${TESTRUN_TMPDIR}/zi-skip.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "${SPINE_DIR}/wrap-zizmor.sh" "$WRAP_REPO" > "$ZI_SKIP_OUT" 2>/dev/null
+ZI_SKIP_EXIT=$?
+set -e
+
+if [[ $ZI_SKIP_EXIT -eq 0 ]]; then
+  pass "wrap-zizmor.sh exits 0 when zizmor absent"
+else
+  fail "wrap-zizmor.sh exits $ZI_SKIP_EXIT (expected 0) when zizmor absent"
+fi
+
+SKIP_COUNT="$(grep -c '"type":"skipped"' "$ZI_SKIP_OUT" 2>/dev/null || printf '0')"
+GAP_COUNT="$(grep -c '"type":"coverage_gap"' "$ZI_SKIP_OUT" 2>/dev/null || printf '0')"
+
+if [[ $SKIP_COUNT -ge 1 ]]; then
+  pass "wrap-zizmor.sh emits skipped note when absent"
+else
+  fail "wrap-zizmor.sh emitted no skipped note"
+fi
+
+if [[ $GAP_COUNT -ge 1 ]]; then
+  pass "wrap-zizmor.sh emits coverage_gap entries when absent"
+else
+  fail "wrap-zizmor.sh emitted no coverage_gap entries"
+fi
+
+# Verify all output lines are valid JSON
+INVALID_JSON_ZI=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID_JSON_ZI=$((INVALID_JSON_ZI + 1))
+  fi
+done < "$ZI_SKIP_OUT"
+if [[ $INVALID_JSON_ZI -eq 0 ]]; then
+  pass "all wrap-zizmor.sh skip output lines are valid JSON"
+else
+  fail "$INVALID_JSON_ZI invalid JSON lines from wrap-zizmor.sh skip"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: wrap-pinact.sh -- graceful skip when pinact absent
+# ---------------------------------------------------------------------------
+printf '\nTest 5: wrap-pinact.sh graceful skip when pinact absent\n'
+
+PI_SKIP_OUT="${TESTRUN_TMPDIR}/pi-skip.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "${SPINE_DIR}/wrap-pinact.sh" "$WRAP_REPO" > "$PI_SKIP_OUT" 2>/dev/null
+PI_SKIP_EXIT=$?
+set -e
+
+if [[ $PI_SKIP_EXIT -eq 0 ]]; then
+  pass "wrap-pinact.sh exits 0 when pinact absent"
+else
+  fail "wrap-pinact.sh exits $PI_SKIP_EXIT (expected 0) when pinact absent"
+fi
+
+PI_SKIP_COUNT="$(grep -c '"type":"skipped"' "$PI_SKIP_OUT" 2>/dev/null || printf '0')"
+PI_GAP_COUNT="$(grep -c '"type":"coverage_gap"' "$PI_SKIP_OUT" 2>/dev/null || printf '0')"
+
+if [[ $PI_SKIP_COUNT -ge 1 ]]; then
+  pass "wrap-pinact.sh emits skipped note when absent"
+else
+  fail "wrap-pinact.sh emitted no skipped note"
+fi
+
+if [[ $PI_GAP_COUNT -ge 1 ]]; then
+  pass "wrap-pinact.sh emits coverage_gap entries when absent"
+else
+  fail "wrap-pinact.sh emitted no coverage_gap entries"
+fi
+
+INVALID_JSON_PI=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID_JSON_PI=$((INVALID_JSON_PI + 1))
+  fi
+done < "$PI_SKIP_OUT"
+if [[ $INVALID_JSON_PI -eq 0 ]]; then
+  pass "all wrap-pinact.sh skip output lines are valid JSON"
+else
+  fail "$INVALID_JSON_PI invalid JSON lines from wrap-pinact.sh skip"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: registry gating -- pack selected iff has_workflows=true
+# ---------------------------------------------------------------------------
+printf '\nTest 6: registry gating for ci-cd pack\n'
+
+# Create a temporary packs dir with only the ci-cd pack
+TMP_PACKS="${TESTRUN_TMPDIR}/tmp-packs"
+mkdir -p "$TMP_PACKS"
+cp -r "${PACK_DIR}" "$TMP_PACKS/ci-cd"
+
+REGISTRY_PY="${SCRIPTS_DIR}/registry.py"
+
+# has_workflows=true -> pack should be selected
+SELECTED_TRUE="$(python3 - "$REGISTRY_PY" "$TMP_PACKS" "true" << 'PYEOF'
+import json, sys, importlib.util, pathlib
+
+registry_py = pathlib.Path(sys.argv[1])
+packs_dir   = pathlib.Path(sys.argv[2])
+has_wf      = sys.argv[3] == "true"
+
+spec = importlib.util.spec_from_file_location("registry", str(registry_py))
+mod  = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+detector = {
+    "detected_ecosystems": [],
+    "project_shape": {
+        "monorepo_packages": [],
+        "frameworks": [],
+        "has_migrations": False,
+        "has_dockerfile": False,
+        "has_workflows": has_wf,
+        "is_extension": False,
+        "is_mobile": False
+    },
+    "available_tools": []
+}
+
+conditions = mod.build_truthy_conditions(detector)
+packs = mod.discover_packs(packs_dir)
+selected = [p for p in packs if mod.is_pack_applicable(p, conditions)]
+ids = [p.get("id","") for p in selected]
+print(" ".join(ids))
+PYEOF
+)" || SELECTED_TRUE=""
+
+if echo "$SELECTED_TRUE" | grep -q "ccgm/ci-cd"; then
+  pass "ci-cd pack selected when has_workflows=true"
+else
+  fail "ci-cd pack NOT selected when has_workflows=true (got: $SELECTED_TRUE)"
+fi
+
+# has_workflows=false -> pack should NOT be selected
+SELECTED_FALSE="$(python3 - "$REGISTRY_PY" "$TMP_PACKS" "false" << 'PYEOF'
+import json, sys, importlib.util, pathlib
+
+registry_py = pathlib.Path(sys.argv[1])
+packs_dir   = pathlib.Path(sys.argv[2])
+has_wf      = sys.argv[3] == "true"
+
+spec = importlib.util.spec_from_file_location("registry", str(registry_py))
+mod  = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+detector = {
+    "detected_ecosystems": [],
+    "project_shape": {
+        "monorepo_packages": [],
+        "frameworks": [],
+        "has_migrations": False,
+        "has_dockerfile": False,
+        "has_workflows": has_wf,
+        "is_extension": False,
+        "is_mobile": False
+    },
+    "available_tools": []
+}
+
+conditions = mod.build_truthy_conditions(detector)
+packs = mod.discover_packs(packs_dir)
+selected = [p for p in packs if mod.is_pack_applicable(p, conditions)]
+ids = [p.get("id","") for p in selected]
+print(" ".join(ids))
+PYEOF
+)" || SELECTED_FALSE=""
+
+if ! echo "$SELECTED_FALSE" | grep -q "ccgm/ci-cd"; then
+  pass "ci-cd pack NOT selected when has_workflows=false"
+else
+  fail "ci-cd pack selected when has_workflows=false (should be excluded)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: shellcheck on wrap-zizmor.sh + wrap-pinact.sh
+# ---------------------------------------------------------------------------
+printf '\nTest 7: shellcheck on wrap-zizmor.sh + wrap-pinact.sh\n'
+
+if command -v shellcheck > /dev/null 2>&1; then
+  for script in "${SPINE_DIR}/wrap-zizmor.sh" "${SPINE_DIR}/wrap-pinact.sh"; do
+    if [[ ! -f "$script" ]]; then
+      fail "shellcheck: script not found: $script"
+      continue
+    fi
+    SC_OUTPUT="$(shellcheck -S warning "$script" 2>&1 || true)"
+    if [[ -z "$SC_OUTPUT" ]]; then
+      pass "shellcheck clean: $(basename "$script")"
+    else
+      fail "shellcheck issues in $(basename "$script"): $SC_OUTPUT"
+    fi
+  done
+else
+  fail "shellcheck not installed -- cannot verify shell safety"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n-------------------------------------------------\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  printf '\nFailed tests:\n'
+  for err in "${ERRORS[@]}"; do
+    printf '  - %s\n' "$err"
+  done
+  exit 1
+fi
+
+printf 'All tests passed.\n'
+exit 0

--- a/modules/commands-extra/skills/audit/tests/test-pack-ci-cd.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-ci-cd.sh
@@ -614,6 +614,103 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 8: parse-zizmor.py fallback -- unmapped rule -> cicd/workflow-security-issue
+# ---------------------------------------------------------------------------
+printf '\nTest 8: parse-zizmor.py fallback routes unmapped rule to cicd/workflow-security-issue\n'
+
+SARIF_UNMAPPED="${TESTRUN_TMPDIR}/zizmor-unmapped.json"
+cat > "$SARIF_UNMAPPED" << 'JSON'
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "zizmor",
+          "rules": [
+            {"id": "cache-poisoning", "name": "cache-poisoning"}
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "cache-poisoning",
+          "level": "warning",
+          "message": {"text": "Cache key derived from untrusted input"},
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {"uri": ".github/workflows/ci.yml"},
+                "region": {"startLine": 22}
+              }
+            }
+          ],
+          "partialFingerprints": {}
+        }
+      ]
+    }
+  ]
+}
+JSON
+
+UNMAPPED_OUT="${TESTRUN_TMPDIR}/zizmor-unmapped-findings.jsonl"
+python3 "${SPINE_DIR}/parse-zizmor.py" "$SARIF_UNMAPPED" "/repo" > "$UNMAPPED_OUT"
+
+# Assert exactly one line emitted
+UNMAPPED_LINES="$(grep -c . "$UNMAPPED_OUT" 2>/dev/null || printf '0')"
+if [[ $UNMAPPED_LINES -ge 1 ]]; then
+  pass "parse-zizmor.py fallback emitted $UNMAPPED_LINES line(s) for unmapped rule"
+else
+  fail "parse-zizmor.py fallback emitted no output for unmapped rule"
+fi
+
+# Assert check_id == cicd/workflow-security-issue
+UNMAPPED_CID="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    lines = [l.strip() for l in f if l.strip()]
+if not lines:
+    print('')
+else:
+    print(json.loads(lines[0]).get('check_id', ''))
+" "$UNMAPPED_OUT" 2>/dev/null || true)"
+
+if [[ "$UNMAPPED_CID" == "cicd/workflow-security-issue" ]]; then
+  pass "parse-zizmor.py fallback emits check_id=cicd/workflow-security-issue"
+else
+  fail "parse-zizmor.py fallback emitted wrong check_id: '$UNMAPPED_CID' (expected cicd/workflow-security-issue)"
+fi
+
+# Assert cicd/workflow-security-issue exists in rubric
+if python3 -c "
+import json, sys
+with open('${RUBRIC}') as f:
+    r = json.load(f)
+sys.exit(0 if 'cicd/workflow-security-issue' in r.get('checks', {}) else 1)
+" 2>/dev/null; then
+  pass "rubric covers cicd/workflow-security-issue (fallback check-id)"
+else
+  fail "rubric missing cicd/workflow-security-issue"
+fi
+
+# Assert rule_id preserves the original zizmor rule (zizmor/cache-poisoning)
+UNMAPPED_RULEID="$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    lines = [l.strip() for l in f if l.strip()]
+if not lines:
+    print('')
+else:
+    print(json.loads(lines[0]).get('rule_id', ''))
+" "$UNMAPPED_OUT" 2>/dev/null || true)"
+
+if [[ "$UNMAPPED_RULEID" == "zizmor/cache-poisoning" ]]; then
+  pass "parse-zizmor.py fallback preserves rule_id=zizmor/cache-poisoning"
+else
+  fail "parse-zizmor.py fallback rule_id wrong: '$UNMAPPED_RULEID' (expected zizmor/cache-poisoning)"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 printf '\n-------------------------------------------------\n'

--- a/modules/commands-extra/skills/audit/tests/test-spine.sh
+++ b/modules/commands-extra/skills/audit/tests/test-spine.sh
@@ -438,6 +438,8 @@ if command -v shellcheck > /dev/null 2>&1; then
     "$SPINE_DIR/wrap-hadolint.sh"
     "$SPINE_DIR/wrap-actionlint.sh"
     "$SPINE_DIR/wrap-trivy.sh"
+    "$SPINE_DIR/wrap-zizmor.sh"
+    "$SPINE_DIR/wrap-pinact.sh"
   )
 
   for script in "${SHELL_SCRIPTS[@]}"; do


### PR DESCRIPTION
## Summary

- Add `wrap-zizmor.sh` + `parse-zizmor.py`: runs `zizmor --format sarif` against `.github/workflows/` files; parses SARIF output into `cicd/dangerous-trigger`, `cicd/excessive-permissions`, `cicd/script-injection`, `cicd/unpinned-action` findings
- Add `wrap-pinact.sh` + `parse-pinact.py`: runs `pinact run --check` against workflow files; parses structured single-line and diff-block output formats into `cicd/unpinned-action` findings
- Register both tools in `run.sh` TOOL_WRAPPERS + TOOL_ORDER (after trivy, before end)
- Add `packs/ci-cd/{pack.json,checks.md}`: id `ccgm/ci-cd`, gated on `has_workflows`, tools `["actionlint","zizmor","pinact"]`, five checks with full severity/confidence rationale + fixtures
- Add `cicd/*` entries to `severity-rubric.json`
- Register 4 new scripts + 2 pack files in `module.json`
- Add `tests/test-pack-ci-cd.sh` (28 tests); extend `tests/test-spine.sh` shellcheck list

## Actionlint namespace decision

The existing `parse-actionlint.py` emits `check_id = "ci/workflow-issue"`. The new `cicd/actionlint-error` check is a logical reference documented in `checks.md`: consumers should treat `ci/workflow-issue` findings with `properties.tool = "actionlint"` as satisfying `cicd/actionlint-error`. No changes to the actionlint wrapper.

## Assumed output shapes

**zizmor** (`--format sarif`): standard SARIF 2.1.0 with `runs[].results[]`. Rule IDs include `dangerous-triggers`, `excessive-permissions`, `template-injection`, `expression-injection`, `pull-request-target`, `unpinned-uses`. Fingerprints via `partialFingerprints.primaryLocationLineHash`. Shape documented in `parse-zizmor.py` header.

**pinact** (`run --check`): two supported formats documented in `parse-pinact.py` header — (1) structured `file:line: action@ref ->` single-line, (2) diff-block with bare filename + `uses:` lines. Parser handles both.

## Test plan

- [x] `shellcheck modules/commands-extra/skills/audit/scripts/spine/wrap-zizmor.sh wrap-pinact.sh` — clean
- [x] `bash modules/commands-extra/skills/audit/tests/test-pack-ci-cd.sh` — 28 passed, 0 failed
- [x] `bash modules/commands-extra/skills/audit/tests/test-spine.sh` — 27 passed, 0 failed (includes shellcheck for both new wrappers)
- [x] `python3 modules/commands-extra/skills/audit/scripts/lint-pack.py` — 10 packs checked, 0 errors
- [x] `bash modules/commands-extra/skills/audit/tests/test-pack-lint.sh` — 7 passed, 0 failed
- [x] `bash modules/commands-extra/skills/audit/tests/test-rubric.sh` — 8 passed, 0 failed
- [x] `bash modules/commands-extra/skills/audit/tests/test-registry.sh` — 8 passed, 0 failed
- [x] `python3 -m json.tool module.json severity-rubric.json` — valid JSON
- [x] `bash tests/test-modules.sh` — 1295 passed, 0 failed
- [x] `bash tests/test-no-personal-data.sh` — PASS

Closes #611