### PR TITLE
#624: suppression applier (.auditignore.yaml + inline comments)

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -123,6 +123,11 @@
       "type": "script",
       "template": false
     },
+    "skills/audit/scripts/suppress.py": {
+      "target": "skills/audit/scripts/suppress.py",
+      "type": "script",
+      "template": false
+    },
     "skills/audit/schemas/severity-rubric.json": {
       "target": "skills/audit/schemas/severity-rubric.json",
       "type": "doc",

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -875,8 +875,8 @@ file is a YAML list of mapping blocks.  Supported keys per entry:
 
 | Key | Required | Description |
 |-----|----------|-------------|
-| `id` (or `check_id`) | yes | The `check_id` to suppress.  Supports `fnmatch` globs (e.g. `security/*`). |
-| `paths` | no | Inline list of repo-relative `fnmatch` globs.  When absent, the rule matches any path. |
+| `id` (or `check_id`) | yes | The `check_id` to suppress.  Supports `fnmatch` globs (e.g. `security/*`).  Note: Python `fnmatch` `*` crosses `/`, so `security/*` also matches `security/sub/deep` — matching is recursive; there is no separate `**`. |
+| `paths` | no | Inline list of repo-relative `fnmatch` globs.  When absent, the rule matches any path.  Note: Python `fnmatch` `*` crosses `/`, so `src/*.js` also matches `src/sub/deep.js` — matching is recursive; there is no separate `**`. |
 | `reason` | **required** | Human-readable justification.  Entries missing `reason` emit a warning and are skipped. |
 | `expires` | no | ISO date `YYYY-MM-DD`.  When present and strictly before today's date, the suppression is **ignored** and a warning is emitted. |
 

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -861,6 +861,88 @@ after `merge-findings.py` in the same inline step; then compile the report (Phas
 directory (e.g., `.audit/history/YYYY-MM-DD.jsonl`). The script never auto-writes a baseline;
 the caller controls when to advance it.
 
+### Suppression (optional, after merge step)
+
+Suppression lets you acknowledge known findings that cannot be fixed immediately, without
+hiding them entirely.  Suppressed findings **remain in the JSONL** with a `suppression`
+field; they are never omitted.  In the audit report, suppressed CRITICAL and HIGH findings
+appear tagged `[SUPPRESSED]` so they remain visible.
+
+#### .auditignore.yaml format
+
+Place a `.auditignore.yaml` file at the repo root (or pass `--auditignore <path>`).  The
+file is a YAML list of mapping blocks.  Supported keys per entry:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `id` (or `check_id`) | yes | The `check_id` to suppress.  Supports `fnmatch` globs (e.g. `security/*`). |
+| `paths` | no | Inline list of repo-relative `fnmatch` globs.  When absent, the rule matches any path. |
+| `reason` | **required** | Human-readable justification.  Entries missing `reason` emit a warning and are skipped. |
+| `expires` | no | ISO date `YYYY-MM-DD`.  When present and strictly before today's date, the suppression is **ignored** and a warning is emitted. |
+
+Example:
+
+```yaml
+- id: security/no-console
+  paths: [src/scripts/*.js]
+  reason: console.log intentional in CLI scripts
+  expires: 2027-01-01
+```
+
+#### Inline comment format
+
+Add a comment on the same line as a problematic line **or the line immediately before it**:
+
+```python
+# audit-ignore: code-quality/unused-import kept for re-export
+import logging
+```
+
+```typescript
+// audit-ignore: typescript-react/missing-prop-types legacy component
+```
+
+Scoping rule: `# audit-ignore: <check-id> [reason]` on line N suppresses a finding with
+`location.line == N` (same line) **or** `location.line == N+1` (the line immediately
+following).  Only the named `check-id` is suppressed at that location.
+
+Both `#` (Python, shell, YAML) and `//` (JavaScript, TypeScript) comment markers are
+supported.
+
+#### Wiring suppression into the emit/report step
+
+Run `suppress.py` **after** `merge-findings.py` writes `findings.jsonl` and (when used)
+after `baseline.py` writes `findings-delta.jsonl`.  The suppressor runs by default whenever
+`.auditignore.yaml` exists in the repo root.
+
+```bash
+# After merge-findings.py (or baseline.py) has written its output:
+SUPPRESS_INPUT="$AUDIT_DIR/current/findings.jsonl"
+
+# When .auditignore.yaml exists or --auditignore is passed:
+if [ -f "$REPO_DIR/.auditignore.yaml" ]; then
+  python3 "$SKILL_ROOT/scripts/suppress.py" \
+    --findings "$SUPPRESS_INPUT" \
+    --auditignore "$REPO_DIR/.auditignore.yaml" \
+    --repo "$REPO_DIR" \
+    --output "$AUDIT_DIR/current/findings-suppressed.jsonl"
+  SUPPRESS_INPUT="$AUDIT_DIR/current/findings-suppressed.jsonl"
+fi
+```
+
+Use `findings-suppressed.jsonl` (instead of `findings.jsonl`) as the input to the report
+compiler.  In the report:
+
+- CRITICAL/HIGH findings with a `suppression` field are shown with `[SUPPRESSED]` after the
+  severity label, e.g. `**[security/leaked-credential]** (CRITICAL) [SUPPRESSED] ...`
+- The Summary table includes a **Suppressed** row showing the count of suppressed findings.
+
+**`--single` mode:** the same suppression step applies after Phase 5 (Run Merge Inline).
+Run `suppress.py` before compiling the Phase 6 report.
+
+**Expiry and missing-reason behaviour:** expired entries and entries missing `reason` are
+skipped with a warning to stderr; their findings are treated as unsuppressed.
+
 ### Phase M7: Issue Creation
 
 Ask the user:

--- a/modules/commands-extra/skills/audit/scripts/suppress.py
+++ b/modules/commands-extra/skills/audit/scripts/suppress.py
@@ -1,0 +1,685 @@
+#!/usr/bin/env python3
+"""
+CCGM /audit suppression applier (Epic 3.3).
+
+Reads a JSONL findings file (merge-findings output) and applies suppression
+rules from a .auditignore.yaml file and/or inline source-file comments.
+Suppressed findings are KEPT in the output with a ``suppression`` field set;
+they are never omitted.
+
+Usage
+-----
+  suppress.py --findings <findings.jsonl>
+              [--auditignore <path>]
+              [--repo <root>]
+              [--output <file>]
+              [--today YYYY-MM-DD]
+
+Arguments
+---------
+  --findings  <path>        Required. JSONL produced by merge-findings.py (or
+                            baseline.py).
+  --auditignore <path>      Path to .auditignore.yaml.  Default: <repo>/.auditignore.yaml
+                            when that file exists, otherwise no file-level suppressions
+                            are applied.
+  --repo <path>             Absolute path to the repository root.  Used to (a) find the
+                            default .auditignore.yaml and (b) resolve location.path when
+                            scanning source files for inline comments.
+                            Default: current working directory.
+  --output <file>           Write output JSONL to this file.  Default: stdout.
+  --today YYYY-MM-DD        Override "today" for expiry comparisons.  Useful for
+                            deterministic testing.  Default: date.today() from the
+                            system clock.
+
+.auditignore.yaml format — supported subset
+--------------------------------------------
+The parser handles a STRICT, fixed YAML subset. Shapes outside this subset
+cause a hard error (exit 1) — they are NEVER silently mis-parsed.
+
+  Supported top-level structure:
+    A sequence (YAML list) of mapping blocks.
+
+  Each mapping block may contain these scalar or inline-list keys:
+    id: <check-id or fnmatch glob>          # also accepted: check_id
+    paths: [<glob>, ...]                     # inline list of repo-relative globs
+    reason: <string>                         # REQUIRED
+    expires: YYYY-MM-DD                      # optional
+
+  Supported value types:
+    - Scalars (unquoted, single-quoted, or double-quoted strings)
+    - Inline lists: [item1, item2, ...]
+
+  NOT supported (will raise a parse error):
+    - Multi-line block scalars (|, >)
+    - Multi-line block sequences (paths written as indented list items
+      under the key rather than as an inline list)
+    - Nested mappings
+    - Anchors and aliases (&anchor, *alias)
+    - Complex YAML keys
+    - Documents starting with ---
+
+  If an entry is missing ``reason``, a warning is printed to stderr and
+  that entry is SKIPPED (the finding is not suppressed by that entry).
+
+Inline comment format
+---------------------
+  # audit-ignore: <check-id> [optional reason text]
+  // audit-ignore: <check-id> [optional reason text]
+
+  The suppression applies to the finding on the SAME LINE as the comment
+  OR the immediately FOLLOWING LINE.
+
+  Block-scoping rule:
+    Line N carries "# audit-ignore: foo/bar".
+    A finding at location.line == N  (same line) is suppressed for foo/bar.
+    A finding at location.line == N+1 (next line) is also suppressed for foo/bar.
+    Findings on any other line are not suppressed by that comment.
+
+  Only the named check-id is suppressed at that location (the comment is
+  check-id-specific, not blanket-ignore-everything).
+
+Expiry
+------
+  If ``expires`` is present on a .auditignore.yaml entry and its date is
+  STRICTLY BEFORE ``--today`` (or today's date), the suppression is NOT
+  applied and a warning is emitted to stderr naming the entry.
+
+  Pass ``--today YYYY-MM-DD`` to make expiry checks deterministic in tests.
+  Internally, the date is obtained via ``datetime.date.today()`` when --today
+  is absent; pass --today to override.
+
+Output
+------
+  Full JSONL: all input records (finding and non-finding) passed through.
+  Finding records that matched a suppression rule gain a ``suppression``
+  field:
+    {"justification": "<reason or inline reason or 'inline'>",
+     "expires": "<YYYY-MM-DD>"}     <- only when an expires date was set
+
+  Records with a ``type`` field (provenance, coverage_gap, etc.) are passed
+  through unchanged.
+
+Exit codes
+----------
+  0  Success.
+  1  Malformed input or parse error.
+"""
+
+import argparse
+import datetime
+import fnmatch
+import json
+import re
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Minimal YAML subset parser
+# ---------------------------------------------------------------------------
+
+class _YAMLParseError(Exception):
+    pass
+
+
+def _parse_scalar(raw: str) -> str:
+    """
+    Parse a YAML scalar value: unquoted, single-quoted, or double-quoted.
+    Raises _YAMLParseError on unsupported shapes (block scalars, etc.).
+    """
+    raw = raw.strip()
+    if not raw:
+        return ""
+    # Block-scalar indicators
+    if raw[0] in ("|", ">"):
+        raise _YAMLParseError(
+            f"block scalars (| >) are not supported: {raw!r}"
+        )
+    # Double-quoted string
+    if raw.startswith('"'):
+        if not raw.endswith('"') or len(raw) < 2:
+            raise _YAMLParseError(f"unterminated double-quoted string: {raw!r}")
+        return raw[1:-1].replace('\\"', '"').replace("\\n", "\n").replace("\\t", "\t")
+    # Single-quoted string
+    if raw.startswith("'"):
+        if not raw.endswith("'") or len(raw) < 2:
+            raise _YAMLParseError(f"unterminated single-quoted string: {raw!r}")
+        return raw[1:-1].replace("''", "'")
+    # Anchors / aliases are unsupported
+    if raw[0] in ("&", "*"):
+        raise _YAMLParseError(f"anchors and aliases are not supported: {raw!r}")
+    # Unquoted scalar — return as-is (stripped)
+    return raw
+
+
+def _parse_inline_list(raw: str) -> list:
+    """
+    Parse an inline YAML list: [item1, item2, ...].
+    Items may be quoted or unquoted scalars.
+    Raises _YAMLParseError on parse failure or nested structures.
+    """
+    raw = raw.strip()
+    if not (raw.startswith("[") and raw.endswith("]")):
+        raise _YAMLParseError(f"expected inline list starting with '[': {raw!r}")
+    inner = raw[1:-1].strip()
+    if not inner:
+        return []
+    # Detect nested brackets
+    if "[" in inner:
+        raise _YAMLParseError(f"nested lists are not supported: {raw!r}")
+    # Split on commas, parse each item as a scalar
+    parts = [p.strip() for p in inner.split(",")]
+    return [_parse_scalar(p) for p in parts if p]
+
+
+def _parse_auditignore_yaml(path: str) -> list:
+    """
+    Parse .auditignore.yaml using the supported subset parser.
+
+    Returns a list of entry dicts:
+      {
+        "id":      str,            # check-id or glob (normalized from id or check_id)
+        "paths":   list[str],      # repo-relative globs
+        "reason":  str | None,     # None means missing (caller should warn+skip)
+        "expires": str | None,     # YYYY-MM-DD or None
+      }
+
+    Raises _YAMLParseError on unsupported YAML shapes.
+    Exits 1 with a clear message on file-read errors.
+    """
+    try:
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError as exc:
+        print(f"suppress: ERROR: cannot read .auditignore.yaml at {path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    lines = text.splitlines()
+
+    # Strip full-line comments and blank lines; track original line numbers for errors.
+    effective: list = []  # list of (lineno, text)
+    for i, line in enumerate(lines, 1):
+        stripped = line.rstrip()
+        # Ignore blank lines and full-line comments
+        if not stripped or stripped.lstrip().startswith("#"):
+            continue
+        effective.append((i, stripped))
+
+    if not effective:
+        return []
+
+    # The document must be a top-level list (sequence of dashes).
+    # Reject YAML documents that start with --- (document separator).
+    if effective[0][1].strip().startswith("---"):
+        raise _YAMLParseError(
+            "YAML document separators (---) are not supported; "
+            "omit the --- line before the list"
+        )
+
+    # Each entry begins with "- " at column 0 (or "- " at any indent within
+    # the top-level list).  We collect blocks of lines per entry.
+    entry_blocks: list = []  # list of list-of-(lineno, text)
+    current_block: list = []
+
+    for lineno, text in effective:
+        # A new list item begins at the line with leading "- " (stripped).
+        stripped = text.lstrip()
+        indent_len = len(text) - len(stripped)
+        if stripped.startswith("- ") and indent_len == 0:
+            if current_block:
+                entry_blocks.append(current_block)
+            current_block = [(lineno, text)]
+        elif stripped.startswith("- ") and indent_len > 0:
+            # Indented list items inside an entry (e.g. block-style paths list) —
+            # we do NOT support this; block-style sequences are unsupported.
+            raise _YAMLParseError(
+                f"line {lineno}: indented list items under a key are not supported; "
+                "use inline list syntax: paths: [glob1, glob2]"
+            )
+        else:
+            if not current_block:
+                raise _YAMLParseError(
+                    f"line {lineno}: expected a list entry starting with '- '"
+                )
+            current_block.append((lineno, text))
+
+    if current_block:
+        entry_blocks.append(current_block)
+
+    entries = []
+    for block in entry_blocks:
+        entry = _parse_entry_block(block)
+        entries.append(entry)
+    return entries
+
+
+_KV_RE = re.compile(r"^-?\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.*)")
+
+
+def _parse_entry_block(block: list) -> dict:
+    """
+    Parse a single entry block (list of (lineno, text) tuples) into a dict.
+    The first line starts with "- " (the list-item marker).
+    """
+    entry: dict = {"id": None, "paths": [], "reason": None, "expires": None}
+    seen_keys: set = set()
+
+    for lineno, text in block:
+        # Strip the leading "- " from the first line
+        stripped = text.lstrip()
+        if stripped.startswith("- "):
+            stripped = stripped[2:]
+        else:
+            stripped = stripped.lstrip()
+
+        if not stripped:
+            continue
+
+        m = _KV_RE.match(stripped)
+        if not m:
+            raise _YAMLParseError(
+                f"line {lineno}: expected 'key: value' pair, got: {text!r}"
+            )
+
+        key = m.group(1).strip()
+        value_raw = m.group(2).strip()
+
+        if key in seen_keys:
+            raise _YAMLParseError(
+                f"line {lineno}: duplicate key {key!r} in entry"
+            )
+        seen_keys.add(key)
+
+        if key in ("id", "check_id"):
+            entry["id"] = _parse_scalar(value_raw)
+        elif key == "paths":
+            if value_raw.startswith("["):
+                entry["paths"] = _parse_inline_list(value_raw)
+            elif value_raw:
+                # Single value (not a list) treated as a single-item list
+                entry["paths"] = [_parse_scalar(value_raw)]
+            else:
+                entry["paths"] = []
+        elif key == "reason":
+            entry["reason"] = _parse_scalar(value_raw)
+        elif key == "expires":
+            entry["expires"] = _parse_scalar(value_raw)
+        else:
+            raise _YAMLParseError(
+                f"line {lineno}: unknown key {key!r}; "
+                "supported keys: id (or check_id), paths, reason, expires"
+            )
+
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Inline comment scanner
+# ---------------------------------------------------------------------------
+
+# Pattern: "# audit-ignore: check/id optional reason" or "// audit-ignore: ..."
+_INLINE_IGNORE_RE = re.compile(
+    r"""
+    (?:\#|//)          # comment marker: # or //
+    \s*
+    audit-ignore:      # keyword
+    \s+
+    ([^\s]+)           # check-id (no whitespace)
+    (?:\s+(.+))?       # optional reason (rest of line)
+    """,
+    re.VERBOSE,
+)
+
+
+def _scan_inline_ignores(source_path: str) -> dict:
+    """
+    Scan a source file for audit-ignore inline comments.
+
+    Returns a dict mapping (check_id, line_number) -> reason_str.
+    The suppression covers the comment line itself AND the immediately
+    following line:
+      key (check_id, N)   -> comment on line N suppresses a finding on line N
+      key (check_id, N+1) -> comment on line N also suppresses line N+1
+
+    If the file cannot be read (missing, binary, permission), returns {}.
+    """
+    try:
+        with open(source_path, encoding="utf-8", errors="replace") as fh:
+            lines = fh.readlines()
+    except OSError:
+        return {}
+
+    result: dict = {}
+    for i, line in enumerate(lines, 1):
+        m = _INLINE_IGNORE_RE.search(line)
+        if not m:
+            continue
+        check_id = m.group(1).strip()
+        reason = m.group(2).strip() if m.group(2) else "inline"
+        # Cover the comment line itself and the following line.
+        result[(check_id, i)] = reason
+        result[(check_id, i + 1)] = reason
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Expiry check
+# ---------------------------------------------------------------------------
+
+def _parse_date(date_str: str) -> datetime.date:
+    """Parse YYYY-MM-DD or raise ValueError."""
+    return datetime.date.fromisoformat(date_str)
+
+
+def _is_expired(expires_str: str, today: datetime.date) -> bool:
+    """Return True if the expires date is strictly before today."""
+    try:
+        exp = _parse_date(expires_str)
+    except ValueError:
+        return False  # malformed — don't suppress but don't error
+    return exp < today
+
+
+# ---------------------------------------------------------------------------
+# Main suppression logic
+# ---------------------------------------------------------------------------
+
+def _apply_suppressions(
+    findings: list,
+    auditignore_entries: list,
+    inline_cache: dict,
+    repo_root: Path,
+    today: datetime.date,
+) -> list:
+    """
+    Apply suppression rules to findings in-place (on copies).
+
+    auditignore_entries: list of parsed entry dicts (already validated — entries
+        missing 'reason' have been filtered out by the caller).
+    inline_cache: dict of source_path -> {(check_id, line): reason}
+        (lazily populated on first access — see _get_inline_for_file).
+
+    Returns the updated findings list (same order, suppression field added
+    where applicable).
+    """
+    result = []
+    for f in findings:
+        f_copy = dict(f)  # shallow copy — we'll modify suppression field only
+        check_id = f_copy.get("check_id", "")
+        loc = f_copy.get("location", {})
+        path = loc.get("path", "") if isinstance(loc, dict) else ""
+        line = loc.get("line", 0) if isinstance(loc, dict) else 0
+
+        # ----------------------------------------------------------------
+        # 1. Check .auditignore.yaml rules
+        # ----------------------------------------------------------------
+        for entry in auditignore_entries:
+            entry_id = entry.get("id") or ""
+            # check-id must match (exact or fnmatch glob)
+            if not (entry_id == check_id or fnmatch.fnmatch(check_id, entry_id)):
+                continue
+            # path must match at least one glob in paths (if paths is specified)
+            entry_paths = entry.get("paths", [])
+            if entry_paths:
+                if not any(fnmatch.fnmatch(path, p) for p in entry_paths):
+                    continue
+            # Expiry check
+            expires = entry.get("expires")
+            if expires and _is_expired(expires, today):
+                continue
+            # Apply suppression
+            sup: dict = {"justification": entry.get("reason", "")}
+            if expires:
+                sup["expires"] = expires
+            f_copy["suppression"] = sup
+            break  # first matching rule wins
+
+        # ----------------------------------------------------------------
+        # 2. Check inline comments (only if not already suppressed)
+        # ----------------------------------------------------------------
+        if "suppression" not in f_copy and path and line:
+            inline_map = _get_inline_for_file(inline_cache, path, repo_root)
+            inline_reason = inline_map.get((check_id, line))
+            if inline_reason is not None:
+                f_copy["suppression"] = {"justification": inline_reason}
+
+        result.append(f_copy)
+    return result
+
+
+def _get_inline_for_file(cache: dict, rel_path: str, repo_root: Path) -> dict:
+    """
+    Return the inline-ignore map for a source file, caching the result.
+    """
+    if rel_path not in cache:
+        abs_path = str(repo_root / rel_path) if rel_path else ""
+        cache[rel_path] = _scan_inline_ignores(abs_path) if abs_path else {}
+    return cache[rel_path]
+
+
+# ---------------------------------------------------------------------------
+# JSONL I/O
+# ---------------------------------------------------------------------------
+
+def _read_jsonl(path: str):
+    """
+    Read a JSONL file.  Returns list of (raw_line, parsed_obj) tuples.
+    Exits 1 with an actionable message on parse errors.
+    """
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw_lines = fh.readlines()
+    except OSError as exc:
+        print(f"suppress: ERROR: cannot read findings file '{path}': {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    records = []
+    for lineno, raw in enumerate(raw_lines, 1):
+        raw = raw.rstrip("\n")
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        try:
+            obj = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            print(
+                f"suppress: ERROR: findings file line {lineno} is not valid JSON: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not isinstance(obj, dict):
+            print(
+                f"suppress: ERROR: findings file line {lineno} is not a JSON object",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        records.append(obj)
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply .auditignore.yaml + inline comment suppressions to findings JSONL.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--findings",
+        required=True,
+        metavar="PATH",
+        help="Findings JSONL (merge-findings or baseline output).",
+    )
+    parser.add_argument(
+        "--auditignore",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to .auditignore.yaml. "
+            "Default: <repo>/.auditignore.yaml when present, otherwise skipped."
+        ),
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        metavar="ABS_PATH",
+        help=(
+            "Absolute path to the repository root. Used to resolve source file paths "
+            "for inline-comment scanning and to locate the default .auditignore.yaml. "
+            "Default: current working directory."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        metavar="PATH",
+        help="Write output JSONL to this file. Default: stdout.",
+    )
+    parser.add_argument(
+        "--today",
+        default=None,
+        metavar="YYYY-MM-DD",
+        help=(
+            "Override today's date for expiry comparisons (YYYY-MM-DD). "
+            "Defaults to datetime.date.today() from the system clock. "
+            "Pass this flag to make expiry checks deterministic in tests."
+        ),
+    )
+    args = parser.parse_args()
+
+    # ------------------------------------------------------------------
+    # Resolve repo root
+    # ------------------------------------------------------------------
+    repo_root = Path(args.repo).resolve() if args.repo else Path.cwd()
+
+    # ------------------------------------------------------------------
+    # Resolve today's date (injectable for deterministic testing)
+    # ------------------------------------------------------------------
+    if args.today:
+        try:
+            today = _parse_date(args.today)
+        except ValueError:
+            print(
+                f"suppress: ERROR: --today value {args.today!r} is not a valid YYYY-MM-DD date",
+                file=sys.stderr,
+            )
+            return 1
+    else:
+        today = datetime.date.today()
+
+    # ------------------------------------------------------------------
+    # Load .auditignore.yaml
+    # ------------------------------------------------------------------
+    auditignore_path = args.auditignore
+    if auditignore_path is None:
+        default = repo_root / ".auditignore.yaml"
+        if default.is_file():
+            auditignore_path = str(default)
+
+    auditignore_entries: list = []
+    if auditignore_path:
+        try:
+            raw_entries = _parse_auditignore_yaml(auditignore_path)
+        except _YAMLParseError as exc:
+            print(
+                f"suppress: ERROR: cannot parse .auditignore.yaml at {auditignore_path}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+
+        for i, entry in enumerate(raw_entries):
+            if not entry.get("reason"):
+                entry_id = entry.get("id") or f"(entry {i})"
+                print(
+                    f"suppress: WARNING: .auditignore.yaml entry {i} (id={entry_id!r}) "
+                    "is missing required 'reason' field — entry skipped",
+                    file=sys.stderr,
+                )
+                continue
+            # Warn on expired entries
+            expires = entry.get("expires")
+            if expires and _is_expired(expires, today):
+                entry_id = entry.get("id") or f"(entry {i})"
+                print(
+                    f"suppress: WARNING: .auditignore.yaml entry (id={entry_id!r}) "
+                    f"has expired (expires={expires!r}, today={today.isoformat()!r}); "
+                    "suppression NOT applied",
+                    file=sys.stderr,
+                )
+                continue
+            auditignore_entries.append(entry)
+
+    # ------------------------------------------------------------------
+    # Read input JSONL
+    # ------------------------------------------------------------------
+    records = _read_jsonl(args.findings)
+
+    # ------------------------------------------------------------------
+    # Separate findings (no type field) from metadata records (have type field)
+    # ------------------------------------------------------------------
+    findings = []
+    metadata = []  # (index, record) tuples preserving original order
+    for i, rec in enumerate(records):
+        if "type" in rec:
+            metadata.append((i, rec))
+        else:
+            findings.append((i, rec))
+
+    # ------------------------------------------------------------------
+    # Apply suppressions to findings
+    # ------------------------------------------------------------------
+    inline_cache: dict = {}  # rel_path -> {(check_id, line): reason}
+    finding_objs = [r for _, r in findings]
+    suppressed_objs = _apply_suppressions(
+        finding_objs, auditignore_entries, inline_cache, repo_root, today
+    )
+
+    # Re-pair with original indices
+    suppressed_findings = list(zip([i for i, _ in findings], suppressed_objs))
+
+    # ------------------------------------------------------------------
+    # Rebuild output in original record order
+    # ------------------------------------------------------------------
+    # Merge metadata and findings back by original index
+    all_out: list = [None] * len(records)
+    for i, rec in metadata:
+        all_out[i] = rec
+    for i, rec in suppressed_findings:
+        all_out[i] = rec
+
+    # ------------------------------------------------------------------
+    # Serialize
+    # ------------------------------------------------------------------
+    output_lines = []
+    for rec in all_out:
+        if rec is not None:
+            output_lines.append(json.dumps(rec, separators=(",", ":")))
+
+    out_text = "\n".join(output_lines)
+    if output_lines:
+        out_text += "\n"
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            out_path.write_text(out_text, encoding="utf-8")
+        except OSError as exc:
+            print(f"suppress: ERROR: cannot write output: {exc}", file=sys.stderr)
+            return 1
+        n_suppressed = sum(1 for _, r in suppressed_findings if "suppression" in r)
+        print(
+            f"suppress: applied suppressions to {n_suppressed} of "
+            f"{len(suppressed_findings)} finding(s); wrote to {args.output}",
+            file=sys.stderr,
+        )
+    else:
+        sys.stdout.write(out_text)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/commands-extra/skills/audit/scripts/suppress.py
+++ b/modules/commands-extra/skills/audit/scripts/suppress.py
@@ -34,7 +34,10 @@ Arguments
 .auditignore.yaml format — supported subset
 --------------------------------------------
 The parser handles a STRICT, fixed YAML subset. Shapes outside this subset
-cause a hard error (exit 1) — they are NEVER silently mis-parsed.
+cause a hard error (exit 1) — they are NEVER silently mis-parsed.  In
+particular: flow collections (``{...}`` or ``[...]``) as scalar values
+are rejected, and lines indented with a TAB character cause an immediate
+parse error.
 
   Supported top-level structure:
     A sequence (YAML list) of mapping blocks.
@@ -148,7 +151,21 @@ def _parse_scalar(raw: str) -> str:
     # Anchors / aliases are unsupported
     if raw[0] in ("&", "*"):
         raise _YAMLParseError(f"anchors and aliases are not supported: {raw!r}")
-    # Unquoted scalar — return as-is (stripped)
+    # Flow collections (out-of-subset) — reject so the docstring's "never silently
+    # mis-parse" claim holds.  A value like `reason: {a: b}` would otherwise be
+    # returned as the literal string "{a: b}" with no indication something was wrong.
+    if raw[0] in ("{", "["):
+        raise _YAMLParseError(
+            f"flow collections ({{ }} or [ ]) are not supported as scalar values: {raw!r}; "
+            "use a plain string value instead"
+        )
+    # Unquoted scalar — strip any trailing inline comment (whitespace + '#' to end of
+    # line) so that `id: security/foo  # legacy` parses as "security/foo", matching
+    # standard YAML comment semantics.  A '#' at the start of a word (e.g. a hex
+    # colour "#abc") is NOT a comment because it is not preceded by whitespace.
+    comment_match = re.search(r"\s+#.*$", raw)
+    if comment_match:
+        raw = raw[: comment_match.start()]
     return raw
 
 
@@ -203,6 +220,13 @@ def _parse_auditignore_yaml(path: str) -> list:
         # Ignore blank lines and full-line comments
         if not stripped or stripped.lstrip().startswith("#"):
             continue
+        # Reject tab-indented lines — tabs are not part of the supported subset and
+        # can silently mis-parse indentation levels (YAML spec §6.1).
+        if stripped and stripped[0] == "	":
+            raise _YAMLParseError(
+                f"line {i}: tab character used for indentation; "
+                "use spaces only (tabs are not supported in this YAML subset)"
+            )
         effective.append((i, stripped))
 
     if not effective:

--- a/modules/commands-extra/skills/audit/tests/test-suppression.sh
+++ b/modules/commands-extra/skills/audit/tests/test-suppression.sh
@@ -1,0 +1,497 @@
+#!/usr/bin/env bash
+# CCGM audit -- test-suppression.sh
+# Tests for Epic 3.3: suppress.py (.auditignore.yaml + inline comments)
+#
+# Test scenarios:
+#   (a) Finding suppressed by .auditignore.yaml path+check-id rule:
+#       -> has suppression.justification, still present in output.
+#   (b) Finding suppressed by inline # audit-ignore: comment:
+#       -> suppressed, still present in output.
+#   (c) .auditignore entry missing reason -> warned/skipped (finding NOT suppressed).
+#   (d) Expired suppression (expires < --today) -> NOT honored (no suppression field) + warning.
+#   (e) Suppressed CRITICAL finding is still in the output (report would tag [SUPPRESSED]).
+#
+# All fixtures are constructed at runtime in mktemp dirs (trailing-XXXXXX).
+# Usage: bash modules/commands-extra/skills/audit/tests/test-suppression.sh
+# Exit:  0 = all tests passed, non-zero = at least one failure
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUPPRESS_SCRIPT="$SCRIPT_DIR/../scripts/suppress.py"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+  printf '  [PASS] %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  ERRORS+=("$1")
+  FAIL=$((FAIL + 1))
+}
+
+# Check whether a fingerprint exists as a finding record (no type field) in JSONL string.
+fp_exists_as_finding() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+output, fp = sys.argv[1], sys.argv[2]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj and obj.get("fingerprint") == fp:
+            print("yes")
+            sys.exit(0)
+    except Exception:
+        pass
+print("no")
+PYEOF
+}
+
+# Get suppression.justification for a finding with given fingerprint.
+# Returns "" if not present, or the justification string.
+get_suppression_justification() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+output, fp = sys.argv[1], sys.argv[2]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj and obj.get("fingerprint") == fp:
+            sup = obj.get("suppression")
+            if sup and isinstance(sup, dict):
+                print(sup.get("justification", ""))
+            else:
+                print("__no_suppression__")
+            sys.exit(0)
+    except Exception:
+        pass
+print("__not_found__")
+PYEOF
+}
+
+# Check whether a finding has a suppression field at all.
+has_suppression() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+output, fp = sys.argv[1], sys.argv[2]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj and obj.get("fingerprint") == fp:
+            if "suppression" in obj:
+                print("yes")
+            else:
+                print("no")
+            sys.exit(0)
+    except Exception:
+        pass
+print("__not_found__")
+PYEOF
+}
+
+# Get severity of a finding with given fingerprint.
+get_severity() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+output, fp = sys.argv[1], sys.argv[2]
+for l in output.splitlines():
+    if not l.strip():
+        continue
+    try:
+        obj = json.loads(l)
+        if isinstance(obj, dict) and "type" not in obj and obj.get("fingerprint") == fp:
+            print(obj.get("severity", ""))
+            sys.exit(0)
+    except Exception:
+        pass
+print("__not_found__")
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Global temp directory
+# ---------------------------------------------------------------------------
+TESTRUN_DIR="$(mktemp -d /tmp/ccgm-test-suppression-XXXXXX)"
+trap 'rm -rf "$TESTRUN_DIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Helper: write a minimal valid findings JSONL with provenance + given findings
+# ---------------------------------------------------------------------------
+write_findings_jsonl() {
+  # write_findings_jsonl <out_file> <finding_json> [<finding_json> ...]
+  local out_file="$1"
+  shift
+  python3 - "$out_file" "$@" << 'PYEOF'
+import json, sys
+out_file = sys.argv[1]
+findings = sys.argv[2:]
+with open(out_file, "w") as fh:
+    fh.write(json.dumps({
+        "type": "provenance",
+        "tool": "ccgm-merge",
+        "version": "1.0",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }) + "\n")
+    for f_json in findings:
+        if f_json:
+            fh.write(f_json + "\n")
+PYEOF
+}
+
+# Build a minimal valid finding JSON given check_id, path, line, severity, fingerprint.
+make_finding() {
+  python3 -c "
+import json, sys
+check_id, path, line, severity, fingerprint = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4], sys.argv[5]
+print(json.dumps({
+    'check_id': check_id,
+    'rule_id': check_id,
+    'severity': severity,
+    'confidence': 'high',
+    'detection': 'tool',
+    'source': 'tool',
+    'message': 'test finding for ' + check_id,
+    'location': {'path': path, 'line': line},
+    'fingerprint': fingerprint,
+}))
+" "$1" "$2" "$3" "$4" "$5"
+}
+
+# ---------------------------------------------------------------------------
+# Test (a): Finding suppressed by .auditignore.yaml path+check-id rule
+#           -> has suppression.justification, still present in output
+# ---------------------------------------------------------------------------
+printf '\nTest (a): .auditignore.yaml path+check-id rule -> suppression applied, finding retained\n'
+
+TA_DIR="$TESTRUN_DIR/ta"
+mkdir -p "$TA_DIR"
+
+FP_A="aaaa1111bbbb2222:1"
+
+# Source file (needed for inline scan path resolution, but no inline comment here)
+mkdir -p "$TA_DIR/src"
+printf 'function foo() {}\n' > "$TA_DIR/src/app.js"
+
+FINDING_A="$(make_finding "security/no-console" "src/app.js" "5" "medium" "$FP_A")"
+write_findings_jsonl "$TA_DIR/findings.jsonl" "$FINDING_A"
+
+# Write .auditignore.yaml
+cat > "$TA_DIR/.auditignore.yaml" << 'YAML_EOF'
+- id: security/no-console
+  paths: [src/app.js]
+  reason: console.log acceptable in this utility script
+YAML_EOF
+
+set +e
+TA_OUT="$(python3 "$SUPPRESS_SCRIPT" \
+  --findings "$TA_DIR/findings.jsonl" \
+  --auditignore "$TA_DIR/.auditignore.yaml" \
+  --repo "$TA_DIR" \
+  --today 2026-06-10 2>/dev/null)"
+TA_EXIT=$?
+set -e
+
+if [[ $TA_EXIT -eq 0 ]]; then
+  pass "(a): suppress.py exits 0"
+else
+  fail "(a): suppress.py exits $TA_EXIT (expected 0)"
+fi
+
+# Finding must still be present in output
+TA_PRESENT="$(fp_exists_as_finding "$TA_OUT" "$FP_A")"
+if [[ "$TA_PRESENT" == "yes" ]]; then
+  pass "(a): suppressed finding still present in output"
+else
+  fail "(a): suppressed finding absent from output (must be retained)"
+fi
+
+# Finding must have suppression.justification
+TA_JUST="$(get_suppression_justification "$TA_OUT" "$FP_A")"
+if [[ "$TA_JUST" == "console.log acceptable in this utility script" ]]; then
+  pass "(a): suppression.justification matches .auditignore reason"
+else
+  fail "(a): suppression.justification='$TA_JUST' (expected the reason string)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test (b): Finding suppressed by inline # audit-ignore: comment
+#           -> suppressed, still present in output
+# ---------------------------------------------------------------------------
+printf '\nTest (b): inline # audit-ignore: comment -> suppression applied, finding retained\n'
+
+TB_DIR="$TESTRUN_DIR/tb"
+mkdir -p "$TB_DIR/src"
+
+FP_B="bbbb2222cccc3333:1"
+
+# Source file with audit-ignore comment on line 3; finding is on line 4 (next line)
+cat > "$TB_DIR/src/utils.py" << 'PY_EOF'
+import os
+import sys
+# audit-ignore: code-quality/unused-import reason: kept for re-export
+import logging
+def main():
+    pass
+PY_EOF
+
+# Finding on line 4 (the import logging line — next line after the comment on line 3)
+FINDING_B="$(make_finding "code-quality/unused-import" "src/utils.py" "4" "low" "$FP_B")"
+write_findings_jsonl "$TB_DIR/findings.jsonl" "$FINDING_B"
+
+set +e
+TB_OUT="$(python3 "$SUPPRESS_SCRIPT" \
+  --findings "$TB_DIR/findings.jsonl" \
+  --repo "$TB_DIR" \
+  --today 2026-06-10 2>/dev/null)"
+TB_EXIT=$?
+set -e
+
+if [[ $TB_EXIT -eq 0 ]]; then
+  pass "(b): suppress.py exits 0"
+else
+  fail "(b): suppress.py exits $TB_EXIT (expected 0)"
+fi
+
+# Finding must still be in output
+TB_PRESENT="$(fp_exists_as_finding "$TB_OUT" "$FP_B")"
+if [[ "$TB_PRESENT" == "yes" ]]; then
+  pass "(b): inline-suppressed finding still present in output"
+else
+  fail "(b): inline-suppressed finding absent from output (must be retained)"
+fi
+
+# Finding must have suppression field
+TB_HAS_SUP="$(has_suppression "$TB_OUT" "$FP_B")"
+if [[ "$TB_HAS_SUP" == "yes" ]]; then
+  pass "(b): inline comment produced suppression field on finding"
+else
+  fail "(b): inline comment did not produce suppression field (has_suppression=$TB_HAS_SUP)"
+fi
+
+# Justification from the inline comment reason text
+TB_JUST="$(get_suppression_justification "$TB_OUT" "$FP_B")"
+if [[ "$TB_JUST" == "reason: kept for re-export" ]]; then
+  pass "(b): suppression.justification contains inline reason text"
+else
+  fail "(b): suppression.justification='$TB_JUST' (expected inline reason)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test (c): .auditignore entry missing reason -> warned/skipped (finding NOT suppressed)
+# ---------------------------------------------------------------------------
+printf '\nTest (c): .auditignore entry missing reason -> warned, finding NOT suppressed\n'
+
+TC_DIR="$TESTRUN_DIR/tc"
+mkdir -p "$TC_DIR/src"
+printf 'x = 1\n' > "$TC_DIR/src/main.py"
+
+FP_C="cccc3333dddd4444:1"
+
+FINDING_C="$(make_finding "security/sql-injection" "src/main.py" "1" "high" "$FP_C")"
+write_findings_jsonl "$TC_DIR/findings.jsonl" "$FINDING_C"
+
+# Entry missing reason
+cat > "$TC_DIR/.auditignore.yaml" << 'YAML_EOF'
+- id: security/sql-injection
+  paths: [src/main.py]
+YAML_EOF
+
+set +e
+TC_STDERR="$(python3 "$SUPPRESS_SCRIPT" \
+  --findings "$TC_DIR/findings.jsonl" \
+  --auditignore "$TC_DIR/.auditignore.yaml" \
+  --repo "$TC_DIR" \
+  --today 2026-06-10 2>&1 >/dev/null)"
+TC_OUT="$(python3 "$SUPPRESS_SCRIPT" \
+  --findings "$TC_DIR/findings.jsonl" \
+  --auditignore "$TC_DIR/.auditignore.yaml" \
+  --repo "$TC_DIR" \
+  --today 2026-06-10 2>/dev/null)"
+TC_EXIT=$?
+set -e
+
+if [[ $TC_EXIT -eq 0 ]]; then
+  pass "(c): suppress.py exits 0 even with missing-reason entry"
+else
+  fail "(c): suppress.py exits $TC_EXIT (expected 0)"
+fi
+
+# A warning must be emitted to stderr
+if echo "$TC_STDERR" | grep -qi "warning\|WARNING\|reason\|missing"; then
+  pass "(c): warning emitted to stderr for missing reason"
+else
+  fail "(c): no warning on stderr for missing reason (got: $TC_STDERR)"
+fi
+
+# Finding must NOT have a suppression field (the entry was skipped)
+TC_HAS_SUP="$(has_suppression "$TC_OUT" "$FP_C")"
+if [[ "$TC_HAS_SUP" == "no" ]]; then
+  pass "(c): finding NOT suppressed when entry missing reason"
+else
+  fail "(c): finding has suppression field (expected no suppression, has_suppression=$TC_HAS_SUP)"
+fi
+
+# Finding must still be present
+TC_PRESENT="$(fp_exists_as_finding "$TC_OUT" "$FP_C")"
+if [[ "$TC_PRESENT" == "yes" ]]; then
+  pass "(c): finding still present in output"
+else
+  fail "(c): finding absent from output"
+fi
+
+# ---------------------------------------------------------------------------
+# Test (d): Expired suppression (expires < --today) -> NOT honored + warning
+# ---------------------------------------------------------------------------
+printf '\nTest (d): expired suppression -> NOT honored, warning emitted\n'
+
+TD_DIR="$TESTRUN_DIR/td"
+mkdir -p "$TD_DIR/src"
+printf 'const x = 1;\n' > "$TD_DIR/src/index.ts"
+
+FP_D="dddd4444eeee5555:1"
+
+FINDING_D="$(make_finding "typescript-react/missing-prop-types" "src/index.ts" "1" "medium" "$FP_D")"
+write_findings_jsonl "$TD_DIR/findings.jsonl" "$FINDING_D"
+
+# Entry with an expires date that is in the past relative to --today 2026-06-10
+cat > "$TD_DIR/.auditignore.yaml" << 'YAML_EOF'
+- id: typescript-react/missing-prop-types
+  paths: [src/index.ts]
+  reason: suppressed during migration
+  expires: 2026-01-01
+YAML_EOF
+
+set +e
+TD_STDERR="$(python3 "$SUPPRESS_SCRIPT" \
+  --findings "$TD_DIR/findings.jsonl" \
+  --auditignore "$TD_DIR/.auditignore.yaml" \
+  --repo "$TD_DIR" \
+  --today 2026-06-10 2>&1 >/dev/null)"
+TD_OUT="$(python3 "$SUPPRESS_SCRIPT" \
+  --findings "$TD_DIR/findings.jsonl" \
+  --auditignore "$TD_DIR/.auditignore.yaml" \
+  --repo "$TD_DIR" \
+  --today 2026-06-10 2>/dev/null)"
+TD_EXIT=$?
+set -e
+
+if [[ $TD_EXIT -eq 0 ]]; then
+  pass "(d): suppress.py exits 0 with expired entry"
+else
+  fail "(d): suppress.py exits $TD_EXIT (expected 0)"
+fi
+
+# A warning must be emitted
+if echo "$TD_STDERR" | grep -qi "warning\|WARNING\|expir"; then
+  pass "(d): warning emitted for expired suppression"
+else
+  fail "(d): no warning for expired suppression (got: $TD_STDERR)"
+fi
+
+# Finding must NOT have a suppression field (expired suppression not honored)
+TD_HAS_SUP="$(has_suppression "$TD_OUT" "$FP_D")"
+if [[ "$TD_HAS_SUP" == "no" ]]; then
+  pass "(d): expired suppression NOT applied to finding"
+else
+  fail "(d): expired suppression was applied (expected no suppression, has_suppression=$TD_HAS_SUP)"
+fi
+
+# Finding must still be present
+TD_PRESENT="$(fp_exists_as_finding "$TD_OUT" "$FP_D")"
+if [[ "$TD_PRESENT" == "yes" ]]; then
+  pass "(d): finding still present when expired suppression not honored"
+else
+  fail "(d): finding absent from output"
+fi
+
+# ---------------------------------------------------------------------------
+# Test (e): Suppressed CRITICAL finding is still in the output
+#           (report would tag it [SUPPRESSED] rather than hiding it)
+# ---------------------------------------------------------------------------
+printf '\nTest (e): suppressed CRITICAL finding stays in output\n'
+
+TE_DIR="$TESTRUN_DIR/te"
+mkdir -p "$TE_DIR/src"
+printf 'const secret = "hardcoded";\n' > "$TE_DIR/src/config.ts"
+
+FP_E="eeee5555ffff6666:1"
+
+FINDING_E="$(make_finding "secrets/hardcoded-credential" "src/config.ts" "1" "critical" "$FP_E")"
+write_findings_jsonl "$TE_DIR/findings.jsonl" "$FINDING_E"
+
+cat > "$TE_DIR/.auditignore.yaml" << 'YAML_EOF'
+- id: secrets/hardcoded-credential
+  paths: [src/config.ts]
+  reason: test credential, not real — see security policy
+YAML_EOF
+
+set +e
+TE_OUT="$(python3 "$SUPPRESS_SCRIPT" \
+  --findings "$TE_DIR/findings.jsonl" \
+  --auditignore "$TE_DIR/.auditignore.yaml" \
+  --repo "$TE_DIR" \
+  --today 2026-06-10 2>/dev/null)"
+TE_EXIT=$?
+set -e
+
+if [[ $TE_EXIT -eq 0 ]]; then
+  pass "(e): suppress.py exits 0 for CRITICAL finding"
+else
+  fail "(e): suppress.py exits $TE_EXIT (expected 0)"
+fi
+
+# CRITICAL finding must still be present in output (not silently dropped)
+TE_PRESENT="$(fp_exists_as_finding "$TE_OUT" "$FP_E")"
+if [[ "$TE_PRESENT" == "yes" ]]; then
+  pass "(e): suppressed CRITICAL finding is still present in output"
+else
+  fail "(e): CRITICAL finding was omitted — suppressions must never drop findings"
+fi
+
+# The finding must have a suppression field
+TE_HAS_SUP="$(has_suppression "$TE_OUT" "$FP_E")"
+if [[ "$TE_HAS_SUP" == "yes" ]]; then
+  pass "(e): CRITICAL finding has suppression field set"
+else
+  fail "(e): CRITICAL finding missing suppression field (has_suppression=$TE_HAS_SUP)"
+fi
+
+# Severity must remain critical (suppression does not downgrade severity)
+TE_SEV="$(get_severity "$TE_OUT" "$FP_E")"
+if [[ "$TE_SEV" == "critical" ]]; then
+  pass "(e): CRITICAL finding retains severity=critical after suppression"
+else
+  fail "(e): CRITICAL finding severity='$TE_SEV' (expected 'critical')"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n-------------------------------------------------\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  printf '\nFailed tests:\n'
+  for err in "${ERRORS[@]}"; do
+    printf '  - %s\n' "$err"
+  done
+  exit 1
+fi
+
+printf 'All tests passed.\n'
+exit 0

--- a/modules/commands-extra/skills/audit/tests/test-suppression.sh
+++ b/modules/commands-extra/skills/audit/tests/test-suppression.sh
@@ -480,6 +480,115 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test (f): Trailing inline # comment on id line -> suppression still applies (FIX 1)
+# ---------------------------------------------------------------------------
+printf '\nTest (f): trailing inline comment on id -> suppression still applies\n'
+
+TF_DIR="$TESTRUN_DIR/tf"
+mkdir -p "$TF_DIR/src"
+printf 'x = 1\n' > "$TF_DIR/src/main.py"
+
+FP_F="ffff6666aaaa7777:1"
+
+FINDING_F="$(make_finding "security/foo" "src/main.py" "1" "high" "$FP_F")"
+write_findings_jsonl "$TF_DIR/findings.jsonl" "$FINDING_F"
+
+# Entry with a trailing inline comment on the id line
+cat > "$TF_DIR/.auditignore.yaml" << 'YAML_EOF'
+- id: security/foo  # legacy check, still suppressed
+  reason: known false-positive in generated code
+YAML_EOF
+
+set +e
+TF_OUT="$(python3 "$SUPPRESS_SCRIPT" \
+  --findings "$TF_DIR/findings.jsonl" \
+  --auditignore "$TF_DIR/.auditignore.yaml" \
+  --repo "$TF_DIR" \
+  --today 2026-06-10 2>/dev/null)"
+TF_EXIT=$?
+set -e
+
+if [[ $TF_EXIT -eq 0 ]]; then
+  pass "(f): suppress.py exits 0 with trailing comment on id"
+else
+  fail "(f): suppress.py exits $TF_EXIT (expected 0)"
+fi
+
+# The finding MUST be suppressed — the comment must have been stripped
+TF_JUST="$(get_suppression_justification "$TF_OUT" "$FP_F")"
+if [[ "$TF_JUST" == "known false-positive in generated code" ]]; then
+  pass "(f): trailing comment stripped from id; suppression applied correctly"
+else
+  fail "(f): suppression.justification='$TF_JUST' (expected the reason — trailing comment was not stripped)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test (g): flow-map scalar value -> suppress.py exits 1 (FIX 2 fail-closed)
+# ---------------------------------------------------------------------------
+printf '\nTest (g): flow-map value in reason -> suppress.py exits 1\n'
+
+TG_DIR="$TESTRUN_DIR/tg"
+mkdir -p "$TG_DIR/src"
+printf 'x = 1\n' > "$TG_DIR/src/main.py"
+
+FP_G="gggg7777hhhh8888:1"
+FINDING_G="$(make_finding "security/foo" "src/main.py" "1" "high" "$FP_G")"
+write_findings_jsonl "$TG_DIR/findings.jsonl" "$FINDING_G"
+
+# Entry where reason is a flow-map (out-of-subset)
+cat > "$TG_DIR/.auditignore.yaml" << 'YAML_EOF'
+- id: security/foo
+  reason: {x: y}
+YAML_EOF
+
+set +e
+python3 "$SUPPRESS_SCRIPT" \
+  --findings "$TG_DIR/findings.jsonl" \
+  --auditignore "$TG_DIR/.auditignore.yaml" \
+  --repo "$TG_DIR" \
+  --today 2026-06-10 > /dev/null 2>&1
+TG_EXIT=$?
+set -e
+
+if [[ $TG_EXIT -eq 1 ]]; then
+  pass "(g): flow-map scalar value causes exit 1 (fail-closed)"
+else
+  fail "(g): suppress.py exited $TG_EXIT (expected 1 for flow-map value)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test (h): tab-indented entry -> suppress.py exits 1 (FIX 2 fail-closed)
+# ---------------------------------------------------------------------------
+printf '\nTest (h): tab-indented entry -> suppress.py exits 1\n'
+
+TH_DIR="$TESTRUN_DIR/th"
+mkdir -p "$TH_DIR/src"
+printf 'x = 1\n' > "$TH_DIR/src/main.py"
+
+FP_H="hhhh8888iiii9999:1"
+FINDING_H="$(make_finding "security/foo" "src/main.py" "1" "high" "$FP_H")"
+write_findings_jsonl "$TH_DIR/findings.jsonl" "$FINDING_H"
+
+# Entry where continuation key uses a TAB for indentation
+printf -- '- id: security/foo\n' > "$TH_DIR/.auditignore.yaml"
+printf '\treason: tab-indented value\n' >> "$TH_DIR/.auditignore.yaml"
+
+set +e
+python3 "$SUPPRESS_SCRIPT" \
+  --findings "$TH_DIR/findings.jsonl" \
+  --auditignore "$TH_DIR/.auditignore.yaml" \
+  --repo "$TH_DIR" \
+  --today 2026-06-10 > /dev/null 2>&1
+TH_EXIT=$?
+set -e
+
+if [[ $TH_EXIT -eq 1 ]]; then
+  pass "(h): tab-indented entry causes exit 1 (fail-closed)"
+else
+  fail "(h): suppress.py exited $TH_EXIT (expected 1 for tab-indented entry)"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 printf '\n-------------------------------------------------\n'


### PR DESCRIPTION
## Summary

- Adds `scripts/suppress.py` — stdlib-only suppression applier for `/audit` findings JSONL
- Supports `.auditignore.yaml` path+check-id rules and inline `# audit-ignore:` / `// audit-ignore:` source comments
- Suppressed findings are retained in output with a `suppression` field (never omitted); CRITICAL/HIGH are tagged `[SUPPRESSED]` in reports
- Registers `suppress.py` in `module.json` and adds `tests/test-suppression.sh` with 19 assertions across 5 scenarios
- Inserts `### Suppression` subsection in `SKILL.md` immediately after `### Baseline / Delta`

## Test plan

- [ ] `bash modules/commands-extra/skills/audit/tests/test-suppression.sh` — 19/19 pass
- [ ] `bash modules/commands-extra/skills/audit/tests/test-baseline.sh` — 38/38 pass (no regression)
- [ ] `bash modules/commands-extra/skills/audit/tests/test-merge.sh` — 41/41 pass (no regression)
- [ ] `python3 -c "import json; json.load(open('modules/commands-extra/module.json'))"` — valid JSON
- [ ] `bash tests/test-no-personal-data.sh` — pass

Closes #624