### PR TITLE
#622: baseline/delta classification for /audit findings

### DIFF
--- a/modules/commands-extra/commands/audit.md
+++ b/modules/commands-extra/commands/audit.md
@@ -21,6 +21,8 @@ Run a comprehensive codebase audit across 9 categories. See the full skill for a
 /audit --diff             # Audit only files changed vs the detected base branch
 /audit --diff main        # Audit only files changed vs a specific ref
 /audit --staged           # Audit only files currently staged for commit (always read-only; --fix ignored)
+/audit --baseline <file>            # Classify findings as new/existing vs a previous run's findings.jsonl
+/audit --baseline <file> --new-only # Report only newly introduced findings
 /audit [PATH]             # Audit a specific path instead of the entire repo
 ```
 

--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -118,6 +118,11 @@
       "type": "script",
       "template": false
     },
+    "skills/audit/scripts/baseline.py": {
+      "target": "skills/audit/scripts/baseline.py",
+      "type": "script",
+      "template": false
+    },
     "skills/audit/schemas/severity-rubric.json": {
       "target": "skills/audit/schemas/severity-rubric.json",
       "type": "doc",

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -21,6 +21,10 @@ Comprehensive codebase audit. Produces a findings document and creates GitHub is
 /audit --diff             # Audit only files changed vs the detected base branch (git diff)
 /audit --diff main        # Audit only files changed vs a specific ref
 /audit --staged           # Audit only files currently staged for commit
+
+# Baseline / delta classification (compare to a previous run)
+/audit --baseline <file>            # Classify findings as new/existing vs a baseline run
+/audit --baseline <file> --new-only # Report only newly introduced findings
 ```
 
 > **Note on `--diff` and `--staged`**: These flags scope the audit to changed files only.
@@ -84,6 +88,8 @@ This ensures the user always knows exactly what the audit will do before it star
 - `--manual` -> Coordinator-Only Mode (Phases M1-M4 + output launch commands)
 - `--diff [ref]` -> sets DIFF_MODE=true; changed files computed via `git diff -z <ref>...HEAD` (ref defaults to BASE_BRANCH). Composable with `--single`, `--fix`, and all execution strategies.
 - `--staged` -> sets STAGED_MODE=true; changed files computed via `git diff -z --staged`. Composable with `--single` and all execution strategies. `--fix` is ignored with a printed note when combined with `--staged` — staged-only runs are always read-only.
+- `--baseline <file>` -> sets BASELINE_FILE=<file>. After merge-findings writes findings.jsonl, run `scripts/baseline.py` to classify each finding as new/existing and emit resolved records. Composable with `--single`, `--diff`, and all execution strategies.
+- `--new-only` -> sets NEW_ONLY=true. Only valid with `--baseline`. Filters the report to new findings only (findings not in the baseline). Passed through to `scripts/baseline.py --new-only`.
 - Remaining argument is the target path (default: entire repo)
 
 **If NO flags are passed, prompt the user with `AskUserQuestion` to configure the audit:**
@@ -806,6 +812,45 @@ Tools that were absent, wrappers that were skipped, or checks that could not run
 
 3. **Write** the compiled document to `$AUDIT_DIR/current/audit-report.md`.
 4. **Display** the summary table and critical/high findings to the user.
+
+### Baseline / Delta (optional, after merge step)
+
+When `--baseline <file>` is passed, run the baseline classifier immediately after
+`merge-findings.py` writes `$AUDIT_DIR/current/findings.jsonl`:
+
+```bash
+BASELINE_ARGS=(--current "$AUDIT_DIR/current/findings.jsonl" --baseline "$BASELINE_FILE")
+if [[ "${NEW_ONLY:-false}" == "true" ]]; then
+  BASELINE_ARGS+=(--new-only)
+fi
+python3 "$SKILL_ROOT/scripts/baseline.py" \
+  "${BASELINE_ARGS[@]}" \
+  --output "$AUDIT_DIR/current/findings-delta.jsonl"
+```
+
+The script compares current findings against the baseline using `(rule_id, fingerprint)` as
+the matching key and tags each finding with `properties.baseline_status`:
+- `"new"` — introduced since the baseline.
+- `"existing"` — present in both runs (persisting).
+- Baseline findings absent from current are emitted as `{"type":"resolved", ...}` records.
+
+A `{"type":"baseline_summary", "new": N, "existing": N, "resolved": N}` record is always
+the first line of the delta output.
+
+**Report impact:** when `--baseline` is set, add a **Delta vs Baseline** row to the Summary
+table showing New / Persisting / Fixed counts sourced from the baseline_summary record.
+When `--new-only` is set, limit the Findings sections to new findings only and note this
+in the report header.
+
+**`--single` mode:** the same `--baseline` / `--new-only` flags and this exact step apply
+after Phase 5 (Run Merge Inline) in Single-Session Mode. Run `baseline.py` in place of or
+after `merge-findings.py` in the same inline step; then compile the report (Phase 6) from
+`findings-delta.jsonl` instead of `findings.jsonl`.
+
+**Persisting the baseline:** to save the current run as the next baseline, pass
+`--save-baseline` to `baseline.py`, or manually copy `findings.jsonl` into a history
+directory (e.g., `.audit/history/YYYY-MM-DD.jsonl`). The script never auto-writes a baseline;
+the caller controls when to advance it.
 
 ### Phase M7: Issue Creation
 

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -837,6 +837,15 @@ the matching key and tags each finding with `properties.baseline_status`:
 A `{"type":"baseline_summary", "new": N, "existing": N, "resolved": N}` record is always
 the first line of the delta output.
 
+**Match key stability:** Tool/spine findings set `rule_id` deterministically, so they
+classify stably across runs.  LLM findings may not: when a worker omits `rule_id`,
+`merge-findings` backfills it from `check_id`.  If a worker's `rule_id` emission is
+inconsistent between runs, the SAME logical finding (same location + fingerprint) can
+carry two different `rule_id` values — producing one phantom **new** and one phantom
+**resolved** for a finding that did not actually change.  To prevent this, ensure LLM
+workers always emit `rule_id` explicitly.  (The key is intentionally composite — dropping
+`rule_id` would silently merge two different rules that share a fingerprint.)
+
 **Report impact:** when `--baseline` is set, add a **Delta vs Baseline** row to the Summary
 table showing New / Persisting / Fixed counts sourced from the baseline_summary record.
 When `--new-only` is set, limit the Findings sections to new findings only and note this

--- a/modules/commands-extra/skills/audit/scripts/baseline.py
+++ b/modules/commands-extra/skills/audit/scripts/baseline.py
@@ -45,6 +45,22 @@ Matching key
 ------------
 (rule_id, fingerprint)
 
+The key is composite: rule_id correctly disambiguates two different rules whose findings
+land on the same line (same fingerprint but different rule_id → two distinct findings).
+Do NOT reduce the key to fingerprint alone.
+
+Stability caveat for LLM findings
+----------------------------------
+Tool/spine findings set rule_id deterministically from the check schema, so they classify
+stably across runs.  LLM findings are different: when a worker omits rule_id,
+merge-findings backfills it from check_id.  If rule_id emission is inconsistent across
+runs — the worker emits it in one run but omits it in another, causing merge-findings to
+backfill a different value — the SAME logical finding (identical location + fingerprint)
+can carry two different rule_ids across runs.  The result is one phantom "new" finding
+and one phantom "resolved" finding for a finding that did not actually change.  This is a
+known limitation of LLM-source findings; the fix is to ensure workers consistently emit
+rule_id.
+
 Classification
 --------------
 Each current finding is tagged in properties.baseline_status:
@@ -242,6 +258,11 @@ def main() -> int:
     new_count = 0
     existing_count = 0
     tagged_findings = []
+    # Dedup current-side by (rule_id, fingerprint): mirrors the resolved-side
+    # dedup below.  merge-findings collapses fingerprints on its output, so
+    # duplicates are not expected on the intended path, but the symmetric guard
+    # prevents double-counting if the same key appears more than once.
+    seen_current_keys: set = set()
 
     for idx, f in enumerate(current_findings):
         if not _validate_key(f, "--current", idx):
@@ -250,6 +271,10 @@ def main() -> int:
             continue
 
         key = _match_key(f)
+        if key in seen_current_keys:
+            continue
+        seen_current_keys.add(key)
+
         if key in baseline_keys:
             status = "existing"
             existing_count += 1

--- a/modules/commands-extra/skills/audit/scripts/baseline.py
+++ b/modules/commands-extra/skills/audit/scripts/baseline.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""
+CCGM /audit baseline classifier (Epic 3.2).
+
+Classifies current audit findings as new, existing, or resolved by comparing
+against a baseline findings.jsonl produced by a previous merge-findings run.
+
+Usage
+-----
+  baseline.py --current <findings.jsonl> --baseline <file> \\
+              [--new-only] [--output <file>] [--save-baseline <path>]
+
+Arguments
+---------
+  --current   <path>  Required. Current findings.jsonl (merge-findings output).
+  --baseline  <path>  Required. Baseline findings.jsonl to compare against.
+                      Must be a file path to a previous merge-findings output.
+                      Ref-resolution (e.g. a git SHA) is not supported by this
+                      script; to compare against a ref, extract the findings.jsonl
+                      from that ref first:
+                        git show <ref>:.audit/current/findings.jsonl > baseline.jsonl
+                      then pass the extracted file here.
+  --new-only          Optional. If set, output only findings tagged "new" (plus
+                      the baseline_summary record). Findings tagged "existing" and
+                      resolved records are omitted from output.
+  --output    <path>  Optional. Write output JSONL to this file instead of stdout.
+  --save-baseline <path>
+                      Optional. Copy the current findings.jsonl to <path> after
+                      classification. Useful for persisting the current run as the
+                      next baseline (e.g. --save-baseline .audit/history/YYYY-MM-DD.jsonl).
+                      The copy is byte-identical to --current; the baseline_summary
+                      record written to --output is NOT included in the saved file.
+
+Input format (both --current and --baseline)
+--------------------------------------------
+JSONL produced by merge-findings.py. Each line is one of:
+  - A finding record (no "type" field): has "rule_id" and "fingerprint".
+  - A metadata record (has a "type" field): provenance, coverage_gap, etc.
+
+Only finding records (those without a "type" field) participate in matching.
+Metadata records in --current are passed through to output unchanged; metadata
+records in --baseline are ignored.
+
+Matching key
+------------
+(rule_id, fingerprint)
+
+Classification
+--------------
+Each current finding is tagged in properties.baseline_status:
+  "new"      — present in current, absent from baseline.
+  "existing" — present in both current and baseline.
+
+Additionally, baseline findings absent from current are emitted as:
+  {"type": "resolved", "rule_id": ..., "fingerprint": ..., "baseline": <path>}
+These represent findings that were fixed since the baseline was captured.
+
+Summary record
+--------------
+A {"type": "baseline_summary", "new": N, "existing": N, "resolved": N, "baseline": <path>}
+record is always emitted as the first line of output.
+
+Output order
+------------
+1. baseline_summary record
+2. Metadata records from --current (provenance, coverage_gap, etc.) — passed through
+3. Tagged finding records (all, or only "new" when --new-only)
+4. Resolved records (omitted when --new-only)
+
+History / save-baseline pattern
+--------------------------------
+To maintain a run history, pass --save-baseline each time:
+  baseline.py --current .audit/current/findings.jsonl \\
+              --baseline .audit/history/last.jsonl \\
+              --save-baseline .audit/history/$(date +%Y-%m-%d).jsonl
+The script copies --current to the save path AFTER classification, so the saved
+file is the verbatim merge-findings output without baseline_status tags.
+
+Exit codes
+----------
+  0  Success.
+  1  Input error, file not found, or malformed JSONL.
+"""
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# JSONL loading helpers
+# ---------------------------------------------------------------------------
+
+def _load_jsonl(path: str, label: str):
+    """
+    Load a JSONL file and return (metadata_records, finding_records).
+
+    metadata_records  list of dicts that have a "type" field
+    finding_records   list of dicts without a "type" field
+
+    Exits 1 with a clear stderr message on any IO or parse error.
+    """
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw_lines = fh.readlines()
+    except OSError as exc:
+        print(
+            f"baseline: ERROR: cannot read {label} file '{path}': {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    metadata_records = []
+    finding_records = []
+
+    for lineno, raw_line in enumerate(raw_lines, 1):
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        try:
+            obj = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            print(
+                f"baseline: ERROR: {label} '{path}' line {lineno} is not valid JSON: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        if not isinstance(obj, dict):
+            print(
+                f"baseline: ERROR: {label} '{path}' line {lineno} is not a JSON object",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        if "type" in obj:
+            metadata_records.append(obj)
+        else:
+            finding_records.append(obj)
+
+    return metadata_records, finding_records
+
+
+# ---------------------------------------------------------------------------
+# Matching key
+# ---------------------------------------------------------------------------
+
+def _match_key(finding: dict):
+    """Return the (rule_id, fingerprint) tuple used for baseline matching."""
+    return (finding.get("rule_id", ""), finding.get("fingerprint", ""))
+
+
+def _validate_key(finding: dict, label: str, lineno: int) -> bool:
+    """
+    Warn if a finding is missing rule_id or fingerprint.
+    Returns True if the finding has a usable key, False otherwise.
+    """
+    rule_id = finding.get("rule_id", "")
+    fingerprint = finding.get("fingerprint", "")
+    if not rule_id or not fingerprint:
+        missing = []
+        if not rule_id:
+            missing.append("rule_id")
+        if not fingerprint:
+            missing.append("fingerprint")
+        print(
+            f"baseline: WARNING: {label} finding (index {lineno}) missing "
+            f"{', '.join(missing)}; skipped in matching",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Classify audit findings as new/existing/resolved vs a baseline.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--current",
+        required=True,
+        metavar="PATH",
+        help="Current findings.jsonl (merge-findings output).",
+    )
+    parser.add_argument(
+        "--baseline",
+        required=True,
+        metavar="FILE",
+        help=(
+            "Baseline findings.jsonl to compare against. Must be a file path. "
+            "To compare against a git ref, extract the file first: "
+            "git show <ref>:.audit/current/findings.jsonl > baseline.jsonl"
+        ),
+    )
+    parser.add_argument(
+        "--new-only",
+        action="store_true",
+        default=False,
+        help="Output only findings tagged 'new' (plus the summary). Omits 'existing' and resolved.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        metavar="PATH",
+        help="Write output JSONL to this file instead of stdout.",
+    )
+    parser.add_argument(
+        "--save-baseline",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Copy --current to this path after classification. "
+            "Useful for persisting the current run as the next baseline."
+        ),
+    )
+    args = parser.parse_args()
+
+    # ------------------------------------------------------------------
+    # Load both JSONL files
+    # ------------------------------------------------------------------
+    current_meta, current_findings = _load_jsonl(args.current, "--current")
+    _baseline_meta, baseline_findings = _load_jsonl(args.baseline, "--baseline")
+
+    # ------------------------------------------------------------------
+    # Build the baseline key set
+    # ------------------------------------------------------------------
+    baseline_keys: set = set()
+    for idx, f in enumerate(baseline_findings):
+        if _validate_key(f, "--baseline", idx):
+            baseline_keys.add(_match_key(f))
+
+    # ------------------------------------------------------------------
+    # Classify current findings
+    # ------------------------------------------------------------------
+    new_count = 0
+    existing_count = 0
+    tagged_findings = []
+
+    for idx, f in enumerate(current_findings):
+        if not _validate_key(f, "--current", idx):
+            # Emit unclassified findings unchanged rather than dropping them.
+            tagged_findings.append(f)
+            continue
+
+        key = _match_key(f)
+        if key in baseline_keys:
+            status = "existing"
+            existing_count += 1
+        else:
+            status = "new"
+            new_count += 1
+
+        # Tag in properties.baseline_status — do not mutate the original dict.
+        tagged = dict(f)
+        props = dict(tagged.get("properties") or {})
+        props["baseline_status"] = status
+        tagged["properties"] = props
+        tagged_findings.append(tagged)
+
+    # ------------------------------------------------------------------
+    # Compute resolved: baseline keys absent from current
+    # ------------------------------------------------------------------
+    current_keys: set = set()
+    for f in current_findings:
+        if f.get("rule_id") and f.get("fingerprint"):
+            current_keys.add(_match_key(f))
+
+    # Build resolved records from baseline findings in baseline order.
+    resolved_records = []
+    seen_resolved_keys: set = set()
+    for f in baseline_findings:
+        key = _match_key(f)
+        if not key[0] or not key[1]:
+            continue
+        if key not in current_keys and key not in seen_resolved_keys:
+            seen_resolved_keys.add(key)
+            resolved_records.append({
+                "type": "resolved",
+                "rule_id": key[0],
+                "fingerprint": key[1],
+                "baseline": args.baseline,
+            })
+
+    resolved_count = len(resolved_records)
+
+    # ------------------------------------------------------------------
+    # Build summary record
+    # ------------------------------------------------------------------
+    summary = {
+        "type": "baseline_summary",
+        "new": new_count,
+        "existing": existing_count,
+        "resolved": resolved_count,
+        "baseline": args.baseline,
+    }
+
+    # ------------------------------------------------------------------
+    # Build output lines
+    # ------------------------------------------------------------------
+    output_lines = []
+
+    # 1. Summary first
+    output_lines.append(json.dumps(summary, separators=(",", ":")))
+
+    # 2. Metadata records from current (provenance, coverage_gap, etc.)
+    for rec in current_meta:
+        output_lines.append(json.dumps(rec, separators=(",", ":")))
+
+    # 3. Tagged findings — all, or new-only
+    for f in tagged_findings:
+        if args.new_only:
+            status = (f.get("properties") or {}).get("baseline_status")
+            if status == "existing":
+                continue
+        output_lines.append(json.dumps(f, separators=(",", ":")))
+
+    # 4. Resolved records (omit when --new-only)
+    if not args.new_only:
+        for rec in resolved_records:
+            output_lines.append(json.dumps(rec, separators=(",", ":")))
+
+    # ------------------------------------------------------------------
+    # Write output
+    # ------------------------------------------------------------------
+    out_text = "\n".join(output_lines)
+    if output_lines:
+        out_text += "\n"
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            out_path.write_text(out_text, encoding="utf-8")
+        except OSError as exc:
+            print(
+                f"baseline: ERROR: cannot write output '{args.output}': {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"baseline: wrote {new_count} new, {existing_count} existing, "
+            f"{resolved_count} resolved finding(s) to {args.output}",
+            file=sys.stderr,
+        )
+    else:
+        sys.stdout.write(out_text)
+
+    # ------------------------------------------------------------------
+    # Save baseline copy if requested
+    # ------------------------------------------------------------------
+    if args.save_baseline:
+        save_path = Path(args.save_baseline)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            shutil.copy2(args.current, str(save_path))
+        except OSError as exc:
+            print(
+                f"baseline: ERROR: cannot save baseline to '{args.save_baseline}': {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"baseline: saved current findings as next baseline to {args.save_baseline}",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/commands-extra/skills/audit/tests/test-baseline.sh
+++ b/modules/commands-extra/skills/audit/tests/test-baseline.sh
@@ -567,6 +567,238 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 7: Composite key — same fingerprint, different rule_id
+#   Both (rule-x, FP_SHARED) and (rule-y, FP_SHARED) exist in BOTH baseline
+#   and current.  Both must classify as "existing" independently.
+#   This pins that the key is (rule_id, fingerprint), not fingerprint alone.
+# ---------------------------------------------------------------------------
+printf '\nTest 7: composite key — same fingerprint + different rule_ids → both existing\n'
+
+T7_DIR="$TESTRUN_DIR/t7"
+mkdir -p "$T7_DIR"
+
+FP_SHARED="dddd4444eeee5555:1"
+
+FINDING_X="$(make_finding "rule-x" "$FP_SHARED" "code-quality/test-rule")"
+FINDING_Y="$(make_finding "rule-y" "$FP_SHARED" "code-quality/test-rule")"
+
+# Both in baseline
+write_findings_jsonl "$T7_DIR/baseline.jsonl" "$FINDING_X" "$FINDING_Y"
+# Both in current (unchanged)
+write_findings_jsonl "$T7_DIR/current.jsonl" "$FINDING_X" "$FINDING_Y"
+
+set +e
+T7_OUT="$(python3 "$BASELINE_SCRIPT" \
+  --current "$T7_DIR/current.jsonl" \
+  --baseline "$T7_DIR/baseline.jsonl" 2>/dev/null)"
+T7_EXIT=$?
+set -e
+
+if [[ $T7_EXIT -eq 0 ]]; then
+  pass "t7: same-fp/different-rule_id run exits 0"
+else
+  fail "t7: same-fp/different-rule_id run exits $T7_EXIT (expected 0)"
+fi
+
+# Helper: get baseline_status for a finding identified by rule_id + fingerprint
+get_status_by_rule_fp() {
+  python3 - "$1" "$2" "$3" << 'PYEOF'
+import json, sys
+output, rule_id, fp = sys.argv[1], sys.argv[2], sys.argv[3]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if (isinstance(obj, dict) and "type" not in obj
+                and obj.get("rule_id") == rule_id
+                and obj.get("fingerprint") == fp):
+            val = (obj.get("properties") or {}).get("baseline_status")
+            print("" if val is None else str(val))
+            sys.exit(0)
+    except Exception:
+        pass
+print("__not_found__")
+PYEOF
+}
+
+# Helper: check whether a (rule_id, fingerprint) pair exists as a resolved record
+resolved_by_rule_fp() {
+  python3 - "$1" "$2" "$3" << 'PYEOF'
+import json, sys
+output, rule_id, fp = sys.argv[1], sys.argv[2], sys.argv[3]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if (isinstance(obj, dict)
+                and obj.get("type") == "resolved"
+                and obj.get("rule_id") == rule_id
+                and obj.get("fingerprint") == fp):
+            print("yes")
+            sys.exit(0)
+    except Exception:
+        pass
+print("no")
+PYEOF
+}
+
+# (rule-x, FP_SHARED) should be "existing"
+T7_X_STATUS="$(get_status_by_rule_fp "$T7_OUT" "rule-x" "$FP_SHARED")"
+if [[ "$T7_X_STATUS" == "existing" ]]; then
+  pass "t7: (rule-x, FP_SHARED) classified as existing"
+else
+  fail "t7: (rule-x, FP_SHARED) baseline_status='$T7_X_STATUS' (expected 'existing')"
+fi
+
+# (rule-y, FP_SHARED) should also be "existing" — independent match, not merged with rule-x
+T7_Y_STATUS="$(get_status_by_rule_fp "$T7_OUT" "rule-y" "$FP_SHARED")"
+if [[ "$T7_Y_STATUS" == "existing" ]]; then
+  pass "t7: (rule-y, FP_SHARED) classified as existing (independent of rule-x)"
+else
+  fail "t7: (rule-y, FP_SHARED) baseline_status='$T7_Y_STATUS' (expected 'existing')"
+fi
+
+# Summary: new=0, existing=2, resolved=0
+T7_SUM_NEW="$(get_summary_field "$T7_OUT" "new")"
+T7_SUM_EXIST="$(get_summary_field "$T7_OUT" "existing")"
+T7_SUM_RESOL="$(get_summary_field "$T7_OUT" "resolved")"
+if [[ "$T7_SUM_NEW" == "0" && "$T7_SUM_EXIST" == "2" && "$T7_SUM_RESOL" == "0" ]]; then
+  pass "t7: summary new=0 existing=2 resolved=0"
+else
+  fail "t7: summary new=$T7_SUM_NEW existing=$T7_SUM_EXIST resolved=$T7_SUM_RESOL (expected 0/2/0)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: Composite key — same fingerprint, rule_id changed between runs
+#   Baseline: (rule-x, FP_SHARED).  Current: (rule-y, FP_SHARED).
+#   Expected: baseline finding is "resolved"; current finding is "new".
+#   This proves the key is (rule_id, fingerprint), not fingerprint-only;
+#   a fingerprint-only key would have classified the current finding as "existing".
+# ---------------------------------------------------------------------------
+printf '\nTest 8: composite key — same fingerprint, rule_id changed → resolved + new\n'
+
+T8_DIR="$TESTRUN_DIR/t8"
+mkdir -p "$T8_DIR"
+
+# Baseline has (rule-x, FP_SHARED)
+write_findings_jsonl "$T8_DIR/baseline.jsonl" "$FINDING_X"
+# Current has (rule-y, FP_SHARED) — same fingerprint, different rule_id
+write_findings_jsonl "$T8_DIR/current.jsonl" "$FINDING_Y"
+
+set +e
+T8_OUT="$(python3 "$BASELINE_SCRIPT" \
+  --current "$T8_DIR/current.jsonl" \
+  --baseline "$T8_DIR/baseline.jsonl" 2>/dev/null)"
+T8_EXIT=$?
+set -e
+
+if [[ $T8_EXIT -eq 0 ]]; then
+  pass "t8: rule_id-changed run exits 0"
+else
+  fail "t8: rule_id-changed run exits $T8_EXIT (expected 0)"
+fi
+
+# Current (rule-y, FP_SHARED) must be "new" — composite key, not fingerprint-only
+T8_Y_STATUS="$(get_status_by_rule_fp "$T8_OUT" "rule-y" "$FP_SHARED")"
+if [[ "$T8_Y_STATUS" == "new" ]]; then
+  pass "t8: (rule-y, FP_SHARED) classified as new (proving key is composite)"
+else
+  fail "t8: (rule-y, FP_SHARED) baseline_status='$T8_Y_STATUS' (expected 'new')"
+fi
+
+# Baseline (rule-x, FP_SHARED) must appear as resolved
+T8_X_RESOLVED="$(resolved_by_rule_fp "$T8_OUT" "rule-x" "$FP_SHARED")"
+if [[ "$T8_X_RESOLVED" == "yes" ]]; then
+  pass "t8: (rule-x, FP_SHARED) emitted as resolved"
+else
+  fail "t8: (rule-x, FP_SHARED) not in resolved records (expected type=resolved)"
+fi
+
+# Summary: new=1, existing=0, resolved=1
+T8_SUM_NEW="$(get_summary_field "$T8_OUT" "new")"
+T8_SUM_EXIST="$(get_summary_field "$T8_OUT" "existing")"
+T8_SUM_RESOL="$(get_summary_field "$T8_OUT" "resolved")"
+if [[ "$T8_SUM_NEW" == "1" && "$T8_SUM_EXIST" == "0" && "$T8_SUM_RESOL" == "1" ]]; then
+  pass "t8: summary new=1 existing=0 resolved=1"
+else
+  fail "t8: summary new=$T8_SUM_NEW existing=$T8_SUM_EXIST resolved=$T8_SUM_RESOL (expected 1/0/1)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 9: Current-side dedup — two identical (rule_id, fingerprint) rows in
+#   --current collapse to one in both the count and the output.
+# ---------------------------------------------------------------------------
+printf '\nTest 9: current-side dedup — duplicate current finding counted once\n'
+
+T9_DIR="$TESTRUN_DIR/t9"
+mkdir -p "$T9_DIR"
+
+# Write a current JSONL with FINDING_A duplicated
+python3 - "$T9_DIR/current_duped.jsonl" "$FINDING_A" << 'PYEOF'
+import json, sys
+out_file, finding_json = sys.argv[1], sys.argv[2]
+with open(out_file, "w") as fh:
+    fh.write(json.dumps({
+        "type": "provenance",
+        "tool": "ccgm-merge",
+        "version": "1.0",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }) + "\n")
+    # Same finding twice
+    fh.write(finding_json + "\n")
+    fh.write(finding_json + "\n")
+PYEOF
+
+# Empty baseline so the deduped finding is classified "new"
+write_findings_jsonl "$T9_DIR/baseline.jsonl"
+
+set +e
+T9_OUT="$(python3 "$BASELINE_SCRIPT" \
+  --current "$T9_DIR/current_duped.jsonl" \
+  --baseline "$T9_DIR/baseline.jsonl" 2>/dev/null)"
+T9_EXIT=$?
+set -e
+
+if [[ $T9_EXIT -eq 0 ]]; then
+  pass "t9: current-side dedup run exits 0"
+else
+  fail "t9: current-side dedup run exits $T9_EXIT (expected 0)"
+fi
+
+# Summary new should be 1 (not 2)
+T9_SUM_NEW="$(get_summary_field "$T9_OUT" "new")"
+if [[ "$T9_SUM_NEW" == "1" ]]; then
+  pass "t9: duplicate current finding counted once (new=1)"
+else
+  fail "t9: new count=$T9_SUM_NEW (expected 1 — duplicate should be collapsed)"
+fi
+
+# FP_A should appear exactly once as a finding record in output
+T9_FP_A_COUNT="$(python3 - "$T9_OUT" "$FP_A" << 'PYEOF'
+import json, sys
+output, fp = sys.argv[1], sys.argv[2]
+count = 0
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj and obj.get("fingerprint") == fp:
+            count += 1
+    except Exception:
+        pass
+print(count)
+PYEOF
+)"
+if [[ "$T9_FP_A_COUNT" == "1" ]]; then
+  pass "t9: FP_A appears exactly once in output (not duplicated)"
+else
+  fail "t9: FP_A appears $T9_FP_A_COUNT time(s) in output (expected 1)"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 printf '\n-------------------------------------------------\n'

--- a/modules/commands-extra/skills/audit/tests/test-baseline.sh
+++ b/modules/commands-extra/skills/audit/tests/test-baseline.sh
@@ -1,0 +1,584 @@
+#!/usr/bin/env bash
+# CCGM audit -- test-baseline.sh
+# Tests for Epic 3.2: baseline/delta classification (baseline.py)
+#
+# Test scenarios:
+#   1. Core classification: run1={A,B}, run2={B,C} -> C=new, B=existing, A=resolved.
+#      Summary counts: new=1, existing=1, resolved=1.
+#   2. --new-only: output contains only C (+summary); A (resolved) and B (existing) absent.
+#   3. Malformed input: baseline file with invalid JSON -> exit 1.
+#   4. --save-baseline: saved file matches --current byte-for-byte.
+#   5. Metadata passthrough: provenance/coverage_gap records from --current appear in output.
+#   6. Missing --baseline file: exit 1 with clear error.
+#
+# All fixtures are constructed at runtime in mktemp dirs.
+# Usage: bash modules/commands-extra/skills/audit/tests/test-baseline.sh
+# Exit:  0 = all tests passed, non-zero = at least one failure
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASELINE_SCRIPT="$SCRIPT_DIR/../scripts/baseline.py"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+  printf '  [PASS] %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  ERRORS+=("$1")
+  FAIL=$((FAIL + 1))
+}
+
+# Get the value of a JSON field from the first line matching a given fingerprint in JSONL.
+# Usage: get_field <jsonl_str> <fingerprint> <field>
+get_field() {
+  python3 - "$1" "$2" "$3" << 'PYEOF'
+import json, sys
+output, fp, field = sys.argv[1], sys.argv[2], sys.argv[3]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj and obj.get("fingerprint") == fp:
+            val = obj.get(field)
+            print("" if val is None else str(val))
+            sys.exit(0)
+    except Exception:
+        pass
+print("__not_found__")
+PYEOF
+}
+
+# Get a nested field: properties.baseline_status etc.
+get_props_field() {
+  python3 - "$1" "$2" "$3" << 'PYEOF'
+import json, sys
+output, fp, child = sys.argv[1], sys.argv[2], sys.argv[3]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj and obj.get("fingerprint") == fp:
+            props = obj.get("properties") or {}
+            if isinstance(props, dict):
+                val = props.get(child)
+                print("" if val is None else str(val))
+            else:
+                print("__no_properties__")
+            sys.exit(0)
+    except Exception:
+        pass
+print("__not_found__")
+PYEOF
+}
+
+# Check whether a fingerprint exists as a finding record (no type field)
+fp_exists_as_finding() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+output, fp = sys.argv[1], sys.argv[2]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj and obj.get("fingerprint") == fp:
+            print("yes")
+            sys.exit(0)
+    except Exception:
+        pass
+print("no")
+PYEOF
+}
+
+# Check whether a fingerprint exists as a resolved record
+fp_exists_as_resolved() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+output, fp = sys.argv[1], sys.argv[2]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and obj.get("type") == "resolved" and obj.get("fingerprint") == fp:
+            print("yes")
+            sys.exit(0)
+    except Exception:
+        pass
+print("no")
+PYEOF
+}
+
+# Get a field from the baseline_summary record
+get_summary_field() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+output, field = sys.argv[1], sys.argv[2]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and obj.get("type") == "baseline_summary":
+            val = obj.get(field)
+            print("" if val is None else str(val))
+            sys.exit(0)
+    except Exception:
+        pass
+print("__not_found__")
+PYEOF
+}
+
+# Count records of a given type in JSONL string
+count_type() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+output, type_val = sys.argv[1], sys.argv[2]
+count = 0
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and obj.get("type") == type_val:
+            count += 1
+    except Exception:
+        pass
+print(count)
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Global temp directory
+# ---------------------------------------------------------------------------
+TESTRUN_DIR="$(mktemp -d /tmp/ccgm-test-baseline-XXXXXX)"
+trap 'rm -rf "$TESTRUN_DIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Helper: write a findings.jsonl with a provenance header + given findings
+# ---------------------------------------------------------------------------
+write_findings_jsonl() {
+  # write_findings_jsonl <out_file> <finding_json> [<finding_json> ...]
+  local out_file="$1"
+  shift
+  python3 - "$out_file" "$@" << 'PYEOF'
+import json, sys
+out_file = sys.argv[1]
+findings = sys.argv[2:]
+with open(out_file, "w") as fh:
+    # provenance record
+    fh.write(json.dumps({
+        "type": "provenance",
+        "tool": "ccgm-merge",
+        "version": "1.0",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }) + "\n")
+    for f_json in findings:
+        if f_json:
+            fh.write(f_json + "\n")
+PYEOF
+}
+
+# Minimal valid finding JSON given rule_id, fingerprint, check_id
+make_finding() {
+  python3 -c "
+import json, sys
+rule_id, fingerprint, check_id = sys.argv[1], sys.argv[2], sys.argv[3]
+print(json.dumps({
+    'check_id': check_id,
+    'rule_id': rule_id,
+    'severity': 'medium',
+    'confidence': 'high',
+    'detection': 'tool',
+    'source': 'tool',
+    'message': 'test finding for ' + rule_id,
+    'location': {'path': 'src/test.py', 'line': 1},
+    'fingerprint': fingerprint,
+}))
+" "$1" "$2" "$3"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Core classification — run1={A,B}, run2={B,C}
+# ---------------------------------------------------------------------------
+printf '\nTest 1: core classification (new/existing/resolved + summary counts)\n'
+
+T1_DIR="$TESTRUN_DIR/t1"
+mkdir -p "$T1_DIR"
+
+FP_A="aaaa1111bbbb2222:1"
+FP_B="bbbb2222cccc3333:1"
+FP_C="cccc3333dddd4444:1"
+
+FINDING_A="$(make_finding "rule-a" "$FP_A" "code-quality/test-rule")"
+FINDING_B="$(make_finding "rule-b" "$FP_B" "code-quality/test-rule")"
+FINDING_C="$(make_finding "rule-c" "$FP_C" "security/test-rule")"
+
+# Baseline (run1): A and B
+write_findings_jsonl "$T1_DIR/baseline.jsonl" "$FINDING_A" "$FINDING_B"
+# Current (run2): B and C
+write_findings_jsonl "$T1_DIR/current.jsonl" "$FINDING_B" "$FINDING_C"
+
+set +e
+T1_OUT="$(python3 "$BASELINE_SCRIPT" \
+  --current "$T1_DIR/current.jsonl" \
+  --baseline "$T1_DIR/baseline.jsonl" 2>/dev/null)"
+T1_EXIT=$?
+set -e
+
+if [[ $T1_EXIT -eq 0 ]]; then
+  pass "t1: baseline.py exits 0"
+else
+  fail "t1: baseline.py exits $T1_EXIT (expected 0)"
+fi
+
+# C should be tagged "new"
+T1_C_STATUS="$(get_props_field "$T1_OUT" "$FP_C" "baseline_status")"
+if [[ "$T1_C_STATUS" == "new" ]]; then
+  pass "t1: finding C tagged baseline_status=new"
+else
+  fail "t1: finding C baseline_status='$T1_C_STATUS' (expected 'new')"
+fi
+
+# B should be tagged "existing"
+T1_B_STATUS="$(get_props_field "$T1_OUT" "$FP_B" "baseline_status")"
+if [[ "$T1_B_STATUS" == "existing" ]]; then
+  pass "t1: finding B tagged baseline_status=existing"
+else
+  fail "t1: finding B baseline_status='$T1_B_STATUS' (expected 'existing')"
+fi
+
+# A should appear as a resolved record
+T1_A_RESOLVED="$(fp_exists_as_resolved "$T1_OUT" "$FP_A")"
+if [[ "$T1_A_RESOLVED" == "yes" ]]; then
+  pass "t1: finding A emitted as a resolved record"
+else
+  fail "t1: finding A is not present as a resolved record (expected type=resolved)"
+fi
+
+# A should NOT appear as a finding
+T1_A_AS_FINDING="$(fp_exists_as_finding "$T1_OUT" "$FP_A")"
+if [[ "$T1_A_AS_FINDING" == "no" ]]; then
+  pass "t1: finding A does NOT appear as a finding record (correctly absent)"
+else
+  fail "t1: finding A incorrectly appears as a finding record"
+fi
+
+# Summary counts: new=1, existing=1, resolved=1
+T1_SUM_NEW="$(get_summary_field "$T1_OUT" "new")"
+T1_SUM_EXIST="$(get_summary_field "$T1_OUT" "existing")"
+T1_SUM_RESOL="$(get_summary_field "$T1_OUT" "resolved")"
+
+if [[ "$T1_SUM_NEW" == "1" ]]; then
+  pass "t1: summary.new=1"
+else
+  fail "t1: summary.new='$T1_SUM_NEW' (expected 1)"
+fi
+if [[ "$T1_SUM_EXIST" == "1" ]]; then
+  pass "t1: summary.existing=1"
+else
+  fail "t1: summary.existing='$T1_SUM_EXIST' (expected 1)"
+fi
+if [[ "$T1_SUM_RESOL" == "1" ]]; then
+  pass "t1: summary.resolved=1"
+else
+  fail "t1: summary.resolved='$T1_SUM_RESOL' (expected 1)"
+fi
+
+# baseline_summary record should be the FIRST line
+T1_FIRST_TYPE="$(python3 - "$T1_OUT" << 'PYEOF'
+import json, sys
+for l in sys.argv[1].splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        print(obj.get("type", "finding"))
+        sys.exit(0)
+    except Exception:
+        pass
+print("empty")
+PYEOF
+)"
+if [[ "$T1_FIRST_TYPE" == "baseline_summary" ]]; then
+  pass "t1: baseline_summary is the first record in output"
+else
+  fail "t1: first record type='$T1_FIRST_TYPE' (expected 'baseline_summary')"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: --new-only
+# ---------------------------------------------------------------------------
+printf '\nTest 2: --new-only filters to only new findings\n'
+
+T2_DIR="$TESTRUN_DIR/t2"
+mkdir -p "$T2_DIR"
+
+# Reuse the same baselines from T1 (copy them)
+cp "$T1_DIR/baseline.jsonl" "$T2_DIR/baseline.jsonl"
+cp "$T1_DIR/current.jsonl" "$T2_DIR/current.jsonl"
+
+set +e
+T2_OUT="$(python3 "$BASELINE_SCRIPT" \
+  --current "$T2_DIR/current.jsonl" \
+  --baseline "$T2_DIR/baseline.jsonl" \
+  --new-only 2>/dev/null)"
+T2_EXIT=$?
+set -e
+
+if [[ $T2_EXIT -eq 0 ]]; then
+  pass "t2: baseline.py --new-only exits 0"
+else
+  fail "t2: baseline.py --new-only exits $T2_EXIT (expected 0)"
+fi
+
+# C (new) should be present as a finding
+T2_C_PRESENT="$(fp_exists_as_finding "$T2_OUT" "$FP_C")"
+if [[ "$T2_C_PRESENT" == "yes" ]]; then
+  pass "t2: --new-only: new finding C is present"
+else
+  fail "t2: --new-only: new finding C is absent (expected present)"
+fi
+
+# B (existing) should be absent
+T2_B_PRESENT="$(fp_exists_as_finding "$T2_OUT" "$FP_B")"
+if [[ "$T2_B_PRESENT" == "no" ]]; then
+  pass "t2: --new-only: existing finding B is absent"
+else
+  fail "t2: --new-only: existing finding B is present (expected absent)"
+fi
+
+# A (resolved) should be absent when --new-only
+T2_A_RESOLVED="$(fp_exists_as_resolved "$T2_OUT" "$FP_A")"
+if [[ "$T2_A_RESOLVED" == "no" ]]; then
+  pass "t2: --new-only: resolved record A is absent"
+else
+  fail "t2: --new-only: resolved record A is present (expected absent)"
+fi
+
+# Summary record still present
+T2_SUM_COUNT="$(count_type "$T2_OUT" "baseline_summary")"
+if [[ "$T2_SUM_COUNT" -eq 1 ]]; then
+  pass "t2: --new-only: baseline_summary record is present"
+else
+  fail "t2: --new-only: baseline_summary count='$T2_SUM_COUNT' (expected 1)"
+fi
+
+# Summary counts still reflect the full picture
+T2_SUM_NEW="$(get_summary_field "$T2_OUT" "new")"
+T2_SUM_RESOL="$(get_summary_field "$T2_OUT" "resolved")"
+if [[ "$T2_SUM_NEW" == "1" && "$T2_SUM_RESOL" == "1" ]]; then
+  pass "t2: --new-only: summary counts (new=1, resolved=1) still accurate"
+else
+  fail "t2: --new-only: summary counts unexpected (new=$T2_SUM_NEW, resolved=$T2_SUM_RESOL)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: malformed baseline -> exit 1
+# ---------------------------------------------------------------------------
+printf '\nTest 3: malformed input -> exit 1\n'
+
+T3_DIR="$TESTRUN_DIR/t3"
+mkdir -p "$T3_DIR"
+
+# Current is valid
+write_findings_jsonl "$T3_DIR/current.jsonl" "$FINDING_B"
+
+# Baseline is intentionally malformed JSON
+printf '{"type":"provenance"}\n{this is not json\n' > "$T3_DIR/bad-baseline.jsonl"
+
+set +e
+T3_STDERR="$(python3 "$BASELINE_SCRIPT" \
+  --current "$T3_DIR/current.jsonl" \
+  --baseline "$T3_DIR/bad-baseline.jsonl" 2>&1 >/dev/null)"
+T3_EXIT=$?
+set -e
+
+if [[ $T3_EXIT -eq 1 ]]; then
+  pass "t3: malformed baseline -> exit 1"
+else
+  fail "t3: malformed baseline exits $T3_EXIT (expected 1)"
+fi
+
+# Stderr should contain an actionable error message
+if echo "$T3_STDERR" | grep -qi "error\|ERROR\|invalid\|not valid"; then
+  pass "t3: stderr contains actionable error message"
+else
+  fail "t3: stderr does not mention 'error' or 'invalid' (got: $T3_STDERR)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: --save-baseline copies --current byte-for-byte
+# ---------------------------------------------------------------------------
+printf '\nTest 4: --save-baseline saves current as next baseline\n'
+
+T4_DIR="$TESTRUN_DIR/t4"
+mkdir -p "$T4_DIR"
+
+write_findings_jsonl "$T4_DIR/baseline.jsonl" "$FINDING_A"
+write_findings_jsonl "$T4_DIR/current.jsonl" "$FINDING_A" "$FINDING_C"
+
+set +e
+python3 "$BASELINE_SCRIPT" \
+  --current "$T4_DIR/current.jsonl" \
+  --baseline "$T4_DIR/baseline.jsonl" \
+  --save-baseline "$T4_DIR/saved.jsonl" \
+  --output "$T4_DIR/classified.jsonl" 2>/dev/null
+T4_EXIT=$?
+set -e
+
+if [[ $T4_EXIT -eq 0 ]]; then
+  pass "t4: --save-baseline run exits 0"
+else
+  fail "t4: --save-baseline run exits $T4_EXIT (expected 0)"
+fi
+
+if [[ -f "$T4_DIR/saved.jsonl" ]]; then
+  pass "t4: --save-baseline created the saved file"
+else
+  fail "t4: --save-baseline did not create the file at expected path"
+fi
+
+if diff -q "$T4_DIR/current.jsonl" "$T4_DIR/saved.jsonl" > /dev/null 2>&1; then
+  pass "t4: saved baseline is byte-identical to --current"
+else
+  fail "t4: saved baseline differs from --current"
+fi
+
+# The classified output file should exist and contain a summary
+if [[ -f "$T4_DIR/classified.jsonl" ]]; then
+  T4_SUM="$(count_type "$(cat "$T4_DIR/classified.jsonl")" "baseline_summary")"
+  if [[ "$T4_SUM" -eq 1 ]]; then
+    pass "t4: --output file contains baseline_summary"
+  else
+    fail "t4: --output file missing baseline_summary (count=$T4_SUM)"
+  fi
+else
+  fail "t4: --output file not created"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: metadata passthrough (provenance/coverage_gap from --current in output)
+# ---------------------------------------------------------------------------
+printf '\nTest 5: metadata passthrough from --current\n'
+
+T5_DIR="$TESTRUN_DIR/t5"
+mkdir -p "$T5_DIR"
+
+# Write current with a coverage_gap record
+python3 - "$T5_DIR/current_with_meta.jsonl" "$FINDING_C" << 'PYEOF'
+import json, sys
+out_file, finding_json = sys.argv[1], sys.argv[2]
+with open(out_file, "w") as fh:
+    fh.write(json.dumps({
+        "type": "provenance",
+        "tool": "ccgm-merge",
+        "version": "1.0",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }) + "\n")
+    fh.write(json.dumps({
+        "type": "coverage_gap",
+        "tool": "actionlint",
+        "check_id": "ci/invalid-workflow",
+        "description": "actionlint not installed",
+    }) + "\n")
+    fh.write(finding_json + "\n")
+PYEOF
+
+# Empty baseline
+write_findings_jsonl "$T5_DIR/empty-baseline.jsonl"
+
+set +e
+T5_OUT="$(python3 "$BASELINE_SCRIPT" \
+  --current "$T5_DIR/current_with_meta.jsonl" \
+  --baseline "$T5_DIR/empty-baseline.jsonl" 2>/dev/null)"
+T5_EXIT=$?
+set -e
+
+if [[ $T5_EXIT -eq 0 ]]; then
+  pass "t5: metadata passthrough run exits 0"
+else
+  fail "t5: metadata passthrough run exits $T5_EXIT (expected 0)"
+fi
+
+# provenance record should be present
+T5_PROV_COUNT="$(count_type "$T5_OUT" "provenance")"
+if [[ "$T5_PROV_COUNT" -ge 1 ]]; then
+  pass "t5: provenance record from --current passed through ($T5_PROV_COUNT found)"
+else
+  fail "t5: provenance record missing from output (expected >= 1)"
+fi
+
+# coverage_gap record should be present
+T5_GAP_COUNT="$(count_type "$T5_OUT" "coverage_gap")"
+if [[ "$T5_GAP_COUNT" -ge 1 ]]; then
+  pass "t5: coverage_gap record from --current passed through ($T5_GAP_COUNT found)"
+else
+  fail "t5: coverage_gap record missing from output (expected >= 1)"
+fi
+
+# Finding C should be present and tagged new (baseline was empty)
+T5_C_STATUS="$(get_props_field "$T5_OUT" "$FP_C" "baseline_status")"
+if [[ "$T5_C_STATUS" == "new" ]]; then
+  pass "t5: finding C tagged new against empty baseline"
+else
+  fail "t5: finding C baseline_status='$T5_C_STATUS' (expected 'new' vs empty baseline)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: missing --baseline file -> exit 1
+# ---------------------------------------------------------------------------
+printf '\nTest 6: missing --baseline file -> exit 1\n'
+
+T6_DIR="$TESTRUN_DIR/t6"
+mkdir -p "$T6_DIR"
+write_findings_jsonl "$T6_DIR/current.jsonl" "$FINDING_A"
+
+set +e
+T6_STDERR="$(python3 "$BASELINE_SCRIPT" \
+  --current "$T6_DIR/current.jsonl" \
+  --baseline "$T6_DIR/nonexistent-baseline.jsonl" 2>&1 >/dev/null)"
+T6_EXIT=$?
+set -e
+
+if [[ $T6_EXIT -eq 1 ]]; then
+  pass "t6: missing --baseline file -> exit 1"
+else
+  fail "t6: missing --baseline exits $T6_EXIT (expected 1)"
+fi
+
+if echo "$T6_STDERR" | grep -qi "error\|ERROR\|cannot\|not found"; then
+  pass "t6: stderr contains actionable error for missing baseline"
+else
+  fail "t6: stderr does not mention error for missing baseline (got: $T6_STDERR)"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n-------------------------------------------------\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  printf '\nFailed tests:\n'
+  for err in "${ERRORS[@]}"; do
+    printf '  - %s\n' "$err"
+  done
+  exit 1
+fi
+
+printf 'All tests passed.\n'
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/baseline.py` (python3 stdlib, executable): classifies a current `findings.jsonl` against a baseline run using `(rule_id, fingerprint)` matching. Tags findings as `new`/`existing` in `properties.baseline_status`, emits `{"type":"resolved", ...}` records for fixed findings, and outputs a `baseline_summary` record first.
- Supports `--new-only` to filter output to introduced findings only; `--save-baseline` to persist current run as next baseline.
- Wires `--baseline` / `--new-only` into SKILL.md: Usage block, Mode Detection flag list, and a self-contained `### Baseline / Delta` subsection anchored after Phase M6 (covers both autonomous and `--single` modes). All other SKILL.md content is byte-identical.
- Updates `commands/audit.md` to maintain stub↔skill parity (parity test 2c requires every Mode Detection flag to appear in the command doc).
- Registers `baseline.py` in `module.json` (type: script).
- Adds `tests/test-baseline.sh` (27 tests): core classification, `--new-only`, malformed input → exit 1, `--save-baseline` byte-identity, metadata passthrough, missing file → exit 1.

## Test plan

- [x] `bash modules/commands-extra/skills/audit/tests/test-baseline.sh` — 27 passed, 0 failed
- [x] `bash modules/commands-extra/skills/audit/tests/test-merge.sh` — 41 passed, 0 failed (unaffected)
- [x] `bash modules/commands-extra/skills/audit/tests/test-command-skill-parity.sh` — 30 passed, 0 failed
- [x] `python3 modules/commands-extra/skills/audit/scripts/lint-pack.py` — 15 packs, 0 errors
- [x] `bash modules/commands-extra/skills/audit/tests/test-reference-wiring.sh` — 41 passed, 0 failed
- [x] `python3 -m json.tool modules/commands-extra/module.json > /dev/null` — valid
- [x] `bash tests/test-modules.sh` — 1310 passed, 0 failed
- [x] `bash tests/test-no-personal-data.sh` — PASS

Closes #622