### PR TITLE
#612: secrets pack + gitleaks history mode + security pack deepening

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -342,6 +342,16 @@
       "target": "skills/audit/packs/architecture/checks.md",
       "type": "doc",
       "template": false
+    },
+    "skills/audit/packs/secrets/pack.json": {
+      "target": "skills/audit/packs/secrets/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/secrets/checks.md": {
+      "target": "skills/audit/packs/secrets/checks.md",
+      "type": "doc",
+      "template": false
     }
   },
   "tags": [

--- a/modules/commands-extra/skills/audit/packs/secrets/checks.md
+++ b/modules/commands-extra/skills/audit/packs/secrets/checks.md
@@ -1,0 +1,371 @@
+# Secrets & Credentials Pack
+
+## Scope
+
+This pack audits git repositories for exposed secrets and credentials: values committed to version
+control that should never be tracked. It covers credentials found in the full git history (including
+commits that were later reverted or squashed), `.env` files tracked by git, and private key material
+checked into the repo. It does NOT audit runtime secret injection, environment variable
+configuration, or secrets stored in external vaults. Dependency CVE scanning is covered by the
+dependencies pack; runtime misconfigurations are covered by the security pack.
+
+**Pack ID:** `ccgm/secrets`
+**Applies when:** `always`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `always` | Secrets can be committed to any repository regardless of language, framework, or purpose. Running on all repos maximises coverage; a single committed credential in a non-JS repo can be just as damaging as one in a production service. |
+
+---
+
+## Checks
+
+---
+
+### `secrets/leaked-credential`
+
+**Severity:** `critical`
+**Confidence:** `high`
+**Detection:** `tool`
+
+#### Detection
+
+**Tool (if detection = tool or hybrid):**
+`gitleaks`
+
+Rule / rule-id: gitleaks default ruleset (all built-in secret patterns)
+
+Fallback when tool absent: none — skip check (emit coverage_gap)
+
+**Scan mode:**
+The secrets pack invokes `wrap-gitleaks.sh` with `CCGM_GITLEAKS_HISTORY=1` to perform a
+**full git history scan** (`gitleaks git`). This finds credentials that were committed in any
+historical commit, including those removed at HEAD. No network calls are made; gitleaks
+works entirely from the local git object store.
+
+**Redaction (§3.7):**
+`parse-gitleaks.py` redacts every matched secret value before it enters the finding message.
+The redaction format is: first 4 characters, then `[redacted:len=N]` where N is the total
+length of the matched value. Example: `ghp_AbcXyz...` becomes `ghp_[redacted:len=40]`.
+The raw secret value never appears in JSONL output.
+
+**--verify-secrets opt-in contract:**
+Live verification (checking whether a detected credential is still active by calling the
+issuing service's API) is OFF by default. Enabling it requires setting
+`CCGM_GITLEAKS_VERIFY=1` AND obtaining explicit security-review approval (gate C1) because
+verification makes outbound network calls to credential issuers. trufflehog provides this
+capability as an independent optional wrapper (not installed by default); do not wire a
+default-on verification path. The default scan is fully offline.
+
+#### Spine Wiring
+
+```yaml
+check_id: secrets/leaked-credential
+detection: tool
+tool: gitleaks
+scan_mode: full-history (CCGM_GITLEAKS_HISTORY=1)
+```
+
+**Note:** `secrets/leaked-credential` is the canonical rubric id for all gitleaks findings.
+The `security/hardcoded-secret` check-id is reserved for LLM-originated findings in the
+security pack. Do not emit `security/hardcoded-secret` from this pack's tool path.
+
+#### Severity / Confidence
+
+**Severity rationale:** Any credential reachable from the git history gives every person
+with repo read access (including anyone who cloned it) direct, persistent access to the
+protected resource. Revocation and rotation are required. CRITICAL.
+
+**Confidence rationale:** gitleaks uses well-tuned pattern rules with low false-positive
+rates for its high-signal detectors (AWS keys, GitHub tokens, Stripe keys). The redaction
+step does not affect confidence scoring. HIGH.
+
+**Rubric entry:** `secrets/leaked-credential`
+
+#### Fixture
+
+**True positive** (`config/prod.env` committed in a prior commit):
+
+```bash
+# FINDS: AWS access key committed in history
+AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+**True negative** (should produce NO finding):
+
+```bash
+# OK: value is a placeholder, not a real credential
+AWS_ACCESS_KEY_ID=your-access-key-here
+AWS_SECRET_ACCESS_KEY=your-secret-key-here
+```
+
+---
+
+### `secrets/tracked-env-file`
+
+**Severity:** `high`
+**Confidence:** `high`
+**Detection:** `hybrid`
+
+#### Detection
+
+**Tool (if detection = tool or hybrid):**
+`grep`
+
+Rule / rule-id: `git ls-files` piped to grep matching `.env`, `.env.*` patterns with
+real-looking key=value assignments (non-placeholder values of length >= 8).
+
+Fallback when tool absent: `llm`
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/security-patterns.md
+Use the pattern regexes and severity guidelines from that file to guide detection.
+
+Check whether the git index (tracked files) contains any .env file or .env.* variant
+(e.g. .env.local, .env.production, .env.staging, .env.test) that contains real-looking
+secret assignments. A "real-looking" assignment is a KEY=value line where the value is
+NOT a placeholder (not "your-key-here", "REPLACE_ME", "TODO", "example", or similar).
+
+Also check for private key files tracked by git: files matching *.pem, id_rsa, id_ed25519,
+*.p12, *.pfx, *.key when tracked in the git index (not just present on disk).
+
+Look for:
+- `git ls-files` output containing .env, .env.local, .env.production, .env.staging, etc.
+- File contents containing lines matching KEY=<non-placeholder-value>
+- Files with names matching private key patterns tracked in the index
+
+Do NOT flag:
+- .env.example or .env.template files (names clearly indicate sample/template)
+- Files whose values are all placeholders or environment-variable references
+- Files outside the git index (only flag files tracked by git, not .gitignored ones)
+
+For each finding: file path (repo-relative), the type of exposed content, and the
+recommended fix (add to .gitignore, rotate any exposed values, use a secrets manager).
+auto_fixable=false -- requires human judgment to determine which values need rotation.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: secrets/tracked-env-file
+detection: hybrid
+tool: grep
+fallback: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A tracked `.env` file exposes all its assignments to every git
+clone recipient. Even if values are rotated, the git history retains the exposure.
+HIGH (not CRITICAL) because the presence of the file in the index does not guarantee
+the values are active production credentials — they may be development stubs.
+
+**Confidence rationale:** The combination of filename pattern matching and non-placeholder
+value detection is deterministic and produces very few false positives. HIGH.
+
+**Rubric entry:** `secrets/tracked-env-file`
+
+#### Fixture
+
+**True positive** (`.env.production` tracked in git):
+
+```bash
+# FINDS: production env file committed with real-looking values
+DATABASE_URL=postgres://admin:s3cr3tp4ss@db.prod.example.com/app
+STRIPE_SECRET_KEY=sk_live_EXAMPLE_DO_NOT_USE_0000000
+```
+
+**True negative** (should produce NO finding):
+
+```bash
+# OK: .env.example is a template -- values are placeholders
+# File: .env.example
+DATABASE_URL=postgres://user:password@localhost/myapp
+STRIPE_SECRET_KEY=your-stripe-secret-key-here
+```
+
+---
+
+### `secrets/tracked-key-material`
+
+**Severity:** `critical`
+**Confidence:** `high`
+**Detection:** `hybrid`
+
+#### Detection
+
+**Tool (if detection = tool or hybrid):**
+`grep`
+
+Rule / rule-id: `git ls-files` output matched against private key filename patterns:
+`*.pem`, `id_rsa`, `id_ed25519`, `id_ecdsa`, `id_dsa`, `*.p12`, `*.pfx`, `*.key`
+(excluding `*.pub` public-key counterparts). Also matches file contents containing
+`-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----`.
+
+Fallback when tool absent: `llm`
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/security-patterns.md
+
+Scan all git-tracked files for private key material. Flag:
+
+1. Files whose names match private key patterns tracked in the git index:
+   - *.pem (certificate/key bundles)
+   - id_rsa, id_ed25519, id_ecdsa, id_dsa (SSH private keys)
+   - *.p12, *.pfx (PKCS#12 key stores)
+   - Files whose names contain "private_key", "privatekey", or "private-key"
+     (excluding *.pub public key counterparts)
+
+2. Files whose contents contain a PEM private key header:
+   -----BEGIN RSA PRIVATE KEY-----
+   -----BEGIN EC PRIVATE KEY-----
+   -----BEGIN OPENSSH PRIVATE KEY-----
+   -----BEGIN PRIVATE KEY-----
+
+Do NOT flag:
+- Public key files (*.pub, files with "public_key" in the name)
+- Certificate files that contain ONLY a public certificate (no private key)
+- PEM headers inside test fixture directories clearly marked as fake/example
+  (e.g. test/fixtures/example.pem containing "EXAMPLE" in the key body)
+
+For each finding: file path (repo-relative), the type of key material found,
+and the recommended fix (remove from git history via git filter-repo or
+BFG Repo Cleaner, rotate the key immediately).
+auto_fixable=false -- key rotation and history rewriting require human action.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: secrets/tracked-key-material
+detection: hybrid
+tool: grep
+fallback: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A tracked private key gives any clone recipient the ability to
+impersonate the key holder, decrypt traffic, or authenticate as the key's owner. This
+is an immediate, irreversible exposure until the key is revoked. CRITICAL.
+
+**Confidence rationale:** Private key PEM headers and standard filename conventions
+(`id_rsa`, `*.p12`) are highly precise signals with virtually no false positives when
+matched against the git index. HIGH.
+
+**Rubric entry:** `secrets/tracked-key-material`
+
+#### Fixture
+
+**True positive** (`deploy/server.key` tracked in git):
+
+```
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA2a2rwplBQLF29amygykEMmYz0+Kcj3bKBp29R2tXRohGEIiJ
+...
+-----END RSA PRIVATE KEY-----
+```
+
+**True negative** (should produce NO finding):
+
+```
+# OK: public key only, no private key material
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2a2rwplBQL...
+-----END PUBLIC KEY-----
+```
+
+---
+
+### `secrets/history-only-credential`
+
+**Severity:** `high`
+**Confidence:** `high`
+**Detection:** `tool`
+
+#### Detection
+
+**Tool (if detection = tool or hybrid):**
+`gitleaks`
+
+Rule / rule-id: gitleaks default ruleset — findings from `gitleaks git` (history scan)
+where the reported file path does not exist at HEAD (i.e., the secret was committed and
+subsequently removed or renamed).
+
+Fallback when tool absent: none — skip check (emit coverage_gap)
+
+**Scan mode:** Same full-history scan as `secrets/leaked-credential`
+(`CCGM_GITLEAKS_HISTORY=1`). This check is a logical refinement: it represents the
+subset of gitleaks findings where the leaking file no longer exists at HEAD. The
+distinction matters for remediation priority — a history-only credential must be
+removed from git history (e.g., via `git filter-repo` or BFG Repo Cleaner) rather than
+simply deleting the file.
+
+**Redaction:** Same §3.7 first-4+length redaction as `secrets/leaked-credential`.
+
+#### Spine Wiring
+
+```yaml
+check_id: secrets/history-only-credential
+detection: tool
+tool: gitleaks
+scan_mode: full-history (CCGM_GITLEAKS_HISTORY=1)
+note: subset of gitleaks findings where the file no longer exists at HEAD
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A credential removed at HEAD is still reachable from any git
+clone via `git log` or object inspection. Anyone who cloned the repo before or after the
+removal has access to the full history. HIGH rather than CRITICAL because the credential
+may already be rotated — but rotation without history rewriting leaves the exposure
+permanently accessible to anyone with repo access.
+
+**Confidence rationale:** gitleaks history detection is high-precision for its built-in
+patterns. The additional filter (file absent at HEAD) is a deterministic git operation.
+HIGH.
+
+**Rubric entry:** `secrets/history-only-credential`
+
+#### Fixture
+
+**True positive** (secret committed in commit A, file deleted in commit B, HEAD has no such file):
+
+```
+Commit A: secrets.env contains
+  GITHUB_TOKEN=ghp_AbcDefGhiJklMnoPqrStuVwxYz012345
+
+Commit B: git rm secrets.env
+
+HEAD: secrets.env does not exist
+-> gitleaks git detects the token in commit A; file absent at HEAD -> history-only-credential
+```
+
+**True negative** (should produce NO finding):
+
+```
+# OK: the file exists at HEAD -- this is a leaked-credential finding, not history-only
+HEAD: secrets.env contains
+  GITHUB_TOKEN=ghp_AbcDefGhiJklMnoPqrStuVwxYz012345
+```
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/secrets/checks.md
+++ b/modules/commands-extra/skills/audit/packs/secrets/checks.md
@@ -91,8 +91,13 @@ step does not affect confidence scoring. HIGH.
 **True positive** (`config/prod.env` committed in a prior commit):
 
 ```bash
-# FINDS: AWS access key committed in history
-AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+# Pattern gitleaks flags: a 20-char AKIA-prefixed AWS access key id committed in source.
+# Access key id shown redacted here (AKIA<NONEXAMPLE_PLACEHOLDER>) because the AWS-docs
+# example value (prefix AKIA + suffix IOSFODNN7EXAMPLE) is on gitleaks' allow-list and
+# produces 0 findings. The pack's runtime test assembles a non-allowlisted value at
+# runtime so gitleaks actually fires. Real-world credentials matching the
+# AKIA[A-Z0-9]{16} pattern are detected.
+AWS_ACCESS_KEY_ID=AKIA<NONEXAMPLE_PLACEHOLDER>
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 

--- a/modules/commands-extra/skills/audit/packs/secrets/pack.json
+++ b/modules/commands-extra/skills/audit/packs/secrets/pack.json
@@ -1,0 +1,45 @@
+{
+  "id": "ccgm/secrets",
+  "name": "Secrets & Credentials",
+  "version": "1.0.0",
+  "applies_when": ["always"],
+  "tags": ["secrets", "credentials", "security"],
+  "severity_floor": "high",
+  "tools": ["gitleaks"],
+  "checks": [
+    {
+      "id": "secrets/leaked-credential",
+      "severity": "critical",
+      "confidence": "high",
+      "detection": "tool",
+      "tool": "gitleaks",
+      "auto_fixable": false
+    },
+    {
+      "id": "secrets/tracked-env-file",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "hybrid",
+      "tool": "grep",
+      "fallback": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "secrets/tracked-key-material",
+      "severity": "critical",
+      "confidence": "high",
+      "detection": "hybrid",
+      "tool": "grep",
+      "fallback": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "secrets/history-only-credential",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "tool",
+      "tool": "gitleaks",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/packs/security/checks.md
+++ b/modules/commands-extra/skills/audit/packs/security/checks.md
@@ -4,6 +4,15 @@
 
 This pack audits source code for security vulnerabilities including hardcoded credentials, injection risks, cross-site scripting vectors, missing security headers, and edge function authentication bypasses. It applies OWASP Top 10 guidance and uses tool-assisted detection (gitleaks for secrets, semgrep for injection/XSS patterns) backed by LLM confirmation. It does NOT audit dependency CVEs (covered by the dependencies pack), infrastructure misconfigurations, or runtime security controls.
 
+**Defense-in-depth cross-reference:** The `ccgm/secrets` pack provides deeper coverage of
+committed secrets: full git history scanning (`secrets/leaked-credential`), tracked `.env`
+files (`secrets/tracked-env-file`), tracked private key material (`secrets/tracked-key-material`),
+and history-only credentials (`secrets/history-only-credential`). When both packs run, the
+security pack's `security/hardcoded-secret` check covers LLM-originated findings and
+live-source-file patterns, while the secrets pack handles tool-detected history and file-tracking
+issues. Running both packs is the recommended defense-in-depth posture for comprehensive
+secrets coverage.
+
 **Pack ID:** `ccgm/security`
 **Applies when:** `always`
 
@@ -503,6 +512,56 @@ Deno.serve(async (req) => {
   return new Response(JSON.stringify(data));
 });
 ```
+
+---
+
+## Migration Mapping
+
+Every bullet from the original Agent 1 Security Audit category prompt is mapped to its owning check-id:
+
+| Original prompt bullet | Check-id |
+|------------------------|----------|
+| Hardcoded secrets, API keys, tokens (NOT auto-fixable - needs env var setup) | `security/hardcoded-secret` |
+| Console.logs with sensitive data (auto-fixable: remove line) | `security/sensitive-console-log` |
+| SQL injection risks (NOT auto-fixable - needs refactor) | `security/sql-injection` |
+| XSS vulnerabilities (NOT auto-fixable - needs sanitization) | `security/xss-vulnerability` |
+| Missing security headers (auto-fixable if config file exists) | `security/missing-security-headers` |
+| Edge function auth bypasses (NOT auto-fixable) | `security/edge-function-auth-bypass` |
+
+All 6 original bullets are covered. No bullet dropped.
+
+---
+
+## Defense-in-Depth Guidance
+
+The checks in this pack are designed as a **layered defence**. No single check is sufficient
+on its own; together they cover progressively deeper attack surfaces:
+
+| Layer | Check | Coverage |
+|-------|-------|----------|
+| 1 — Entry point | `security/hardcoded-secret` | Secrets visible in current source files |
+| 2 — Runtime logging | `security/sensitive-console-log` | Secrets accidentally logged at runtime |
+| 3 — Business logic | `security/sql-injection`, `security/xss-vulnerability` | Input not sanitised before use in queries or HTML |
+| 4 — Environment | `security/missing-security-headers` | Browser-level attack surface left open |
+| 5 — Auth boundary | `security/edge-function-auth-bypass` | Auth checks absent at the function entry point |
+
+**Cross-pack layering with ccgm/secrets:**
+For full secrets coverage, run the `ccgm/secrets` pack alongside this one. The secrets
+pack extends Layer 1 with:
+- `secrets/leaked-credential` — full git history scan for any committed credential
+- `secrets/tracked-env-file` — `.env` files committed to the index
+- `secrets/tracked-key-material` — private key files committed to the index
+- `secrets/history-only-credential` — credentials removed from HEAD but still in history
+
+These two packs are complementary and do not overlap on check-ids.
+
+**Validation-layering principle:**
+When fixing a finding from this pack, apply validation at every layer the unsafe value
+passes through — not just at the point of the symptom. For example, fixing
+`security/sql-injection` by parameterising the query also warrants adding input validation
+at the API entry point (layer 1) and an integration test that sends malicious input and
+asserts it is rejected. A single fix is correct but fragile; layered validation makes the
+class of bug structurally impossible.
 
 ---
 

--- a/modules/commands-extra/skills/audit/packs/security/checks.md
+++ b/modules/commands-extra/skills/audit/packs/security/checks.md
@@ -565,23 +565,6 @@ class of bug structurally impossible.
 
 ---
 
-## Migration Mapping
-
-Every bullet from the original Agent 1 Security Audit category prompt is mapped to its owning check-id:
-
-| Original prompt bullet | Check-id |
-|------------------------|----------|
-| Hardcoded secrets, API keys, tokens (NOT auto-fixable - needs env var setup) | `security/hardcoded-secret` |
-| Console.logs with sensitive data (auto-fixable: remove line) | `security/sensitive-console-log` |
-| SQL injection risks (NOT auto-fixable - needs refactor) | `security/sql-injection` |
-| XSS vulnerabilities (NOT auto-fixable - needs sanitization) | `security/xss-vulnerability` |
-| Missing security headers (auto-fixable if config file exists) | `security/missing-security-headers` |
-| Edge function auth bypasses (NOT auto-fixable) | `security/edge-function-auth-bypass` |
-
-All 6 original bullets are covered. No bullet dropped.
-
----
-
 ## Quality Checklist
 
 - [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -14,6 +14,21 @@
       "confidence": "high",
       "fix_confidence": "low"
     },
+    "secrets/tracked-env-file": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "secrets/tracked-key-material": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "secrets/history-only-credential": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
     "security/hardcoded-secret": {
       "severity": "critical",
       "confidence": "medium",

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-gitleaks.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-gitleaks.sh
@@ -1,9 +1,28 @@
 #!/usr/bin/env bash
 # CCGM audit spine -- gitleaks wrapper
-# Detects hard-coded secrets in the working tree.
+# Detects hard-coded secrets in the working tree (default) or full git history.
 #
 # Usage: wrap-gitleaks.sh <repo_root>
 #   repo_root: absolute path to the repository root
+#
+# Scan modes:
+#   Working-tree (default):
+#     Uses `gitleaks detect --no-git` -- scans files present in the working
+#     directory. Works in worktrees and detached-HEAD states.
+#
+#   History (opt-in):
+#     Set CCGM_GITLEAKS_HISTORY=1 before invoking to use `gitleaks git`
+#     instead. Walks every commit in the full git history -- finds secrets
+#     that were committed and later removed. Requires a real git repo with
+#     at least one commit. No network calls are made.
+#
+# --verify-secrets (opt-in, NOT wired by default):
+#   Live verification of detected secrets by calling credential-issuer APIs
+#   is intentionally out of scope for the default path; it makes network calls
+#   to external services and triggers security-review gate C1. To add opt-in
+#   verification, set CCGM_GITLEAKS_VERIFY=1 only after obtaining approval.
+#   The trufflehog wrapper (currently not installed) provides this capability
+#   as an independent optional step; do not rely on it being present.
 #
 # Output (stdout): JSONL -- one JSON object per line.
 # Exit code: always 0
@@ -31,17 +50,32 @@ fi
 TMPFILE="$(mktemp /tmp/ccgm-gitleaks-XXXXXX.json)"
 trap 'rm -f "$TMPFILE"' EXIT
 
-# Run gitleaks -- repo root passed as positional arg (never shell-interpolated)
-# --no-git: scan working tree (works in worktrees / detached heads)
-# --exit-code 0: we handle non-zero ourselves
+# Determine scan mode: history or working-tree
+HISTORY_MODE="${CCGM_GITLEAKS_HISTORY:-0}"
+
 set +e
-gitleaks detect \
-  --source "$REPO_ROOT" \
-  --report-format json \
-  --report-path "$TMPFILE" \
-  --no-git \
-  --exit-code 0 \
-  > /dev/null 2>&1
+if [[ "$HISTORY_MODE" == "1" ]]; then
+  # Full-history scan: walks every commit in the repository.
+  # Uses `gitleaks git` which requires a real git repo.
+  # --no-banner: suppress the gitleaks ASCII banner (keeps output clean)
+  gitleaks git \
+    --report-format json \
+    --report-path "$TMPFILE" \
+    --exit-code 0 \
+    --no-banner \
+    "$REPO_ROOT" \
+    > /dev/null 2>&1
+else
+  # Working-tree scan (default): scans files present in the working directory.
+  # --no-git: works in worktrees / detached heads
+  gitleaks detect \
+    --source "$REPO_ROOT" \
+    --report-format json \
+    --report-path "$TMPFILE" \
+    --no-git \
+    --exit-code 0 \
+    > /dev/null 2>&1
+fi
 GL_EXIT=$?
 set -e
 

--- a/modules/commands-extra/skills/audit/tests/test-pack-secrets.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-secrets.sh
@@ -1,0 +1,469 @@
+#!/usr/bin/env bash
+# CCGM audit -- test-pack-secrets.sh
+# Tests for Epic 2.6: Secrets pack + gitleaks full-history scan.
+#
+# What this tests:
+#   1. pack.json + checks.md validate (lint-pack passes on secrets pack)
+#   2. severity-rubric.json is valid JSON and contains all secrets/* ids
+#   3. (REAL-TOOL E2E) gitleaks full-history scan via wrap-gitleaks.sh with
+#      CCGM_GITLEAKS_HISTORY=1:
+#        a. Creates a throwaway git repo (mktemp, core.hooksPath=/dev/null)
+#        b. Commits a fake credential in a prior commit (ADV-009 fragment-assembled)
+#        c. Removes the file at HEAD
+#        d. Also commits a .env file with a fake-looking assignment
+#        e. Runs the real gitleaks history scan via the wrapper
+#        f. Asserts >= 1 secrets/leaked-credential finding from history
+#        g. Asserts the matched value is REDACTED in output (assembled key absent)
+#        h. Asserts the .env file is tracked in git (grep check)
+#   4. Working-tree mode (default, no CCGM_GITLEAKS_HISTORY) still works after
+#      the wrapper edit (regression guard for test-merge.sh's e2e).
+#
+# ADV-009: the fake-secret fixture is CONSTRUCTED AT RUNTIME from fragments;
+# the assembled string never appears in this tracked file.
+#
+# Usage: bash modules/commands-extra/skills/audit/tests/test-pack-secrets.sh
+# Exit:  0 = all tests passed, non-zero = at least one failure
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WRAP_GL="$AUDIT_DIR/scripts/spine/wrap-gitleaks.sh"
+LINT_PACK="$AUDIT_DIR/scripts/lint-pack.py"
+LINT_RUBRIC="$AUDIT_DIR/scripts/lint-rubric.py"
+RUBRIC_FILE="$AUDIT_DIR/schemas/severity-rubric.json"
+PACK_DIR="$AUDIT_DIR/packs/secrets"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+  printf '  [PASS] %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  ERRORS+=("$1")
+  FAIL=$((FAIL + 1))
+}
+
+TESTRUN_DIR="$(mktemp -d /tmp/ccgm-test-pack-secrets-XXXXXX)"
+trap 'rm -rf "$TESTRUN_DIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Test 1: lint-pack passes on the secrets pack
+# ---------------------------------------------------------------------------
+printf '\nTest 1: lint-pack passes on secrets pack\n'
+
+set +e
+LINT_OUT="$(python3 "$LINT_PACK" --packs-dir "$PACK_DIR/.." --rubric "$RUBRIC_FILE" 2>&1)"
+LINT_EXIT=$?
+set -e
+
+# Grep for the secrets pack specifically
+if echo "$LINT_OUT" | grep -q "PASS: secrets"; then
+  pass "t1: lint-pack PASS for secrets pack"
+elif echo "$LINT_OUT" | grep -q "FAIL: secrets"; then
+  fail "t1: lint-pack FAIL for secrets pack"
+  printf '    Output: %s\n' "$LINT_OUT" >&2
+else
+  # Fall back to overall exit code
+  if [[ $LINT_EXIT -eq 0 ]]; then
+    pass "t1: lint-pack exits 0 (all packs pass)"
+  else
+    fail "t1: lint-pack exits $LINT_EXIT"
+    printf '    Output: %s\n' "$LINT_OUT" >&2
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: lint-pack passes when run against secrets pack directory alone
+# ---------------------------------------------------------------------------
+printf '\nTest 2: lint-pack passes against secrets pack directory directly\n'
+
+set +e
+LINT2_OUT="$(python3 "$LINT_PACK" --packs-dir "$PACK_DIR" --rubric "$RUBRIC_FILE" 2>&1)"
+LINT2_EXIT=$?
+set -e
+
+if [[ $LINT2_EXIT -eq 0 ]]; then
+  pass "t2: lint-pack exits 0 on secrets pack dir"
+else
+  fail "t2: lint-pack exits $LINT2_EXIT on secrets pack dir"
+  printf '    Output: %s\n' "$LINT2_OUT" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: rubric valid JSON + contains secrets/* ids
+# ---------------------------------------------------------------------------
+printf '\nTest 3: rubric valid JSON + contains secrets/* check ids\n'
+
+if python3 -c "import json, sys; json.load(open('$RUBRIC_FILE'))" 2>/dev/null; then
+  pass "t3: rubric parses as valid JSON"
+else
+  fail "t3: rubric is not valid JSON"
+fi
+
+RUBRIC_IDS="$(python3 - "$RUBRIC_FILE" << 'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    rubric = json.load(fh)
+checks = rubric.get("checks", {})
+for cid in ["secrets/leaked-credential", "secrets/tracked-env-file",
+            "secrets/tracked-key-material", "secrets/history-only-credential"]:
+    if cid in checks:
+        print("FOUND:" + cid)
+    else:
+        print("MISSING:" + cid)
+PYEOF
+)"
+
+for line in $RUBRIC_IDS; do
+  if [[ "$line" == FOUND:* ]]; then
+    pass "t3: rubric has entry for ${line#FOUND:}"
+  else
+    fail "t3: rubric missing entry for ${line#MISSING:}"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Test 4: lint-rubric passes on the real rubric file
+# ---------------------------------------------------------------------------
+printf '\nTest 4: lint-rubric passes on real rubric file\n'
+
+set +e
+LRUBRIC_OUT="$(python3 "$LINT_RUBRIC" --rubric "$RUBRIC_FILE" 2>&1)"
+LRUBRIC_EXIT=$?
+set -e
+
+if [[ $LRUBRIC_EXIT -eq 0 ]]; then
+  pass "t4: lint-rubric exits 0 on real severity-rubric.json"
+else
+  fail "t4: lint-rubric exits $LRUBRIC_EXIT on real severity-rubric.json"
+  printf '    Output: %s\n' "$LRUBRIC_OUT" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5 (REAL-TOOL E2E): gitleaks full-history scan via wrap-gitleaks.sh
+# ---------------------------------------------------------------------------
+printf '\nTest 5 (real-tool e2e): gitleaks full-history scan (CCGM_GITLEAKS_HISTORY=1)\n'
+
+if ! command -v gitleaks > /dev/null 2>&1; then
+  printf '  [SKIP] gitleaks not installed -- history e2e test skipped\n'
+else
+  E2E_DIR="$(mktemp -d /tmp/ccgm-secrets-e2e-XXXXXX)"
+  TESTRUN_DIR="$TESTRUN_DIR $E2E_DIR"  # track for cleanup
+
+  # Build a throwaway git repo.
+  # ADV-009: the fake key is assembled at runtime from two string fragments.
+  # The prefix and the suffix are NEVER concatenated in this tracked file.
+  # We use a suffix that is NOT the AWS docs example ("IOSFODNN7EXAMPLE") to
+  # ensure real gitleaks detection without being the allow-listed example value.
+  git init "$E2E_DIR/repo" --quiet 2>/dev/null
+  git -C "$E2E_DIR/repo" config user.email "test@test.test"
+  git -C "$E2E_DIR/repo" config user.name "Test"
+  git -C "$E2E_DIR/repo" config core.hooksPath /dev/null 2>/dev/null || true
+
+  # Assemble the fake key at runtime from two separate variable fragments.
+  # Neither variable contains a scannable key on its own.
+  # The 16-char suffix uses a sequential alphabetic pattern to ensure sufficient
+  # Shannon entropy for gitleaks detection (all-caps sequential triggers aws-access-token).
+  # NOTE: the AWS docs example key uses "IOSFODNN7EXAMPLE" (which gitleaks allow-lists).
+  # We use "ABCDEFGHIJKLMNOP" -- different, triggers real detection, not a real key.
+  KEY_FRAG_A="AKIA"
+  KEY_FRAG_B="ABCDEFGHIJKLMNOP"
+  FAKE_KEY="${KEY_FRAG_A}${KEY_FRAG_B}"
+
+  # Commit 1: add a file containing the fake key (simulates a secret accidentally committed)
+  python3 - "$E2E_DIR/repo/leaked.env" "$FAKE_KEY" << 'PYEOF'
+import sys
+path, key = sys.argv[1], sys.argv[2]
+with open(path, "w") as fh:
+    fh.write("# Leaked credential file\n")
+    fh.write("AWS_ACCESS_KEY_ID=" + key + "\n")
+    fh.write("APP_ENV=production\n")
+PYEOF
+  git -C "$E2E_DIR/repo" add leaked.env
+  git -C "$E2E_DIR/repo" commit -m "feat: initial commit with leaked credential" --quiet 2>/dev/null
+
+  # Commit 2: remove the leaked file (history-only scenario: file absent at HEAD)
+  git -C "$E2E_DIR/repo" rm leaked.env --quiet 2>/dev/null
+  git -C "$E2E_DIR/repo" commit -m "fix: remove leaked credential file" --quiet 2>/dev/null
+
+  # Commit 3: add a tracked .env file with a fake-looking assignment
+  python3 - "$E2E_DIR/repo/.env" << 'PYEOF'
+import sys
+with open(sys.argv[1] if len(sys.argv) > 1 else ".env", "w") as fh:
+    fh.write("# Application environment\n")
+    fh.write("DATABASE_URL=postgres://admin:s3cr3tp4ss@db.prod.example.com/app\n")
+    fh.write("APP_ENV=development\n")
+PYEOF
+  git -C "$E2E_DIR/repo" add .env
+  git -C "$E2E_DIR/repo" commit -m "feat: add .env configuration" --quiet 2>/dev/null
+
+  # Verify HEAD state: leaked.env must NOT exist at HEAD
+  if [[ ! -f "$E2E_DIR/repo/leaked.env" ]]; then
+    pass "t5: leaked.env is absent at HEAD (history-only scenario confirmed)"
+  else
+    fail "t5: leaked.env unexpectedly present at HEAD (test setup error)"
+  fi
+
+  # Verify .env IS tracked at HEAD
+  if git -C "$E2E_DIR/repo" ls-files --error-unmatch .env 2>/dev/null; then
+    pass "t5: .env is tracked in git index"
+  else
+    fail "t5: .env is NOT tracked in git index (test setup error)"
+  fi
+
+  # Run wrap-gitleaks.sh with CCGM_GITLEAKS_HISTORY=1 (full history scan)
+  E2E_JSONL="$E2E_DIR/gitleaks-history.jsonl"
+  set +e
+  CCGM_GITLEAKS_HISTORY=1 bash "$WRAP_GL" "$E2E_DIR/repo" > "$E2E_JSONL" 2>/dev/null
+  GL_EXIT=$?
+  set -e
+
+  if [[ $GL_EXIT -eq 0 ]]; then
+    pass "t5: wrap-gitleaks exits 0 in history mode"
+  else
+    fail "t5: wrap-gitleaks exits $GL_EXIT in history mode (expected 0)"
+  fi
+
+  # Count secrets/leaked-credential findings from history
+  HISTORY_CRED_COUNT="$(python3 - "$E2E_JSONL" << 'PYEOF'
+import json, sys
+count = 0
+try:
+    with open(sys.argv[1]) as fh:
+        for l in fh:
+            l = l.strip()
+            if not l:
+                continue
+            try:
+                obj = json.loads(l)
+                if isinstance(obj, dict) and "type" not in obj:
+                    if obj.get("check_id") == "secrets/leaked-credential":
+                        count += 1
+            except Exception:
+                pass
+except OSError:
+    pass
+print(count)
+PYEOF
+)"
+
+  if [[ "$HISTORY_CRED_COUNT" -ge 1 ]]; then
+    pass "t5: >= 1 secrets/leaked-credential finding from full history scan (got $HISTORY_CRED_COUNT)"
+  else
+    fail "t5: 0 secrets/leaked-credential findings from history scan (expected >= 1)"
+  fi
+
+  # Assert the assembled fake key does NOT appear in the JSONL output (redaction held)
+  if grep -qF "$FAKE_KEY" "$E2E_JSONL" 2>/dev/null; then
+    fail "t5: assembled fake key appears in gitleaks JSONL output -- redaction failed"
+  else
+    pass "t5: assembled fake key is NOT in gitleaks JSONL output -- redaction held"
+  fi
+
+  # Assert redaction format is present (first-4+length pattern)
+  # The fake key starts with KEY_FRAG_A (4 chars) and gitleaks redacts to first4[redacted:len=N]
+  REDACTION_PRESENT="$(python3 - "$E2E_JSONL" "$KEY_FRAG_A" << 'PYEOF'
+import json, sys, re
+found = False
+prefix = sys.argv[2]
+try:
+    with open(sys.argv[1]) as fh:
+        for l in fh:
+            l = l.strip()
+            if not l:
+                continue
+            try:
+                obj = json.loads(l)
+                if isinstance(obj, dict) and "type" not in obj:
+                    msg = obj.get("message", "")
+                    # Check for first-4+[redacted:len=N] pattern in the message
+                    pattern = re.compile(re.escape(prefix) + r'\[redacted:len=\d+\]')
+                    if pattern.search(msg):
+                        found = True
+                        break
+            except Exception:
+                pass
+except OSError:
+    pass
+print("yes" if found else "no")
+PYEOF
+)"
+
+  if [[ "$REDACTION_PRESENT" == "yes" ]]; then
+    pass "t5: redaction format (first4[redacted:len=N]) present in finding message"
+  else
+    fail "t5: redaction format not found in finding message (expected first4[redacted:len=N])"
+  fi
+
+  # Check the properties.tool field is set to gitleaks
+  TOOL_PROP="$(python3 - "$E2E_JSONL" << 'PYEOF'
+import json, sys
+try:
+    with open(sys.argv[1]) as fh:
+        for l in fh:
+            l = l.strip()
+            if not l:
+                continue
+            try:
+                obj = json.loads(l)
+                if isinstance(obj, dict) and "type" not in obj:
+                    if obj.get("check_id") == "secrets/leaked-credential":
+                        props = obj.get("properties", {})
+                        print(props.get("tool", "missing"))
+                        sys.exit(0)
+            except Exception:
+                pass
+except OSError:
+    pass
+print("not_found")
+PYEOF
+)"
+
+  if [[ "$TOOL_PROP" == "gitleaks" ]]; then
+    pass "t5: properties.tool=gitleaks on secrets/leaked-credential finding"
+  else
+    fail "t5: properties.tool='$TOOL_PROP' (expected 'gitleaks')"
+  fi
+
+  # Test 6: verify .env file is tracked in git (grep check for tracked-env-file)
+  printf '\nTest 6: .env file tracked in git (grep-based tracked-env-file check)\n'
+
+  ENV_TRACKED="$(git -C "$E2E_DIR/repo" ls-files .env 2>/dev/null)"
+  if [[ "$ENV_TRACKED" == ".env" ]]; then
+    pass "t6: .env is listed in git ls-files (would be flagged by secrets/tracked-env-file)"
+  else
+    fail "t6: .env is NOT listed in git ls-files (expected to be tracked)"
+  fi
+
+  # Verify .env contains a real-looking assignment (non-placeholder value)
+  ENV_HAS_REAL_ASSIGNMENT="$(python3 - "$E2E_DIR/repo/.env" << 'PYEOF'
+import re, sys
+try:
+    with open(sys.argv[1]) as fh:
+        content = fh.read()
+    # Look for KEY=value where value is not a placeholder (len >= 8, not placeholder words)
+    PLACEHOLDER_WORDS = {"your", "replace", "example", "todo", "placeholder", "changeme"}
+    for line in content.splitlines():
+        m = re.match(r'^[A-Z_][A-Z0-9_]+=(.+)$', line.strip())
+        if m:
+            val = m.group(1).strip('"\'')
+            if len(val) >= 8:
+                lower_val = val.lower()
+                if not any(p in lower_val for p in PLACEHOLDER_WORDS):
+                    print("yes")
+                    sys.exit(0)
+    print("no")
+except OSError:
+    print("error")
+PYEOF
+)"
+
+  if [[ "$ENV_HAS_REAL_ASSIGNMENT" == "yes" ]]; then
+    pass "t6: .env contains real-looking assignment (non-placeholder value >= 8 chars)"
+  else
+    fail "t6: .env does not contain real-looking assignment (test data issue)"
+  fi
+
+  # Test 7: working-tree mode (default, no CCGM_GITLEAKS_HISTORY) regression guard
+  # Ensures the wrapper edit did not break the working-tree path.
+  printf '\nTest 7: working-tree mode regression guard (no CCGM_GITLEAKS_HISTORY)\n'
+
+  WT_E2E_DIR="$(mktemp -d /tmp/ccgm-secrets-wt-XXXXXX)"
+  TESTRUN_DIR="$TESTRUN_DIR $WT_E2E_DIR"  # track for cleanup
+
+  git init "$WT_E2E_DIR/repo" --quiet 2>/dev/null
+  git -C "$WT_E2E_DIR/repo" config user.email "test@test.test"
+  git -C "$WT_E2E_DIR/repo" config user.name "Test"
+  git -C "$WT_E2E_DIR/repo" config core.hooksPath /dev/null 2>/dev/null || true
+
+  # Write a file containing the assembled fake key to the working tree (not committed)
+  python3 - "$WT_E2E_DIR/repo/wt_secrets.env" "$FAKE_KEY" << 'PYEOF'
+import sys
+path, key = sys.argv[1], sys.argv[2]
+with open(path, "w") as fh:
+    fh.write("# Working tree credential test\n")
+    fh.write("AWS_ACCESS_KEY_ID=" + key + "\n")
+PYEOF
+
+  WT_JSONL="$WT_E2E_DIR/gitleaks-wt.jsonl"
+  set +e
+  bash "$WRAP_GL" "$WT_E2E_DIR/repo" > "$WT_JSONL" 2>/dev/null
+  WT_EXIT=$?
+  set -e
+
+  if [[ $WT_EXIT -eq 0 ]]; then
+    pass "t7: wrap-gitleaks exits 0 in working-tree mode (default)"
+  else
+    fail "t7: wrap-gitleaks exits $WT_EXIT in working-tree mode (expected 0)"
+  fi
+
+  WT_CRED_COUNT="$(python3 - "$WT_JSONL" << 'PYEOF'
+import json, sys
+count = 0
+try:
+    with open(sys.argv[1]) as fh:
+        for l in fh:
+            l = l.strip()
+            if not l:
+                continue
+            try:
+                obj = json.loads(l)
+                if isinstance(obj, dict) and "type" not in obj:
+                    if obj.get("check_id") == "secrets/leaked-credential":
+                        count += 1
+            except Exception:
+                pass
+except OSError:
+    pass
+print(count)
+PYEOF
+)"
+
+  if [[ "$WT_CRED_COUNT" -ge 1 ]]; then
+    pass "t7: working-tree mode finds >= 1 secrets/leaked-credential in working tree (got $WT_CRED_COUNT)"
+  else
+    fail "t7: working-tree mode found 0 credentials in working tree (expected >= 1)"
+  fi
+
+  # Assert the assembled fake key does NOT appear in working-tree output (redaction)
+  if grep -qF "$FAKE_KEY" "$WT_JSONL" 2>/dev/null; then
+    fail "t7: assembled fake key appears in working-tree output -- redaction failed"
+  else
+    pass "t7: assembled fake key NOT in working-tree output -- redaction held"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# ADV-009 self-check: this test file must not contain the assembled AKIA key
+# ---------------------------------------------------------------------------
+printf '\nADV-009 self-check: this file must not contain assembled AKIA key pattern\n'
+
+SELF_GREP="$(grep -cE 'AKIA[A-Z0-9]{12,}' "$SCRIPT_DIR/test-pack-secrets.sh" 2>/dev/null || true)"
+if [[ "$SELF_GREP" -eq 0 ]]; then
+  pass "ADV-009: grep -nE 'AKIA[A-Z0-9]{12,}' is empty in test file"
+else
+  fail "ADV-009: assembled AKIA key pattern found $SELF_GREP time(s) in test file -- violates ADV-009"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n-------------------------------------------------\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  printf '\nFailed tests:\n'
+  for err in "${ERRORS[@]}"; do
+    printf '  - %s\n' "$err"
+  done
+  exit 1
+fi
+
+printf 'All tests passed.\n'
+exit 0

--- a/modules/commands-extra/skills/audit/tests/test-pack-secrets.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-secrets.sh
@@ -50,7 +50,8 @@ fail() {
 }
 
 TESTRUN_DIR="$(mktemp -d /tmp/ccgm-test-pack-secrets-XXXXXX)"
-trap 'rm -rf "$TESTRUN_DIR"' EXIT
+CLEANUP_DIRS=("$TESTRUN_DIR")
+trap 'rm -rf "${CLEANUP_DIRS[@]}"' EXIT
 
 # ---------------------------------------------------------------------------
 # Test 1: lint-pack passes on the secrets pack
@@ -154,7 +155,7 @@ if ! command -v gitleaks > /dev/null 2>&1; then
   printf '  [SKIP] gitleaks not installed -- history e2e test skipped\n'
 else
   E2E_DIR="$(mktemp -d /tmp/ccgm-secrets-e2e-XXXXXX)"
-  TESTRUN_DIR="$TESTRUN_DIR $E2E_DIR"  # track for cleanup
+  CLEANUP_DIRS+=("$E2E_DIR")
 
   # Build a throwaway git repo.
   # ADV-009: the fake key is assembled at runtime from two string fragments.
@@ -375,7 +376,7 @@ PYEOF
   printf '\nTest 7: working-tree mode regression guard (no CCGM_GITLEAKS_HISTORY)\n'
 
   WT_E2E_DIR="$(mktemp -d /tmp/ccgm-secrets-wt-XXXXXX)"
-  TESTRUN_DIR="$TESTRUN_DIR $WT_E2E_DIR"  # track for cleanup
+  CLEANUP_DIRS+=("$WT_E2E_DIR")
 
   git init "$WT_E2E_DIR/repo" --quiet 2>/dev/null
   git -C "$WT_E2E_DIR/repo" config user.email "test@test.test"


### PR DESCRIPTION
## Summary

Implements Epic 2.6: Secrets-in-history pack + Security pack deepening.

- **`packs/secrets/`** (new pack, `ccgm/secrets`): four checks — `secrets/leaked-credential` (full-history gitleaks scan), `secrets/tracked-env-file` (hybrid grep/llm), `secrets/tracked-key-material` (hybrid grep/llm), `secrets/history-only-credential` (gitleaks history subset where file absent at HEAD).
- **`wrap-gitleaks.sh`** (additive edit): `CCGM_GITLEAKS_HISTORY=1` env toggle switches from `gitleaks detect --no-git` (working tree, default, unchanged) to `gitleaks git` (full history, no network). Existing callers unaffected; test-merge.sh e2e stays green. `--verify-secrets` opt-in contract documented in comments; not wired by default (gate C1, live network calls).
- **`severity-rubric.json`** (additive): three new entries — `secrets/tracked-env-file` (high), `secrets/tracked-key-material` (critical), `secrets/history-only-credential` (high). `secrets/leaked-credential` already present.
- **`packs/security/checks.md`** (additive): defense-in-depth cross-reference section + validation-layering guidance appended. All 6 existing checks and their rubric ids unchanged.
- **`module.json`**: registers `packs/secrets/pack.json` and `packs/secrets/checks.md`.
- **`tests/test-pack-secrets.sh`** (new): real gitleaks full-history e2e (ADV-009 fragment-key, fake key absent at HEAD), redaction assertion, working-tree regression guard, lint/rubric validation. 21 tests, all pass.

## Test plan

- [ ] `bash modules/commands-extra/skills/audit/tests/test-pack-secrets.sh` → 21 passed, 0 failed
- [ ] `bash modules/commands-extra/skills/audit/tests/test-merge.sh` → 41 passed, 0 failed (wrapper regression)
- [ ] `bash modules/commands-extra/skills/audit/tests/test-spine.sh` → 25 passed, 0 failed (shellcheck clean)
- [ ] `python3 modules/commands-extra/skills/audit/scripts/lint-pack.py` → 10 packs, 0 errors
- [ ] `bash modules/commands-extra/skills/audit/tests/test-pack-lint.sh` → 7 passed, 0 failed
- [ ] `bash modules/commands-extra/skills/audit/tests/test-rubric.sh` → 8 passed, 0 failed
- [ ] `bash modules/commands-extra/skills/audit/tests/test-registry.sh` → 8 passed, 0 failed
- [ ] `grep -nE 'AKIA[A-Z0-9]{12,}' modules/commands-extra/skills/audit/tests/test-pack-secrets.sh` → empty
- [ ] `python3 -m json.tool modules/commands-extra/module.json` → valid
- [ ] `python3 -m json.tool modules/commands-extra/skills/audit/schemas/severity-rubric.json` → valid
- [ ] `bash tests/test-modules.sh` → 1291 passed, 0 failed
- [ ] `bash tests/test-no-personal-data.sh` → PASS

Closes #612