### PR TITLE
#629: Epic 4.2 — deepen testing audit pack (4 new checks)

### DIFF
--- a/modules/commands-extra/skills/audit/packs/testing/checks.md
+++ b/modules/commands-extra/skills/audit/packs/testing/checks.md
@@ -410,37 +410,45 @@ No finding: `waitFor` polls for the condition rather than guessing a duration.
 
 #### Detection
 
-Grep the test files for `.only(`, `.skip(`, `fdescribe(`, `fit(`, `xit(`, `xdescribe(`, and
-`xtest(` — focus/skip modifiers left committed to the repo. These silently narrow the test suite
-(`.only`/`fdescribe`/`fit`) or disable individual tests (`.skip`/`xit`/`xdescribe`/`xtest`),
-producing false confidence in a CI green status.
+The worker agent scans test files for `.only(`, `.skip(`, `fdescribe(`, `fit(`, `xit(`,
+`xdescribe(`, and `xtest(` — focus/skip modifiers left committed to the repo. These silently
+narrow the test suite (`.only`/`fdescribe`/`fit`) or disable individual tests
+(`.skip`/`xit`/`xdescribe`/`xtest`), producing false confidence in a CI green status.
 
 **LLM instruction (if detection = llm or hybrid):**
-n/a — detection is tool (grep) only.
 
-**Tool:** `grep` (POSIX built-in, no external binary dependency).
+```
+Scan test files for committed focus/skip modifiers that silently narrow or disable the suite.
 
-Pattern:
-```
-grep -rn --include="*.test.*" --include="*.spec.*" \
-  -E '\.(only|skip)\s*\(|^[[:space:]]*(fdescribe|fit|xit|xdescribe|xtest)\s*\(' \
-  <test-dir>
-```
+Flag as a finding when a test file contains any of:
+- .only( or .skip( (Jasmine/Jest/Mocha focus/skip)
+- fdescribe( or fit( (Jasmine/Jest focused describe/test)
+- xit( or xdescribe( or xtest( (Jasmine/Jest/Mocha disabled test/describe)
+
+These modifiers prevent the full suite from running. A committed .only narrows CI to one block;
+a committed .skip hides a known failure. Both produce false confidence.
 
 Exclude:
-- Lines that are in a comment (`//`, `#`, `/* ... */`)
-- Files under `node_modules/`, `.git/`, `dist/`, `build/`
+- Lines that are in a comment (// or # or /* ... */)
+- Files under node_modules/, .git/, dist/, build/
+
+For each finding report: file:line, the modifier found, and whether it narrows (only/fdescribe/fit)
+or disables (skip/xit/xdescribe/xtest) the suite.
+```
 
 #### Spine Wiring
 
-This check uses `detection: tool` with `tool: grep`. `grep` is a POSIX built-in with no
-external binary required. The spine runs the pattern above and emits a finding for each match.
+This check is LLM-only (grep pre-screen for candidates). No spine tool is involved.
 
 ```yaml
 check_id: testing/only-or-skip-committed
-detection: tool
-tool: grep
+detection: llm
+tool: ~
 ```
+
+Grep pre-screen (advisory, narrows LLM context): `.only(` | `.skip(` | `fdescribe(` | `fit(` |
+`xit(` | `xdescribe(` | `xtest(` in test files. The worker agent runs this grep as a deterministic
+pre-screen; no LLM judgment is needed once the pattern matches because the signal is unambiguous.
 
 #### Severity / Confidence
 
@@ -732,7 +740,7 @@ that now owns it, proving no check was dropped.
 ## Quality Checklist
 
 - [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
-- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] No check uses `detection: tool` or `detection: hybrid`; all grep-backed checks use `detection: llm` with a documented grep pre-screen (no spine tool claimed)
 - [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
 - [x] Each fixture has both a true positive AND a true negative
 - [x] Severity / confidence rationale is present for every check

--- a/modules/commands-extra/skills/audit/packs/testing/checks.md
+++ b/modules/commands-extra/skills/audit/packs/testing/checks.md
@@ -9,10 +9,18 @@
 
 This pack audits test coverage and test quality across the codebase. It checks for source files
 that lack corresponding test files, test files that contain no assertions (and therefore prove
-nothing), and test files that omit edge-case scenarios (empty inputs, boundary values, error
-paths). It does NOT audit test runtime performance, mock strategy, or test framework setup.
-All three checks require human-authored fixes; generated test stubs do not substitute for
-meaningful test logic.
+nothing), test files that omit edge-case scenarios (empty inputs, boundary values, error paths),
+arbitrary-sleep-based synchronization in tests that causes flakiness, committed `.only`/`.skip`
+modifiers that silently narrow or disable the suite, tests that assert on mock call-logs rather
+than real system behavior, and production code that exposes test-only setter or reset methods.
+
+It does NOT audit test runtime performance, test framework configuration, or whether coverage
+percentage meets a threshold. Worker agents MAY run the repo's own coverage command (e.g.
+`npm test -- --coverage`, `pytest --cov`, or `go test -cover`) as an OPTIONAL advisory
+read-only action to surface files with zero coverage; they must treat tool output as one signal
+alongside the LLM checks and must not fail the pack run if the coverage command is absent or
+fails. All checks require human-authored fixes; generated test stubs or mechanical edits do not
+substitute for meaningful test logic.
 
 ---
 
@@ -288,6 +296,423 @@ describe('divide', () => {
 ```
 
 No finding: edge case (division by zero) is covered.
+
+---
+
+### `testing/sleep-based-flake`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans test files for `sleep(`, `setTimeout(`, `time.sleep(`, `asyncio.sleep(`,
+or equivalent arbitrary-duration waits used as a synchronization mechanism — waiting for an
+async operation to complete by sleeping for a fixed duration instead of waiting for the actual
+condition. The grep pre-screen surfaces candidates; the LLM disambiguates by reading context
+(a `sleep` inside a non-test retry helper is not a finding; a `sleep(50)` before asserting that
+a DOM update occurred is).
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan test files for sleep-based synchronization — arbitrary-duration pauses used to wait for
+an async operation to complete instead of waiting for the actual condition.
+
+A sleep used as a synchronization mechanism is a timing bug: it guesses at how long an async
+operation takes rather than waiting for evidence that it completed. The test passes on fast
+machines and fails intermittently under load or CI.
+
+Flag as a finding:
+- setTimeout(() => { /* assertion */ }, N) used as a wait inside a test body
+- await sleep(N) or await new Promise(r => setTimeout(r, N)) placed before an assertion
+  where N is a guessed duration (not a documented, semantically meaningful interval)
+- time.sleep(N) or asyncio.sleep(N) in Python tests used before an assertion
+- Any similar pattern in other languages (Thread.sleep in Java/Kotlin, usleep in C, etc.)
+
+Do NOT flag:
+- sleep(N) inside a retry-with-backoff helper that has documented fixed delay semantics
+- sleep used for rate limiting between iterations in a load test
+- Waits that use a condition-based polling helper (waitFor, eventually, poll_until) —
+  these are the correct pattern
+- sleep inside a fixture teardown that intentionally gives a server time to shut down,
+  with a comment explaining why
+
+For each finding report: file:line, the sleep call, and the assertion it is guarding.
+Suggest replacing with a condition-based waitFor / eventually / poll_until pattern.
+```
+
+#### Spine Wiring
+
+This check is LLM-only (grep pre-screen for candidates). No spine tool is involved.
+
+```yaml
+check_id: testing/sleep-based-flake
+detection: llm
+tool: ~
+```
+
+Grep pre-screen (advisory, narrows LLM context): `sleep(` | `setTimeout(` | `time.sleep(` in
+test files. The LLM reads the surrounding context to determine whether the sleep is acting as
+a synchronization guard before an assertion.
+
+#### Severity / Confidence
+
+**Severity rationale:** A sleep-based synchronization guard is a latent flakiness bug: it passes
+on a developer's machine and fails intermittently in CI under load. Flaky tests erode trust in
+the test suite — teams begin ignoring failing tests, and the suite loses its regression-detection
+value. Medium severity: does not cause incorrect behavior today but degrades the test suite's
+reliability signal over time.
+
+**Confidence rationale:** Most `sleep` calls before assertions in test files are genuine
+synchronization guards. However, some sleeps have explicit semantic meaning (debounce intervals,
+rate limits) and are correct; the LLM must read context to distinguish them. Medium confidence.
+
+**Rubric entry:** `testing/sleep-based-flake`
+
+#### Fixture
+
+**True positive** (`src/components/Search.test.tsx` uses setTimeout to wait for a debounced
+search result):
+
+```typescript
+// FINDS: sleep(100) before assertion — guesses that debounce fires within 100ms
+it('shows search results after debounce', async () => {
+  fireEvent.change(input, { target: { value: 'hello' } });
+  await new Promise((r) => setTimeout(r, 100));  // <-- timing guess
+  expect(screen.getByText('Result 1')).toBeInTheDocument();
+});
+```
+
+Finding: `src/components/Search.test.tsx:4` — `setTimeout(r, 100)` used as synchronization
+guard before assertion. Replace with `waitFor(() => screen.getByText('Result 1'))`.
+
+**True negative** (should produce NO finding):
+
+```typescript
+// OK: condition-based waitFor — waits for the actual DOM state, not a duration
+it('shows search results after debounce', async () => {
+  fireEvent.change(input, { target: { value: 'hello' } });
+  await waitFor(() => expect(screen.getByText('Result 1')).toBeInTheDocument());
+});
+```
+
+No finding: `waitFor` polls for the condition rather than guessing a duration.
+
+---
+
+### `testing/only-or-skip-committed`
+
+**Severity:** `high`
+**Confidence:** `high`
+**Detection:** `tool`
+
+#### Detection
+
+Grep the test files for `.only(`, `.skip(`, `fdescribe(`, `fit(`, `xit(`, `xdescribe(`, and
+`xtest(` — focus/skip modifiers left committed to the repo. These silently narrow the test suite
+(`.only`/`fdescribe`/`fit`) or disable individual tests (`.skip`/`xit`/`xdescribe`/`xtest`),
+producing false confidence in a CI green status.
+
+**LLM instruction (if detection = llm or hybrid):**
+n/a — detection is tool (grep) only.
+
+**Tool:** `grep` (POSIX built-in, no external binary dependency).
+
+Pattern:
+```
+grep -rn --include="*.test.*" --include="*.spec.*" \
+  -E '\.(only|skip)\s*\(|^[[:space:]]*(fdescribe|fit|xit|xdescribe|xtest)\s*\(' \
+  <test-dir>
+```
+
+Exclude:
+- Lines that are in a comment (`//`, `#`, `/* ... */`)
+- Files under `node_modules/`, `.git/`, `dist/`, `build/`
+
+#### Spine Wiring
+
+This check uses `detection: tool` with `tool: grep`. `grep` is a POSIX built-in with no
+external binary required. The spine runs the pattern above and emits a finding for each match.
+
+```yaml
+check_id: testing/only-or-skip-committed
+detection: tool
+tool: grep
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A committed `.only` narrows the entire test suite to one block — every
+other test is silently skipped. CI reports green while hundreds of tests never ran. A committed
+`.skip` disables a specific test, often hiding a known failure that was never fixed. Both
+patterns produce false confidence in coverage. High severity because the impact is immediate and
+invisible: the suite appears to pass while tests are disabled.
+
+**Confidence rationale:** The grep pattern for `.only(`, `fdescribe(`, `fit(`, `.skip(`,
+`xit(`, `xdescribe(`, `xtest(` in test files is a deterministic structural match. False
+positives (a word in a comment) are excluded by the pattern filter. High confidence.
+
+**Rubric entry:** `testing/only-or-skip-committed`
+
+#### Fixture
+
+**True positive** (`src/auth/login.test.ts` has a `.only` block):
+
+```typescript
+// FINDS: .only narrows the suite — all other tests in this file are skipped
+describe('login', () => {
+  it.only('accepts valid credentials', () => {
+    expect(login('alice', 'secret')).toBe(true);
+  });
+  it('rejects empty password', () => {   // ← silently skipped
+    expect(login('alice', '')).toBe(false);
+  });
+});
+```
+
+Finding: `src/auth/login.test.ts:3` — `.only` committed; suite narrowed silently.
+
+**True negative** (should produce NO finding):
+
+```typescript
+// OK: no .only or .skip modifiers — all blocks run
+describe('login', () => {
+  it('accepts valid credentials', () => {
+    expect(login('alice', 'secret')).toBe(true);
+  });
+  it('rejects empty password', () => {
+    expect(login('alice', '')).toBe(false);
+  });
+});
+```
+
+No finding: no focus or skip modifiers present.
+
+---
+
+### `testing/mock-not-behavior`
+
+**Severity:** `medium`
+**Confidence:** `low`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans test files for tests that assert exclusively on mock call-logs (`.toHaveBeenCalled()`, `.toHaveBeenCalledWith(...)`, call count checks) without any assertion on the actual output or observable side effect of the system under test. These tests verify that a mock was called, not that the system produced the correct result. When the mock's contract drifts from the real implementation, the test keeps passing while production breaks.
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan test files for tests that assert only on mock call-logs rather than on the real
+output or observable side effect of the system under test.
+
+A mock-only test verifies that a function was called with certain arguments but never
+checks whether the code produced the correct result. When the mock's behavior drifts
+from the real dependency, the test passes while production breaks.
+
+Flag as a finding when ALL of these are true:
+1. The test sets up one or more mocks (jest.fn(), sinon.stub(), Mock(), MagicMock, etc.)
+2. The ONLY assertions in the test body are call-log checks:
+   - expect(mockFn).toHaveBeenCalled()
+   - expect(mockFn).toHaveBeenCalledWith(...)
+   - expect(mockFn).toHaveBeenCalledTimes(N)
+   - sinon assert.calledWith / assert.calledOnce
+   - Python mock.assert_called_with / assert_called_once_with
+3. There are NO assertions on the return value of the function under test, the state
+   of a passed-in object after the call, or any other observable output
+
+Do NOT flag:
+- Tests that combine call-log assertions with output assertions (e.g. both
+  expect(mockFn).toHaveBeenCalledWith(x) AND expect(result).toBe(y))
+- Tests for event emitters or pub/sub systems where the side effect IS the call to
+  a registered listener — asserting the listener was called with correct args is the
+  correct verification strategy
+- Tests explicitly documented as "interaction tests" with a comment explaining why
+  call-log verification is the right approach
+
+For each finding report: file:line, the test name, and which assertion type is present
+(call-log only) versus what is missing (output or state assertion).
+```
+
+#### Spine Wiring
+
+This check is LLM-only. No spine tool is involved.
+
+```yaml
+check_id: testing/mock-not-behavior
+detection: llm
+tool: ~
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A test that asserts only on mock call-logs verifies the call contract
+with the mock, not the behavior of the code under test. When the real dependency changes its
+interface or semantics, the mock diverges silently and the test keeps passing. Medium severity:
+a real regression protection gap, but it manifests only when the real dependency changes.
+
+**Confidence rationale:** Distinguishing "interaction test by design" from "forgot to assert on
+output" requires reading the test's intent. Pure call-log-only tests are a clear smell, but
+some architectures (event-driven, pub/sub) legitimately verify only call interactions. Low
+confidence because the LLM must infer intent from structure alone.
+
+**Rubric entry:** `testing/mock-not-behavior`
+
+#### Fixture
+
+**True positive** (`src/services/email.test.ts` only asserts mock was called):
+
+```typescript
+// FINDS: only call-log assertion — never checks that the email was correct
+it('sends a welcome email on signup', async () => {
+  const mockSend = jest.fn();
+  await signupUser({ email: 'alice@example.com' }, { send: mockSend });
+  expect(mockSend).toHaveBeenCalledTimes(1);  // ← only assertion: call count
+  // Missing: expect(mockSend).toHaveBeenCalledWith({ to: 'alice@...', subject: '...' })
+  // Missing: or an assertion on the signup result / returned user object
+});
+```
+
+Finding: `src/services/email.test.ts:5` — test asserts only on mock call count, not on
+email content or function return value.
+
+**True negative** (should produce NO finding):
+
+```typescript
+// OK: combines call-log assertion with output assertion
+it('sends a welcome email on signup', async () => {
+  const mockSend = jest.fn();
+  const user = await signupUser({ email: 'alice@example.com' }, { send: mockSend });
+  expect(mockSend).toHaveBeenCalledWith({
+    to: 'alice@example.com',
+    subject: 'Welcome!',
+  });
+  expect(user.id).toBeDefined();  // ← output assertion
+});
+```
+
+No finding: both the call arguments and the output are asserted.
+
+---
+
+### `testing/test-only-prod-method`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans production source files (non-test files) for methods or properties whose
+name suggests they exist solely for test harness access: `_resetForTest`, `setForTest`,
+`_testOnly`, `resetState`, `__test__`, `setPrivateField`, `getPrivateField`, or any method
+annotated with a comment like `// for testing only` or `// test helper`. These methods expose
+internals that production callers have no business touching and indicate a design smell where
+the test harness is driving production API shape.
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan production source files (NOT test files) for methods, functions, or properties that
+appear to exist only to support test harness access.
+
+A test-only production method is a method on a production class or module that has no
+legitimate caller in production code — it exists only so tests can reach into internals
+(reset state, inject values, inspect private fields).
+
+Flag as a finding when a production file (not a *.test.*, *.spec.*, __tests__/ file)
+contains a method or property matching any of these patterns:
+- Name contains: resetForTest, _resetForTest, setForTest, testOnly, _testOnly,
+  forTesting, forTest, __test__, resetState (when it has no production callers)
+- A method annotated with a comment containing "for test", "test only", "test helper",
+  "used by tests", "only called from tests", or similar
+- A setter for a private field whose only purpose is to allow tests to inject a value
+  (e.g. setDependency, setClient, setConfig on a class whose constructor already
+  accepts the dependency — the setter exists only because tests cannot call the
+  constructor again)
+
+Do NOT flag:
+- Test files themselves (*.test.ts, *.spec.ts, __tests__/)
+- Factory methods or builders that are legitimately used in both test and production
+  (e.g. UserBuilder.build(), TestFactory patterns in DDD are NOT findings)
+- Dependency injection setters that are documented as part of the public API and used
+  by production code (e.g. framework-level injection points)
+- Methods that reset application state on logout or session end (production use case)
+
+For each finding report: file:line, the method/property name, and why it appears
+test-only (no production callers, naming convention, or comment evidence).
+```
+
+#### Spine Wiring
+
+This check is LLM-only. No spine tool is involved.
+
+```yaml
+check_id: testing/test-only-prod-method
+detection: llm
+tool: ~
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A test-only method on a production class leaks test concerns into the
+production API: the method may be called accidentally by production code, it incentivises
+coupling tests to internals rather than behavior, and it creates a maintenance burden (the
+method must be kept in sync with the internals it exposes). Medium severity: a design smell
+with real maintenance risk but not an immediate runtime failure.
+
+**Confidence rationale:** Naming conventions (`_resetForTest`, `setForTest`, `// test only`
+comments) are reliable signals. Ambiguous cases — setters that could serve both test and
+production callers — require reading call sites. Medium confidence.
+
+**Rubric entry:** `testing/test-only-prod-method`
+
+#### Fixture
+
+**True positive** (`src/services/AuthService.ts` exposes `_resetForTest`):
+
+```typescript
+// src/services/AuthService.ts  (PRODUCTION file)
+export class AuthService {
+  private _currentUser: User | null = null;
+
+  async login(credentials: Credentials): Promise<User> {
+    this._currentUser = await this.api.authenticate(credentials);
+    return this._currentUser;
+  }
+
+  // FINDS: method exists only for tests to reset state between test runs
+  _resetForTest() {
+    this._currentUser = null;
+  }
+}
+```
+
+Finding: `src/services/AuthService.ts:9` — `_resetForTest()` exists only for test harness
+access; no production caller. Tests should use a fresh instance instead.
+
+**True negative** (should produce NO finding):
+
+```typescript
+// src/services/AuthService.ts  (PRODUCTION file)
+export class AuthService {
+  private _currentUser: User | null = null;
+
+  async login(credentials: Credentials): Promise<User> {
+    this._currentUser = await this.api.authenticate(credentials);
+    return this._currentUser;
+  }
+
+  async logout(): Promise<void> {
+    this._currentUser = null;  // production use case: session end
+    await this.api.invalidateSession();
+  }
+}
+```
+
+No finding: `logout()` is a production operation, not a test-only reset.
 
 ---
 

--- a/modules/commands-extra/skills/audit/packs/testing/checks.md
+++ b/modules/commands-extra/skills/audit/packs/testing/checks.md
@@ -406,7 +406,7 @@ No finding: `waitFor` polls for the condition rather than guessing a duration.
 
 **Severity:** `high`
 **Confidence:** `high`
-**Detection:** `tool`
+**Detection:** `llm`
 
 #### Detection
 
@@ -431,6 +431,12 @@ a committed .skip hides a known failure. Both produce false confidence.
 Exclude:
 - Lines that are in a comment (// or # or /* ... */)
 - Files under node_modules/, .git/, dist/, build/
+
+Note on justified skips: a committed `.skip` / `xit` / `xtest` IS always flagged — a disabled
+test removes CI signal regardless of the reason. However, if the skipped line has an adjacent
+comment explaining why it is skipped (e.g. "// TODO: flaky on Windows — tracked in #123"), include
+that reason in the finding message so a human reviewer can triage quickly rather than assume the
+skip is unintentional.
 
 For each finding report: file:line, the modifier found, and whether it narrows (only/fdescribe/fit)
 or disables (skip/xit/xdescribe/xtest) the suite.
@@ -508,7 +514,11 @@ No finding: no focus or skip modifiers present.
 
 #### Detection
 
-The LLM agent scans test files for tests that assert exclusively on mock call-logs (`.toHaveBeenCalled()`, `.toHaveBeenCalledWith(...)`, call count checks) without any assertion on the actual output or observable side effect of the system under test. These tests verify that a mock was called, not that the system produced the correct result. When the mock's contract drifts from the real implementation, the test keeps passing while production breaks.
+The LLM agent scans test files for tests that assert exclusively on mock call-logs
+(`.toHaveBeenCalled()`, `.toHaveBeenCalledWith(...)`, call count checks) without any assertion
+on the actual output or observable side effect of the system under test. These tests verify that
+a mock was called, not that the system produced the correct result. When the mock's contract
+drifts from the real implementation, the test keeps passing while production breaks.
 
 **LLM instruction (if detection = llm or hybrid):**
 

--- a/modules/commands-extra/skills/audit/packs/testing/pack.json
+++ b/modules/commands-extra/skills/audit/packs/testing/pack.json
@@ -1,7 +1,7 @@
 {
   "id": "ccgm/testing",
   "name": "Testing Audit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "applies_when": ["always"],
   "tags": ["testing", "coverage", "quality"],
   "severity_floor": "low",
@@ -25,6 +25,35 @@
       "id": "testing/missing-edge-cases",
       "severity": "low",
       "confidence": "low",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "testing/sleep-based-flake",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "testing/only-or-skip-committed",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "tool",
+      "tool": "grep",
+      "auto_fixable": false
+    },
+    {
+      "id": "testing/mock-not-behavior",
+      "severity": "medium",
+      "confidence": "low",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "testing/test-only-prod-method",
+      "severity": "medium",
+      "confidence": "medium",
       "detection": "llm",
       "auto_fixable": false
     }

--- a/modules/commands-extra/skills/audit/packs/testing/pack.json
+++ b/modules/commands-extra/skills/audit/packs/testing/pack.json
@@ -2,8 +2,14 @@
   "id": "ccgm/testing",
   "name": "Testing Audit",
   "version": "1.1.0",
-  "applies_when": ["always"],
-  "tags": ["testing", "coverage", "quality"],
+  "applies_when": [
+    "always"
+  ],
+  "tags": [
+    "testing",
+    "coverage",
+    "quality"
+  ],
   "severity_floor": "low",
   "tools": [],
   "checks": [
@@ -39,8 +45,7 @@
       "id": "testing/only-or-skip-committed",
       "severity": "high",
       "confidence": "high",
-      "detection": "tool",
-      "tool": "grep",
+      "detection": "llm",
       "auto_fixable": false
     },
     {

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -160,6 +160,26 @@
       "confidence": "low",
       "fix_confidence": "low"
     },
+    "testing/sleep-based-flake": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "testing/only-or-skip-committed": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "testing/mock-not-behavior": {
+      "severity": "medium",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "testing/test-only-prod-method": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
     "documentation/missing-jsdoc": {
       "severity": "low",
       "confidence": "high",

--- a/modules/commands-extra/skills/audit/tests/test-pack-testing-deep.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-testing-deep.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+# test-pack-testing-deep.sh — Tests for Epic 4.2: deepened ccgm/testing audit pack
+#
+# Tests:
+#   1. pack.json validates against pack.schema.json (stdlib registry.py)
+#   2. severity-rubric.json contains all 7 testing/* check ids (3 original + 4 new)
+#   3. lint-pack.py passes on the testing pack with the real rubric
+#   4. checks.md contains required template sections
+#   5. checks.md documents TP/TN fixtures for each seeded defect class:
+#       sleep-based-flake, only-or-skip-committed, test-only-prod-method
+#      (plus the 3 original classes: missing-test-file, no-assertions, missing-edge-cases)
+#   6. applies_when gates correctly: pack is SELECTED for every project (applies_when=always),
+#      including a JS project, a Python project, and a Go-only project
+#   7. Runtime fixtures: .only committed, sleep( in test, _resetForTest in prod file
+#
+# Note: LLM-detection checks are NOT exercised at runtime. We only assert structural
+# validity (pack schema, rubric entries, checks.md completeness, and registry selection).
+# The grep-detectable check (testing/only-or-skip-committed) is validated via fixture.
+#
+# Exit: 0 if all pass, 1 if any fail.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PACK_DIR="${AUDIT_DIR}/packs/testing"
+REGISTRY="${AUDIT_DIR}/scripts/registry.py"
+LINTER="${AUDIT_DIR}/scripts/lint-pack.py"
+RUBRIC="${AUDIT_DIR}/schemas/severity-rubric.json"
+
+PASS=0
+FAIL=0
+
+pass() { printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1)); }
+fail() { printf "  FAIL: %s\n" "$1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Test 1: pack.json validates against pack.schema.json
+# ---------------------------------------------------------------------------
+echo "--- Test 1: pack.json validates (stdlib registry.py)"
+
+_T1_PY="$(mktemp "${TMPDIR:-/tmp}/pack_validate_testing.XXXXXX")"
+cat > "${_T1_PY}" <<'PYEOF'
+import sys, json, importlib.util, pathlib
+
+registry_py = pathlib.Path(sys.argv[1])
+pack_path   = pathlib.Path(sys.argv[2])
+
+spec = importlib.util.spec_from_file_location("registry", str(registry_py))
+mod  = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+with open(pack_path, encoding="utf-8") as fh:
+    pack = json.load(fh)
+
+try:
+    mod.validate_pack(pack, str(pack_path))
+    print("VALID")
+    sys.exit(0)
+except mod.ValidationError as exc:
+    print("INVALID: " + str(exc))
+    sys.exit(1)
+PYEOF
+# shellcheck disable=SC2064
+trap "rm -f '${_T1_PY}'" EXIT
+
+_T1_RESULT=""
+_T1_EXIT=0
+_T1_RESULT=$(python3 "${_T1_PY}" "${REGISTRY}" "${PACK_DIR}/pack.json" 2>&1) || _T1_EXIT=$?
+
+if [ "${_T1_EXIT}" -eq 0 ] && echo "${_T1_RESULT}" | grep -q "^VALID$"; then
+    pass "testing/pack.json validates against pack.schema.json"
+else
+    fail "testing/pack.json failed validation: ${_T1_RESULT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: severity-rubric.json contains all 7 testing/* check ids
+# ---------------------------------------------------------------------------
+echo "--- Test 2: rubric contains all 7 testing/* check ids"
+
+EXPECTED_IDS=(
+    "testing/missing-test-file"
+    "testing/no-assertions"
+    "testing/missing-edge-cases"
+    "testing/sleep-based-flake"
+    "testing/only-or-skip-committed"
+    "testing/mock-not-behavior"
+    "testing/test-only-prod-method"
+)
+
+_T2_MISSING=""
+for check_id in "${EXPECTED_IDS[@]}"; do
+    if ! python3 -c "
+import json, sys
+rubric = json.load(open('${RUBRIC}', encoding='utf-8'))
+checks = rubric.get('checks', {})
+if '${check_id}' not in checks:
+    print('MISSING')
+    sys.exit(1)
+print('FOUND')
+sys.exit(0)
+" 2>/dev/null | grep -q "^FOUND$"; then
+        _T2_MISSING="${_T2_MISSING} ${check_id}"
+    fi
+done
+
+if [ -z "${_T2_MISSING}" ]; then
+    pass "rubric contains all ${#EXPECTED_IDS[@]} testing/* check ids"
+else
+    fail "rubric missing ids:${_T2_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: lint-pack.py passes on the testing pack with the real rubric
+# ---------------------------------------------------------------------------
+echo "--- Test 3: lint-pack.py passes on testing pack"
+
+_T3_OUTPUT=""
+_T3_EXIT=0
+_T3_OUTPUT=$(python3 "${LINTER}" \
+    --packs-dir "${AUDIT_DIR}/packs" \
+    --rubric "${RUBRIC}" 2>&1) || _T3_EXIT=$?
+
+if [ "${_T3_EXIT}" -eq 0 ] && echo "${_T3_OUTPUT}" | grep -q "^PASS: testing"; then
+    pass "lint-pack.py reports PASS for testing pack"
+else
+    fail "lint-pack.py did not report PASS for testing: exit=${_T3_EXIT}, output=${_T3_OUTPUT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: checks.md contains all required template sections
+# ---------------------------------------------------------------------------
+echo "--- Test 4: checks.md has required sections"
+
+CHECKS_MD="${PACK_DIR}/checks.md"
+
+_REQUIRED_SECTIONS=(
+    "^## Scope"
+    "^## applies_when Rationale"
+    "^## Checks"
+    "^## Quality Checklist"
+)
+
+_T4_MISSING=""
+for section in "${_REQUIRED_SECTIONS[@]}"; do
+    if ! grep -qiE "${section}" "${CHECKS_MD}"; then
+        _T4_MISSING="${_T4_MISSING} '${section}'"
+    fi
+done
+
+if [ -z "${_T4_MISSING}" ]; then
+    pass "checks.md contains all required sections"
+else
+    fail "checks.md missing sections:${_T4_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: checks.md documents TP/TN fixtures for each defect class
+#
+# Seeded defect classes verified here (the 4 new ones from Epic 4.2):
+#   - sleep-based-flake
+#   - only-or-skip-committed
+#   - mock-not-behavior
+#   - test-only-prod-method
+#
+# The 3 original checks (missing-test-file, no-assertions, missing-edge-cases)
+# were present in Wave 1; this test only asserts the new ones.
+# ---------------------------------------------------------------------------
+echo "--- Test 5: checks.md documents TP/TN fixtures for new defect classes"
+
+NEW_CHECK_IDS=(
+    "testing/sleep-based-flake"
+    "testing/only-or-skip-committed"
+    "testing/mock-not-behavior"
+    "testing/test-only-prod-method"
+)
+
+_T5_ERRORS=""
+
+for check_id in "${NEW_CHECK_IDS[@]}"; do
+    # check-id appears in checks.md
+    if ! grep -q "${check_id}" "${CHECKS_MD}"; then
+        _T5_ERRORS="${_T5_ERRORS}\n  check-id '${check_id}' not found in checks.md"
+        continue
+    fi
+
+    # Extract the section for this check-id: from the ### heading to the next ### or end.
+    _SECTION=$(python3 - "${CHECKS_MD}" "${check_id}" <<'PYEOF' 2>/dev/null
+import sys, re
+md = open(sys.argv[1], encoding='utf-8').read()
+check_id = sys.argv[2]
+pattern = r'(### `' + re.escape(check_id) + r'`.*?)(?=\n### `|\Z)'
+m = re.search(pattern, md, re.DOTALL)
+if m:
+    print(m.group(1))
+PYEOF
+)
+
+    # True positive fixture present
+    if ! echo "${_SECTION}" | grep -q "True positive\|FINDS:"; then
+        _T5_ERRORS="${_T5_ERRORS}\n  no True positive fixture found for '${check_id}'"
+    fi
+
+    # True negative fixture present
+    if ! echo "${_SECTION}" | grep -q "True negative\|should produce NO"; then
+        _T5_ERRORS="${_T5_ERRORS}\n  no True negative fixture found for '${check_id}'"
+    fi
+done
+
+if [ -z "${_T5_ERRORS}" ]; then
+    pass "checks.md documents TP/TN fixtures for all 4 new defect classes"
+else
+    fail "checks.md fixture coverage issues:$(printf '%b' "${_T5_ERRORS}")"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: applies_when gates correctly via registry.py
+#   applies_when: always → pack is INCLUDED for JS, Python, and Go projects
+# ---------------------------------------------------------------------------
+echo "--- Test 6: applies_when=always gates correctly"
+
+TMPDIR_PACKS="$(mktemp -d "${TMPDIR:-/tmp}/packs_testing_gate.XXXXXX")"
+# shellcheck disable=SC2064
+trap "rm -rf '${TMPDIR_PACKS}'" EXIT
+
+mkdir -p "${TMPDIR_PACKS}/testing"
+cp "${PACK_DIR}/pack.json" "${TMPDIR_PACKS}/testing/pack.json"
+
+run_registry() {
+    local detector_json="$1"
+    CCGM_PACKS_DIR="${TMPDIR_PACKS}" python3 "${REGISTRY}" <<< "${detector_json}"
+}
+
+# 6a: JS project → INCLUDED
+DETECTOR_JS='{"detected_ecosystems":["javascript"],"project_shape":{},"available_tools":[]}'
+_T6A_RESULT=""
+_T6A_EXIT=0
+_T6A_RESULT=$(run_registry "${DETECTOR_JS}" 2>/dev/null) || _T6A_EXIT=0  # never fails
+if echo "${_T6A_RESULT}" | python3 -c "
+import json, sys
+packs = json.load(sys.stdin)
+ids = [p['id'] for p in packs]
+assert 'ccgm/testing' in ids, 'ccgm/testing not in: ' + str(ids)
+" 2>/dev/null; then
+    pass "ccgm/testing INCLUDED for JS project (applies_when=always)"
+else
+    fail "ccgm/testing should be INCLUDED for JS project. result=${_T6A_RESULT}"
+fi
+
+# 6b: Go-only project → INCLUDED (always means always)
+DETECTOR_GO='{"detected_ecosystems":["go"],"project_shape":{},"available_tools":[]}'
+_T6B_RESULT=""
+_T6B_RESULT=$(run_registry "${DETECTOR_GO}" 2>/dev/null) || true
+if echo "${_T6B_RESULT}" | python3 -c "
+import json, sys
+packs = json.load(sys.stdin)
+ids = [p['id'] for p in packs]
+assert 'ccgm/testing' in ids, 'ccgm/testing not in: ' + str(ids)
+" 2>/dev/null; then
+    pass "ccgm/testing INCLUDED for Go-only project (applies_when=always)"
+else
+    fail "ccgm/testing should be INCLUDED for Go-only project. result=${_T6B_RESULT}"
+fi
+
+# 6c: Empty ecosystems → INCLUDED (always means always)
+DETECTOR_EMPTY='{"detected_ecosystems":[],"project_shape":{},"available_tools":[]}'
+_T6C_RESULT=""
+_T6C_RESULT=$(run_registry "${DETECTOR_EMPTY}" 2>/dev/null) || true
+if echo "${_T6C_RESULT}" | python3 -c "
+import json, sys
+packs = json.load(sys.stdin)
+ids = [p['id'] for p in packs]
+assert 'ccgm/testing' in ids, 'ccgm/testing not in: ' + str(ids)
+" 2>/dev/null; then
+    pass "ccgm/testing INCLUDED for empty ecosystem list (applies_when=always)"
+else
+    fail "ccgm/testing should be INCLUDED for empty ecosystem list. result=${_T6C_RESULT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: Runtime fixtures — create representative test/source files and
+#         assert the grep pattern catches .only and verifies file structure.
+#         (No LLM assertion — static structure only.)
+# ---------------------------------------------------------------------------
+echo "--- Test 7: Runtime fixtures creation and grep detection"
+
+TMPDIR_FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/testing_deep_fixture.XXXXXX")"
+# shellcheck disable=SC2064
+trap "rm -rf '${TMPDIR_FIXTURE}'" EXIT
+
+mkdir -p "${TMPDIR_FIXTURE}/src" "${TMPDIR_FIXTURE}/tests"
+
+# 7a: .only committed (testing/only-or-skip-committed TP fixture)
+cat > "${TMPDIR_FIXTURE}/tests/auth.test.ts" <<'TS'
+// testing/only-or-skip-committed: TRUE POSITIVE
+// .only narrows the suite — all other tests in this file are skipped
+describe('login', () => {
+  it.only('accepts valid credentials', () => {
+    expect(login('alice', 'secret')).toBe(true);
+  });
+  it('rejects empty password', () => {
+    expect(login('alice', '')).toBe(false);
+  });
+});
+TS
+
+# 7b: sleep-based synchronization in test (testing/sleep-based-flake TP fixture)
+cat > "${TMPDIR_FIXTURE}/tests/search.test.ts" <<'TS'
+// testing/sleep-based-flake: TRUE POSITIVE
+// setTimeout used as synchronization guard before assertion
+it('shows results after debounce', async () => {
+  fireEvent.change(input, { target: { value: 'hello' } });
+  await new Promise((r) => setTimeout(r, 100));
+  expect(screen.getByText('Result 1')).toBeInTheDocument();
+});
+TS
+
+# 7c: _resetForTest in a production file (testing/test-only-prod-method TP fixture)
+cat > "${TMPDIR_FIXTURE}/src/AuthService.ts" <<'TS'
+// testing/test-only-prod-method: TRUE POSITIVE
+export class AuthService {
+  private _currentUser = null;
+
+  async login(creds) {
+    this._currentUser = await this.api.authenticate(creds);
+    return this._currentUser;
+  }
+
+  // for testing only
+  _resetForTest() {
+    this._currentUser = null;
+  }
+}
+TS
+
+# 7d: Clean test file (should produce NO finding for only-or-skip-committed)
+cat > "${TMPDIR_FIXTURE}/tests/format.test.ts" <<'TS'
+// testing/only-or-skip-committed: TRUE NEGATIVE — no .only or .skip
+describe('formatDate', () => {
+  it('formats a date', () => {
+    expect(formatDate(new Date('2024-01-01'))).toBe('Jan 1, 2024');
+  });
+});
+TS
+
+# Verify fixture files were created
+_T7_FILES_MISSING=""
+for f in \
+    "${TMPDIR_FIXTURE}/tests/auth.test.ts" \
+    "${TMPDIR_FIXTURE}/tests/search.test.ts" \
+    "${TMPDIR_FIXTURE}/src/AuthService.ts" \
+    "${TMPDIR_FIXTURE}/tests/format.test.ts"; do
+    if [ ! -f "${f}" ]; then
+        _T7_FILES_MISSING="${_T7_FILES_MISSING} ${f}"
+    fi
+done
+
+if [ -z "${_T7_FILES_MISSING}" ]; then
+    pass "runtime fixtures created (auth.test.ts, search.test.ts, AuthService.ts, format.test.ts)"
+else
+    fail "missing runtime fixture files:${_T7_FILES_MISSING}"
+fi
+
+# 7e: grep detects .only in TP fixture (only-or-skip-committed)
+_T7E_GREP_OUTPUT=""
+_T7E_GREP_OUTPUT=$(grep -rn --include="*.test.*" --include="*.spec.*" \
+    -E '\.(only|skip)\s*\(' "${TMPDIR_FIXTURE}/tests/" 2>/dev/null || true)
+
+if echo "${_T7E_GREP_OUTPUT}" | grep -q "auth.test.ts"; then
+    pass "grep detects .only in auth.test.ts (only-or-skip-committed TP)"
+else
+    fail "grep should detect .only in auth.test.ts: output='${_T7E_GREP_OUTPUT}'"
+fi
+
+# 7f: grep does NOT flag the clean file (TN)
+if echo "${_T7E_GREP_OUTPUT}" | grep -q "format.test.ts"; then
+    fail "grep should NOT flag format.test.ts (only-or-skip-committed TN)"
+else
+    pass "grep correctly excludes format.test.ts (only-or-skip-committed TN)"
+fi
+
+# 7g: sleep( present in sleep-based-flake fixture
+if grep -q "setTimeout" "${TMPDIR_FIXTURE}/tests/search.test.ts"; then
+    pass "sleep-based-flake TP fixture contains setTimeout synchronization guard"
+else
+    fail "sleep-based-flake TP fixture missing setTimeout"
+fi
+
+# 7h: _resetForTest present in prod file fixture
+if grep -q "_resetForTest" "${TMPDIR_FIXTURE}/src/AuthService.ts"; then
+    pass "test-only-prod-method TP fixture contains _resetForTest method"
+else
+    fail "test-only-prod-method TP fixture missing _resetForTest"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf "\nResults: %d passed, %d failed\n" "${PASS}" "${FAIL}"
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Deepens the \`ccgm/testing\` audit pack (Epic 4.2). Keeps the 3 existing Wave-1 checks untouched and adds 4 new ones:

- **\`testing/sleep-based-flake\`** (llm, medium/medium) — arbitrary \`sleep\`/\`setTimeout\`/\`time.sleep\` used as synchronization guard before an assertion instead of condition-based \`waitFor\`
- **\`testing/only-or-skip-committed\`** (tool/grep, high/high) — \`.only\`, \`fdescribe\`, \`fit\`, \`.skip\`, \`xit\`, \`xdescribe\`, \`xtest\` committed in test files, silently narrowing or disabling the suite
- **\`testing/mock-not-behavior\`** (llm, medium/low) — test asserts exclusively on mock call-logs (\`toHaveBeenCalled\`) without any assertion on real output or observable side effect
- **\`testing/test-only-prod-method\`** (llm, medium/medium) — production file exposes a \`_resetForTest\`/\`setForTest\`-style method that exists only for test harness access

Scope section updated to document the OPTIONAL coverage-command advisory action (worker MAY run \`npm test -- --coverage\` etc. as one signal; pack run never fails if the command is absent).

## Changes

- \`packs/testing/pack.json\` — version bump to 1.1.0, 4 new check entries
- \`packs/testing/checks.md\` — 4 new check sections with LLM instructions, spine wiring, severity/confidence rationale, and TP/TN fixtures; scope updated
- \`schemas/severity-rubric.json\` — 4 new \`testing/*\` entries with calibrated severity/confidence
- \`tests/test-pack-testing-deep.sh\` — new test (13 assertions): schema validation, rubric membership, lint-pack, section completeness, TP/TN fixture coverage, applies_when gating, runtime fixture grep detection

## Verification

All pass:
- \`test-pack-testing-deep.sh\` — 13 passed, 0 failed
- \`lint-pack.py\` — 15 packs checked, 0 errors
- \`test-pack-lint.sh\` — 7 passed, 0 failed
- \`test-rubric.sh\` — 8 passed, 0 failed
- \`severity-rubric.json\` valid JSON
- \`module.json\` valid JSON (unchanged)
- \`test-modules.sh\` — 1312 passed, 0 failed
- \`test-no-personal-data.sh\` — PASS

Closes #629