### PR TITLE
#632: Epic 4.5 — privacy and observability audit packs

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -458,6 +458,26 @@
       "target": "skills/audit/packs/data-migrations/checks.md",
       "type": "doc",
       "template": false
+    },
+    "skills/audit/packs/privacy/pack.json": {
+      "target": "skills/audit/packs/privacy/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/privacy/checks.md": {
+      "target": "skills/audit/packs/privacy/checks.md",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/observability/pack.json": {
+      "target": "skills/audit/packs/observability/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/observability/checks.md": {
+      "target": "skills/audit/packs/observability/checks.md",
+      "type": "doc",
+      "template": false
     }
   },
   "tags": [

--- a/modules/commands-extra/skills/audit/packs/observability/checks.md
+++ b/modules/commands-extra/skills/audit/packs/observability/checks.md
@@ -1,0 +1,320 @@
+# checks.md — Observability & Logging Quality Pack
+
+---
+
+## Scope
+
+This pack audits source code for observability anti-patterns: logging calls that emit user objects or PII fields directly (leaking personal data into log infrastructure), raw `console.log` statements used in server-side code where a structured logger is expected, and caught errors that are silently swallowed with no telemetry or error-reporting call. All checks use LLM detection targeting code behavior. This pack does NOT audit privacy policy compliance, consent gates, or data retention — those belong in the `ccgm/privacy` pack. It also does NOT audit general empty-catch patterns without considering the observability context (that overlaps `code-quality/empty-catch-block`); the `observability/missing-error-reporting` check is specifically scoped to cases where an error is caught and no reporting or telemetry call follows.
+
+**Pack ID:** `ccgm/observability`
+**Applies when:** `always`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `always` | PII leakage into logs, absent structured logging, and swallowed errors can occur in any language and project type. Gating on `language:javascript` would miss Python/Go/Ruby server-side log calls. The pack is self-scoping: checks instruct the LLM agent to produce no findings when no relevant logging or error-handling code is present. |
+
+---
+
+## Checks
+
+---
+
+### `observability/pii-in-logs`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans for logging calls (`console.log`, `console.error`, `console.warn`, `console.info`, `logger.info`, `logger.error`, `logger.warn`, `logger.debug`, `log.info`, `winston`, `pino`, `bunyan`, Python `logging.*`, Go `log.*`, `zerolog`, `zap`, etc.) that pass a user object, request body, or field known to contain PII directly as a log argument, without redaction.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a (no standard tool rule exists for PII-in-log detection)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan the repository for logging calls that emit user objects, request bodies, or
+Personally Identifiable Information (PII) fields directly as log arguments without
+redaction.
+
+Logging calls include: console.log, console.error, console.warn, console.info,
+logger.info, logger.error, logger.warn, logger.debug, log.info, log.error,
+winston logger methods, pino logger methods, bunyan logger methods, Python
+logging.info/error/warning/debug, Go log.Printf/Println/Fatal, zerolog, zap.
+
+Flag as a finding when:
+- A logging call receives a whole user object: console.log(user), logger.info(req.body),
+  logger.debug({ user }), log.Printf("%+v", user)
+- A logging call receives a field name that is clearly PII: console.log(user.email),
+  logger.info({ email: user.email }), logger.error('Failed for ' + req.body.ssn)
+- A logging call receives the raw request body without redaction:
+  console.log(req.body), logger.info(request.body), log.Printf("%v", r.Body)
+
+Do NOT flag:
+- Logging calls that use a redact/sanitize helper before logging:
+  logger.info(redactPII(user)), logger.info(sanitize(req.body))
+- Logging calls that reference only opaque identifiers: logger.info({ userId: user.id })
+  where id is a UUID or numeric ID with no PII meaning
+- Test files (*.test.ts, *.spec.ts, *.test.js, __tests__/, test/)
+- Debug-only log calls clearly gated by a NODE_ENV !== 'production' or equivalent
+  development-mode check
+
+For each finding report: file:line, the logging call, and what PII or user data
+is being passed unredacted.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: observability/pii-in-logs
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Log aggregation systems (Datadog, Splunk, CloudWatch, Loki) often retain logs for months or years. Emitting user objects or PII fields into logs means personal data is stored in log infrastructure with different access controls and retention policies than the primary database, violating GDPR and similar regulations and creating a secondary data-breach surface. High severity: passive, long-lived PII leakage.
+
+**Confidence rationale:** Detecting whole-object log calls (`console.log(user)`) is highly reliable. Detecting specific PII field references requires reading variable and field names. LLMs can identify obvious cases (`.email`, `.phone`, `.ssn`) reliably; ambiguous field names reduce precision. Medium confidence.
+
+**Rubric entry:** `observability/pii-in-logs`
+
+#### Fixture
+
+**True positive** (`src/routes/auth.ts`):
+
+```ts
+// FINDS: entire user object logged — includes email, name, and other PII
+async function handleLogin(req: Request, res: Response) {
+  const user = await findUser(req.body.email);
+  console.log(user);   // logs PII: email, name, phone, etc.
+  if (!user) return res.status(404).json({ error: 'Not found' });
+  // ...
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: only opaque user ID logged — no PII
+async function handleLogin(req: Request, res: Response) {
+  const user = await findUser(req.body.email);
+  logger.info({ userId: user?.id }, 'login attempt');
+  if (!user) return res.status(404).json({ error: 'Not found' });
+  // ...
+}
+```
+
+---
+
+### `observability/missing-structured-logging`
+
+**Severity:** `low`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans server-side source files for raw `console.log` / `console.error` / `console.warn` calls used in place of a structured logger (winston, pino, bunyan, morgan, Python `logging` module, Go `zerolog`/`zap`/`slog`, etc.). Unstructured log output cannot be parsed, filtered, aggregated, or alerted on reliably in production log systems. This check targets server-side code only; browser/client-side `console.log` usage is expected and not flagged.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a (no standard tool rule exists for this cross-project pattern)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan server-side source files for raw console.log, console.error, console.warn,
+console.info, or console.debug calls in production code paths, in projects where
+a structured logger library is also present.
+
+Server-side files include: files under src/server/, src/api/, src/routes/, src/handlers/,
+server.ts, app.ts, index.ts (when the project is a Node.js server), or any non-browser
+context. Python server files (views.py, routes.py, handlers.py), Go server files
+(main.go, handlers.go).
+
+A structured logger is present when the project imports winston, pino, bunyan, morgan,
+@nestjs/common Logger, Python logging module, Go zerolog/zap/slog, or similar.
+
+Flag as a finding when:
+- A server-side file uses console.log/error/warn as the primary logging mechanism
+  in a project that also imports a structured logger elsewhere (inconsistent use)
+- A server-side file uses console.log/error/warn in any capacity when no structured
+  logger is present anywhere in the project (missing logging infrastructure entirely)
+
+Do NOT flag:
+- console.log in browser/client-side files (*.client.ts, files under src/components/,
+  src/pages/, src/app/ in Next.js context, etc.)
+- console.log statements that are clearly temporary debug statements with a TODO/FIXME
+  comment attached
+- Test files (*.test.ts, *.spec.ts, *.test.js, __tests__/, test/)
+- console.error used as an error handler of last resort (process.on('uncaughtException'))
+
+For each finding report: file:line, the console call, and whether a structured logger
+is present in the project (explain if not).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: observability/missing-structured-logging
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Using raw `console.log` in server code prevents structured log aggregation, alerting, and correlation. Log noise increases, signal-to-noise ratio drops, and production debugging becomes harder. Low severity: a hygiene/operational issue that does not cause immediate runtime failures but degrades production observability over time.
+
+**Confidence rationale:** Detecting console.log in server-side context is reliable when the file's server-side nature is clear from path or imports. Distinguishing intentional debug console.log from accidental ones requires some judgment. Whether a structured logger is "present" in the project can be ambiguous in monorepos. Medium confidence.
+
+**Rubric entry:** `observability/missing-structured-logging`
+
+#### Fixture
+
+**True positive** (`src/api/users.ts` in a project that imports `pino` in `src/lib/logger.ts`):
+
+```ts
+// FINDS: raw console.log in server route; pino logger exists in the project
+import { db } from '../db';
+
+export async function getUser(req: Request, res: Response) {
+  console.log('Getting user', req.params.id);   // should use structured logger
+  const user = await db.users.findById(req.params.id);
+  console.log('Found user', user?.email);       // also logs PII
+  res.json(user);
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: structured logger used consistently
+import { logger } from '../lib/logger';
+import { db } from '../db';
+
+export async function getUser(req: Request, res: Response) {
+  logger.info({ userId: req.params.id }, 'fetching user');
+  const user = await db.users.findById(req.params.id);
+  res.json(user);
+}
+```
+
+---
+
+### `observability/missing-error-reporting`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans for `catch` blocks (and equivalent error handlers in Python/Go) that catch an error but do not forward it to any telemetry or error-reporting system — no `Sentry.captureException`, no `logger.error`, no `reportError`, no `captureError`, no re-throw, no error metric increment. Silently swallowed errors mean production failures go undetected. This check differs from `code-quality/empty-catch-block` (which flags syntactically empty catch blocks) by specifically targeting non-empty catch blocks that do have code but that code never reports or re-throws the error.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a (no standard tool rule exists for this pattern)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan the repository for catch blocks (or equivalent error-handling constructs in
+Python/Go) that catch an error but neither report it to any telemetry system nor
+re-throw it, causing the error to be silently swallowed in production.
+
+Flag as a finding when a catch block:
+- Contains code that does NOT include any of the following:
+    * A call to an error-reporting service: Sentry.captureException(err),
+      Bugsnag.notify(err), Rollbar.error(err), reportError(err), captureException(err)
+    * A structured log call at error level: logger.error(err), log.error(err),
+      console.error(err) (console.error is acceptable here as a minimum)
+    * A re-throw: throw err, throw new Error(..., { cause: err })
+    * A return of an error-typed value clearly propagating the failure up the call chain
+- The catch block instead only: sets a local variable, calls a UI-only function
+  (setError, showToast, setLoading(false)), logs a custom user-facing message with
+  no error object attached, or is empty/comment-only
+
+Do NOT flag:
+- Catch blocks that call console.error(err) — this is an acceptable minimum reporting
+- Catch blocks that re-throw the error
+- Catch blocks at the top-level application boundary that display user-facing error
+  messages — these are an acceptable last resort when combined with any logging
+- Test files (*.test.ts, *.spec.ts, *.test.js, __tests__/, test/)
+- Catch blocks that return a typed error Result/Either value (functional error handling)
+
+For each finding report: file:line, the catch block contents, and what reporting
+mechanism is missing.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: observability/missing-error-reporting
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A catch block that swallows an error with no reporting means production failures are invisible. Database failures, API timeouts, and validation errors that would normally alert on-call engineers go unnoticed until a user complains or data corruption is discovered. Medium severity: operational blindness that delays incident response but does not directly expose data or cause immediate user harm.
+
+**Confidence rationale:** Identifying that a catch block has code but no reporting or re-throw requires reading the catch block body and understanding what each call does. UI state setters (`setError(true)`) do not count as error reporting. The LLM must distinguish error-reporting calls from UI calls, which is generally reliable for named functions but requires judgment for project-specific utilities. Medium confidence.
+
+**Rubric entry:** `observability/missing-error-reporting`
+
+#### Fixture
+
+**True positive** (`src/services/payment.ts`):
+
+```ts
+// FINDS: error caught and only used to update UI state — no reporting to telemetry
+async function processPayment(orderId: string) {
+  try {
+    await stripe.charges.create({ amount: getOrderAmount(orderId) });
+  } catch (err) {
+    setPaymentError(true);   // only UI state — error is invisible to monitoring
+    setLoading(false);
+  }
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: Sentry captures the error before updating UI state
+async function processPayment(orderId: string) {
+  try {
+    await stripe.charges.create({ amount: getOrderAmount(orderId) });
+  } catch (err) {
+    Sentry.captureException(err);
+    setPaymentError(true);
+    setLoading(false);
+  }
+}
+```
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/observability/pack.json
+++ b/modules/commands-extra/skills/audit/packs/observability/pack.json
@@ -1,0 +1,32 @@
+{
+  "id": "ccgm/observability",
+  "name": "Observability & Logging Quality",
+  "version": "1.0.0",
+  "applies_when": ["always"],
+  "tags": ["observability", "logging", "error-reporting", "telemetry"],
+  "severity_floor": "low",
+  "tools": [],
+  "checks": [
+    {
+      "id": "observability/pii-in-logs",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "observability/missing-structured-logging",
+      "severity": "low",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "observability/missing-error-reporting",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/packs/privacy/checks.md
+++ b/modules/commands-extra/skills/audit/packs/privacy/checks.md
@@ -1,0 +1,323 @@
+# checks.md — Privacy & PII Handling Pack
+
+---
+
+## Scope
+
+This pack audits source code for data-handling patterns that put Personally Identifiable Information (PII) at risk: analytics or tracking SDKs wired without a user consent gate, PII stored or persisted with no documented retention or deletion path, and PII passed in URL query strings or GET parameters where it leaks into server logs, browser history, and referrer headers. All three checks target code behavior — what the application does with personal data — not legal documents or license terms. This pack does NOT audit license compliance, terms-of-service adherence, or the presence of a privacy policy document; those are covered by the `ccgm/tos-compliance` pack. Checks produce nothing when no data-handling code is present (`applies_when: always` is self-scoping by design).
+
+**Pack ID:** `ccgm/privacy`
+**Applies when:** `always`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `always` | PII handling defects can appear in any language and any project type (web, mobile, CLI, library). Gating on a language or ecosystem flag would miss server-side PII leaks in Go/Python repos or mobile apps with no JavaScript. The pack is self-scoping: all three checks instruct the LLM agent to produce no findings when no data-handling code is present. |
+
+---
+
+## Checks
+
+---
+
+### `privacy/pii-without-consent`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans for analytics or tracking SDK initialisation calls (Segment, Mixpanel, Amplitude, Google Analytics, Facebook Pixel, Intercom, Heap, Hotjar, Posthog, Sentry user identification, etc.) and PII collection forms or endpoints that capture email, name, phone, address, or government ID — where no consent gate (cookie banner, opt-in dialog, permission check, or feature flag controlled by consent) is visible in the same code path. The check targets code patterns, not privacy policy documents.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a (no standard tool rule exists for consent-gate presence)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan the repository for analytics or tracking SDK initialisation and PII collection
+code paths where no consent gate is present.
+
+A consent gate is any of:
+- An explicit opt-in check (e.g. if (user.hasConsented), if (cookieConsent.analytics))
+- A call to a consent management library (OneTrust, Cookiebot, Osano, usercentrics,
+  react-cookie-consent, etc.) that must resolve before the tracking call executes
+- A feature flag or environment variable that requires affirmative user opt-in
+- A documented TODO or comment explicitly referencing pending consent integration
+  (flag as a finding with lower confidence — the code will be live without consent)
+
+Flag as a finding when:
+- A tracking or analytics SDK (Segment, Mixpanel, Amplitude, Google Analytics,
+  gtag, fbq, Intercom, Heap, Hotjar, Posthog, Sentry.setUser, etc.) is initialised
+  or called with user-identifiable data (userId, email, name, phone) and no consent
+  gate is visible in the same code path or in the file that calls this code
+- A form submission or API handler collects PII fields (email, name, phone, address,
+  national ID, date of birth) and forwards them to a third-party service with no
+  prior consent check
+
+Do NOT flag:
+- Server-side error logging that does NOT include user PII (stack traces, error codes
+  without user identifiers are fine)
+- SDK calls that pass only anonymous identifiers (random UUIDs, session tokens with
+  no connection to real-world identity in context)
+- SDK initialisation without any user data attached (anonymous mode)
+- Test files (*.test.ts, *.spec.ts, *.test.js, __tests__/, test/)
+
+For each finding report: file:line, the tracking/collection call, and what PII or
+identifying data is passed without a visible consent gate.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: privacy/pii-without-consent
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Collecting and transmitting user PII to third-party analytics services without consent is a violation of GDPR, CCPA, and similar regulations, exposing the organisation to regulatory fines and reputational harm. High severity: direct legal and ethical risk.
+
+**Confidence rationale:** Detecting the *absence* of a consent gate requires understanding the control flow around a tracking call. The LLM must reason about what is NOT present, which is harder than detecting a present pattern. Consent gates can be implemented in many ways (middleware, HOCs, feature flags, build-time conditions). Medium confidence accounts for false positives where consent is handled in an unconventional way not visible in the immediate code path.
+
+**Rubric entry:** `privacy/pii-without-consent`
+
+#### Fixture
+
+**True positive** (`src/analytics/init.ts`):
+
+```ts
+// FINDS: Segment analytics initialised with user email on login — no consent check
+import analytics from '@segment/analytics-next';
+
+export function identifyUser(user: User) {
+  analytics.identify(user.id, {
+    email: user.email,
+    name: user.displayName,
+  });
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: consent check gates the identify call
+import analytics from '@segment/analytics-next';
+import { getConsentState } from '@/lib/consent';
+
+export function identifyUser(user: User) {
+  if (!getConsentState().analytics) return;
+  analytics.identify(user.id, {
+    email: user.email,
+    name: user.displayName,
+  });
+}
+```
+
+---
+
+### `privacy/pii-no-retention`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans for database schema definitions, ORM models, or data-store writes that persist PII fields (email, phone, name, address, national/government ID, date of birth, IP address, device fingerprint) with no evidence of a documented retention policy or deletion path — no TTL, no scheduled cleanup job, no soft-delete field with a noted deletion window, and no code comment or migration referencing a data retention requirement.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a (no standard tool rule exists for retention documentation)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan the repository for database schema definitions, ORM model files, or persistent
+data-store write operations that store Personally Identifiable Information (PII) with
+no documented retention or deletion path.
+
+PII fields to look for: email, phone, phone_number, name, first_name, last_name,
+address, street_address, postal_code, zip_code, national_id, ssn, date_of_birth,
+dob, ip_address, device_id, fingerprint, passport_number, tax_id, credit_card,
+payment_info.
+
+A documented retention/deletion path is any of:
+- A TTL or expiry field on the model (expires_at, deleted_at with a cleanup job
+  visible elsewhere in the codebase, ttl, purge_after)
+- A migration or comment explicitly stating a retention window
+  (e.g. "-- retained for 90 days per privacy policy")
+- A scheduled job or cron that deletes records older than N days
+- A soft-delete pattern (is_deleted, archived_at) where a purge job exists
+
+Flag as a finding when:
+- A SQL schema (CREATE TABLE), ORM model class (TypeORM @Entity, Prisma model,
+  Django model, ActiveRecord), or NoSQL document schema contains one or more PII
+  fields and there is no evidence in the file or in any related migration/job
+  that these records are ever deleted or anonymised after a stated period
+
+Do NOT flag:
+- Logging or audit tables that only store event metadata with no user PII fields
+- Models that store only non-identifying system data
+- Models where PII fields have a comment referencing a retention policy (even if
+  the policy duration is not stated — the reference is sufficient)
+- Test fixture files or seed files
+
+For each finding report: file:line or model name, the PII field(s) present, and
+the absence of any documented retention/deletion path.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: privacy/pii-no-retention
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Storing PII indefinitely without a documented retention policy violates GDPR Article 5(1)(e) (storage limitation) and equivalent regulations. The risk is real but secondary to active disclosure without consent. Medium severity: compliance gap that creates long-term liability rather than immediate harm.
+
+**Confidence rationale:** Detecting the absence of a retention policy requires searching across schema files, migration files, and background job definitions. A retention policy may be documented outside the codebase (in a README, GDPR register, or comment in a different file). The LLM cannot be certain retention is undocumented just because it is not visible in one file. Medium confidence.
+
+**Rubric entry:** `privacy/pii-no-retention`
+
+#### Fixture
+
+**True positive** (`db/schema.sql`):
+
+```sql
+-- FINDS: email and phone stored with no TTL, no deleted_at, no comment about retention
+CREATE TABLE user_profiles (
+  id          UUID PRIMARY KEY,
+  email       TEXT NOT NULL,
+  phone       TEXT,
+  full_name   TEXT,
+  created_at  TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+**True negative** (should produce NO finding):
+
+```sql
+-- OK: deleted_at column documents the soft-delete retention path
+CREATE TABLE user_profiles (
+  id          UUID PRIMARY KEY,
+  email       TEXT NOT NULL,
+  phone       TEXT,
+  full_name   TEXT,
+  created_at  TIMESTAMPTZ DEFAULT NOW(),
+  deleted_at  TIMESTAMPTZ  -- purged after 90 days by nightly cleanup job (see jobs/purge_users.ts)
+);
+```
+
+---
+
+### `privacy/pii-in-url`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans for URL construction, routing definitions, or API client calls where PII values (email address, full name, national/government ID, phone number, date of birth) are appended as GET query parameters or embedded as path segments. PII in URLs leaks into server access logs, browser history, CDN request logs, referrer headers, and third-party analytics that capture full URLs.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a (no standard tool rule exists for PII-in-URL detection)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+Scan the repository for URL construction or API calls where Personally Identifiable
+Information (PII) is passed in URL query parameters (GET params) or as path segments.
+
+PII values to look for: email address, full name, first name + last name together,
+national ID / SSN, phone number, date of birth, passport number, tax ID.
+
+Note: opaque identifiers (UUID, numeric user IDs with no direct PII meaning) are
+acceptable in URL paths. The concern is PII values themselves (e.g. email=user@example.com
+or /search?name=John+Smith&dob=1990-01-01).
+
+Flag as a finding when:
+- A URL is constructed using string interpolation, template literals, URLSearchParams,
+  or query-string builders that include email, name, phone, or other PII fields as
+  parameter values (not as opaque IDs)
+- An API endpoint definition (Express route, FastAPI path, Rails route) defines a
+  route parameter that accepts PII directly: /users/:email, /verify/:ssn
+- A redirect or navigation call embeds PII in the destination URL
+
+Do NOT flag:
+- URLs that include only opaque identifiers (UUIDs, numeric IDs, session tokens)
+- Internal routing between microservices where no PII value is serialised into
+  the URL path or query string
+- Test files (*.test.ts, *.spec.ts, *.test.js, __tests__/, test/)
+- URLs where the PII field is clearly in a POST body, not a query param
+
+For each finding report: file:line, the URL construction pattern, and which PII
+field is being embedded in the URL.
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: privacy/pii-in-url
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** PII in URLs leaks into server logs, CDN logs, browser history, and referrer headers whenever the user navigates away or the page includes third-party resources. This is a well-known OWASP and GDPR risk. High severity: passive, hard-to-detect data leakage that persists across log retention periods.
+
+**Confidence rationale:** Distinguishing PII values from opaque IDs in URL parameters requires reading variable names and context. A field named `userId` is fine; `userEmail` or `email` is a finding. LLMs can make this distinction with reasonable accuracy for clearly named fields, but ambiguous naming (e.g., `q`, `id`) reduces precision. Medium confidence.
+
+**Rubric entry:** `privacy/pii-in-url`
+
+#### Fixture
+
+**True positive** (`src/api/verify.ts`):
+
+```ts
+// FINDS: email address passed as a GET query parameter — leaks into server logs
+async function sendVerificationLink(email: string, token: string) {
+  const url = `https://app.example.com/verify?email=${encodeURIComponent(email)}&token=${token}`;
+  await sendEmail(email, 'Verify your account', `Click here: ${url}`);
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: only opaque token in URL — no PII exposed
+async function sendVerificationLink(email: string, token: string) {
+  const url = `https://app.example.com/verify?token=${token}`;
+  await sendEmail(email, 'Verify your account', `Click here: ${url}`);
+}
+```
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/privacy/pack.json
+++ b/modules/commands-extra/skills/audit/packs/privacy/pack.json
@@ -1,0 +1,32 @@
+{
+  "id": "ccgm/privacy",
+  "name": "Privacy & PII Handling",
+  "version": "1.0.0",
+  "applies_when": ["always"],
+  "tags": ["privacy", "pii", "gdpr", "consent", "data-handling"],
+  "severity_floor": "medium",
+  "tools": [],
+  "checks": [
+    {
+      "id": "privacy/pii-without-consent",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "privacy/pii-no-retention",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "privacy/pii-in-url",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -1,492 +1,539 @@
 {
-    "name": "commands-extra",
-    "version": "1.0.0",
-    "displayName": "Extra Commands",
-    "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global), /freeze + /unfreeze + /guard (safety-hook state management), /checkpoint (save/resume WIP session state).",
-    "category": "commands",
-    "scope": [
-        "global"
-    ],
-    "dependencies": [],
-    "files": {
-        "commands/audit.md": {
-            "target": "commands/audit.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/pwv.md": {
-            "target": "commands/pwv.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/walkthrough.md": {
-            "target": "commands/walkthrough.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/promote-rule.md": {
-            "target": "commands/promote-rule.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/freeze.md": {
-            "target": "commands/freeze.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/unfreeze.md": {
-            "target": "commands/unfreeze.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/guard.md": {
-            "target": "commands/guard.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/checkpoint.md": {
-            "target": "commands/checkpoint.md",
-            "type": "command",
-            "template": false
-        },
-        "skills/audit/SKILL.md": {
-            "target": "skills/audit/SKILL.md",
-            "type": "skill",
-            "template": false
-        },
-        "skills/audit/reference/security-patterns.md": {
-            "target": "skills/audit/reference/security-patterns.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/code-quality.md": {
-            "target": "skills/audit/reference/code-quality.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/architecture.md": {
-            "target": "skills/audit/reference/architecture.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/fix-patterns.md": {
-            "target": "skills/audit/reference/fix-patterns.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/multi-agent-config.md": {
-            "target": "skills/audit/reference/multi-agent-config.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/output-template.md": {
-            "target": "skills/audit/reference/output-template.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/schemas/pack.schema.json": {
-            "target": "skills/audit/schemas/pack.schema.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/schemas/finding.schema.json": {
-            "target": "skills/audit/schemas/finding.schema.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/scripts/registry.py": {
-            "target": "skills/audit/scripts/registry.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/assign-packs.py": {
-            "target": "skills/audit/scripts/assign-packs.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/detect-ecosystems.sh": {
-            "target": "skills/audit/scripts/detect-ecosystems.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/emit-findings.py": {
-            "target": "skills/audit/scripts/emit-findings.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/merge-findings.py": {
-            "target": "skills/audit/scripts/merge-findings.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/baseline.py": {
-            "target": "skills/audit/scripts/baseline.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/suppress.py": {
-            "target": "skills/audit/scripts/suppress.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/schemas/severity-rubric.json": {
-            "target": "skills/audit/schemas/severity-rubric.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/scripts/lint-rubric.py": {
-            "target": "skills/audit/scripts/lint-rubric.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/lint-pack.py": {
-            "target": "skills/audit/scripts/lint-pack.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/provenance.py": {
-            "target": "skills/audit/scripts/provenance.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/packs/_TEMPLATE/checks.md": {
-            "target": "skills/audit/packs/_TEMPLATE/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/security/pack.json": {
-            "target": "skills/audit/packs/security/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/security/checks.md": {
-            "target": "skills/audit/packs/security/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/dependencies/pack.json": {
-            "target": "skills/audit/packs/dependencies/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/dependencies/checks.md": {
-            "target": "skills/audit/packs/dependencies/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/tos-compliance/pack.json": {
-            "target": "skills/audit/packs/tos-compliance/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/tos-compliance/checks.md": {
-            "target": "skills/audit/packs/tos-compliance/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/pack-quality-bar.md": {
-            "target": "skills/audit/reference/pack-quality-bar.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/testing/pack.json": {
-            "target": "skills/audit/packs/testing/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/testing/checks.md": {
-            "target": "skills/audit/packs/testing/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/documentation/pack.json": {
-            "target": "skills/audit/packs/documentation/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/documentation/checks.md": {
-            "target": "skills/audit/packs/documentation/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/performance/pack.json": {
-            "target": "skills/audit/packs/performance/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/performance/checks.md": {
-            "target": "skills/audit/packs/performance/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/scripts/spine/run.sh": {
-            "target": "skills/audit/scripts/spine/run.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/normalize.py": {
-            "target": "skills/audit/scripts/spine/normalize.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-gitleaks.sh": {
-            "target": "skills/audit/scripts/spine/wrap-gitleaks.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-gitleaks.py": {
-            "target": "skills/audit/scripts/spine/parse-gitleaks.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-semgrep.sh": {
-            "target": "skills/audit/scripts/spine/wrap-semgrep.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-semgrep.py": {
-            "target": "skills/audit/scripts/spine/parse-semgrep.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-dep-audit.sh": {
-            "target": "skills/audit/scripts/spine/wrap-dep-audit.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-dep-audit.py": {
-            "target": "skills/audit/scripts/spine/parse-dep-audit.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-knip.sh": {
-            "target": "skills/audit/scripts/spine/wrap-knip.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-knip.py": {
-            "target": "skills/audit/scripts/spine/parse-knip.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-eslint.sh": {
-            "target": "skills/audit/scripts/spine/wrap-eslint.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-eslint.py": {
-            "target": "skills/audit/scripts/spine/parse-eslint.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-govulncheck.sh": {
-            "target": "skills/audit/scripts/spine/wrap-govulncheck.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-govulncheck.py": {
-            "target": "skills/audit/scripts/spine/parse-govulncheck.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-bandit.sh": {
-            "target": "skills/audit/scripts/spine/wrap-bandit.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-bandit.py": {
-            "target": "skills/audit/scripts/spine/parse-bandit.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-hadolint.sh": {
-            "target": "skills/audit/scripts/spine/wrap-hadolint.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-hadolint.py": {
-            "target": "skills/audit/scripts/spine/parse-hadolint.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-actionlint.sh": {
-            "target": "skills/audit/scripts/spine/wrap-actionlint.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-actionlint.py": {
-            "target": "skills/audit/scripts/spine/parse-actionlint.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-trivy.sh": {
-            "target": "skills/audit/scripts/spine/wrap-trivy.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-trivy.py": {
-            "target": "skills/audit/scripts/spine/parse-trivy.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-zizmor.sh": {
-            "target": "skills/audit/scripts/spine/wrap-zizmor.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-zizmor.py": {
-            "target": "skills/audit/scripts/spine/parse-zizmor.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-pinact.sh": {
-            "target": "skills/audit/scripts/spine/wrap-pinact.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-pinact.py": {
-            "target": "skills/audit/scripts/spine/parse-pinact.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/packs/ci-cd/pack.json": {
-            "target": "skills/audit/packs/ci-cd/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/ci-cd/checks.md": {
-            "target": "skills/audit/packs/ci-cd/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/code-quality/pack.json": {
-            "target": "skills/audit/packs/code-quality/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/code-quality/checks.md": {
-            "target": "skills/audit/packs/code-quality/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/typescript-react/pack.json": {
-            "target": "skills/audit/packs/typescript-react/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/typescript-react/checks.md": {
-            "target": "skills/audit/packs/typescript-react/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/architecture/pack.json": {
-            "target": "skills/audit/packs/architecture/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/architecture/checks.md": {
-            "target": "skills/audit/packs/architecture/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/accessibility/pack.json": {
-            "target": "skills/audit/packs/accessibility/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/accessibility/checks.md": {
-            "target": "skills/audit/packs/accessibility/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/reliability/pack.json": {
-            "target": "skills/audit/packs/reliability/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/reliability/checks.md": {
-            "target": "skills/audit/packs/reliability/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/correctness/pack.json": {
-            "target": "skills/audit/packs/correctness/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/correctness/checks.md": {
-            "target": "skills/audit/packs/correctness/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/secrets/pack.json": {
-            "target": "skills/audit/packs/secrets/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/secrets/checks.md": {
-            "target": "skills/audit/packs/secrets/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-squawk.sh": {
-            "target": "skills/audit/scripts/spine/wrap-squawk.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-squawk.py": {
-            "target": "skills/audit/scripts/spine/parse-squawk.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-sqlfluff.sh": {
-            "target": "skills/audit/scripts/spine/wrap-sqlfluff.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-sqlfluff.py": {
-            "target": "skills/audit/scripts/spine/parse-sqlfluff.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/packs/data-migrations/pack.json": {
-            "target": "skills/audit/packs/data-migrations/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/data-migrations/checks.md": {
-            "target": "skills/audit/packs/data-migrations/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/privacy/pack.json": {
-            "target": "skills/audit/packs/privacy/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/privacy/checks.md": {
-            "target": "skills/audit/packs/privacy/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/observability/pack.json": {
-            "target": "skills/audit/packs/observability/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/observability/checks.md": {
-            "target": "skills/audit/packs/observability/checks.md",
-            "type": "doc",
-            "template": false
-        }
+  "version": "1.0.0",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "ccgm/audit/severity-rubric.json",
+  "title": "CCGM Audit Severity Rubric",
+  "description": "Rule-level, deterministic severity/confidence table. Agents source severity from here; they do NOT invent it. Keyed by check_id (pattern: <pack>/<check>, matching finding.schema.json). Pack epics add entries under their own namespace; use the [RUBRIC-serial] gate to avoid concurrent edits.",
+  "_format": {
+    "severity": "critical|high|medium|low|info",
+    "confidence": "high|medium|low \u2014 signal precision (how often this check fires correctly)",
+    "fix_confidence": "high|medium|low \u2014 safety confidence for auto-fix when applicable"
+  },
+  "checks": {
+    "secrets/leaked-credential": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
     },
-    "tags": [
-        "commands",
-        "audit",
-        "verification",
-        "walkthrough",
-        "safety",
-        "checkpoint"
-    ],
-    "configPrompts": []
+    "security/hardcoded-secret": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "security/sensitive-console-log": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "security/sql-injection": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "security/xss-vulnerability": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "security/missing-security-headers": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "security/edge-function-auth-bypass": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dependencies/npm-audit-vulnerability": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dependencies/outdated-minor": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dependencies/outdated-major": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "dependencies/unused-dependency": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "dependencies/duplicate-dependency": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "code-quality/eslint-violation": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "code-quality/prettier-violation": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "code-quality/unused-import": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "code-quality/long-method": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "code-quality/large-file": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "code-quality/empty-catch-block": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "architecture/circular-dependency": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "architecture/god-object": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "architecture/improper-layering": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "architecture/wrong-layer-import": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "medium"
+    },
+    "typescript/excessive-any": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "typescript/missing-return-type": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "typescript/react-hooks-violation": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "typescript/fast-refresh-violation": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "typescript/missing-key-prop": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "testing/missing-test-file": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "testing/no-assertions": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "testing/missing-edge-cases": {
+      "severity": "low",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "documentation/missing-jsdoc": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "documentation/stale-comment": {
+      "severity": "low",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "documentation/incomplete-readme": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "performance/n-plus-one-query": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "performance/missing-react-memo": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "medium"
+    },
+    "performance/large-bundle-import": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/copyleft-in-proprietary": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/non-commercial-in-commercial": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/missing-attribution": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/unlicensed-dependency": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/scraping-prohibited-site": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/credential-misuse": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/remote-code-extension": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/overbroad-extension-permissions": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-output-training-competitor": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/undisclosed-telemetry": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/rate-limit-circumvention": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/paywall-bypass": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/trademark-misuse": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/store-policy-violation": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/missing-privacy-policy": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-prohibited-use": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-output-misrepresentation": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-data-retention-violation": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/platform-tos-violation": {
+      "severity": "medium",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/iap-bypass": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "deps/vulnerable-dependency": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dead-code/unused-dependency": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "dead-code/unused-file": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dead-code/unused-export": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dead-code/unlisted-dependency": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "a11y/img-missing-alt": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "a11y/click-without-keyboard": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "a11y/anchor-missing-rel": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "a11y/missing-prefers-reduced-motion": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "a11y/tailwind-cursor-pointer": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "reliability/floating-promise": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/misused-promise": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/unhandled-promise": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/await-in-loop": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/fetch-without-timeout": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/retry-without-backoff": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/promise-all-vs-allsettled": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "lint/eqeqeq": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/use-isnan": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/valid-typeof": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/no-unreachable": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/no-constant-condition": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "lint/no-fallthrough": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/default-case": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "correctness/off-by-one": {
+      "severity": "high",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "correctness/float-equality": {
+      "severity": "medium",
+      "confidence": "low",
+      "fix_confidence": "medium"
+    },
+    "correctness/wrong-branch-logic": {
+      "severity": "high",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "secrets/tracked-env-file": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "secrets/tracked-key-material": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "secrets/history-only-credential": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "dm/unquoted-reserved-keyword": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "dm/index-without-concurrently": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dm/missing-rls": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dm/on-conflict-without-unique": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dm/security-definer-function": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "dm/squawk-violation": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dm/sqlfluff-violation": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "cicd/unpinned-action": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "cicd/dangerous-trigger": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "cicd/excessive-permissions": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "cicd/script-injection": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "cicd/actionlint-error": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "cicd/workflow-security-issue": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "privacy/pii-without-consent": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "privacy/pii-no-retention": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "privacy/pii-in-url": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "observability/pii-in-logs": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "observability/missing-structured-logging": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "observability/missing-error-reporting": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    }
+  }
 }

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -1,509 +1,492 @@
 {
-  "version": "1.0.0",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "ccgm/audit/severity-rubric.json",
-  "title": "CCGM Audit Severity Rubric",
-  "description": "Rule-level, deterministic severity/confidence table. Agents source severity from here; they do NOT invent it. Keyed by check_id (pattern: <pack>/<check>, matching finding.schema.json). Pack epics add entries under their own namespace; use the [RUBRIC-serial] gate to avoid concurrent edits.",
-  "_format": {
-    "severity": "critical|high|medium|low|info",
-    "confidence": "high|medium|low \u2014 signal precision (how often this check fires correctly)",
-    "fix_confidence": "high|medium|low \u2014 safety confidence for auto-fix when applicable"
-  },
-  "checks": {
-    "secrets/leaked-credential": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "security/hardcoded-secret": {
-      "severity": "critical",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "security/sensitive-console-log": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "security/sql-injection": {
-      "severity": "critical",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "security/xss-vulnerability": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "security/missing-security-headers": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "security/edge-function-auth-bypass": {
-      "severity": "critical",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dependencies/npm-audit-vulnerability": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "dependencies/outdated-minor": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "dependencies/outdated-major": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "dependencies/unused-dependency": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "dependencies/duplicate-dependency": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "code-quality/eslint-violation": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "code-quality/prettier-violation": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "code-quality/unused-import": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "code-quality/long-method": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "code-quality/large-file": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "code-quality/empty-catch-block": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "architecture/circular-dependency": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "architecture/god-object": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "architecture/improper-layering": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "architecture/wrong-layer-import": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "medium"
-    },
-    "typescript/excessive-any": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "typescript/missing-return-type": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "typescript/react-hooks-violation": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "typescript/fast-refresh-violation": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "typescript/missing-key-prop": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "testing/missing-test-file": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "testing/no-assertions": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "testing/missing-edge-cases": {
-      "severity": "low",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "documentation/missing-jsdoc": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "documentation/stale-comment": {
-      "severity": "low",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "documentation/incomplete-readme": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "performance/n-plus-one-query": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "performance/missing-react-memo": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "medium"
-    },
-    "performance/large-bundle-import": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/copyleft-in-proprietary": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/non-commercial-in-commercial": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/missing-attribution": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/unlicensed-dependency": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/scraping-prohibited-site": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/credential-misuse": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/remote-code-extension": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/overbroad-extension-permissions": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/ai-output-training-competitor": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/undisclosed-telemetry": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/rate-limit-circumvention": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/paywall-bypass": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/trademark-misuse": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/store-policy-violation": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/missing-privacy-policy": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/ai-prohibited-use": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/ai-output-misrepresentation": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/ai-data-retention-violation": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/platform-tos-violation": {
-      "severity": "medium",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/iap-bypass": {
-      "severity": "critical",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "deps/vulnerable-dependency": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "dead-code/unused-dependency": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "dead-code/unused-file": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dead-code/unused-export": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dead-code/unlisted-dependency": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "a11y/img-missing-alt": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "a11y/click-without-keyboard": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "a11y/anchor-missing-rel": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "a11y/missing-prefers-reduced-motion": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "a11y/tailwind-cursor-pointer": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "reliability/floating-promise": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/misused-promise": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/unhandled-promise": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/await-in-loop": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/fetch-without-timeout": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/retry-without-backoff": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/promise-all-vs-allsettled": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "lint/eqeqeq": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/use-isnan": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/valid-typeof": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/no-unreachable": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/no-constant-condition": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "lint/no-fallthrough": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/default-case": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "correctness/off-by-one": {
-      "severity": "high",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "correctness/float-equality": {
-      "severity": "medium",
-      "confidence": "low",
-      "fix_confidence": "medium"
-    },
-    "correctness/wrong-branch-logic": {
-      "severity": "high",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "secrets/tracked-env-file": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "secrets/tracked-key-material": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "secrets/history-only-credential": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "dm/unquoted-reserved-keyword": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "dm/index-without-concurrently": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "dm/missing-rls": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dm/on-conflict-without-unique": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dm/security-definer-function": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "dm/squawk-violation": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dm/sqlfluff-violation": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "cicd/unpinned-action": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "cicd/dangerous-trigger": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "cicd/excessive-permissions": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "cicd/script-injection": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "cicd/actionlint-error": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "cicd/workflow-security-issue": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    }
-  }
+    "name": "commands-extra",
+    "version": "1.0.0",
+    "displayName": "Extra Commands",
+    "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global), /freeze + /unfreeze + /guard (safety-hook state management), /checkpoint (save/resume WIP session state).",
+    "category": "commands",
+    "scope": [
+        "global"
+    ],
+    "dependencies": [],
+    "files": {
+        "commands/audit.md": {
+            "target": "commands/audit.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/pwv.md": {
+            "target": "commands/pwv.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/walkthrough.md": {
+            "target": "commands/walkthrough.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/promote-rule.md": {
+            "target": "commands/promote-rule.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/freeze.md": {
+            "target": "commands/freeze.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/unfreeze.md": {
+            "target": "commands/unfreeze.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/guard.md": {
+            "target": "commands/guard.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/checkpoint.md": {
+            "target": "commands/checkpoint.md",
+            "type": "command",
+            "template": false
+        },
+        "skills/audit/SKILL.md": {
+            "target": "skills/audit/SKILL.md",
+            "type": "skill",
+            "template": false
+        },
+        "skills/audit/reference/security-patterns.md": {
+            "target": "skills/audit/reference/security-patterns.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/code-quality.md": {
+            "target": "skills/audit/reference/code-quality.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/architecture.md": {
+            "target": "skills/audit/reference/architecture.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/fix-patterns.md": {
+            "target": "skills/audit/reference/fix-patterns.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/multi-agent-config.md": {
+            "target": "skills/audit/reference/multi-agent-config.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/output-template.md": {
+            "target": "skills/audit/reference/output-template.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/schemas/pack.schema.json": {
+            "target": "skills/audit/schemas/pack.schema.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/schemas/finding.schema.json": {
+            "target": "skills/audit/schemas/finding.schema.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/scripts/registry.py": {
+            "target": "skills/audit/scripts/registry.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/assign-packs.py": {
+            "target": "skills/audit/scripts/assign-packs.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/detect-ecosystems.sh": {
+            "target": "skills/audit/scripts/detect-ecosystems.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/emit-findings.py": {
+            "target": "skills/audit/scripts/emit-findings.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/merge-findings.py": {
+            "target": "skills/audit/scripts/merge-findings.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/baseline.py": {
+            "target": "skills/audit/scripts/baseline.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/suppress.py": {
+            "target": "skills/audit/scripts/suppress.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/schemas/severity-rubric.json": {
+            "target": "skills/audit/schemas/severity-rubric.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/scripts/lint-rubric.py": {
+            "target": "skills/audit/scripts/lint-rubric.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/lint-pack.py": {
+            "target": "skills/audit/scripts/lint-pack.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/provenance.py": {
+            "target": "skills/audit/scripts/provenance.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/packs/_TEMPLATE/checks.md": {
+            "target": "skills/audit/packs/_TEMPLATE/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/security/pack.json": {
+            "target": "skills/audit/packs/security/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/security/checks.md": {
+            "target": "skills/audit/packs/security/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/dependencies/pack.json": {
+            "target": "skills/audit/packs/dependencies/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/dependencies/checks.md": {
+            "target": "skills/audit/packs/dependencies/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/tos-compliance/pack.json": {
+            "target": "skills/audit/packs/tos-compliance/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/tos-compliance/checks.md": {
+            "target": "skills/audit/packs/tos-compliance/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/pack-quality-bar.md": {
+            "target": "skills/audit/reference/pack-quality-bar.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/testing/pack.json": {
+            "target": "skills/audit/packs/testing/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/testing/checks.md": {
+            "target": "skills/audit/packs/testing/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/documentation/pack.json": {
+            "target": "skills/audit/packs/documentation/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/documentation/checks.md": {
+            "target": "skills/audit/packs/documentation/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/performance/pack.json": {
+            "target": "skills/audit/packs/performance/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/performance/checks.md": {
+            "target": "skills/audit/packs/performance/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/scripts/spine/run.sh": {
+            "target": "skills/audit/scripts/spine/run.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/normalize.py": {
+            "target": "skills/audit/scripts/spine/normalize.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-gitleaks.sh": {
+            "target": "skills/audit/scripts/spine/wrap-gitleaks.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-gitleaks.py": {
+            "target": "skills/audit/scripts/spine/parse-gitleaks.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-semgrep.sh": {
+            "target": "skills/audit/scripts/spine/wrap-semgrep.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-semgrep.py": {
+            "target": "skills/audit/scripts/spine/parse-semgrep.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-dep-audit.sh": {
+            "target": "skills/audit/scripts/spine/wrap-dep-audit.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-dep-audit.py": {
+            "target": "skills/audit/scripts/spine/parse-dep-audit.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-knip.sh": {
+            "target": "skills/audit/scripts/spine/wrap-knip.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-knip.py": {
+            "target": "skills/audit/scripts/spine/parse-knip.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-eslint.sh": {
+            "target": "skills/audit/scripts/spine/wrap-eslint.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-eslint.py": {
+            "target": "skills/audit/scripts/spine/parse-eslint.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-govulncheck.sh": {
+            "target": "skills/audit/scripts/spine/wrap-govulncheck.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-govulncheck.py": {
+            "target": "skills/audit/scripts/spine/parse-govulncheck.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-bandit.sh": {
+            "target": "skills/audit/scripts/spine/wrap-bandit.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-bandit.py": {
+            "target": "skills/audit/scripts/spine/parse-bandit.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-hadolint.sh": {
+            "target": "skills/audit/scripts/spine/wrap-hadolint.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-hadolint.py": {
+            "target": "skills/audit/scripts/spine/parse-hadolint.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-actionlint.sh": {
+            "target": "skills/audit/scripts/spine/wrap-actionlint.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-actionlint.py": {
+            "target": "skills/audit/scripts/spine/parse-actionlint.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-trivy.sh": {
+            "target": "skills/audit/scripts/spine/wrap-trivy.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-trivy.py": {
+            "target": "skills/audit/scripts/spine/parse-trivy.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-zizmor.sh": {
+            "target": "skills/audit/scripts/spine/wrap-zizmor.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-zizmor.py": {
+            "target": "skills/audit/scripts/spine/parse-zizmor.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-pinact.sh": {
+            "target": "skills/audit/scripts/spine/wrap-pinact.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-pinact.py": {
+            "target": "skills/audit/scripts/spine/parse-pinact.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/packs/ci-cd/pack.json": {
+            "target": "skills/audit/packs/ci-cd/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/ci-cd/checks.md": {
+            "target": "skills/audit/packs/ci-cd/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/code-quality/pack.json": {
+            "target": "skills/audit/packs/code-quality/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/code-quality/checks.md": {
+            "target": "skills/audit/packs/code-quality/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/typescript-react/pack.json": {
+            "target": "skills/audit/packs/typescript-react/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/typescript-react/checks.md": {
+            "target": "skills/audit/packs/typescript-react/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/architecture/pack.json": {
+            "target": "skills/audit/packs/architecture/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/architecture/checks.md": {
+            "target": "skills/audit/packs/architecture/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/accessibility/pack.json": {
+            "target": "skills/audit/packs/accessibility/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/accessibility/checks.md": {
+            "target": "skills/audit/packs/accessibility/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/reliability/pack.json": {
+            "target": "skills/audit/packs/reliability/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/reliability/checks.md": {
+            "target": "skills/audit/packs/reliability/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/correctness/pack.json": {
+            "target": "skills/audit/packs/correctness/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/correctness/checks.md": {
+            "target": "skills/audit/packs/correctness/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/secrets/pack.json": {
+            "target": "skills/audit/packs/secrets/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/secrets/checks.md": {
+            "target": "skills/audit/packs/secrets/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-squawk.sh": {
+            "target": "skills/audit/scripts/spine/wrap-squawk.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-squawk.py": {
+            "target": "skills/audit/scripts/spine/parse-squawk.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-sqlfluff.sh": {
+            "target": "skills/audit/scripts/spine/wrap-sqlfluff.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-sqlfluff.py": {
+            "target": "skills/audit/scripts/spine/parse-sqlfluff.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/packs/data-migrations/pack.json": {
+            "target": "skills/audit/packs/data-migrations/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/data-migrations/checks.md": {
+            "target": "skills/audit/packs/data-migrations/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/privacy/pack.json": {
+            "target": "skills/audit/packs/privacy/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/privacy/checks.md": {
+            "target": "skills/audit/packs/privacy/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/observability/pack.json": {
+            "target": "skills/audit/packs/observability/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/observability/checks.md": {
+            "target": "skills/audit/packs/observability/checks.md",
+            "type": "doc",
+            "template": false
+        }
+    },
+    "tags": [
+        "commands",
+        "audit",
+        "verification",
+        "walkthrough",
+        "safety",
+        "checkpoint"
+    ],
+    "configPrompts": []
 }

--- a/modules/commands-extra/skills/audit/tests/test-pack-privacy-obs.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-privacy-obs.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+# test-pack-privacy-obs.sh — Tests for the ccgm/privacy and ccgm/observability audit packs
+# (issue #632, Epic 4.5)
+#
+# Tests:
+#   1.  privacy/pack.json validates against pack.schema.json
+#   2.  observability/pack.json validates against pack.schema.json
+#   3.  severity-rubric.json contains all privacy/* check ids
+#   4.  severity-rubric.json contains all observability/* check ids
+#   5.  lint-pack.py passes on privacy pack with the real rubric
+#   6.  lint-pack.py passes on observability pack with the real rubric
+#   7.  privacy/checks.md contains all required template sections
+#   8.  observability/checks.md contains all required template sections
+#   9.  privacy/checks.md documents TP/TN fixture for each check
+#  10.  observability/checks.md documents TP/TN fixture for each check
+#  11.  Both packs use applies_when: ["always"]
+#  12.  runtime fixture: tracking SDK init without consent gate (privacy TP)
+#  13.  runtime fixture: console.log(user) (observability TP)
+#  14.  runtime fixture: clean counterparts (TN for both)
+#  15.  privacy pack is self-distinct from tos-compliance (no shared check ids)
+#
+# Note: All checks are LLM-detection. We do NOT assert the LLM finds issues in
+# fixtures — only structural validity and registry selection logic.
+#
+# Exit: 0 if all pass, 1 if any fail.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PRIVACY_PACK_DIR="${AUDIT_DIR}/packs/privacy"
+OBS_PACK_DIR="${AUDIT_DIR}/packs/observability"
+TOS_PACK_DIR="${AUDIT_DIR}/packs/tos-compliance"
+REGISTRY="${AUDIT_DIR}/scripts/registry.py"
+LINTER="${AUDIT_DIR}/scripts/lint-pack.py"
+RUBRIC="${AUDIT_DIR}/schemas/severity-rubric.json"
+
+PASS=0
+FAIL=0
+
+pass() { printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1)); }
+fail() { printf "  FAIL: %s\n" "$1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Helper: validate a pack.json via registry.py
+# ---------------------------------------------------------------------------
+_T_PY="$(mktemp "${TMPDIR:-/tmp}/pack_validate_privacy_obs.XXXXXX")"
+cat > "${_T_PY}" <<'PYEOF'
+import sys, json, importlib.util, pathlib
+
+registry_py = pathlib.Path(sys.argv[1])
+pack_path   = pathlib.Path(sys.argv[2])
+
+spec = importlib.util.spec_from_file_location("registry", str(registry_py))
+mod  = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+with open(pack_path, encoding="utf-8") as fh:
+    pack = json.load(fh)
+
+try:
+    mod.validate_pack(pack, str(pack_path))
+    print("VALID")
+    sys.exit(0)
+except mod.ValidationError as exc:
+    print("INVALID: " + str(exc))
+    sys.exit(1)
+PYEOF
+# shellcheck disable=SC2064
+trap "rm -f '${_T_PY}'" EXIT
+
+# ---------------------------------------------------------------------------
+# Test 1: privacy/pack.json validates against pack.schema.json
+# ---------------------------------------------------------------------------
+echo "--- Test 1: privacy/pack.json validates"
+
+_T1_RESULT=""
+_T1_EXIT=0
+_T1_RESULT=$(python3 "${_T_PY}" "${REGISTRY}" "${PRIVACY_PACK_DIR}/pack.json" 2>&1) || _T1_EXIT=$?
+
+if [ "${_T1_EXIT}" -eq 0 ] && echo "${_T1_RESULT}" | grep -q "^VALID$"; then
+    pass "privacy/pack.json validates against pack.schema.json"
+else
+    fail "privacy/pack.json failed validation: ${_T1_RESULT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: observability/pack.json validates against pack.schema.json
+# ---------------------------------------------------------------------------
+echo "--- Test 2: observability/pack.json validates"
+
+_T2_RESULT=""
+_T2_EXIT=0
+_T2_RESULT=$(python3 "${_T_PY}" "${REGISTRY}" "${OBS_PACK_DIR}/pack.json" 2>&1) || _T2_EXIT=$?
+
+if [ "${_T2_EXIT}" -eq 0 ] && echo "${_T2_RESULT}" | grep -q "^VALID$"; then
+    pass "observability/pack.json validates against pack.schema.json"
+else
+    fail "observability/pack.json failed validation: ${_T2_RESULT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: rubric contains all privacy/* check ids
+# ---------------------------------------------------------------------------
+echo "--- Test 3: rubric contains all privacy/* check ids"
+
+PRIVACY_IDS=(
+    "privacy/pii-without-consent"
+    "privacy/pii-no-retention"
+    "privacy/pii-in-url"
+)
+
+_T3_MISSING=""
+for check_id in "${PRIVACY_IDS[@]}"; do
+    if ! python3 -c "
+import json, sys
+rubric = json.load(open('${RUBRIC}', encoding='utf-8'))
+checks = rubric.get('checks', {})
+if '${check_id}' not in checks:
+    print('MISSING')
+    sys.exit(1)
+print('FOUND')
+sys.exit(0)
+" 2>/dev/null | grep -q "^FOUND$"; then
+        _T3_MISSING="${_T3_MISSING} ${check_id}"
+    fi
+done
+
+if [ -z "${_T3_MISSING}" ]; then
+    pass "rubric contains all ${#PRIVACY_IDS[@]} privacy/* check ids"
+else
+    fail "rubric missing privacy ids:${_T3_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: rubric contains all observability/* check ids
+# ---------------------------------------------------------------------------
+echo "--- Test 4: rubric contains all observability/* check ids"
+
+OBS_IDS=(
+    "observability/pii-in-logs"
+    "observability/missing-structured-logging"
+    "observability/missing-error-reporting"
+)
+
+_T4_MISSING=""
+for check_id in "${OBS_IDS[@]}"; do
+    if ! python3 -c "
+import json, sys
+rubric = json.load(open('${RUBRIC}', encoding='utf-8'))
+checks = rubric.get('checks', {})
+if '${check_id}' not in checks:
+    print('MISSING')
+    sys.exit(1)
+print('FOUND')
+sys.exit(0)
+" 2>/dev/null | grep -q "^FOUND$"; then
+        _T4_MISSING="${_T4_MISSING} ${check_id}"
+    fi
+done
+
+if [ -z "${_T4_MISSING}" ]; then
+    pass "rubric contains all ${#OBS_IDS[@]} observability/* check ids"
+else
+    fail "rubric missing observability ids:${_T4_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: lint-pack.py passes on privacy pack with the real rubric
+# ---------------------------------------------------------------------------
+echo "--- Test 5: lint-pack.py passes on privacy pack"
+
+_T5_OUTPUT=""
+_T5_EXIT=0
+_T5_OUTPUT=$(python3 "${LINTER}" \
+    --packs-dir "${AUDIT_DIR}/packs" \
+    --rubric "${RUBRIC}" 2>&1) || _T5_EXIT=$?
+
+if [ "${_T5_EXIT}" -eq 0 ] && echo "${_T5_OUTPUT}" | grep -q "^PASS: privacy"; then
+    pass "lint-pack.py reports PASS for privacy pack"
+else
+    fail "lint-pack.py did not report PASS for privacy: exit=${_T5_EXIT}, output=${_T5_OUTPUT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: lint-pack.py passes on observability pack with the real rubric
+# ---------------------------------------------------------------------------
+echo "--- Test 6: lint-pack.py passes on observability pack"
+
+_T6_OUTPUT=""
+_T6_EXIT=0
+_T6_OUTPUT=$(python3 "${LINTER}" \
+    --packs-dir "${AUDIT_DIR}/packs" \
+    --rubric "${RUBRIC}" 2>&1) || _T6_EXIT=$?
+
+if [ "${_T6_EXIT}" -eq 0 ] && echo "${_T6_OUTPUT}" | grep -q "^PASS: observability"; then
+    pass "lint-pack.py reports PASS for observability pack"
+else
+    fail "lint-pack.py did not report PASS for observability: exit=${_T6_EXIT}, output=${_T6_OUTPUT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: privacy/checks.md has all required template sections
+# ---------------------------------------------------------------------------
+echo "--- Test 7: privacy/checks.md has required sections"
+
+PRIVACY_CHECKS_MD="${PRIVACY_PACK_DIR}/checks.md"
+_REQUIRED_SECTIONS=(
+    "^## Scope"
+    "^## applies_when Rationale"
+    "^## Checks"
+    "^## Quality Checklist"
+)
+
+_T7_MISSING=""
+for section in "${_REQUIRED_SECTIONS[@]}"; do
+    if ! grep -qiE "${section}" "${PRIVACY_CHECKS_MD}"; then
+        _T7_MISSING="${_T7_MISSING} '${section}'"
+    fi
+done
+
+if [ -z "${_T7_MISSING}" ]; then
+    pass "privacy/checks.md contains all required sections"
+else
+    fail "privacy/checks.md missing sections:${_T7_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: observability/checks.md has all required template sections
+# ---------------------------------------------------------------------------
+echo "--- Test 8: observability/checks.md has required sections"
+
+OBS_CHECKS_MD="${OBS_PACK_DIR}/checks.md"
+_T8_MISSING=""
+for section in "${_REQUIRED_SECTIONS[@]}"; do
+    if ! grep -qiE "${section}" "${OBS_CHECKS_MD}"; then
+        _T8_MISSING="${_T8_MISSING} '${section}'"
+    fi
+done
+
+if [ -z "${_T8_MISSING}" ]; then
+    pass "observability/checks.md contains all required sections"
+else
+    fail "observability/checks.md missing sections:${_T8_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 9: privacy/checks.md documents TP/TN fixtures for each check
+# ---------------------------------------------------------------------------
+echo "--- Test 9: privacy/checks.md documents TP/TN fixtures"
+
+_T9_ERRORS=""
+
+for check_id in "${PRIVACY_IDS[@]}"; do
+    if ! grep -q "${check_id}" "${PRIVACY_CHECKS_MD}"; then
+        _T9_ERRORS="${_T9_ERRORS}\n  check-id '${check_id}' not found in privacy/checks.md"
+        continue
+    fi
+
+    _SECTION=$(python3 - "${PRIVACY_CHECKS_MD}" "${check_id}" <<'PYEOF' 2>/dev/null
+import sys, re
+md = open(sys.argv[1], encoding='utf-8').read()
+check_id = sys.argv[2]
+pattern = r'(### `' + re.escape(check_id) + r'`.*?)(?=\n### `|\Z)'
+m = re.search(pattern, md, re.DOTALL)
+if m:
+    print(m.group(1))
+PYEOF
+)
+
+    if ! echo "${_SECTION}" | grep -q "True positive\|FINDS:"; then
+        _T9_ERRORS="${_T9_ERRORS}\n  no True positive fixture found for '${check_id}'"
+    fi
+
+    if ! echo "${_SECTION}" | grep -q "True negative\|should produce NO"; then
+        _T9_ERRORS="${_T9_ERRORS}\n  no True negative fixture found for '${check_id}'"
+    fi
+done
+
+if [ -z "${_T9_ERRORS}" ]; then
+    pass "privacy/checks.md documents TP/TN fixtures for all ${#PRIVACY_IDS[@]} privacy checks"
+else
+    fail "privacy/checks.md fixture coverage issues:$(printf '%b' "${_T9_ERRORS}")"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 10: observability/checks.md documents TP/TN fixtures for each check
+# ---------------------------------------------------------------------------
+echo "--- Test 10: observability/checks.md documents TP/TN fixtures"
+
+_T10_ERRORS=""
+
+for check_id in "${OBS_IDS[@]}"; do
+    if ! grep -q "${check_id}" "${OBS_CHECKS_MD}"; then
+        _T10_ERRORS="${_T10_ERRORS}\n  check-id '${check_id}' not found in observability/checks.md"
+        continue
+    fi
+
+    _SECTION=$(python3 - "${OBS_CHECKS_MD}" "${check_id}" <<'PYEOF' 2>/dev/null
+import sys, re
+md = open(sys.argv[1], encoding='utf-8').read()
+check_id = sys.argv[2]
+pattern = r'(### `' + re.escape(check_id) + r'`.*?)(?=\n### `|\Z)'
+m = re.search(pattern, md, re.DOTALL)
+if m:
+    print(m.group(1))
+PYEOF
+)
+
+    if ! echo "${_SECTION}" | grep -q "True positive\|FINDS:"; then
+        _T10_ERRORS="${_T10_ERRORS}\n  no True positive fixture found for '${check_id}'"
+    fi
+
+    if ! echo "${_SECTION}" | grep -q "True negative\|should produce NO"; then
+        _T10_ERRORS="${_T10_ERRORS}\n  no True negative fixture found for '${check_id}'"
+    fi
+done
+
+if [ -z "${_T10_ERRORS}" ]; then
+    pass "observability/checks.md documents TP/TN fixtures for all ${#OBS_IDS[@]} observability checks"
+else
+    fail "observability/checks.md fixture coverage issues:$(printf '%b' "${_T10_ERRORS}")"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11: both packs declare applies_when: ["always"]
+# ---------------------------------------------------------------------------
+echo "--- Test 11: both packs use applies_when: [\"always\"]"
+
+_T11_ERRORS=""
+
+for pack_path in "${PRIVACY_PACK_DIR}/pack.json" "${OBS_PACK_DIR}/pack.json"; do
+    _AW=$(python3 -c "
+import json, sys
+pack = json.load(open('${pack_path}', encoding='utf-8'))
+aw = pack.get('applies_when', [])
+if aw == ['always']:
+    print('OK')
+else:
+    print('WRONG: ' + str(aw))
+" 2>/dev/null)
+    if ! echo "${_AW}" | grep -q "^OK$"; then
+        _PACK_NAME=$(basename "$(dirname "${pack_path}")")
+        _T11_ERRORS="${_T11_ERRORS}\n  ${_PACK_NAME}/pack.json applies_when is not [\"always\"]: ${_AW}"
+    fi
+done
+
+if [ -z "${_T11_ERRORS}" ]; then
+    pass "both packs declare applies_when: [\"always\"]"
+else
+    fail "applies_when mismatch:$(printf '%b' "${_T11_ERRORS}")"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 12: runtime fixture — tracking SDK init without consent gate (privacy TP)
+# ---------------------------------------------------------------------------
+echo "--- Test 12: runtime fixture — privacy TP (tracking SDK without consent)"
+
+_T12_DIR="$(mktemp -d "${TMPDIR:-/tmp}/privacy_obs_fixtures.XXXXXX")"
+# shellcheck disable=SC2064
+trap "rm -rf '${_T12_DIR}'" EXIT
+
+# Privacy TP: Segment analytics.identify() with user.email — no consent check
+cat > "${_T12_DIR}/analytics-tp.ts" <<'TS'
+// privacy/pii-without-consent TRUE POSITIVE fixture
+// analytics.identify() called with user email — no consent gate present
+import analytics from '@segment/analytics-next';
+
+export function identifyUser(user) {
+  analytics.identify(user.id, {
+    email: user.email,
+    name: user.displayName,
+  });
+}
+TS
+
+if [ -f "${_T12_DIR}/analytics-tp.ts" ]; then
+    pass "privacy TP fixture created: tracking SDK init with user PII, no consent gate"
+else
+    fail "privacy TP fixture creation failed"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 13: runtime fixture — console.log(user) (observability TP)
+# ---------------------------------------------------------------------------
+echo "--- Test 13: runtime fixture — observability TP (console.log(user))"
+
+# Observability TP: entire user object logged in server route handler
+cat > "${_T12_DIR}/log-pii-tp.ts" <<'TS'
+// observability/pii-in-logs TRUE POSITIVE fixture
+// console.log(user) in a server route — entire user object including PII emitted
+async function handleLogin(req, res) {
+  const user = await findUser(req.body.email);
+  console.log(user);   // logs PII: email, name, phone, etc.
+  if (!user) return res.status(404).json({ error: 'Not found' });
+  res.json({ token: createToken(user.id) });
+}
+TS
+
+if [ -f "${_T12_DIR}/log-pii-tp.ts" ]; then
+    pass "observability TP fixture created: console.log(user) in server handler"
+else
+    fail "observability TP fixture creation failed"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 14: runtime fixtures — clean counterparts (TN for both packs)
+# ---------------------------------------------------------------------------
+echo "--- Test 14: runtime fixtures — clean counterparts (TN)"
+
+# Privacy TN: consent check gates the identify call
+cat > "${_T12_DIR}/analytics-tn.ts" <<'TS'
+// privacy/pii-without-consent TRUE NEGATIVE fixture
+// consent check gates the identify call — no finding expected
+import analytics from '@segment/analytics-next';
+import { getConsentState } from './consent';
+
+export function identifyUser(user) {
+  if (!getConsentState().analytics) return;
+  analytics.identify(user.id, {
+    email: user.email,
+    name: user.displayName,
+  });
+}
+TS
+
+# Observability TN: structured logger used, only opaque userId
+cat > "${_T12_DIR}/log-pii-tn.ts" <<'TS'
+// observability/pii-in-logs TRUE NEGATIVE fixture
+// structured logger with only opaque userId — no PII, no finding expected
+import { logger } from './logger';
+
+async function handleLogin(req, res) {
+  const user = await findUser(req.body.email);
+  logger.info({ userId: user?.id }, 'login attempt');
+  if (!user) return res.status(404).json({ error: 'Not found' });
+  res.json({ token: createToken(user.id) });
+}
+TS
+
+if [ -f "${_T12_DIR}/analytics-tn.ts" ] && [ -f "${_T12_DIR}/log-pii-tn.ts" ]; then
+    pass "TN fixtures created: consent-gated analytics + structured logger with opaque userId"
+else
+    fail "TN fixture creation failed"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 15: privacy is distinct from tos-compliance (no shared check ids)
+# ---------------------------------------------------------------------------
+echo "--- Test 15: privacy check ids are distinct from tos-compliance check ids"
+
+_T15_OVERLAP=$(python3 - "${PRIVACY_PACK_DIR}/pack.json" "${TOS_PACK_DIR}/pack.json" <<'PYEOF' 2>/dev/null
+import json, sys
+privacy = json.load(open(sys.argv[1], encoding='utf-8'))
+tos = json.load(open(sys.argv[2], encoding='utf-8'))
+
+privacy_ids = {c['id'] for c in privacy.get('checks', [])}
+tos_ids = {c['id'] for c in tos.get('checks', [])}
+
+overlap = privacy_ids & tos_ids
+if overlap:
+    print('OVERLAP: ' + ', '.join(sorted(overlap)))
+    sys.exit(1)
+else:
+    print('DISTINCT')
+    sys.exit(0)
+PYEOF
+)
+
+if echo "${_T15_OVERLAP}" | grep -q "^DISTINCT$"; then
+    pass "privacy check ids are fully distinct from tos-compliance check ids"
+else
+    fail "privacy and tos-compliance share check ids: ${_T15_OVERLAP}"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf "\nResults: %d passed, %d failed\n" "${PASS}" "${FAIL}"
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `packs/privacy/` (`ccgm/privacy`, `applies_when: [always]`): 3 LLM-detection checks for `pii-without-consent` (high), `pii-no-retention` (medium), and `pii-in-url` (high)
- Adds `packs/observability/` (`ccgm/observability`, `applies_when: [always]`): 3 LLM-detection checks for `pii-in-logs` (high), `missing-structured-logging` (low), and `missing-error-reporting` (medium)
- Extends `severity-rubric.json` with 6 new entries (`privacy/*` + `observability/*`)
- Registers all 4 new pack files in `module.json`
- Adds `test-pack-privacy-obs.sh` with 15 tests (schema, rubric, lint, sections, TP/TN fixtures, applies_when, runtime fixtures, distinctness from tos-compliance)

## Privacy vs ToS-Compliance distinction

`ccgm/privacy` targets **data-handling code patterns** — tracking SDKs wired without consent gates, PII stored with no deletion path, PII passed in URL query strings. These are code defects detectable from source. `ccgm/tos-compliance` targets **legal and policy compliance** — missing privacy policy documents, license violations, store policy violations, AI output misrepresentation. The two packs share zero check IDs (asserted in Test 15).

## Verification (all pass)

```
test-pack-privacy-obs.sh: 15 passed, 0 failed
lint-pack.py (all packs):  17 pack(s) checked, 0 error(s)
test-pack-lint.sh:          7 passed, 0 failed
test-rubric.sh:             8 passed, 0 failed
test-registry.sh:           8 passed, 0 failed
python3 -m json.tool (module.json + severity-rubric.json): valid
test-modules.sh:         1316 passed, 0 failed
test-no-personal-data.sh:   PASS
```

Closes #632