### PR TITLE
#625: Epic 3.4 provenance header + CODEOWNERS routing + per-package scoping

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -138,6 +138,11 @@
       "type": "script",
       "template": false
     },
+    "skills/audit/scripts/provenance.py": {
+      "target": "skills/audit/scripts/provenance.py",
+      "type": "script",
+      "template": false
+    },
     "skills/audit/packs/_TEMPLATE/checks.md": {
       "target": "skills/audit/packs/_TEMPLATE/checks.md",
       "type": "doc",

--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -1,5 +1,6 @@
 {
   "name": "commands-extra",
+  "version": "1.0.0",
   "displayName": "Extra Commands",
   "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global), /freeze + /unfreeze + /guard (safety-hook state management), /checkpoint (save/resume WIP session state).",
   "category": "commands",

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -861,6 +861,59 @@ after `merge-findings.py` in the same inline step; then compile the report (Phas
 directory (e.g., `.audit/history/YYYY-MM-DD.jsonl`). The script never auto-writes a baseline;
 the caller controls when to advance it.
 
+### Provenance & Routing
+
+After `merge-findings.py` produces `findings.jsonl` (or `findings-delta.jsonl` in delta mode),
+run `provenance.py` to prepend an audit-level provenance header and tag findings for routing:
+
+```bash
+python3 skills/audit/scripts/provenance.py \
+  --findings .audit/current/findings.jsonl \
+  --repo "$REPO_ROOT" \
+  --model "$AUDIT_MODEL" \
+  --output .audit/current/findings-tagged.jsonl
+```
+
+Pass `findings-tagged.jsonl` (instead of `findings.jsonl`) to the report compiler and any
+downstream consumers.  In `--single` mode the same invocation applies; use `--single` only
+when suppression/baseline is not needed, but provenance tagging is always beneficial.
+
+**audit_provenance header** — the first record in output has `type: "audit_provenance"` and
+carries these fields for traceability and report display:
+
+| Field | Source |
+|---|---|
+| `commit` | `git -C <repo> rev-parse HEAD` |
+| `rubric_version` | `version` field from `severity-rubric.json` |
+| `skill_version` | `version` field from `module.json` |
+| `tool_versions` | `{tool: version_string}` for spine tools present on PATH |
+| `model` | `--model` arg or `AUDIT_MODEL` env var |
+| `optional_checks_ran` | list of check IDs passed via `--optional-check` |
+
+The report header (Phase 6) should display `commit`, `rubric_version`, and `model` so readers
+can trace any finding back to its rubric snapshot.  When the rubric changes between runs,
+different `rubric_version` values explain severity shifts (see ADV-007).
+
+**CODEOWNERS owner tagging** — if a `CODEOWNERS` file exists in the repo (checked in order:
+`.github/CODEOWNERS`, `CODEOWNERS`, `docs/CODEOWNERS`), each finding whose `location.path`
+matches a CODEOWNERS rule gains `properties.owner` set to the owning team or user handle(s).
+Uses last-match-wins semantics identical to GitHub's own evaluation.  Owner tags enable
+per-team issue routing and allow the issue-creation step (Phase M7) to notify the right team.
+Findings with no matching CODEOWNERS rule receive no `owner` field (omitted, not null).
+
+**Per-package monorepo scoping** — for monorepos, `provenance.py` detects package roots from
+`pnpm-workspace.yaml` or the root `package.json#workspaces` field (pass `--packages` to
+override).  Each finding in a detected package root gains `properties.package` set to the
+package directory path.  After tagging, the script emits one `package_summary` record per
+package with per-severity counts:
+
+```json
+{"type":"package_summary","package":"packages/auth","counts":{"critical":0,"high":1,"medium":2,"low":0,"info":3}}
+```
+
+Package summaries appear after all finding records in the output and can drive per-package
+report sections or Slack/issue routing.
+
 ### Phase M7: Issue Creation
 
 Ask the user:

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -867,7 +867,7 @@ After `merge-findings.py` produces `findings.jsonl` (or `findings-delta.jsonl` i
 run `provenance.py` to prepend an audit-level provenance header and tag findings for routing:
 
 ```bash
-python3 skills/audit/scripts/provenance.py \
+python3 "$SKILL_ROOT/scripts/provenance.py" \
   --findings .audit/current/findings.jsonl \
   --repo "$REPO_ROOT" \
   --model "$AUDIT_MODEL" \
@@ -897,7 +897,7 @@ different `rubric_version` values explain severity shifts (see ADV-007).
 **CODEOWNERS owner tagging** — if a `CODEOWNERS` file exists in the repo (checked in order:
 `.github/CODEOWNERS`, `CODEOWNERS`, `docs/CODEOWNERS`), each finding whose `location.path`
 matches a CODEOWNERS rule gains `properties.owner` set to the owning team or user handle(s).
-Uses last-match-wins semantics identical to GitHub's own evaluation.  Owner tags enable
+Follows GitHub CODEOWNERS last-match-wins with directory-prefix and glob matching.  Owner tags enable
 per-team issue routing and allow the issue-creation step (Phase M7) to notify the right team.
 Findings with no matching CODEOWNERS rule receive no `owner` field (omitted, not null).
 

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0.0",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "ccgm/audit/severity-rubric.json",
   "title": "CCGM Audit Severity Rubric",

--- a/modules/commands-extra/skills/audit/scripts/provenance.py
+++ b/modules/commands-extra/skills/audit/scripts/provenance.py
@@ -44,7 +44,8 @@ Output (valid JSONL):
 
 Exit codes:
   0  success
-  1  malformed input (bad JSONL, missing required --findings/--repo)
+  1  malformed input (bad JSONL, unreadable file, invalid --repo path)
+  2  missing or invalid CLI arguments (handled by argparse before script logic runs)
 """
 
 import argparse

--- a/modules/commands-extra/skills/audit/scripts/provenance.py
+++ b/modules/commands-extra/skills/audit/scripts/provenance.py
@@ -1,0 +1,694 @@
+#!/usr/bin/env python3
+"""
+CCGM /audit provenance.py (Epic 3.4) — STDLIB ONLY.
+
+Three capabilities in one script:
+
+1. HEADER  — emit an audit_provenance record (type: "audit_provenance") with:
+     commit           git SHA of the audited repo (git -C <repo> rev-parse HEAD)
+     rubric_version   version field from severity-rubric.json
+     skill_version    version from the audit module.json (or DEFAULT_SKILL_VERSION)
+     tool_versions    map of installed spine tools -> version string (absent tools omitted)
+     model            placeholder; fill from --model / AUDIT_MODEL env var (default "unknown")
+     optional_checks_ran  list (empty by default; caller may pass --optional-check repeatedly)
+
+   Naming note: the spine already emits {"type":"provenance","tool":"ccgm-spine",...} for
+   run-time bookkeeping.  The audit-level record uses type="audit_provenance" to remain
+   unambiguous.  merge-findings.py routes "provenance" records first in output; the caller
+   must prepend the audit_provenance header before findings.jsonl content (see SKILL.md).
+
+2. CODEOWNERS  — parse the repo's CODEOWNERS file (checked in order:
+   .github/CODEOWNERS, CODEOWNERS, docs/CODEOWNERS) and for each finding in --findings,
+   set properties.owner to the matching owner(s) using last-match-wins, gitignore-style
+   path glob semantics.  Findings with no match get no owner field (omit rather than null).
+
+3. PER-PACKAGE  — given monorepo package roots (detected from pnpm-workspace.yaml /
+   package.json workspaces, or supplied via --packages), set properties.package on each
+   finding to the owning package dir and emit a per-package summary record:
+     {"type":"package_summary","package":"<dir>","counts":{"critical":N,"high":N,...}}
+
+CLI:
+  provenance.py --findings <jsonl> --repo <root>
+                [--rubric <path>]          default: ../schemas/severity-rubric.json relative to script
+                [--output <file>]          default: stdout
+                [--model <str>]            model identifier; also read from AUDIT_MODEL env var
+                [--optional-check <id>]   may be repeated
+                [--packages <dir> ...]    explicit package roots (repo-relative); may be repeated
+                [--skip-tool-versions]    omit tool_versions from header (speeds up tests)
+
+Output (valid JSONL):
+  1. {"type":"audit_provenance", ...}  header record
+  2. finding records with properties.owner and/or properties.package set (where applicable)
+  3. non-finding records from --findings (provenance, coverage_gap, etc.) -- passed through
+  4. {"type":"package_summary","package":"<rel>","counts":{...}}  one per detected package
+
+Exit codes:
+  0  success
+  1  malformed input (bad JSONL, missing required --findings/--repo)
+"""
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_SKILL_VERSION = "1.0.0"
+
+# Spine tools whose --version we query (must not run untrusted code against the repo)
+_SPINE_TOOLS = [
+    "gitleaks",
+    "semgrep",
+    "trivy",
+    "knip",
+    "eslint",
+    "govulncheck",
+    "bandit",
+    "hadolint",
+    "actionlint",
+    "zizmor",
+    "pinact",
+    "squawk",
+    "sqlfluff",
+]
+
+# Per-tool version flags (most tools use --version; a few differ)
+_VERSION_FLAGS: dict = {
+    "gitleaks":    ["version"],
+    "knip":        ["--version"],
+    "eslint":      ["--version"],
+    "govulncheck": ["-version"],
+    "bandit":      ["--version"],
+    "hadolint":    ["--version"],
+    "actionlint":  ["-version"],
+    "zizmor":      ["--version"],
+    "pinact":      ["--version"],
+    "squawk":      ["--version"],
+    "sqlfluff":    ["--version"],
+    "semgrep":     ["--version"],
+    "trivy":       ["--version"],
+}
+
+_VALID_SEVERITIES = ["critical", "high", "medium", "low", "info"]
+
+# CODEOWNERS file locations in standard precedence order
+_CODEOWNERS_LOCATIONS = [
+    ".github/CODEOWNERS",
+    "CODEOWNERS",
+    "docs/CODEOWNERS",
+]
+
+
+# ---------------------------------------------------------------------------
+# Rubric loading (version only)
+# ---------------------------------------------------------------------------
+
+def _load_rubric_version(rubric_path: Path) -> str:
+    """
+    Read the 'version' field from severity-rubric.json.
+    Returns "unknown" if missing, unreadable, or field absent.
+    """
+    if not rubric_path.exists():
+        return "unknown"
+    try:
+        with open(rubric_path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (json.JSONDecodeError, OSError):
+        return "unknown"
+    if isinstance(data, dict):
+        v = data.get("version")
+        if isinstance(v, str) and v:
+            return v
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Skill version loading
+# ---------------------------------------------------------------------------
+
+def _load_skill_version() -> str:
+    """
+    Read version from the audit module's module.json (commands-extra/module.json).
+    The audit skill lives inside commands-extra/skills/audit/scripts/; module.json
+    is three levels up from scripts/.
+    Falls back to DEFAULT_SKILL_VERSION if not found or no version field.
+    """
+    script_dir = Path(__file__).parent
+    # scripts/../../../module.json -> commands-extra/module.json
+    candidate = (script_dir / ".." / ".." / ".." / "module.json").resolve()
+    if candidate.exists():
+        try:
+            with open(candidate, encoding="utf-8") as fh:
+                data = json.load(fh)
+            v = data.get("version")
+            if isinstance(v, str) and v:
+                return v
+        except (json.JSONDecodeError, OSError):
+            pass
+    return DEFAULT_SKILL_VERSION
+
+
+# ---------------------------------------------------------------------------
+# git commit
+# ---------------------------------------------------------------------------
+
+def _get_commit(repo_root: Path) -> str:
+    """
+    Return HEAD SHA of the repo using git plumbing only.
+    Returns "unknown" on failure.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            sha = result.stdout.decode("utf-8", errors="replace").strip()
+            if sha:
+                return sha
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Tool version probing
+# ---------------------------------------------------------------------------
+
+def _probe_tool_version(tool: str) -> "str | None":
+    """
+    Query a single tool for its version string.
+    Returns the first non-empty output line, or None on failure.
+    NO repo path is passed; only --version flags are used.
+    """
+    flags = _VERSION_FLAGS.get(tool, ["--version"])
+    try:
+        result = subprocess.run(
+            [tool] + flags,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=5,
+        )
+        output = result.stdout.decode("utf-8", errors="replace").strip()
+        for line in output.splitlines():
+            line = line.strip()
+            if line:
+                return line
+    except (OSError, FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _collect_tool_versions(skip: bool = False) -> dict:
+    """
+    Probe each spine tool for its version string.
+    Returns {tool: version_str} for tools present on PATH.
+    If skip is True, returns {}.
+    """
+    if skip:
+        return {}
+    versions: dict = {}
+    for tool in _SPINE_TOOLS:
+        v = _probe_tool_version(tool)
+        if v is not None:
+            versions[tool] = v
+    return versions
+
+
+# ---------------------------------------------------------------------------
+# CODEOWNERS parsing -- last-match-wins, gitignore-style globs
+# ---------------------------------------------------------------------------
+
+def _find_codeowners(repo_root: Path) -> "Path | None":
+    """Return the first CODEOWNERS file found in standard precedence order."""
+    for rel in _CODEOWNERS_LOCATIONS:
+        p = repo_root / rel
+        if p.exists():
+            return p
+    return None
+
+
+def _parse_codeowners(codeowners_path: Path) -> "list[tuple[str, list[str]]]":
+    """
+    Parse CODEOWNERS into [(pattern, [owner, ...]), ...] in file order.
+    Last-match-wins: caller should iterate in reverse when matching.
+    """
+    rules: list = []
+    try:
+        with open(codeowners_path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.rstrip("\n")
+                # Strip inline comments
+                if "#" in line:
+                    line = line[: line.index("#")]
+                line = line.strip()
+                if not line:
+                    continue
+                parts = line.split()
+                if not parts:
+                    continue
+                pattern = parts[0]
+                owners = parts[1:]
+                rules.append((pattern, owners))
+    except OSError:
+        pass
+    return rules
+
+
+def _fnmatch_with_doublestar(path: str, pattern: str) -> bool:
+    """
+    Minimal '**' aware matcher.  Splits pattern on '**' and builds a regex
+    where '**' segments match anything including '/'.
+    """
+    parts = pattern.split("**")
+    regex_parts = []
+    for p in parts:
+        # Escape the literal part, then un-escape our own wildcards
+        escaped = re.escape(p).replace(r"\*", "[^/]*").replace(r"\?", "[^/]")
+        regex_parts.append(escaped)
+    regex = ".*".join(regex_parts)
+    try:
+        return bool(re.fullmatch(regex, path))
+    except re.error:
+        return False
+
+
+def _codeowners_match(path: str, pattern: str) -> bool:
+    """
+    Determine whether a repo-relative file path matches a CODEOWNERS pattern.
+
+    Semantics (gitignore-style):
+    - Trailing '/' matches the directory and everything under it.
+    - Leading '/' anchors to the repo root.
+    - Pattern with '/' in the middle matches relative to the repo root.
+    - No '/' in the pattern (no leading, no middle): match against the basename.
+    - '**' matches across directory separators.
+    """
+    path = path.replace("\\", "/").lstrip("/")
+
+    if pattern.endswith("/"):
+        prefix = pattern.rstrip("/").lstrip("/")
+        return path.startswith(prefix + "/") or path == prefix
+
+    if pattern.startswith("/"):
+        anchored = pattern.lstrip("/")
+        if "**" in anchored:
+            return _fnmatch_with_doublestar(path, anchored)
+        return fnmatch.fnmatchcase(path, anchored)
+
+    if "/" in pattern:
+        stripped = pattern.lstrip("/")
+        if "**" in stripped:
+            return _fnmatch_with_doublestar(path, stripped)
+        return fnmatch.fnmatchcase(path, stripped)
+
+    # No slash: match basename anywhere in the tree
+    basename = path.rsplit("/", 1)[-1] if "/" in path else path
+    return fnmatch.fnmatchcase(basename, pattern)
+
+
+def _tag_owners(findings: list, rules: list) -> None:
+    """
+    Tag each finding dict in-place with properties.owner.
+    Last-match-wins: iterates rules in reverse order.
+    """
+    if not rules:
+        return
+    reversed_rules = list(reversed(rules))
+    for f in findings:
+        if "type" in f:
+            continue
+        path = (f.get("location") or {}).get("path", "")
+        if not path:
+            continue
+        for pattern, owners in reversed_rules:
+            if _codeowners_match(path, pattern):
+                if owners:
+                    props = dict(f.get("properties") or {})
+                    props["owner"] = owners if len(owners) > 1 else owners[0]
+                    f["properties"] = props
+                break
+
+
+# ---------------------------------------------------------------------------
+# Per-package detection and tagging
+# ---------------------------------------------------------------------------
+
+def _parse_pnpm_workspace(path: Path) -> list:
+    """
+    Simple YAML parser for pnpm-workspace.yaml's 'packages:' list.
+    Does NOT require PyYAML (STDLIB only).
+    """
+    patterns: list = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            in_packages = False
+            for line in fh:
+                stripped = line.strip()
+                if stripped.startswith("packages:"):
+                    in_packages = True
+                    continue
+                if in_packages:
+                    if stripped.startswith("- "):
+                        val = stripped[2:].strip().strip('"').strip("'")
+                        if val:
+                            patterns.append(val)
+                    elif stripped and not stripped.startswith("#"):
+                        in_packages = False
+    except OSError:
+        pass
+    return patterns
+
+
+def _expand_workspace_globs(repo_root: Path, patterns: list) -> list:
+    """
+    Expand workspace glob patterns into concrete repo-relative directory paths.
+    Handles patterns like "packages/*", "apps/fe-*", "packages/auth".
+    If a pattern contains a glob char (* or ?), always expand children; never
+    add the static prefix directory itself.
+    """
+    results: list = []
+    for pattern in patterns:
+        pattern = pattern.rstrip("/")
+        has_glob = "*" in pattern or "?" in pattern
+        if not pattern:
+            continue
+        if has_glob:
+            # Strip the trailing glob portion to find the parent directory
+            # e.g. "packages/*"  -> parent_path="packages", name_glob="*"
+            # e.g. "apps/fe-*"  -> parent_path="apps",     name_glob="fe-*"
+            slash_pos = pattern.rfind("/")
+            if slash_pos == -1:
+                parent_rel = ""
+                name_glob = pattern
+            else:
+                parent_rel = pattern[:slash_pos]
+                name_glob = pattern[slash_pos + 1:]
+            parent = repo_root / parent_rel if parent_rel else repo_root
+            if parent.is_dir():
+                for child in sorted(parent.iterdir()):
+                    if child.is_dir() and fnmatch.fnmatchcase(child.name, name_glob):
+                        results.append(str(child.relative_to(repo_root)))
+        else:
+            candidate = repo_root / pattern
+            if candidate.is_dir():
+                results.append(str(candidate.relative_to(repo_root)))
+    return results
+
+
+def _detect_packages(repo_root: Path) -> list:
+    """
+    Detect monorepo package roots from workspace config files.
+    Returns repo-relative directory path strings.
+    """
+    packages: list = []
+
+    pnpm_ws = repo_root / "pnpm-workspace.yaml"
+    if pnpm_ws.exists():
+        patterns = _parse_pnpm_workspace(pnpm_ws)
+        packages.extend(_expand_workspace_globs(repo_root, patterns))
+        if packages:
+            return packages
+
+    pkg_json = repo_root / "package.json"
+    if pkg_json.exists():
+        try:
+            with open(pkg_json, encoding="utf-8") as fh:
+                pkg = json.load(fh)
+            ws = pkg.get("workspaces", [])
+            if isinstance(ws, dict):
+                ws = ws.get("packages", [])
+            if isinstance(ws, list):
+                packages.extend(_expand_workspace_globs(repo_root, ws))
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return packages
+
+
+def _tag_packages(findings: list, package_roots: list) -> None:
+    """
+    Tag each finding in-place with properties.package.
+    Longest-prefix match wins (most-specific package).
+    """
+    if not package_roots:
+        return
+    sorted_roots = sorted(package_roots, key=len, reverse=True)
+    for f in findings:
+        if "type" in f:
+            continue
+        path = (f.get("location") or {}).get("path", "")
+        if not path:
+            continue
+        path_norm = path.replace("\\", "/").lstrip("/")
+        for root in sorted_roots:
+            root_norm = root.replace("\\", "/").rstrip("/")
+            if path_norm == root_norm or path_norm.startswith(root_norm + "/"):
+                props = dict(f.get("properties") or {})
+                props["package"] = root_norm
+                f["properties"] = props
+                break
+
+
+def _build_package_summaries(findings: list) -> list:
+    """Build per-package summary records from tagged findings."""
+    counts: dict = {}
+    for f in findings:
+        if "type" in f:
+            continue
+        pkg = (f.get("properties") or {}).get("package")
+        if not pkg:
+            continue
+        if pkg not in counts:
+            counts[pkg] = {s: 0 for s in _VALID_SEVERITIES}
+        sev = f.get("severity", "")
+        if sev in counts[pkg]:
+            counts[pkg][sev] += 1
+        else:
+            counts[pkg]["info"] += 1
+    summaries = []
+    for pkg, c in sorted(counts.items()):
+        summaries.append({
+            "type": "package_summary",
+            "package": pkg,
+            "counts": c,
+        })
+    return summaries
+
+
+# ---------------------------------------------------------------------------
+# JSONL loading
+# ---------------------------------------------------------------------------
+
+def _load_jsonl(path: str) -> "tuple[list, list]":
+    """
+    Load a JSONL file.  Returns (metadata_records, finding_records).
+    metadata_records have a 'type' field; finding_records do not.
+    Exits 1 with a clear error on IO or parse failure.
+    """
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw_lines = fh.readlines()
+    except OSError as exc:
+        print(f"provenance: ERROR: cannot read findings file '{path}': {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    metadata: list = []
+    findings: list = []
+    for lineno, raw in enumerate(raw_lines, 1):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            print(
+                f"provenance: ERROR: findings line {lineno} is not valid JSON: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not isinstance(obj, dict):
+            print(
+                f"provenance: ERROR: findings line {lineno} is not a JSON object",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if "type" in obj:
+            metadata.append(obj)
+        else:
+            findings.append(obj)
+    return metadata, findings
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Emit audit_provenance header, tag CODEOWNERS owners, "
+            "and add per-package scoping to audit findings."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--findings",
+        required=True,
+        metavar="PATH",
+        help="Input findings JSONL (merge-findings output).",
+    )
+    parser.add_argument(
+        "--repo",
+        required=True,
+        metavar="PATH",
+        help="Absolute path to the repository root.",
+    )
+    parser.add_argument(
+        "--rubric",
+        default=None,
+        metavar="PATH",
+        help="Path to severity-rubric.json (default: ../schemas/severity-rubric.json).",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        metavar="PATH",
+        help="Write output JSONL to this file (default: stdout).",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        metavar="STR",
+        help=(
+            "Model identifier for this audit run. "
+            "Also read from AUDIT_MODEL env var. Default: 'unknown'. "
+            "Fill from the coordinator at runtime."
+        ),
+    )
+    parser.add_argument(
+        "--optional-check",
+        action="append",
+        default=[],
+        metavar="ID",
+        dest="optional_checks",
+        help="Optional check that ran during this audit (may be repeated).",
+    )
+    parser.add_argument(
+        "--packages",
+        action="append",
+        default=[],
+        metavar="DIR",
+        help=(
+            "Explicit package root (repo-relative, may be repeated). "
+            "Disables auto-detection from workspace files."
+        ),
+    )
+    parser.add_argument(
+        "--skip-tool-versions",
+        action="store_true",
+        default=False,
+        help="Skip tool-version probing (useful in tests).",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo).resolve()
+    if not repo_root.is_dir():
+        print(
+            f"provenance: ERROR: --repo '{args.repo}' is not a directory",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Resolve rubric path
+    script_dir = Path(__file__).parent
+    if args.rubric:
+        rubric_path = Path(args.rubric).resolve()
+    else:
+        rubric_path = (script_dir / ".." / "schemas" / "severity-rubric.json").resolve()
+
+    # Load input findings
+    metadata_records, findings = _load_jsonl(args.findings)
+
+    # Build the audit_provenance header
+    model = args.model or os.environ.get("AUDIT_MODEL", "unknown")
+    rubric_version = _load_rubric_version(rubric_path)
+    skill_version = _load_skill_version()
+    commit = _get_commit(repo_root)
+    tool_versions = _collect_tool_versions(skip=args.skip_tool_versions)
+
+    header: dict = {
+        "type": "audit_provenance",
+        "commit": commit,
+        "rubric_version": rubric_version,
+        "skill_version": skill_version,
+        "tool_versions": tool_versions,
+        "model": model,
+        "optional_checks_ran": args.optional_checks,
+    }
+
+    # CODEOWNERS tagging
+    codeowners_path = _find_codeowners(repo_root)
+    if codeowners_path is not None:
+        rules = _parse_codeowners(codeowners_path)
+        _tag_owners(findings, rules)
+
+    # Per-package tagging
+    if args.packages:
+        package_roots = args.packages
+    else:
+        package_roots = _detect_packages(repo_root)
+
+    if package_roots:
+        _tag_packages(findings, package_roots)
+
+    package_summaries = _build_package_summaries(findings)
+
+    # Build output lines
+    output_lines: list = []
+    # 1. audit_provenance header first
+    output_lines.append(json.dumps(header, separators=(",", ":")))
+    # 2. Tagged findings
+    for f in findings:
+        output_lines.append(json.dumps(f, separators=(",", ":")))
+    # 3. Metadata passthrough (provenance, coverage_gap, etc.)
+    for rec in metadata_records:
+        output_lines.append(json.dumps(rec, separators=(",", ":")))
+    # 4. Per-package summaries
+    for rec in package_summaries:
+        output_lines.append(json.dumps(rec, separators=(",", ":")))
+
+    out_text = "\n".join(output_lines)
+    if output_lines:
+        out_text += "\n"
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            out_path.write_text(out_text, encoding="utf-8")
+        except OSError as exc:
+            print(f"provenance: ERROR: cannot write output: {exc}", file=sys.stderr)
+            return 1
+        print(
+            f"provenance: wrote header + {len(findings)} finding(s) + "
+            f"{len(package_summaries)} package-summary record(s) to {args.output}",
+            file=sys.stderr,
+        )
+    else:
+        sys.stdout.write(out_text)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/commands-extra/skills/audit/scripts/provenance.py
+++ b/modules/commands-extra/skills/audit/scripts/provenance.py
@@ -204,7 +204,7 @@ def _probe_tool_version(tool: str) -> "str | None":
             line = line.strip()
             if line:
                 return line
-    except (OSError, FileNotFoundError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired):
         pass
     return None
 
@@ -310,6 +310,10 @@ def _codeowners_match(path: str, pattern: str) -> bool:
         stripped = pattern.lstrip("/")
         if "**" in stripped:
             return _fnmatch_with_doublestar(path, stripped)
+        # No glob metacharacters and no trailing slash: treat as directory prefix
+        # (e.g. "apps/web" matches "apps/web/x.ts" and "apps/web" itself).
+        if "*" not in stripped and "?" not in stripped:
+            return path == stripped or path.startswith(stripped + "/")
         return fnmatch.fnmatchcase(path, stripped)
 
     # No slash: match basename anywhere in the tree

--- a/modules/commands-extra/skills/audit/tests/test-provenance.sh
+++ b/modules/commands-extra/skills/audit/tests/test-provenance.sh
@@ -412,6 +412,67 @@ PYEOF
   fi
 }
 
+
+# ---------------------------------------------------------------------------
+# Scenario D: live tool_versions — gitleaks key present when installed
+# ---------------------------------------------------------------------------
+
+run_scenario_d() {
+  if ! command -v gitleaks > /dev/null 2>&1; then
+    printf '  [SKIP] scenario-d: gitleaks not on PATH\n'
+    return
+  fi
+
+  local tmpdir
+  tmpdir="$(mktemp -d /tmp/ccgm-test-provenance-XXXXXX)"
+  trap "rm -rf '$tmpdir'" RETURN
+
+  git -C "$tmpdir" init -q
+  git -C "$tmpdir" -c core.hooksPath=/dev/null \
+      -c user.email="test@test.invalid" \
+      -c user.name="Test" \
+      commit --allow-empty -m "init" -q
+
+  local findings_file="$tmpdir/findings.jsonl"
+  make_finding "src/app.ts" > "$findings_file"
+
+  local out_file="$tmpdir/out.jsonl"
+
+  # Run WITHOUT --skip-tool-versions so tool_versions is populated
+  python3 "$PROV_SCRIPT" \
+    --findings "$findings_file" \
+    --repo "$tmpdir" \
+    --rubric "$RUBRIC_FILE" \
+    --output "$out_file"
+
+  local got_tv
+  got_tv="$(jsonl_header_field "$out_file" tool_versions)"
+
+  # tool_versions must not be empty object when gitleaks is installed
+  if [[ "$got_tv" == "{}" ]]; then
+    fail "scenario-d: tool_versions={} but gitleaks is installed; expected gitleaks key"
+    return
+  fi
+
+  # gitleaks key must be present
+  local has_gitleaks
+  has_gitleaks="$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); print('yes' if 'gitleaks' in d else 'no')" "$got_tv")"
+  if [[ "$has_gitleaks" != "yes" ]]; then
+    fail "scenario-d: tool_versions missing gitleaks key; got: $got_tv"
+    return
+  fi
+
+  # gitleaks version string must be non-empty
+  local gitleaks_ver
+  gitleaks_ver="$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); print(d.get('gitleaks',''))" "$got_tv")"
+  if [[ -z "$gitleaks_ver" ]]; then
+    fail "scenario-d: gitleaks version string is empty"
+    return
+  fi
+
+  pass "scenario-d: tool_versions contains gitleaks='$gitleaks_ver' (live probe)"
+}
+
 # ---------------------------------------------------------------------------
 # Run all scenarios
 # ---------------------------------------------------------------------------
@@ -426,6 +487,9 @@ run_scenario_b
 
 printf '\nScenario C: per-package scoping + package_summary records\n'
 run_scenario_c
+
+printf '\nScenario D: live tool_versions — gitleaks key\n'
+run_scenario_d
 
 # ---------------------------------------------------------------------------
 # Report

--- a/modules/commands-extra/skills/audit/tests/test-provenance.sh
+++ b/modules/commands-extra/skills/audit/tests/test-provenance.sh
@@ -1,0 +1,443 @@
+#!/usr/bin/env bash
+# CCGM audit -- test-provenance.sh
+# Tests for Epic 3.4: provenance.py (audit_provenance header + CODEOWNERS tagging +
+# per-package scoping).
+#
+# Usage: bash modules/commands-extra/skills/audit/tests/test-provenance.sh
+# Exit:  0 = all tests passed, non-zero = at least one failure
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROV_SCRIPT="$SCRIPT_DIR/../scripts/provenance.py"
+RUBRIC_FILE="$SCRIPT_DIR/../schemas/severity-rubric.json"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+  printf '  [PASS] %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  ERRORS+=("$1")
+  FAIL=$((FAIL + 1))
+}
+
+# Extract value for a top-level key from the first line of a JSONL file.
+# Usage: jsonl_header_field <file> <key>
+jsonl_header_field() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    line = fh.readline().strip()
+obj = json.loads(line)
+val = obj.get(sys.argv[2], "")
+if isinstance(val, dict):
+    print(json.dumps(val))
+elif isinstance(val, list):
+    print(json.dumps(val))
+else:
+    print(val)
+PYEOF
+}
+
+# Return the value of properties.owner for the first non-type-record whose
+# location.path matches the given path.
+# Usage: finding_owner <file> <path>
+finding_owner() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        if "type" in obj:
+            continue
+        loc = obj.get("location", {})
+        if loc.get("path") == sys.argv[2]:
+            owner = (obj.get("properties") or {}).get("owner", "")
+            if isinstance(owner, list):
+                print(",".join(owner))
+            else:
+                print(owner)
+            sys.exit(0)
+print("")
+PYEOF
+}
+
+# Return the value of properties.package for the first non-type-record whose
+# location.path matches the given path.
+# Usage: finding_package <file> <path>
+finding_package() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        if "type" in obj:
+            continue
+        loc = obj.get("location", {})
+        if loc.get("path") == sys.argv[2]:
+            pkg = (obj.get("properties") or {}).get("package", "")
+            print(pkg)
+            sys.exit(0)
+print("")
+PYEOF
+}
+
+# Count records of a given type in a JSONL file.
+# Usage: count_type <file> <type>
+count_type() {
+  python3 - "$1" "$2" << 'PYEOF'
+import json, sys
+count = 0
+with open(sys.argv[1]) as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        if obj.get("type") == sys.argv[2]:
+            count += 1
+print(count)
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Minimal finding fixture (no external tool deps)
+# ---------------------------------------------------------------------------
+
+make_finding() {
+  local path="$1"
+  python3 - "$path" << 'PYEOF'
+import json, sys
+print(json.dumps({
+    "check_id": "security/hardcoded-secret",
+    "rule_id": "gitleaks/generic-api-key",
+    "severity": "high",
+    "confidence": "high",
+    "location": {"path": sys.argv[1], "line": 10},
+    "message": "Hardcoded secret detected",
+    "fingerprint": "aaaaaaaaaaaaaaaa",
+    "detection": "tool",
+    "source": "tool",
+    "properties": {}
+}))
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Scenario A: audit_provenance header fields populated
+# ---------------------------------------------------------------------------
+
+run_scenario_a() {
+  local tmpdir
+  tmpdir="$(mktemp -d /tmp/ccgm-test-provenance-XXXXXX)"
+  trap "rm -rf '$tmpdir'" RETURN
+
+  # Create a minimal git repo so git rev-parse HEAD returns a real SHA
+  git -C "$tmpdir" init -q
+  git -C "$tmpdir" -c core.hooksPath=/dev/null \
+      -c user.email="test@test.invalid" \
+      -c user.name="Test" \
+      commit --allow-empty -m "init" -q
+
+  local expected_sha
+  expected_sha="$(git -C "$tmpdir" rev-parse HEAD)"
+
+  # Build a minimal findings.jsonl
+  local findings_file="$tmpdir/findings.jsonl"
+  make_finding "src/app.ts" > "$findings_file"
+
+  local out_file="$tmpdir/out.jsonl"
+
+  python3 "$PROV_SCRIPT" \
+    --findings "$findings_file" \
+    --repo "$tmpdir" \
+    --rubric "$RUBRIC_FILE" \
+    --model "test-model-x" \
+    --optional-check "security/extra-check" \
+    --skip-tool-versions \
+    --output "$out_file"
+
+  # Verify header is first line and type is correct
+  local record_type
+  record_type="$(jsonl_header_field "$out_file" type)"
+  if [[ "$record_type" == "audit_provenance" ]]; then
+    pass "scenario-a: header type=audit_provenance"
+  else
+    fail "scenario-a: expected type=audit_provenance, got '$record_type'"
+  fi
+
+  # commit matches real SHA
+  local got_commit
+  got_commit="$(jsonl_header_field "$out_file" commit)"
+  if [[ "$got_commit" == "$expected_sha" ]]; then
+    pass "scenario-a: commit matches git HEAD SHA"
+  else
+    fail "scenario-a: expected commit='$expected_sha', got '$got_commit'"
+  fi
+
+  # rubric_version comes from rubric file
+  local expected_rubric_ver
+  expected_rubric_ver="$(python3 -c "import json; d=json.load(open('$RUBRIC_FILE')); print(d.get('version','unknown'))")"
+  local got_rubric_ver
+  got_rubric_ver="$(jsonl_header_field "$out_file" rubric_version)"
+  if [[ "$got_rubric_ver" == "$expected_rubric_ver" ]]; then
+    pass "scenario-a: rubric_version='$got_rubric_ver'"
+  else
+    fail "scenario-a: expected rubric_version='$expected_rubric_ver', got '$got_rubric_ver'"
+  fi
+
+  # model matches --model arg
+  local got_model
+  got_model="$(jsonl_header_field "$out_file" model)"
+  if [[ "$got_model" == "test-model-x" ]]; then
+    pass "scenario-a: model='test-model-x'"
+  else
+    fail "scenario-a: expected model='test-model-x', got '$got_model'"
+  fi
+
+  # optional_checks_ran contains the passed check id
+  local got_opts
+  got_opts="$(jsonl_header_field "$out_file" optional_checks_ran)"
+  if echo "$got_opts" | grep -q "security/extra-check"; then
+    pass "scenario-a: optional_checks_ran contains passed id"
+  else
+    fail "scenario-a: optional_checks_ran='$got_opts' missing 'security/extra-check'"
+  fi
+
+  # tool_versions is {} when --skip-tool-versions
+  local got_tv
+  got_tv="$(jsonl_header_field "$out_file" tool_versions)"
+  if [[ "$got_tv" == "{}" ]]; then
+    pass "scenario-a: tool_versions={} with --skip-tool-versions"
+  else
+    fail "scenario-a: expected tool_versions={}, got '$got_tv'"
+  fi
+
+  # skill_version is a non-empty string
+  local got_sv
+  got_sv="$(jsonl_header_field "$out_file" skill_version)"
+  if [[ -n "$got_sv" ]]; then
+    pass "scenario-a: skill_version='$got_sv' is non-empty"
+  else
+    fail "scenario-a: skill_version is empty"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Scenario B: CODEOWNERS owner tagging — last-match-wins
+# ---------------------------------------------------------------------------
+
+run_scenario_b() {
+  local tmpdir
+  tmpdir="$(mktemp -d /tmp/ccgm-test-provenance-XXXXXX)"
+  trap "rm -rf '$tmpdir'" RETURN
+
+  # Create a git repo
+  git -C "$tmpdir" init -q
+  git -C "$tmpdir" -c core.hooksPath=/dev/null \
+      -c user.email="test@test.invalid" \
+      -c user.name="Test" \
+      commit --allow-empty -m "init" -q
+
+  # Write CODEOWNERS
+  mkdir -p "$tmpdir/.github"
+  cat > "$tmpdir/.github/CODEOWNERS" << 'EOF'
+# Global owner
+* @default-owner
+
+# Backend overrides global for src/
+src/ @backend-team
+
+# The auth subdirectory has a more specific owner — should win over src/
+src/auth/ @auth-team
+EOF
+
+  # Two findings: one in src/auth/ and one in src/api/
+  {
+    make_finding "src/auth/session.ts"
+    make_finding "src/api/routes.ts"
+    make_finding "docs/README.md"
+  } > "$tmpdir/findings.jsonl"
+
+  local out_file="$tmpdir/out.jsonl"
+
+  python3 "$PROV_SCRIPT" \
+    --findings "$tmpdir/findings.jsonl" \
+    --repo "$tmpdir" \
+    --rubric "$RUBRIC_FILE" \
+    --skip-tool-versions \
+    --output "$out_file"
+
+  # src/auth/session.ts -> last-match-wins: src/auth/ rule -> @auth-team
+  local auth_owner
+  auth_owner="$(finding_owner "$out_file" "src/auth/session.ts")"
+  if [[ "$auth_owner" == "@auth-team" ]]; then
+    pass "scenario-b: src/auth/ finding tagged @auth-team (last-match-wins)"
+  else
+    fail "scenario-b: expected @auth-team for src/auth/, got '$auth_owner'"
+  fi
+
+  # src/api/routes.ts -> matches src/ rule -> @backend-team
+  local api_owner
+  api_owner="$(finding_owner "$out_file" "src/api/routes.ts")"
+  if [[ "$api_owner" == "@backend-team" ]]; then
+    pass "scenario-b: src/api/ finding tagged @backend-team"
+  else
+    fail "scenario-b: expected @backend-team for src/api/, got '$api_owner'"
+  fi
+
+  # docs/README.md -> matches only * -> @default-owner
+  local docs_owner
+  docs_owner="$(finding_owner "$out_file" "docs/README.md")"
+  if [[ "$docs_owner" == "@default-owner" ]]; then
+    pass "scenario-b: docs/ finding tagged @default-owner (catch-all)"
+  else
+    fail "scenario-b: expected @default-owner for docs/, got '$docs_owner'"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Scenario C: per-package monorepo scoping + package_summary records
+# ---------------------------------------------------------------------------
+
+run_scenario_c() {
+  local tmpdir
+  tmpdir="$(mktemp -d /tmp/ccgm-test-provenance-XXXXXX)"
+  trap "rm -rf '$tmpdir'" RETURN
+
+  # Create a git repo
+  git -C "$tmpdir" init -q
+  git -C "$tmpdir" -c core.hooksPath=/dev/null \
+      -c user.email="test@test.invalid" \
+      -c user.name="Test" \
+      commit --allow-empty -m "init" -q
+
+  # Create two package directories
+  mkdir -p "$tmpdir/packages/auth" "$tmpdir/packages/api"
+
+  # Write pnpm-workspace.yaml
+  cat > "$tmpdir/pnpm-workspace.yaml" << 'EOF'
+packages:
+  - "packages/*"
+EOF
+
+  # Findings in each package and one outside
+  {
+    make_finding "packages/auth/src/login.ts"
+    make_finding "packages/auth/src/token.ts"
+    make_finding "packages/api/routes/users.ts"
+    make_finding "scripts/deploy.sh"
+  } > "$tmpdir/findings.jsonl"
+
+  local out_file="$tmpdir/out.jsonl"
+
+  python3 "$PROV_SCRIPT" \
+    --findings "$tmpdir/findings.jsonl" \
+    --repo "$tmpdir" \
+    --rubric "$RUBRIC_FILE" \
+    --skip-tool-versions \
+    --output "$out_file"
+
+  # Check properties.package for auth finding
+  local auth_pkg
+  auth_pkg="$(finding_package "$out_file" "packages/auth/src/login.ts")"
+  if [[ "$auth_pkg" == "packages/auth" ]]; then
+    pass "scenario-c: packages/auth finding tagged packages/auth"
+  else
+    fail "scenario-c: expected packages/auth, got '$auth_pkg'"
+  fi
+
+  # Check properties.package for api finding
+  local api_pkg
+  api_pkg="$(finding_package "$out_file" "packages/api/routes/users.ts")"
+  if [[ "$api_pkg" == "packages/api" ]]; then
+    pass "scenario-c: packages/api finding tagged packages/api"
+  else
+    fail "scenario-c: expected packages/api, got '$api_pkg'"
+  fi
+
+  # scripts/deploy.sh is not in any package root — should have no package property
+  local no_pkg
+  no_pkg="$(finding_package "$out_file" "scripts/deploy.sh")"
+  if [[ -z "$no_pkg" ]]; then
+    pass "scenario-c: scripts/ finding has no package tag"
+  else
+    fail "scenario-c: scripts/ finding should have no package, got '$no_pkg'"
+  fi
+
+  # Count package_summary records: expect 2 (one per detected package with findings)
+  local summary_count
+  summary_count="$(count_type "$out_file" package_summary)"
+  if [[ "$summary_count" -ge 2 ]]; then
+    pass "scenario-c: $summary_count package_summary record(s) emitted"
+  else
+    fail "scenario-c: expected >=2 package_summary records, got $summary_count"
+  fi
+
+  # Verify counts for packages/auth: 2 high findings
+  local auth_counts
+  auth_counts="$(python3 - "$out_file" << 'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        if obj.get("type") == "package_summary" and obj.get("package") == "packages/auth":
+            print(obj["counts"].get("high", 0))
+            break
+PYEOF
+)"
+  if [[ "$auth_counts" -eq 2 ]]; then
+    pass "scenario-c: packages/auth summary shows 2 high findings"
+  else
+    fail "scenario-c: expected packages/auth high=2, got '$auth_counts'"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Run all scenarios
+# ---------------------------------------------------------------------------
+
+printf '\n=== test-provenance.sh ===\n'
+
+printf '\nScenario A: audit_provenance header fields\n'
+run_scenario_a
+
+printf '\nScenario B: CODEOWNERS last-match-wins owner tagging\n'
+run_scenario_b
+
+printf '\nScenario C: per-package scoping + package_summary records\n'
+run_scenario_c
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+printf '\n--- Summary ---\n'
+printf 'PASS: %d  FAIL: %d\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  printf 'FAILURES:\n'
+  for e in "${ERRORS[@]}"; do
+    printf '  - %s\n' "$e"
+  done
+  exit 1
+fi
+exit 0

--- a/modules/commands-extra/skills/audit/tests/test-provenance.sh
+++ b/modules/commands-extra/skills/audit/tests/test-provenance.sh
@@ -229,13 +229,16 @@ run_scenario_a() {
     fail "scenario-a: expected tool_versions={}, got '$got_tv'"
   fi
 
-  # skill_version is a non-empty string
+  # skill_version matches the version field in module.json
+  local module_json="$SCRIPT_DIR/../../../module.json"
+  local expected_sv
+  expected_sv="$(python3 -c "import json; d=json.load(open('$module_json')); print(d.get('version',''))")"
   local got_sv
   got_sv="$(jsonl_header_field "$out_file" skill_version)"
-  if [[ -n "$got_sv" ]]; then
-    pass "scenario-a: skill_version='$got_sv' is non-empty"
+  if [[ -n "$expected_sv" && "$got_sv" == "$expected_sv" ]]; then
+    pass "scenario-a: skill_version='$got_sv' matches module.json version"
   else
-    fail "scenario-a: skill_version is empty"
+    fail "scenario-a: expected skill_version='$expected_sv', got '$got_sv'"
   fi
 }
 
@@ -474,6 +477,71 @@ run_scenario_d() {
 }
 
 # ---------------------------------------------------------------------------
+# Scenario E: CODEOWNERS directory-prefix matching without trailing slash
+# ---------------------------------------------------------------------------
+
+run_scenario_e() {
+  local tmpdir
+  tmpdir="$(mktemp -d /tmp/ccgm-test-provenance-XXXXXX)"
+  trap "rm -rf '$tmpdir'" RETURN
+
+  git -C "$tmpdir" init -q
+  git -C "$tmpdir" -c core.hooksPath=/dev/null \
+      -c user.email="test@test.invalid" \
+      -c user.name="Test" \
+      commit --allow-empty -m "init" -q
+
+  # "apps/web" without trailing slash — GitHub treats this as a directory prefix
+  mkdir -p "$tmpdir/.github"
+  cat > "$tmpdir/.github/CODEOWNERS" << 'EOF'
+* @default-owner
+apps/web @web-team
+EOF
+
+  {
+    make_finding "apps/web/x.ts"
+    make_finding "apps/web/nested/y.ts"
+    make_finding "apps/other/z.ts"
+  } > "$tmpdir/findings.jsonl"
+
+  local out_file="$tmpdir/out.jsonl"
+
+  python3 "$PROV_SCRIPT" \
+    --findings "$tmpdir/findings.jsonl" \
+    --repo "$tmpdir" \
+    --rubric "$RUBRIC_FILE" \
+    --skip-tool-versions \
+    --output "$out_file"
+
+  # apps/web/x.ts must be tagged @web-team (direct child)
+  local owner_direct
+  owner_direct="$(finding_owner "$out_file" "apps/web/x.ts")"
+  if [[ "$owner_direct" == "@web-team" ]]; then
+    pass "scenario-e: apps/web/x.ts tagged @web-team (no-trailing-slash dir pattern)"
+  else
+    fail "scenario-e: expected @web-team for apps/web/x.ts, got '$owner_direct'"
+  fi
+
+  # apps/web/nested/y.ts must also be tagged @web-team (deeper child)
+  local owner_nested
+  owner_nested="$(finding_owner "$out_file" "apps/web/nested/y.ts")"
+  if [[ "$owner_nested" == "@web-team" ]]; then
+    pass "scenario-e: apps/web/nested/y.ts tagged @web-team (nested child)"
+  else
+    fail "scenario-e: expected @web-team for apps/web/nested/y.ts, got '$owner_nested'"
+  fi
+
+  # apps/other/z.ts must fall through to @default-owner (not prefixed by apps/web)
+  local owner_other
+  owner_other="$(finding_owner "$out_file" "apps/other/z.ts")"
+  if [[ "$owner_other" == "@default-owner" ]]; then
+    pass "scenario-e: apps/other/z.ts tagged @default-owner (not under apps/web)"
+  else
+    fail "scenario-e: expected @default-owner for apps/other/z.ts, got '$owner_other'"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Run all scenarios
 # ---------------------------------------------------------------------------
 
@@ -490,6 +558,9 @@ run_scenario_c
 
 printf '\nScenario D: live tool_versions — gitleaks key\n'
 run_scenario_d
+
+printf '\nScenario E: CODEOWNERS directory-prefix matching (no trailing slash)\n'
+run_scenario_e
 
 # ---------------------------------------------------------------------------
 # Report


### PR DESCRIPTION
## Summary

- **`scripts/provenance.py`** — stdlib-only; emits `audit_provenance` header record (commit, rubric_version, skill_version, tool_versions, model, optional_checks_ran), tags each finding with `properties.owner` via CODEOWNERS last-match-wins semantics, tags findings with `properties.package` for monorepo scoping, and emits per-package `package_summary` records
- **`schemas/severity-rubric.json`** — adds `"version": "1.0.0"` top-level key for ADV-007 rubric traceability (single additive change; lint-rubric.py tolerates extra top-level keys)
- **`SKILL.md`** — inserts `### Provenance & Routing` subsection immediately after `### Baseline / Delta`; all other content byte-identical
- **`module.json`** — registers `provenance.py` as a `script` entry
- **`tests/test-provenance.sh`** — three scenarios (header fields, CODEOWNERS tagging, per-package rollup); 15 assertions all passing

## Test plan

- [x] `bash modules/commands-extra/skills/audit/tests/test-provenance.sh` — 15/15 PASS (run ×2)
- [x] `bash modules/commands-extra/skills/audit/tests/test-rubric.sh` — 8/8 PASS
- [x] `bash modules/commands-extra/skills/audit/tests/test-baseline.sh` — 38/38 PASS
- [x] `bash modules/commands-extra/skills/audit/tests/test-merge.sh` — 41/41 PASS
- [x] `bash modules/commands-extra/skills/audit/tests/test-command-skill-parity.sh` — 30/30 PASS
- [x] `bash modules/commands-extra/skills/audit/tests/test-reference-wiring.sh` — 41/41 PASS
- [x] `python3 scripts/lint-pack.py` — 15 packs, 0 errors
- [x] `python3 scripts/lint-rubric.py` — 99 entries valid, 84 check-ids verified
- [x] JSON validation — module.json and severity-rubric.json both valid
- [x] `bash tests/test-modules.sh` — 1311/1311 PASS
- [x] `bash tests/test-no-personal-data.sh` — PASS

Closes #625