### PR TITLE
#620: update orchestration expected sets for Wave-2 packs + fix BSD mktemp flake

### DIFF
--- a/modules/commands-extra/skills/audit/tests/test-orchestration.sh
+++ b/modules/commands-extra/skills/audit/tests/test-orchestration.sh
@@ -102,23 +102,24 @@ done
 echo "--- [1] Pack selection: detector + registry against fixture repos ---"
 echo ""
 
-# Expected pack id sets (derived from pack.json applies_when values):
-#   Always-packs (applies_when=["always"]): 7 packs:
+# Expected pack id sets (derived from pack.json applies_when values, Wave 2 state):
+#   Always-packs (applies_when=["always"]): 8 packs:
 #     ccgm/architecture, ccgm/code-quality, ccgm/documentation, ccgm/performance,
-#     ccgm/security, ccgm/testing, ccgm/tos-compliance
-#   JS-gated (applies_when=["language:javascript"]): 2 packs:
-#     ccgm/dependencies, ccgm/typescript-react
-#   No pack currently gates on has_migrations (that is Wave 2 data-migrations pack).
+#     ccgm/secrets, ccgm/security, ccgm/testing, ccgm/tos-compliance
+#   JS-gated (applies_when=["language:javascript"]): 5 packs:
+#     ccgm/accessibility, ccgm/correctness, ccgm/dependencies, ccgm/reliability,
+#     ccgm/typescript-react
+#   has_migrations-gated: ccgm/data-migrations
+#   has_workflows-gated:  ccgm/ci-cd
 #
-# Fixture A: JS+TS -> all 9 packs (7 always + 2 JS-gated, since package.json is present)
-EXPECTED_A="ccgm/architecture,ccgm/code-quality,ccgm/dependencies,ccgm/documentation,ccgm/performance,ccgm/security,ccgm/testing,ccgm/tos-compliance,ccgm/typescript-react"
+# Fixture A: JS+TS -> 13 packs (8 always + 5 JS-gated, no migrations/workflows)
+EXPECTED_A="ccgm/accessibility,ccgm/architecture,ccgm/code-quality,ccgm/correctness,ccgm/dependencies,ccgm/documentation,ccgm/performance,ccgm/reliability,ccgm/secrets,ccgm/security,ccgm/testing,ccgm/tos-compliance,ccgm/typescript-react"
 
-# Fixture B: Go only -> 7 always-packs (no JS/TS files)
-EXPECTED_B="ccgm/architecture,ccgm/code-quality,ccgm/documentation,ccgm/performance,ccgm/security,ccgm/testing,ccgm/tos-compliance"
+# Fixture B: Go only -> 8 always-packs (no JS/TS files, no migrations, no workflows)
+EXPECTED_B="ccgm/architecture,ccgm/code-quality,ccgm/documentation,ccgm/performance,ccgm/secrets,ccgm/security,ccgm/testing,ccgm/tos-compliance"
 
-# Fixture C: migrations + JS -> all 9 packs (package.json present -> JS detected -> 9 packs)
-#   has_migrations=true but no pack currently requires it, so selection same as A.
-EXPECTED_C="ccgm/architecture,ccgm/code-quality,ccgm/dependencies,ccgm/documentation,ccgm/performance,ccgm/security,ccgm/testing,ccgm/tos-compliance,ccgm/typescript-react"
+# Fixture C: migrations + JS -> 14 packs (8 always + 5 JS-gated + data-migrations)
+EXPECTED_C="ccgm/accessibility,ccgm/architecture,ccgm/code-quality,ccgm/correctness,ccgm/data-migrations,ccgm/dependencies,ccgm/documentation,ccgm/performance,ccgm/reliability,ccgm/secrets,ccgm/security,ccgm/testing,ccgm/tos-compliance,ccgm/typescript-react"
 
 # Fixture A: JS+TS
 FIX_A=$(make_tmp)
@@ -146,7 +147,7 @@ ACTUAL_A=$(pack_ids_sorted "$REG_A_FILE" 2>/dev/null || echo "ERROR")
 set -e
 
 if [ "$ACTUAL_A" = "$EXPECTED_A" ]; then
-  pass "fixture A (JS+TS): selected all 9 packs (7 always + 2 JS-gated)"
+  pass "fixture A (JS+TS): selected 13 packs (8 always + 5 JS-gated)"
 else
   fail "fixture A (JS+TS): expected '$EXPECTED_A' but got '$ACTUAL_A'"
 fi
@@ -160,7 +161,7 @@ ACTUAL_B=$(pack_ids_sorted "$REG_B_FILE" 2>/dev/null || echo "ERROR")
 set -e
 
 if [ "$ACTUAL_B" = "$EXPECTED_B" ]; then
-  pass "fixture B (Go): selected 7 always-packs (no JS-gated packs)"
+  pass "fixture B (Go): selected 8 always-packs (no JS-gated packs)"
 else
   fail "fixture B (Go): expected '$EXPECTED_B' but got '$ACTUAL_B'"
 fi
@@ -174,7 +175,7 @@ ACTUAL_C=$(pack_ids_sorted "$REG_C_FILE" 2>/dev/null || echo "ERROR")
 set -e
 
 if [ "$ACTUAL_C" = "$EXPECTED_C" ]; then
-  pass "fixture C (migrations+JS): selected all 9 packs (has_migrations gates no current pack)"
+  pass "fixture C (migrations+JS): selected 14 packs (8 always + 5 JS-gated + data-migrations)"
 else
   fail "fixture C (migrations+JS): expected '$EXPECTED_C' but got '$ACTUAL_C'"
 fi

--- a/modules/commands-extra/skills/audit/tests/test-pack-correctness.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-correctness.sh
@@ -40,7 +40,7 @@ fail() {
 # ---------------------------------------------------------------------------
 printf '\n(a) parse-eslint.py: synthetic output with eqeqeq + no-unreachable\n'
 
-SYNTHETIC_INPUT="$(mktemp /tmp/ccgm-eslint-synth-XXXXXX.json)"
+SYNTHETIC_INPUT="$(mktemp "${TMPDIR:-/tmp}/ccgm-eslint-synth.XXXXXX")"
 trap 'rm -f "$SYNTHETIC_INPUT"' EXIT
 
 # Construct ESLint-shaped JSON with one eqeqeq violation and one no-unreachable violation
@@ -141,7 +141,7 @@ fi
 
 # Verify all emitted check_ids are in the rubric (rubric-known).
 # Write findings to a temp file to avoid stdin/heredoc conflict.
-PARSE_OUTPUT_FILE="$(mktemp /tmp/ccgm-parse-out-XXXXXX.jsonl)"
+PARSE_OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/ccgm-parse-out.XXXXXX")"
 printf '%s\n' "$PARSE_OUTPUT" > "$PARSE_OUTPUT_FILE"
 trap 'rm -f "$SYNTHETIC_INPUT" "$PARSE_OUTPUT_FILE"' EXIT
 

--- a/modules/commands-extra/skills/audit/tests/test-pack-reliability.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-reliability.sh
@@ -42,7 +42,7 @@ fail() { printf "  FAIL: %s\n" "$1"; FAIL=$((FAIL + 1)); }
 echo "--- Test 1: pack.json validates (stdlib registry.py)"
 
 # Write validator to a temp file to avoid heredoc-in-command-substitution warnings.
-_T1_PY="$(mktemp /tmp/pack_validate_rel_XXXXXX.py)"
+_T1_PY="$(mktemp "${TMPDIR:-/tmp}/pack_validate_rel.XXXXXX")"
 cat > "${_T1_PY}" <<'PYEOF'
 import sys, json, importlib.util, pathlib
 


### PR DESCRIPTION
## Summary

- **test-orchestration.sh**: refreshes fixture A/B/C expected pack-id sets to match the post-Wave-2 registry (6 new packs merged). Always-packs: 7→8 (secrets); JS-gated: 2→5 (accessibility, correctness, reliability); Fixture C gains `data-migrations` via `has_migrations` gate. Exact sets confirmed against a live registry.py run — the "got" from the failing assertions became the new "expected".
- **test-pack-reliability.sh**: replaces `mktemp /tmp/pack_validate_rel_XXXXXX.py` with `mktemp "${TMPDIR:-/tmp}/pack_validate_rel.XXXXXX"` — BSD mktemp on macOS only substitutes trailing XXXXXX; a mid-string pattern produces a literal collision path that fails on second run.
- **test-pack-correctness.sh**: same fix for two mktemp calls (`ccgm-eslint-synth-XXXXXX.json` and `ccgm-parse-out-XXXXXX.jsonl`).

No pack, schema, script, or SKILL changes. No assertions weakened — all three fixture assertions remain exact-set equality.

Closes #620

## Test plan

- [x] `bash modules/commands-extra/skills/audit/tests/test-orchestration.sh` — 34/34 pass (was 31/34)
- [x] `bash modules/commands-extra/skills/audit/tests/test-pack-reliability.sh` — 8/8 pass, twice consecutively
- [x] `bash modules/commands-extra/skills/audit/tests/test-pack-correctness.sh` — 40/40 pass, twice consecutively
- [x] `bash tests/test-no-personal-data.sh` — PASS