### PR TITLE
#631: Epic 4.4 — api-contract audit pack

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -458,6 +458,16 @@
       "target": "skills/audit/packs/data-migrations/checks.md",
       "type": "doc",
       "template": false
+    },
+    "skills/audit/packs/api-contract/pack.json": {
+      "target": "skills/audit/packs/api-contract/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/api-contract/checks.md": {
+      "target": "skills/audit/packs/api-contract/checks.md",
+      "type": "doc",
+      "template": false
     }
   },
   "tags": [

--- a/modules/commands-extra/skills/audit/packs/api-contract/checks.md
+++ b/modules/commands-extra/skills/audit/packs/api-contract/checks.md
@@ -1,0 +1,428 @@
+# API & Contract Audit Pack
+
+## Scope
+
+This pack audits JavaScript and TypeScript HTTP route handlers and API endpoints for
+contract-level defects: missing input validation, mass-assignment vulnerabilities,
+unbounded list endpoints, and absent API versioning. It targets the surface area where
+untrusted caller data enters a backend handler and where the API contract lacks
+structural controls. Checks are LLM-based (no spine tool) because the defects require
+understanding handler intent, not just syntactic patterns. This pack does NOT cover SQL
+injection or XSS (owned by `ccgm/security`), authentication bypass (also
+`ccgm/security`), or dependency vulnerabilities (`ccgm/dependencies`).
+
+**Pack ID:** `ccgm/api-contract`
+**Applies when:** `["language:javascript"]`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `language:javascript` | All four checks target JavaScript/TypeScript route handlers using Node.js frameworks (Express, Fastify, Next.js API routes, SvelteKit endpoints, Koa). They produce zero signal in Go, Python, or Ruby codebases that use different routing conventions. Restricting to `language:javascript` avoids false-positive noise and keeps the pack focused on the ecosystem where these patterns are idiomatic. TypeScript repos are detected as `javascript` by the ecosystem detector (`.ts` files trigger the JS ecosystem flag). |
+
+---
+
+## Checks
+
+---
+
+### `api/missing-input-validation`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan all route handler files (Express/Fastify/Koa/Next.js API routes/SvelteKit endpoints)
+for handlers that read from req.body, req.query, req.params, event.body, context.params,
+request.json(), or equivalent framework-specific input accessors AND then use the value
+directly in business logic, a database query, an ORM call, a file-system operation, or
+an HTTP response — WITHOUT first passing the value through a schema validation library.
+
+Schema validation libraries to recognize as satisfying the check (NOT a finding):
+  - zod (z.parse, z.safeParse, z.object().parse, schema.parseAsync)
+  - joi (schema.validate, joi.object().validate)
+  - yup (schema.validate, schema.validateSync, schema.cast)
+  - class-validator (validate(), validateOrReject(), @IsString(), @IsEmail(), etc.)
+  - superstruct (assert(), is(), create())
+  - valibot (parse(), safeParse())
+  - express-validator (validationResult(), body(), param(), query())
+  - ajv (ajv.validate(), ajv.compile())
+  - Any other library that clearly performs schema or type validation on the input
+
+Do NOT flag:
+  - Handlers that call any of the above validators before using the input.
+  - Handlers that only read a typed path parameter that is narrowed by a router (e.g.
+    Next.js dynamic route [id] used as a string UUID that is then passed directly to
+    a parameterized query — the router guarantees string type, but business-logic
+    validation is still missing; flag it unless a UUID format check is present).
+  - Middleware that validates at a higher level (e.g. a global validateBody middleware
+    applied to all routes in the same file) — only skip if the middleware is clearly
+    present in the same handler chain.
+  - Test files (*.test.ts, *.spec.ts, __tests__/, test/).
+  - Pure pass-through proxies that forward the body unchanged to a downstream trusted service.
+
+For each finding: file path, handler name or route path, the specific input field
+accessed without validation, and the first use of that field that triggers the issue.
+auto_fixable=false — fix requires choosing and applying a schema validation library.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: api/missing-input-validation
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A route handler that trusts unvalidated input is the direct
+precursor to injection attacks, type-coercion bugs, and business-logic abuse. An
+attacker can send a crafted payload (extra fields, wrong types, oversized strings) that
+the handler passes straight to a database or downstream service. HIGH because the
+missing control is a fundamental API contract obligation, not a defence-in-depth layer.
+
+**Confidence rationale:** Determining whether validation is present requires reading the
+full handler and its middleware chain; the LLM may miss a validator applied in an outer
+middleware file or through a decorator. MEDIUM to account for these false-positive and
+false-negative risks.
+
+**Rubric entry:** `api/missing-input-validation`
+
+#### Fixture
+
+**True positive** (`src/routes/users.ts`):
+
+```typescript
+// FINDS: req.body.email used directly without schema validation
+import express from "express";
+const router = express.Router();
+
+router.post("/users", async (req, res) => {
+  const { email, role } = req.body;
+  const user = await db.user.create({ data: { email, role } });
+  res.json(user);
+});
+```
+
+**True negative** (should produce NO finding):
+
+```typescript
+// OK: zod validates the body before any use
+import express from "express";
+import { z } from "zod";
+const router = express.Router();
+
+const CreateUserBody = z.object({
+  email: z.string().email(),
+  role: z.enum(["user", "admin"]),
+});
+
+router.post("/users", async (req, res) => {
+  const { email, role } = CreateUserBody.parse(req.body);
+  const user = await db.user.create({ data: { email, role } });
+  res.json(user);
+});
+```
+
+---
+
+### `api/mass-assignment`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan all route handler files for mass-assignment vulnerabilities: places where the entire
+request body (or a spread of it) is passed directly into an ORM or database create/update
+call without an explicit allow-list of safe fields.
+
+Patterns that constitute a finding:
+  - Prisma: prisma.model.create({ data: req.body }) or
+            prisma.model.create({ data: { ...req.body } })
+  - Prisma: prisma.model.update({ where: ..., data: req.body })
+  - Mongoose/Sequelize: Model.create(req.body), instance.update(req.body)
+  - TypeORM: repository.save(req.body), repository.update(id, req.body)
+  - Drizzle: db.insert(table).values(req.body)
+  - knex: db('table').insert(req.body), db('table').where(...).update(req.body)
+  - Any ORM where the entire untrusted body or a spread of it reaches a write operation
+
+The risk: an attacker can include extra fields (e.g. `isAdmin: true`, `role: "admin"`,
+`credits: 99999`) that the ORM writes to protected columns.
+
+Do NOT flag:
+  - Code that destructures only specific fields from req.body before the ORM call,
+    e.g. const { name, email } = req.body; Model.create({ name, email }) — only the
+    named fields are used, not the full spread.
+  - Code that passes req.body through a schema validator (zod, joi, yup, class-validator)
+    that strips unknown fields via .strip(), .unknown(false), or equivalent, then passes
+    the validated (and sanitised) output to the ORM.
+  - Read-only operations (SELECT/find/findMany) — mass-assignment only affects writes.
+  - Test files (*.test.ts, *.spec.ts, __tests__/, test/).
+
+For each finding: file path, handler name or route path, the ORM call with the
+mass-assignment, and the specific req.body reference.
+auto_fixable=false — fix requires explicit field allow-listing or a validating schema.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: api/mass-assignment
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Mass assignment lets an unauthenticated or under-privileged
+caller promote their own role, override protected fields, or corrupt data. This maps
+directly to OWASP API Security Top 10 — API6:2023 (Unrestricted Access to Sensitive
+Business Flows) and was the root cause of the GitHub Rails mass-assignment exploit
+(2012) and numerous similar incidents. HIGH because the impact is privilege escalation
+or data corruption with low attacker effort.
+
+**Confidence rationale:** The LLM must distinguish between a safe destructured-field
+pattern and a genuine spread of the full body. This is usually clear from source but
+requires understanding the shape of the input and the ORM call context. MEDIUM to
+account for cases where the spread is indirect (via a helper function) or the
+validation/stripping is in a non-obvious location.
+
+**Rubric entry:** `api/mass-assignment`
+
+#### Fixture
+
+**True positive** (`src/api/profile.ts`):
+
+```typescript
+// FINDS: entire req.body spread into Prisma update — attacker can include `isAdmin: true`
+router.put("/profile/:id", async (req, res) => {
+  const updated = await prisma.user.update({
+    where: { id: req.params.id },
+    data: { ...req.body },
+  });
+  res.json(updated);
+});
+```
+
+**True negative** (should produce NO finding):
+
+```typescript
+// OK: only specific allow-listed fields forwarded to ORM
+router.put("/profile/:id", async (req, res) => {
+  const { name, bio } = req.body;
+  const updated = await prisma.user.update({
+    where: { id: req.params.id },
+    data: { name, bio },
+  });
+  res.json(updated);
+});
+```
+
+---
+
+### `api/unbounded-list`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan all route handler files for list or collection endpoints that return a potentially
+unbounded result set — no pagination, no LIMIT/take/top, and no maximum enforced either
+in the query or via a validated query parameter.
+
+Patterns that constitute a finding:
+  - Prisma: prisma.model.findMany() with no `take` argument (or with a `take` derived
+    from an unvalidated req.query parameter with no maximum cap).
+  - Mongoose: Model.find() with no .limit() call.
+  - Sequelize: Model.findAll() with no `limit` option.
+  - TypeORM: repository.find() with no `take` option.
+  - knex: db('table').select() with no .limit() call.
+  - Any ORM/query where a GET /collection endpoint returns rows without a finite cap.
+
+Do NOT flag:
+  - Endpoints that enforce a hardcoded LIMIT / take / top (e.g. take: 100).
+  - Endpoints that read a `limit` or `pageSize` query parameter AND cap it with a
+    Math.min(limit, MAX_PAGE_SIZE) or equivalent guard.
+  - Internal admin-only endpoints clearly not exposed to public callers (look for auth
+    middleware that restricts to admin role).
+  - findFirst / findOne / findUnique / findById calls — these return at most one row.
+  - Test files (*.test.ts, *.spec.ts, __tests__/, test/).
+
+For each finding: file path, handler name or route path, the ORM call with no limit,
+and whether the handler accepts any pagination query parameters (for context).
+auto_fixable=false — fix requires adding pagination logic and a maximum page size.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: api/unbounded-list
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** An unbounded list endpoint is a DoS vector: an attacker (or
+runaway client) can repeatedly call it to force the database to scan the full table,
+saturate the event loop, exhaust connection-pool slots, and degrade the service for all
+users. It also leaks potentially large volumes of data in a single response. MEDIUM
+rather than HIGH because it requires repeated calls or a large dataset for meaningful
+impact, and many staging/dev environments are low-traffic enough that the issue is
+latent.
+
+**Confidence rationale:** Determining whether a cap is present requires reading the
+full query options and any upstream middleware that might inject a LIMIT. The LLM may
+miss an indirect cap applied via a utility function. MEDIUM to reflect this context
+sensitivity.
+
+**Rubric entry:** `api/unbounded-list`
+
+#### Fixture
+
+**True positive** (`src/routes/posts.ts`):
+
+```typescript
+// FINDS: findMany with no take — returns all rows on every request
+router.get("/posts", async (req, res) => {
+  const posts = await prisma.post.findMany({
+    where: { published: true },
+    orderBy: { createdAt: "desc" },
+  });
+  res.json(posts);
+});
+```
+
+**True negative** (should produce NO finding):
+
+```typescript
+// OK: take is capped at 100 regardless of caller input
+router.get("/posts", async (req, res) => {
+  const limit = Math.min(Number(req.query.limit) || 20, 100);
+  const posts = await prisma.post.findMany({
+    where: { published: true },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+  res.json(posts);
+});
+```
+
+---
+
+### `api/missing-versioning`
+
+**Severity:** `low`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan route definitions for HTTP API endpoints that lack a version indicator. An API is
+considered versioned when EITHER:
+  (a) the route path includes a version segment, e.g. /v1/, /v2/, /api/v1/,
+      /api/2024-01-01/, etc., OR
+  (b) the handler reads an API-Version header (or Accept-Version, or a custom
+      version header) and branches on it.
+
+This check is informational/low severity. Flag only definite absences:
+  - Route files where all public API routes share a common prefix that has no version
+    segment (e.g. all routes under /api/users, /api/posts — no /v1/ segment anywhere
+    in the router or parent router mount point).
+  - Express Router mounted without a version segment:
+    app.use('/api', router) where the router itself has no versioned sub-routes.
+
+Do NOT flag:
+  - Routes where at least one parent mount or path segment contains a version
+    (e.g. app.use('/api/v1', router) — even if individual router paths omit /v1/).
+  - GraphQL endpoints — versioning through URL paths is not idiomatic for GraphQL.
+  - WebSocket upgrade endpoints.
+  - Internal service-to-service routes that are not part of the public API contract.
+  - Webhook receiver endpoints (e.g. /webhooks/stripe) — these are dictated by
+    the caller's URL, not the API's own versioning policy.
+  - Test files (*.test.ts, *.spec.ts, __tests__/, test/).
+  - Routes that clearly handle versioning via the Accept header (Content Negotiation).
+
+For each finding: file path, the route or router mount that lacks a version indicator,
+and a brief note on the recommended fix (add /v1/ prefix or version header routing).
+This is an informational finding — severity LOW. Do not escalate.
+auto_fixable=false — requires route restructuring.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: api/missing-versioning
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Missing API versioning does not cause an immediate security or
+reliability failure, but it makes it impossible to evolve the API contract without
+breaking existing callers. LOW because the impact is operational and long-term
+(technical debt, breaking changes at deprecation) rather than an exploitable
+vulnerability.
+
+**Confidence rationale:** Versioning conventions vary widely; a router mounted at
+`/api` with sub-routes that include `/v1/` elsewhere still satisfies the intent. The
+LLM must inspect the full router tree to correctly classify the presence or absence of
+versioning. MEDIUM to reflect this traversal risk.
+
+**Rubric entry:** `api/missing-versioning`
+
+#### Fixture
+
+**True positive** (`src/routes/index.ts`):
+
+```typescript
+// FINDS: all routes mounted under /api with no version segment
+import express from "express";
+const app = express();
+
+app.use("/api/users", userRouter);
+app.use("/api/posts", postRouter);
+app.use("/api/comments", commentRouter);
+```
+
+**True negative** (should produce NO finding):
+
+```typescript
+// OK: all routes share a /v1/ version prefix at the mount point
+import express from "express";
+const app = express();
+
+app.use("/api/v1/users", userRouter);
+app.use("/api/v1/posts", postRouter);
+app.use("/api/v1/comments", commentRouter);
+```
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/api-contract/pack.json
+++ b/modules/commands-extra/skills/audit/packs/api-contract/pack.json
@@ -1,0 +1,39 @@
+{
+  "id": "ccgm/api-contract",
+  "name": "API & Contract Audit",
+  "version": "1.0.0",
+  "applies_when": ["language:javascript"],
+  "tags": ["api", "security", "validation", "contract"],
+  "severity_floor": "low",
+  "tools": [],
+  "checks": [
+    {
+      "id": "api/missing-input-validation",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "api/mass-assignment",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "api/unbounded-list",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "api/missing-versioning",
+      "severity": "low",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -1,482 +1,529 @@
 {
-    "name": "commands-extra",
-    "version": "1.0.0",
-    "displayName": "Extra Commands",
-    "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global), /freeze + /unfreeze + /guard (safety-hook state management), /checkpoint (save/resume WIP session state).",
-    "category": "commands",
-    "scope": [
-        "global"
-    ],
-    "dependencies": [],
-    "files": {
-        "commands/audit.md": {
-            "target": "commands/audit.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/pwv.md": {
-            "target": "commands/pwv.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/walkthrough.md": {
-            "target": "commands/walkthrough.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/promote-rule.md": {
-            "target": "commands/promote-rule.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/freeze.md": {
-            "target": "commands/freeze.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/unfreeze.md": {
-            "target": "commands/unfreeze.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/guard.md": {
-            "target": "commands/guard.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/checkpoint.md": {
-            "target": "commands/checkpoint.md",
-            "type": "command",
-            "template": false
-        },
-        "skills/audit/SKILL.md": {
-            "target": "skills/audit/SKILL.md",
-            "type": "skill",
-            "template": false
-        },
-        "skills/audit/reference/security-patterns.md": {
-            "target": "skills/audit/reference/security-patterns.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/code-quality.md": {
-            "target": "skills/audit/reference/code-quality.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/architecture.md": {
-            "target": "skills/audit/reference/architecture.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/fix-patterns.md": {
-            "target": "skills/audit/reference/fix-patterns.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/multi-agent-config.md": {
-            "target": "skills/audit/reference/multi-agent-config.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/output-template.md": {
-            "target": "skills/audit/reference/output-template.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/schemas/pack.schema.json": {
-            "target": "skills/audit/schemas/pack.schema.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/schemas/finding.schema.json": {
-            "target": "skills/audit/schemas/finding.schema.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/scripts/registry.py": {
-            "target": "skills/audit/scripts/registry.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/assign-packs.py": {
-            "target": "skills/audit/scripts/assign-packs.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/detect-ecosystems.sh": {
-            "target": "skills/audit/scripts/detect-ecosystems.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/emit-findings.py": {
-            "target": "skills/audit/scripts/emit-findings.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/merge-findings.py": {
-            "target": "skills/audit/scripts/merge-findings.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/baseline.py": {
-            "target": "skills/audit/scripts/baseline.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/suppress.py": {
-            "target": "skills/audit/scripts/suppress.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/schemas/severity-rubric.json": {
-            "target": "skills/audit/schemas/severity-rubric.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/scripts/lint-rubric.py": {
-            "target": "skills/audit/scripts/lint-rubric.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/lint-pack.py": {
-            "target": "skills/audit/scripts/lint-pack.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/provenance.py": {
-            "target": "skills/audit/scripts/provenance.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/packs/_TEMPLATE/checks.md": {
-            "target": "skills/audit/packs/_TEMPLATE/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/security/pack.json": {
-            "target": "skills/audit/packs/security/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/security/checks.md": {
-            "target": "skills/audit/packs/security/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/dependencies/pack.json": {
-            "target": "skills/audit/packs/dependencies/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/dependencies/checks.md": {
-            "target": "skills/audit/packs/dependencies/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/tos-compliance/pack.json": {
-            "target": "skills/audit/packs/tos-compliance/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/tos-compliance/checks.md": {
-            "target": "skills/audit/packs/tos-compliance/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/pack-quality-bar.md": {
-            "target": "skills/audit/reference/pack-quality-bar.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/testing/pack.json": {
-            "target": "skills/audit/packs/testing/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/testing/checks.md": {
-            "target": "skills/audit/packs/testing/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/documentation/pack.json": {
-            "target": "skills/audit/packs/documentation/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/documentation/checks.md": {
-            "target": "skills/audit/packs/documentation/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/performance/pack.json": {
-            "target": "skills/audit/packs/performance/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/performance/checks.md": {
-            "target": "skills/audit/packs/performance/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/scripts/spine/run.sh": {
-            "target": "skills/audit/scripts/spine/run.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/normalize.py": {
-            "target": "skills/audit/scripts/spine/normalize.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-gitleaks.sh": {
-            "target": "skills/audit/scripts/spine/wrap-gitleaks.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-gitleaks.py": {
-            "target": "skills/audit/scripts/spine/parse-gitleaks.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-semgrep.sh": {
-            "target": "skills/audit/scripts/spine/wrap-semgrep.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-semgrep.py": {
-            "target": "skills/audit/scripts/spine/parse-semgrep.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-dep-audit.sh": {
-            "target": "skills/audit/scripts/spine/wrap-dep-audit.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-dep-audit.py": {
-            "target": "skills/audit/scripts/spine/parse-dep-audit.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-knip.sh": {
-            "target": "skills/audit/scripts/spine/wrap-knip.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-knip.py": {
-            "target": "skills/audit/scripts/spine/parse-knip.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-eslint.sh": {
-            "target": "skills/audit/scripts/spine/wrap-eslint.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-eslint.py": {
-            "target": "skills/audit/scripts/spine/parse-eslint.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-govulncheck.sh": {
-            "target": "skills/audit/scripts/spine/wrap-govulncheck.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-govulncheck.py": {
-            "target": "skills/audit/scripts/spine/parse-govulncheck.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-bandit.sh": {
-            "target": "skills/audit/scripts/spine/wrap-bandit.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-bandit.py": {
-            "target": "skills/audit/scripts/spine/parse-bandit.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-hadolint.sh": {
-            "target": "skills/audit/scripts/spine/wrap-hadolint.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-hadolint.py": {
-            "target": "skills/audit/scripts/spine/parse-hadolint.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-actionlint.sh": {
-            "target": "skills/audit/scripts/spine/wrap-actionlint.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-actionlint.py": {
-            "target": "skills/audit/scripts/spine/parse-actionlint.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-trivy.sh": {
-            "target": "skills/audit/scripts/spine/wrap-trivy.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-trivy.py": {
-            "target": "skills/audit/scripts/spine/parse-trivy.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-zizmor.sh": {
-            "target": "skills/audit/scripts/spine/wrap-zizmor.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-zizmor.py": {
-            "target": "skills/audit/scripts/spine/parse-zizmor.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-pinact.sh": {
-            "target": "skills/audit/scripts/spine/wrap-pinact.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-pinact.py": {
-            "target": "skills/audit/scripts/spine/parse-pinact.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/packs/ci-cd/pack.json": {
-            "target": "skills/audit/packs/ci-cd/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/ci-cd/checks.md": {
-            "target": "skills/audit/packs/ci-cd/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/code-quality/pack.json": {
-            "target": "skills/audit/packs/code-quality/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/code-quality/checks.md": {
-            "target": "skills/audit/packs/code-quality/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/typescript-react/pack.json": {
-            "target": "skills/audit/packs/typescript-react/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/typescript-react/checks.md": {
-            "target": "skills/audit/packs/typescript-react/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/architecture/pack.json": {
-            "target": "skills/audit/packs/architecture/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/architecture/checks.md": {
-            "target": "skills/audit/packs/architecture/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/accessibility/pack.json": {
-            "target": "skills/audit/packs/accessibility/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/accessibility/checks.md": {
-            "target": "skills/audit/packs/accessibility/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/reliability/pack.json": {
-            "target": "skills/audit/packs/reliability/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/reliability/checks.md": {
-            "target": "skills/audit/packs/reliability/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/correctness/pack.json": {
-            "target": "skills/audit/packs/correctness/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/correctness/checks.md": {
-            "target": "skills/audit/packs/correctness/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/secrets/pack.json": {
-            "target": "skills/audit/packs/secrets/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/secrets/checks.md": {
-            "target": "skills/audit/packs/secrets/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-squawk.sh": {
-            "target": "skills/audit/scripts/spine/wrap-squawk.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-squawk.py": {
-            "target": "skills/audit/scripts/spine/parse-squawk.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-sqlfluff.sh": {
-            "target": "skills/audit/scripts/spine/wrap-sqlfluff.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-sqlfluff.py": {
-            "target": "skills/audit/scripts/spine/parse-sqlfluff.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/packs/data-migrations/pack.json": {
-            "target": "skills/audit/packs/data-migrations/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/data-migrations/checks.md": {
-            "target": "skills/audit/packs/data-migrations/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/api-contract/pack.json": {
-            "target": "skills/audit/packs/api-contract/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/api-contract/checks.md": {
-            "target": "skills/audit/packs/api-contract/checks.md",
-            "type": "doc",
-            "template": false
-        }
+  "version": "1.0.0",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "ccgm/audit/severity-rubric.json",
+  "title": "CCGM Audit Severity Rubric",
+  "description": "Rule-level, deterministic severity/confidence table. Agents source severity from here; they do NOT invent it. Keyed by check_id (pattern: <pack>/<check>, matching finding.schema.json). Pack epics add entries under their own namespace; use the [RUBRIC-serial] gate to avoid concurrent edits.",
+  "_format": {
+    "severity": "critical|high|medium|low|info",
+    "confidence": "high|medium|low \u2014 signal precision (how often this check fires correctly)",
+    "fix_confidence": "high|medium|low \u2014 safety confidence for auto-fix when applicable"
+  },
+  "checks": {
+    "secrets/leaked-credential": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
     },
-    "tags": [
-        "commands",
-        "audit",
-        "verification",
-        "walkthrough",
-        "safety",
-        "checkpoint"
-    ],
-    "configPrompts": []
+    "security/hardcoded-secret": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "security/sensitive-console-log": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "security/sql-injection": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "security/xss-vulnerability": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "security/missing-security-headers": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "security/edge-function-auth-bypass": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dependencies/npm-audit-vulnerability": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dependencies/outdated-minor": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dependencies/outdated-major": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "dependencies/unused-dependency": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "dependencies/duplicate-dependency": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "code-quality/eslint-violation": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "code-quality/prettier-violation": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "code-quality/unused-import": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "code-quality/long-method": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "code-quality/large-file": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "code-quality/empty-catch-block": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "architecture/circular-dependency": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "architecture/god-object": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "architecture/improper-layering": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "architecture/wrong-layer-import": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "medium"
+    },
+    "typescript/excessive-any": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "typescript/missing-return-type": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "typescript/react-hooks-violation": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "typescript/fast-refresh-violation": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "typescript/missing-key-prop": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "testing/missing-test-file": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "testing/no-assertions": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "testing/missing-edge-cases": {
+      "severity": "low",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "documentation/missing-jsdoc": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "documentation/stale-comment": {
+      "severity": "low",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "documentation/incomplete-readme": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "performance/n-plus-one-query": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "performance/missing-react-memo": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "medium"
+    },
+    "performance/large-bundle-import": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/copyleft-in-proprietary": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/non-commercial-in-commercial": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/missing-attribution": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/unlicensed-dependency": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/scraping-prohibited-site": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/credential-misuse": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/remote-code-extension": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/overbroad-extension-permissions": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-output-training-competitor": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/undisclosed-telemetry": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/rate-limit-circumvention": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/paywall-bypass": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/trademark-misuse": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/store-policy-violation": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/missing-privacy-policy": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-prohibited-use": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-output-misrepresentation": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-data-retention-violation": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/platform-tos-violation": {
+      "severity": "medium",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/iap-bypass": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "deps/vulnerable-dependency": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dead-code/unused-dependency": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "dead-code/unused-file": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dead-code/unused-export": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dead-code/unlisted-dependency": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "a11y/img-missing-alt": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "a11y/click-without-keyboard": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "a11y/anchor-missing-rel": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "a11y/missing-prefers-reduced-motion": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "a11y/tailwind-cursor-pointer": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "reliability/floating-promise": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/misused-promise": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/unhandled-promise": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/await-in-loop": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/fetch-without-timeout": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/retry-without-backoff": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/promise-all-vs-allsettled": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "lint/eqeqeq": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/use-isnan": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/valid-typeof": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/no-unreachable": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/no-constant-condition": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "lint/no-fallthrough": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/default-case": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "correctness/off-by-one": {
+      "severity": "high",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "correctness/float-equality": {
+      "severity": "medium",
+      "confidence": "low",
+      "fix_confidence": "medium"
+    },
+    "correctness/wrong-branch-logic": {
+      "severity": "high",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "secrets/tracked-env-file": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "secrets/tracked-key-material": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "secrets/history-only-credential": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "dm/unquoted-reserved-keyword": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "dm/index-without-concurrently": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dm/missing-rls": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dm/on-conflict-without-unique": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dm/security-definer-function": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "dm/squawk-violation": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dm/sqlfluff-violation": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "cicd/unpinned-action": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "cicd/dangerous-trigger": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "cicd/excessive-permissions": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "cicd/script-injection": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "cicd/actionlint-error": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "cicd/workflow-security-issue": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "api/missing-input-validation": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "api/mass-assignment": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "api/unbounded-list": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "api/missing-versioning": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    }
+  }
 }

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -1,509 +1,482 @@
 {
-  "version": "1.0.0",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "ccgm/audit/severity-rubric.json",
-  "title": "CCGM Audit Severity Rubric",
-  "description": "Rule-level, deterministic severity/confidence table. Agents source severity from here; they do NOT invent it. Keyed by check_id (pattern: <pack>/<check>, matching finding.schema.json). Pack epics add entries under their own namespace; use the [RUBRIC-serial] gate to avoid concurrent edits.",
-  "_format": {
-    "severity": "critical|high|medium|low|info",
-    "confidence": "high|medium|low \u2014 signal precision (how often this check fires correctly)",
-    "fix_confidence": "high|medium|low \u2014 safety confidence for auto-fix when applicable"
-  },
-  "checks": {
-    "secrets/leaked-credential": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "security/hardcoded-secret": {
-      "severity": "critical",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "security/sensitive-console-log": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "security/sql-injection": {
-      "severity": "critical",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "security/xss-vulnerability": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "security/missing-security-headers": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "security/edge-function-auth-bypass": {
-      "severity": "critical",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dependencies/npm-audit-vulnerability": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "dependencies/outdated-minor": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "dependencies/outdated-major": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "dependencies/unused-dependency": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "dependencies/duplicate-dependency": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "code-quality/eslint-violation": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "code-quality/prettier-violation": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "code-quality/unused-import": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "code-quality/long-method": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "code-quality/large-file": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "code-quality/empty-catch-block": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "architecture/circular-dependency": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "architecture/god-object": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "architecture/improper-layering": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "architecture/wrong-layer-import": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "medium"
-    },
-    "typescript/excessive-any": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "typescript/missing-return-type": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "typescript/react-hooks-violation": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "typescript/fast-refresh-violation": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "typescript/missing-key-prop": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "testing/missing-test-file": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "testing/no-assertions": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "testing/missing-edge-cases": {
-      "severity": "low",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "documentation/missing-jsdoc": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "documentation/stale-comment": {
-      "severity": "low",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "documentation/incomplete-readme": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "performance/n-plus-one-query": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "performance/missing-react-memo": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "medium"
-    },
-    "performance/large-bundle-import": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/copyleft-in-proprietary": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/non-commercial-in-commercial": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/missing-attribution": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/unlicensed-dependency": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/scraping-prohibited-site": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/credential-misuse": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/remote-code-extension": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/overbroad-extension-permissions": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/ai-output-training-competitor": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/undisclosed-telemetry": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/rate-limit-circumvention": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/paywall-bypass": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/trademark-misuse": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/store-policy-violation": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/missing-privacy-policy": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/ai-prohibited-use": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/ai-output-misrepresentation": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/ai-data-retention-violation": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/platform-tos-violation": {
-      "severity": "medium",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/iap-bypass": {
-      "severity": "critical",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "deps/vulnerable-dependency": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "dead-code/unused-dependency": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "dead-code/unused-file": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dead-code/unused-export": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dead-code/unlisted-dependency": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "a11y/img-missing-alt": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "a11y/click-without-keyboard": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "a11y/anchor-missing-rel": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "a11y/missing-prefers-reduced-motion": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "a11y/tailwind-cursor-pointer": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "reliability/floating-promise": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/misused-promise": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/unhandled-promise": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/await-in-loop": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/fetch-without-timeout": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/retry-without-backoff": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/promise-all-vs-allsettled": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "lint/eqeqeq": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/use-isnan": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/valid-typeof": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/no-unreachable": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/no-constant-condition": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "lint/no-fallthrough": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/default-case": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "correctness/off-by-one": {
-      "severity": "high",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "correctness/float-equality": {
-      "severity": "medium",
-      "confidence": "low",
-      "fix_confidence": "medium"
-    },
-    "correctness/wrong-branch-logic": {
-      "severity": "high",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "secrets/tracked-env-file": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "secrets/tracked-key-material": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "secrets/history-only-credential": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "dm/unquoted-reserved-keyword": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "dm/index-without-concurrently": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "dm/missing-rls": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dm/on-conflict-without-unique": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dm/security-definer-function": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "dm/squawk-violation": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dm/sqlfluff-violation": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "cicd/unpinned-action": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "cicd/dangerous-trigger": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "cicd/excessive-permissions": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "cicd/script-injection": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "cicd/actionlint-error": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "cicd/workflow-security-issue": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    }
-  }
+    "name": "commands-extra",
+    "version": "1.0.0",
+    "displayName": "Extra Commands",
+    "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global), /freeze + /unfreeze + /guard (safety-hook state management), /checkpoint (save/resume WIP session state).",
+    "category": "commands",
+    "scope": [
+        "global"
+    ],
+    "dependencies": [],
+    "files": {
+        "commands/audit.md": {
+            "target": "commands/audit.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/pwv.md": {
+            "target": "commands/pwv.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/walkthrough.md": {
+            "target": "commands/walkthrough.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/promote-rule.md": {
+            "target": "commands/promote-rule.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/freeze.md": {
+            "target": "commands/freeze.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/unfreeze.md": {
+            "target": "commands/unfreeze.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/guard.md": {
+            "target": "commands/guard.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/checkpoint.md": {
+            "target": "commands/checkpoint.md",
+            "type": "command",
+            "template": false
+        },
+        "skills/audit/SKILL.md": {
+            "target": "skills/audit/SKILL.md",
+            "type": "skill",
+            "template": false
+        },
+        "skills/audit/reference/security-patterns.md": {
+            "target": "skills/audit/reference/security-patterns.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/code-quality.md": {
+            "target": "skills/audit/reference/code-quality.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/architecture.md": {
+            "target": "skills/audit/reference/architecture.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/fix-patterns.md": {
+            "target": "skills/audit/reference/fix-patterns.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/multi-agent-config.md": {
+            "target": "skills/audit/reference/multi-agent-config.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/output-template.md": {
+            "target": "skills/audit/reference/output-template.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/schemas/pack.schema.json": {
+            "target": "skills/audit/schemas/pack.schema.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/schemas/finding.schema.json": {
+            "target": "skills/audit/schemas/finding.schema.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/scripts/registry.py": {
+            "target": "skills/audit/scripts/registry.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/assign-packs.py": {
+            "target": "skills/audit/scripts/assign-packs.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/detect-ecosystems.sh": {
+            "target": "skills/audit/scripts/detect-ecosystems.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/emit-findings.py": {
+            "target": "skills/audit/scripts/emit-findings.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/merge-findings.py": {
+            "target": "skills/audit/scripts/merge-findings.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/baseline.py": {
+            "target": "skills/audit/scripts/baseline.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/suppress.py": {
+            "target": "skills/audit/scripts/suppress.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/schemas/severity-rubric.json": {
+            "target": "skills/audit/schemas/severity-rubric.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/scripts/lint-rubric.py": {
+            "target": "skills/audit/scripts/lint-rubric.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/lint-pack.py": {
+            "target": "skills/audit/scripts/lint-pack.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/provenance.py": {
+            "target": "skills/audit/scripts/provenance.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/packs/_TEMPLATE/checks.md": {
+            "target": "skills/audit/packs/_TEMPLATE/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/security/pack.json": {
+            "target": "skills/audit/packs/security/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/security/checks.md": {
+            "target": "skills/audit/packs/security/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/dependencies/pack.json": {
+            "target": "skills/audit/packs/dependencies/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/dependencies/checks.md": {
+            "target": "skills/audit/packs/dependencies/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/tos-compliance/pack.json": {
+            "target": "skills/audit/packs/tos-compliance/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/tos-compliance/checks.md": {
+            "target": "skills/audit/packs/tos-compliance/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/pack-quality-bar.md": {
+            "target": "skills/audit/reference/pack-quality-bar.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/testing/pack.json": {
+            "target": "skills/audit/packs/testing/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/testing/checks.md": {
+            "target": "skills/audit/packs/testing/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/documentation/pack.json": {
+            "target": "skills/audit/packs/documentation/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/documentation/checks.md": {
+            "target": "skills/audit/packs/documentation/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/performance/pack.json": {
+            "target": "skills/audit/packs/performance/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/performance/checks.md": {
+            "target": "skills/audit/packs/performance/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/scripts/spine/run.sh": {
+            "target": "skills/audit/scripts/spine/run.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/normalize.py": {
+            "target": "skills/audit/scripts/spine/normalize.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-gitleaks.sh": {
+            "target": "skills/audit/scripts/spine/wrap-gitleaks.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-gitleaks.py": {
+            "target": "skills/audit/scripts/spine/parse-gitleaks.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-semgrep.sh": {
+            "target": "skills/audit/scripts/spine/wrap-semgrep.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-semgrep.py": {
+            "target": "skills/audit/scripts/spine/parse-semgrep.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-dep-audit.sh": {
+            "target": "skills/audit/scripts/spine/wrap-dep-audit.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-dep-audit.py": {
+            "target": "skills/audit/scripts/spine/parse-dep-audit.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-knip.sh": {
+            "target": "skills/audit/scripts/spine/wrap-knip.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-knip.py": {
+            "target": "skills/audit/scripts/spine/parse-knip.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-eslint.sh": {
+            "target": "skills/audit/scripts/spine/wrap-eslint.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-eslint.py": {
+            "target": "skills/audit/scripts/spine/parse-eslint.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-govulncheck.sh": {
+            "target": "skills/audit/scripts/spine/wrap-govulncheck.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-govulncheck.py": {
+            "target": "skills/audit/scripts/spine/parse-govulncheck.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-bandit.sh": {
+            "target": "skills/audit/scripts/spine/wrap-bandit.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-bandit.py": {
+            "target": "skills/audit/scripts/spine/parse-bandit.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-hadolint.sh": {
+            "target": "skills/audit/scripts/spine/wrap-hadolint.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-hadolint.py": {
+            "target": "skills/audit/scripts/spine/parse-hadolint.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-actionlint.sh": {
+            "target": "skills/audit/scripts/spine/wrap-actionlint.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-actionlint.py": {
+            "target": "skills/audit/scripts/spine/parse-actionlint.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-trivy.sh": {
+            "target": "skills/audit/scripts/spine/wrap-trivy.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-trivy.py": {
+            "target": "skills/audit/scripts/spine/parse-trivy.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-zizmor.sh": {
+            "target": "skills/audit/scripts/spine/wrap-zizmor.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-zizmor.py": {
+            "target": "skills/audit/scripts/spine/parse-zizmor.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-pinact.sh": {
+            "target": "skills/audit/scripts/spine/wrap-pinact.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-pinact.py": {
+            "target": "skills/audit/scripts/spine/parse-pinact.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/packs/ci-cd/pack.json": {
+            "target": "skills/audit/packs/ci-cd/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/ci-cd/checks.md": {
+            "target": "skills/audit/packs/ci-cd/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/code-quality/pack.json": {
+            "target": "skills/audit/packs/code-quality/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/code-quality/checks.md": {
+            "target": "skills/audit/packs/code-quality/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/typescript-react/pack.json": {
+            "target": "skills/audit/packs/typescript-react/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/typescript-react/checks.md": {
+            "target": "skills/audit/packs/typescript-react/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/architecture/pack.json": {
+            "target": "skills/audit/packs/architecture/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/architecture/checks.md": {
+            "target": "skills/audit/packs/architecture/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/accessibility/pack.json": {
+            "target": "skills/audit/packs/accessibility/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/accessibility/checks.md": {
+            "target": "skills/audit/packs/accessibility/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/reliability/pack.json": {
+            "target": "skills/audit/packs/reliability/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/reliability/checks.md": {
+            "target": "skills/audit/packs/reliability/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/correctness/pack.json": {
+            "target": "skills/audit/packs/correctness/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/correctness/checks.md": {
+            "target": "skills/audit/packs/correctness/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/secrets/pack.json": {
+            "target": "skills/audit/packs/secrets/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/secrets/checks.md": {
+            "target": "skills/audit/packs/secrets/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-squawk.sh": {
+            "target": "skills/audit/scripts/spine/wrap-squawk.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-squawk.py": {
+            "target": "skills/audit/scripts/spine/parse-squawk.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-sqlfluff.sh": {
+            "target": "skills/audit/scripts/spine/wrap-sqlfluff.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-sqlfluff.py": {
+            "target": "skills/audit/scripts/spine/parse-sqlfluff.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/packs/data-migrations/pack.json": {
+            "target": "skills/audit/packs/data-migrations/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/data-migrations/checks.md": {
+            "target": "skills/audit/packs/data-migrations/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/api-contract/pack.json": {
+            "target": "skills/audit/packs/api-contract/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/api-contract/checks.md": {
+            "target": "skills/audit/packs/api-contract/checks.md",
+            "type": "doc",
+            "template": false
+        }
+    },
+    "tags": [
+        "commands",
+        "audit",
+        "verification",
+        "walkthrough",
+        "safety",
+        "checkpoint"
+    ],
+    "configPrompts": []
 }

--- a/modules/commands-extra/skills/audit/tests/test-pack-api.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-api.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# test-pack-api.sh — Tests for the ccgm/api-contract audit pack (issue #631)
+#
+# Tests:
+#   1. pack.json validates against pack.schema.json (stdlib validator via registry.py)
+#   2. severity-rubric.json contains all api/* check ids from pack.json
+#   3. lint-pack.py passes on the api-contract pack with the real rubric
+#   4. checks.md contains all required template sections
+#   5. checks.md documents TP/TN fixtures for each check:
+#        missing-input-validation, mass-assignment, unbounded-list, missing-versioning
+#   6. applies_when gates correctly:
+#        6a. JS project (package.json present) → pack INCLUDED
+#        6b. Go-only project (no package.json) → pack EXCLUDED
+#   7. Runtime fixtures: Express-style handler with NO validation (TP) and one WITH
+#      validation (TN) are created; pack schema + rubric validate; lint-pack passes
+#
+# Exit: 0 if all pass, 1 if any fail.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PACK_DIR="${AUDIT_DIR}/packs/api-contract"
+REGISTRY="${AUDIT_DIR}/scripts/registry.py"
+LINTER="${AUDIT_DIR}/scripts/lint-pack.py"
+RUBRIC="${AUDIT_DIR}/schemas/severity-rubric.json"
+
+PASS=0
+FAIL=0
+
+pass() { printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1)); }
+fail() { printf "  FAIL: %s\n" "$1"; FAIL=$((FAIL + 1)); }
+
+# Shared temp dir for the whole run; cleaned up on EXIT
+TESTRUN_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/ccgm-test-api-XXXXXX")"
+trap 'rm -rf "${TESTRUN_TMPDIR}"' EXIT
+
+# ---------------------------------------------------------------------------
+# Test 1: pack.json validates against pack.schema.json
+# ---------------------------------------------------------------------------
+echo "--- Test 1: pack.json validates (stdlib registry.py)"
+
+_T1_PY="${TESTRUN_TMPDIR}/pack_validate_api.py"
+cat > "${_T1_PY}" <<'PYEOF'
+import sys, json, importlib.util, pathlib
+
+registry_py = pathlib.Path(sys.argv[1])
+pack_path   = pathlib.Path(sys.argv[2])
+
+spec = importlib.util.spec_from_file_location("registry", str(registry_py))
+mod  = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+with open(pack_path, encoding="utf-8") as fh:
+    pack = json.load(fh)
+
+try:
+    mod.validate_pack(pack, str(pack_path))
+    print("VALID")
+    sys.exit(0)
+except mod.ValidationError as exc:
+    print("INVALID: " + str(exc))
+    sys.exit(1)
+PYEOF
+
+_T1_RESULT=""
+_T1_EXIT=0
+_T1_RESULT=$(python3 "${_T1_PY}" "${REGISTRY}" "${PACK_DIR}/pack.json" 2>&1) || _T1_EXIT=$?
+
+if [ "${_T1_EXIT}" -eq 0 ] && echo "${_T1_RESULT}" | grep -q "^VALID$"; then
+    pass "api-contract/pack.json validates against pack.schema.json"
+else
+    fail "api-contract/pack.json failed validation: ${_T1_RESULT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: severity-rubric.json contains all api/* check ids
+# ---------------------------------------------------------------------------
+echo "--- Test 2: rubric contains all api/* check ids"
+
+EXPECTED_IDS=(
+    "api/missing-input-validation"
+    "api/mass-assignment"
+    "api/unbounded-list"
+    "api/missing-versioning"
+)
+
+_T2_MISSING=""
+for check_id in "${EXPECTED_IDS[@]}"; do
+    if ! python3 -c "
+import json, sys
+rubric = json.load(open('${RUBRIC}', encoding='utf-8'))
+checks = rubric.get('checks', {})
+if '${check_id}' not in checks:
+    print('MISSING')
+    sys.exit(1)
+print('FOUND')
+sys.exit(0)
+" 2>/dev/null | grep -q "^FOUND$"; then
+        _T2_MISSING="${_T2_MISSING} ${check_id}"
+    fi
+done
+
+if [ -z "${_T2_MISSING}" ]; then
+    pass "rubric contains all ${#EXPECTED_IDS[@]} api/* check ids"
+else
+    fail "rubric missing ids:${_T2_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: lint-pack.py passes on the api-contract pack with the real rubric
+# ---------------------------------------------------------------------------
+echo "--- Test 3: lint-pack.py passes on api-contract pack"
+
+_T3_OUTPUT=""
+_T3_EXIT=0
+_T3_OUTPUT=$(python3 "${LINTER}" \
+    --packs-dir "${AUDIT_DIR}/packs" \
+    --rubric "${RUBRIC}" 2>&1) || _T3_EXIT=$?
+
+if [ "${_T3_EXIT}" -eq 0 ] && echo "${_T3_OUTPUT}" | grep -q "^PASS: api-contract"; then
+    pass "lint-pack.py reports PASS for api-contract pack"
+else
+    fail "lint-pack.py did not report PASS for api-contract: exit=${_T3_EXIT}, output=${_T3_OUTPUT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: checks.md contains all required template sections
+# ---------------------------------------------------------------------------
+echo "--- Test 4: checks.md has required sections"
+
+CHECKS_MD="${PACK_DIR}/checks.md"
+
+_REQUIRED_SECTIONS=(
+    "^## Scope"
+    "^## applies_when Rationale"
+    "^## Checks"
+    "^## Quality Checklist"
+)
+
+_T4_MISSING=""
+for section in "${_REQUIRED_SECTIONS[@]}"; do
+    if ! grep -qiE "${section}" "${CHECKS_MD}"; then
+        _T4_MISSING="${_T4_MISSING} '${section}'"
+    fi
+done
+
+if [ -z "${_T4_MISSING}" ]; then
+    pass "checks.md contains all required sections"
+else
+    fail "checks.md missing sections:${_T4_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: checks.md documents TP/TN fixtures for every check
+# ---------------------------------------------------------------------------
+echo "--- Test 5: checks.md documents TP/TN fixtures for each check"
+
+SEEDED_CHECK_IDS=(
+    "api/missing-input-validation"
+    "api/mass-assignment"
+    "api/unbounded-list"
+    "api/missing-versioning"
+)
+
+_T5_ERRORS=""
+
+for check_id in "${SEEDED_CHECK_IDS[@]}"; do
+    # check-id appears in checks.md
+    if ! grep -q "${check_id}" "${CHECKS_MD}"; then
+        _T5_ERRORS="${_T5_ERRORS}\n  check-id '${check_id}' not found in checks.md"
+        continue
+    fi
+
+    # Extract the per-check section (from ### heading to next ### heading or EOF)
+    _SECTION=$(python3 - "${CHECKS_MD}" "${check_id}" <<'PYEOF' 2>/dev/null
+import sys, re
+md = open(sys.argv[1], encoding='utf-8').read()
+check_id = sys.argv[2]
+pattern = r'(### `' + re.escape(check_id) + r'`.*?)(?=\n### `|\Z)'
+m = re.search(pattern, md, re.DOTALL)
+if m:
+    print(m.group(1))
+PYEOF
+)
+
+    # True positive marker
+    if ! echo "${_SECTION}" | grep -q "True positive\|FINDS:"; then
+        _T5_ERRORS="${_T5_ERRORS}\n  no True positive fixture found for '${check_id}'"
+    fi
+
+    # True negative marker
+    if ! echo "${_SECTION}" | grep -q "True negative\|should produce NO"; then
+        _T5_ERRORS="${_T5_ERRORS}\n  no True negative fixture found for '${check_id}'"
+    fi
+done
+
+if [ -z "${_T5_ERRORS}" ]; then
+    pass "checks.md documents TP/TN fixtures for all ${#SEEDED_CHECK_IDS[@]} checks"
+else
+    fail "checks.md fixture coverage issues:$(printf '%b' "${_T5_ERRORS}")"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: applies_when gates correctly via registry.py
+#   6a. JS project (package.json present) → pack INCLUDED
+#   6b. Go-only project (no package.json) → pack EXCLUDED
+# ---------------------------------------------------------------------------
+echo "--- Test 6: applies_when gates correctly"
+
+TMPDIR_PACKS="${TESTRUN_TMPDIR}/packs-gate"
+mkdir -p "${TMPDIR_PACKS}/api-contract"
+cp "${PACK_DIR}/pack.json" "${TMPDIR_PACKS}/api-contract/pack.json"
+
+run_registry() {
+    local detector_json="$1"
+    CCGM_PACKS_DIR="${TMPDIR_PACKS}" python3 "${REGISTRY}" <<< "${detector_json}"
+}
+
+# 6a: JS project → pack INCLUDED
+DETECTOR_JS='{"detected_ecosystems":["javascript"],"project_shape":{},"available_tools":[]}'
+_T6A_RESULT=""
+_T6A_EXIT=0
+_T6A_RESULT=$(run_registry "${DETECTOR_JS}" 2>/dev/null) || _T6A_EXIT=$?
+
+_T6A_INCLUDED=0
+if [ "${_T6A_EXIT}" -eq 0 ]; then
+    if echo "${_T6A_RESULT}" | python3 -c "
+import json, sys
+packs = json.load(sys.stdin)
+ids = [p['id'] for p in packs]
+assert 'ccgm/api-contract' in ids, 'ccgm/api-contract not in: ' + str(ids)
+" 2>/dev/null; then
+        _T6A_INCLUDED=1
+    fi
+fi
+
+if [ "${_T6A_INCLUDED}" -eq 1 ]; then
+    pass "ccgm/api-contract INCLUDED for JS project (language:javascript)"
+else
+    fail "ccgm/api-contract should be INCLUDED for JS project but was not. exit=${_T6A_EXIT}, result=${_T6A_RESULT}"
+fi
+
+# 6b: Go-only project → pack EXCLUDED
+DETECTOR_GO='{"detected_ecosystems":["go"],"project_shape":{},"available_tools":[]}'
+_T6B_RESULT=""
+_T6B_EXIT=0
+_T6B_RESULT=$(run_registry "${DETECTOR_GO}" 2>/dev/null) || _T6B_EXIT=$?
+
+_T6B_EXCLUDED=0
+if [ "${_T6B_EXIT}" -eq 0 ]; then
+    if echo "${_T6B_RESULT}" | python3 -c "
+import json, sys
+packs = json.load(sys.stdin)
+ids = [p['id'] for p in packs]
+assert 'ccgm/api-contract' not in ids, 'ccgm/api-contract should not be in: ' + str(ids)
+" 2>/dev/null; then
+        _T6B_EXCLUDED=1
+    fi
+fi
+
+if [ "${_T6B_EXCLUDED}" -eq 1 ]; then
+    pass "ccgm/api-contract EXCLUDED for Go-only project (no language:javascript)"
+else
+    fail "ccgm/api-contract should be EXCLUDED for Go project but was not. exit=${_T6B_EXIT}, result=${_T6B_RESULT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: Runtime fixtures — Express handler fixtures (static structure only;
+#         no LLM assertion). TP fixture has no schema validation; TN has zod.
+#         Verify: files created, pack validates, rubric validates, lint-pack passes.
+# ---------------------------------------------------------------------------
+echo "--- Test 7: Runtime fixtures (TP handler without validation, TN with zod)"
+
+FIXTURE_DIR="${TESTRUN_TMPDIR}/fixture-project"
+mkdir -p "${FIXTURE_DIR}/src/routes"
+
+# TP: Express handler reading req.body directly — no schema validation
+cat > "${FIXTURE_DIR}/src/routes/users.ts" <<'TSEOF'
+// api-contract fixture: missing-input-validation (TP)
+// req.body used directly — no zod/joi/yup validation before ORM call
+import express from "express";
+const router = express.Router();
+
+router.post("/users", async (req, res) => {
+  const { email, role } = req.body;
+  // mass-assignment (TP): full spread into ORM create
+  const user = await db.user.create({ data: { ...req.body } });
+  // unbounded-list (TP): findMany with no take
+  const allUsers = await db.user.findMany();
+  res.json({ user, allUsers });
+});
+
+export default router;
+TSEOF
+
+# TN: Express handler with zod validation — should NOT trigger missing-input-validation
+cat > "${FIXTURE_DIR}/src/routes/posts.ts" <<'TSEOF'
+// api-contract fixture: with zod validation (TN for missing-input-validation)
+import express from "express";
+import { z } from "zod";
+const router = express.Router();
+
+const CreatePostBody = z.object({
+  title: z.string().min(1).max(200),
+  content: z.string(),
+});
+
+router.post("/api/v1/posts", async (req, res) => {
+  const { title, content } = CreatePostBody.parse(req.body);
+  // Only allow-listed fields forwarded to ORM (TN for mass-assignment)
+  const post = await db.post.create({ data: { title, content } });
+  // Bounded list with max cap (TN for unbounded-list)
+  const limit = Math.min(Number(req.query.limit) || 20, 100);
+  const posts = await db.post.findMany({ take: limit });
+  res.json({ post, posts });
+});
+
+export default router;
+TSEOF
+
+# package.json so the ecosystem detector recognises this as a JS project
+cat > "${FIXTURE_DIR}/package.json" <<'JSON'
+{ "name": "api-contract-test-fixture", "version": "1.0.0", "dependencies": { "express": "^4.18.0", "zod": "^3.22.0" } }
+JSON
+
+# Verify files were created
+if [ -f "${FIXTURE_DIR}/src/routes/users.ts" ] && \
+   [ -f "${FIXTURE_DIR}/src/routes/posts.ts" ] && \
+   [ -f "${FIXTURE_DIR}/package.json" ]; then
+    pass "JS runtime fixtures created (TP handler, TN handler, package.json)"
+else
+    fail "JS runtime fixture creation failed"
+fi
+
+# Pack schema and rubric must still validate after adding the rubric entries
+_T7_LINT_OUTPUT=""
+_T7_LINT_EXIT=0
+_T7_LINT_OUTPUT=$(python3 "${LINTER}" \
+    --packs-dir "${AUDIT_DIR}/packs" \
+    --rubric "${RUBRIC}" 2>&1) || _T7_LINT_EXIT=$?
+
+if [ "${_T7_LINT_EXIT}" -eq 0 ] && echo "${_T7_LINT_OUTPUT}" | grep -q "^PASS: api-contract"; then
+    pass "lint-pack.py still reports PASS for api-contract after adding rubric entries"
+else
+    fail "lint-pack.py failed after rubric entries added: exit=${_T7_LINT_EXIT}, output=${_T7_LINT_OUTPUT}"
+fi
+
+# Verify rubric JSON is still valid after edit
+_T7_RUBRIC_EXIT=0
+python3 -m json.tool "${RUBRIC}" > /dev/null 2>&1 || _T7_RUBRIC_EXIT=$?
+if [ "${_T7_RUBRIC_EXIT}" -eq 0 ]; then
+    pass "severity-rubric.json is valid JSON after api/* entries added"
+else
+    fail "severity-rubric.json is NOT valid JSON after api/* entries added"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf "\nResults: %d passed, %d failed\n" "${PASS}" "${FAIL}"
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `packs/api-contract/{pack.json,checks.md}` — pack id `ccgm/api-contract`, `applies_when: ["language:javascript"]`, `tools: []` (all LLM detection), 4 checks: `api/missing-input-validation` (high), `api/mass-assignment` (high), `api/unbounded-list` (medium), `api/missing-versioning` (low)
- Adds 4 `api/*` entries to `schemas/severity-rubric.json` and 2 doc entries to `modules/commands-extra/module.json`
- Adds `tests/test-pack-api.sh` (10 tests): pack schema validation, rubric membership, lint-pack pass, required checks.md sections, TP/TN fixture coverage for all 4 checks, gate selection (JS included / Go excluded), runtime fixtures with post-rubric lint

## applies_when gate choice

`language:javascript` — all 4 checks target Express/Fastify/Next.js/SvelteKit/Koa handler patterns that are idiomatic to the JS/TS ecosystem. Zero signal without JS files. TypeScript repos are detected as `javascript` by the existing ecosystem detector.

## Test plan

- [x] `bash modules/commands-extra/skills/audit/tests/test-pack-api.sh` — 10/10 pass
- [x] `python3 modules/commands-extra/skills/audit/scripts/lint-pack.py` — 16/16 packs PASS, 0 errors
- [x] `bash modules/commands-extra/skills/audit/tests/test-pack-lint.sh` — 7/7 pass
- [x] `bash modules/commands-extra/skills/audit/tests/test-rubric.sh` — 8/8 pass
- [x] `bash modules/commands-extra/skills/audit/tests/test-registry.sh` — 8/8 pass
- [x] `python3 -m json.tool modules/commands-extra/module.json modules/commands-extra/skills/audit/schemas/severity-rubric.json` — valid JSON
- [x] `bash tests/test-modules.sh` — 1314/1314 pass
- [x] `bash tests/test-no-personal-data.sh` — PASS

Closes #631