### PR TITLE
#630: Epic 4.3 infra-iac pack — has_iac detector + checkov spine wrapper

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -458,6 +458,26 @@
       "target": "skills/audit/packs/data-migrations/checks.md",
       "type": "doc",
       "template": false
+    },
+    "skills/audit/scripts/spine/wrap-checkov.sh": {
+      "target": "skills/audit/scripts/spine/wrap-checkov.sh",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/scripts/spine/parse-checkov.py": {
+      "target": "skills/audit/scripts/spine/parse-checkov.py",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/packs/infra-iac/pack.json": {
+      "target": "skills/audit/packs/infra-iac/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/infra-iac/checks.md": {
+      "target": "skills/audit/packs/infra-iac/checks.md",
+      "type": "doc",
+      "template": false
     }
   },
   "tags": [

--- a/modules/commands-extra/skills/audit/packs/infra-iac/checks.md
+++ b/modules/commands-extra/skills/audit/packs/infra-iac/checks.md
@@ -1,0 +1,393 @@
+# Infrastructure & IaC Security Pack
+
+## Scope
+
+This pack audits Infrastructure-as-Code files for security and misconfiguration issues. It covers Dockerfiles, Terraform HCL, Kubernetes manifests, and CloudFormation templates. It does NOT audit application source code, dependency vulnerabilities, or secret management systems outside of IaC configuration.
+
+**Pack ID:** `ccgm/infra-iac`
+**Applies when:** `["has_iac"]`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `has_iac` | Pack is only useful when IaC files exist; running on repos without Dockerfiles, Terraform, k8s manifests, or CloudFormation templates produces zero signal. `has_iac` is true when any of these IaC file types are detected by the ecosystem detector. |
+
+---
+
+## Checks
+
+---
+
+### `iac/dockerfile-root-user`
+
+**Severity:** `high`
+**Confidence:** `high`
+**Detection:** `hybrid`
+
+#### Detection
+
+Detects Dockerfiles that run container processes as root (no `USER` directive, or `USER root` set without a subsequent non-root `USER` directive).
+
+**Tool (detection = hybrid):**
+`hadolint`
+
+Rule / rule-id: `DL3002` — Avoid running as root in the final image.
+
+Fallback when tool absent: `grep` — scan for absence of `USER` directive or presence of `USER root` as last USER line.
+
+**LLM instruction (hybrid fallback confirmation):**
+
+```
+Review each Dockerfile for root user execution risk. A container runs as root if:
+1. No USER directive is present at all.
+2. The last USER directive sets "root" or uid 0.
+
+Flag each Dockerfile that runs as root. Do NOT flag Dockerfiles where USER is set
+to a non-root user as the final USER instruction. Report: file path, line number
+of the relevant USER directive (or line 1 if no USER directive exists), and a
+brief description of why this is a finding.
+```
+
+#### Spine Wiring
+
+hadolint emits its own rule IDs (e.g. `DL3002`). The parse-hadolint.py normalizer maps all hadolint findings to check_id `iac/dockerfile-issue` with `rule_id` carrying the hadolint code. Pack-level check_id `iac/dockerfile-root-user` is the conceptual owner; the spine emits the underlying hadolint rule_id for traceability.
+
+```yaml
+check_id: iac/dockerfile-root-user
+detection: hybrid
+tool: hadolint
+rule: DL3002
+fallback: grep
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** HIGH — Running a container as root means any process escape grants root access on the host (if the host namespace is shared or if container isolation is broken). Direct path to privilege escalation.
+
+**Confidence rationale:** HIGH — hadolint DL3002 is a deterministic check with very low false-positive rate; the USER directive presence/absence is unambiguous.
+
+**Rubric entry:** `iac/dockerfile-root-user`
+
+#### Fixture
+
+**True positive** (`Dockerfile`):
+
+```dockerfile
+FROM node:20-alpine
+WORKDIR /app
+COPY . .
+RUN npm install
+# FINDS: No USER directive — runs as root
+CMD ["node", "index.js"]
+```
+
+**True negative** (should produce NO finding):
+
+```dockerfile
+FROM node:20-alpine
+WORKDIR /app
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+COPY . .
+RUN npm install
+USER appuser
+CMD ["node", "index.js"]
+```
+
+---
+
+### `iac/dockerfile-latest-tag`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `tool`
+
+#### Detection
+
+Detects Dockerfile `FROM` directives that use the `:latest` tag or no tag at all, making builds non-reproducible.
+
+**Tool (detection = tool):**
+`hadolint`
+
+Rule / rule-id: `DL3007` — Using latest is prone to errors if the image will ever be updated. Pin the version explicitly to a release tag.
+
+Fallback when tool absent: `none — skip check`
+
+#### Spine Wiring
+
+```yaml
+check_id: iac/dockerfile-latest-tag
+detection: tool
+tool: hadolint
+rule: DL3007
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** MEDIUM — Non-reproducible builds can introduce unexpected changes on rebuild, including security regressions. Does not directly expose a vulnerability but degrades the security posture over time.
+
+**Confidence rationale:** HIGH — hadolint DL3007 is a deterministic check on the FROM line tag.
+
+**Rubric entry:** `iac/dockerfile-latest-tag`
+
+#### Fixture
+
+**True positive** (`Dockerfile`):
+
+```dockerfile
+# FINDS: :latest tag is non-deterministic
+FROM node:latest
+WORKDIR /app
+```
+
+**True negative** (should produce NO finding):
+
+```dockerfile
+# OK: pinned to a specific version
+FROM node:20.11.0-alpine3.19
+WORKDIR /app
+```
+
+---
+
+### `iac/public-ingress`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `hybrid`
+
+#### Detection
+
+Detects security group or firewall rules in IaC (Terraform, CloudFormation) that allow unrestricted inbound access from `0.0.0.0/0` or `::/0` on sensitive ports or all ports.
+
+**Tool (detection = hybrid):**
+`checkov`
+
+Rule / rule-id: Various checkov rules including `CKV_AWS_25` (unrestricted security group), `CKV_AWS_24`, and similar cloud-provider checks.
+
+Fallback when tool absent: `llm`
+
+**LLM instruction (hybrid fallback / confirmation):**
+
+```
+Scan all Terraform (.tf), CloudFormation (.yaml/.json), and Kubernetes manifest
+files for network ingress rules that permit unrestricted access from 0.0.0.0/0
+(IPv4) or ::/0 (IPv6).
+
+Flag each resource that:
+1. Defines a security group, firewall rule, network ACL, or k8s NetworkPolicy that
+   allows inbound traffic from 0.0.0.0/0 or ::/0.
+2. The rule applies to ALL ports (port range 0-65535 or equivalent) OR to a
+   sensitive port (22/SSH, 3389/RDP, 3306/MySQL, 5432/PostgreSQL, 27017/MongoDB,
+   6379/Redis, 9200/Elasticsearch).
+
+Do NOT flag rules that restrict source CIDRs to known non-public ranges
+(10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16).
+
+Report: file path, line number, resource name, and which CIDR/port combination
+triggered the finding.
+```
+
+#### Spine Wiring
+
+checkov findings are emitted with check_id `iac/checkov-violation` and the checkov rule_id in the `rule_id` field (e.g. `CKV_AWS_25`). The pack-level check_id `iac/public-ingress` is the conceptual grouping; post-processing can filter by rule_id pattern to isolate ingress-related findings.
+
+```yaml
+check_id: iac/public-ingress
+detection: hybrid
+tool: checkov
+fallback: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** HIGH — Unrestricted public ingress on sensitive ports or all ports directly exposes services to the internet, enabling brute force, exploitation, or unauthorized access with no network-level mitigation.
+
+**Confidence rationale:** MEDIUM — checkov's automated rules catch the most common patterns; unusual resource structures or custom abstractions may evade automated detection, hence hybrid with LLM fallback.
+
+**Rubric entry:** `iac/public-ingress`
+
+#### Fixture
+
+**True positive** (`main.tf`):
+
+```hcl
+# FINDS: security group allows all inbound from 0.0.0.0/0
+resource "aws_security_group" "web" {
+  ingress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+```
+
+**True negative** (should produce NO finding):
+
+```hcl
+# OK: restricted to known internal range
+resource "aws_security_group" "internal" {
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/8"]
+  }
+}
+```
+
+---
+
+### `iac/missing-encryption`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `tool`
+
+#### Detection
+
+Detects IaC resources (S3 buckets, RDS instances, EBS volumes, SQS queues, etc.) that do not have encryption at rest configured.
+
+**Tool (detection = tool):**
+`checkov`
+
+Rule / rule-id: Various checkov rules including `CKV_AWS_19` (S3 encryption), `CKV_AWS_17` (RDS encryption), `CKV_AWS_3` (EBS encryption), and similar.
+
+Fallback when tool absent: `none — skip check`
+
+#### Spine Wiring
+
+```yaml
+check_id: iac/missing-encryption
+detection: tool
+tool: checkov
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** MEDIUM — Unencrypted storage means data is readable if the underlying infrastructure is compromised. Significant compliance risk; moderate operational security risk depending on data sensitivity.
+
+**Confidence rationale:** MEDIUM — checkov accurately detects when encryption flags are absent from resource definitions; however, some resources may inherit encryption from account-level defaults not visible in the IaC files alone.
+
+**Rubric entry:** `iac/missing-encryption`
+
+#### Fixture
+
+**True positive** (`main.tf`):
+
+```hcl
+# FINDS: S3 bucket with no server-side encryption configured
+resource "aws_s3_bucket" "data" {
+  bucket = "my-data-bucket"
+}
+```
+
+**True negative** (should produce NO finding):
+
+```hcl
+# OK: encryption enabled
+resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+  }
+}
+```
+
+---
+
+### `iac/hardcoded-secret-in-iac`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `hybrid`
+
+#### Detection
+
+Detects hardcoded credentials, API keys, passwords, or other secrets embedded directly in IaC configuration files rather than referenced from a secrets manager.
+
+**Tool (detection = hybrid):**
+`checkov`
+
+Rule / rule-id: `CKV_SECRET_*` family — checkov's secrets detection rules scan for common credential patterns in IaC files.
+
+Fallback when tool absent: `grep` — pattern-match for `password`, `secret`, `api_key`, `access_key`, `private_key` assignments containing non-variable literal values.
+
+**LLM instruction (hybrid fallback confirmation):**
+
+```
+Scan all IaC files (.tf, .yaml, .yml, .json) for hardcoded secrets. A hardcoded
+secret is a literal string value assigned to a field whose name suggests it holds
+a credential (password, secret, key, token, credential, api_key, access_key,
+private_key, auth_token).
+
+Flag each occurrence where:
+1. The field name matches the patterns above.
+2. The value is a non-empty literal string (not a variable reference like
+   ${var.password} or !Ref MySecret or a placeholder like "CHANGEME").
+
+Do NOT flag:
+- Variable references (${...}, !Ref, !Sub with only references)
+- Empty strings ("")
+- Obvious placeholder values ("CHANGEME", "PLACEHOLDER", "TODO", "your-secret-here")
+- KMS key ARNs or resource ARNs (these are identifiers, not secrets)
+
+Report: file path, line number, field name, and first 4 characters of the value
+(do not include the full value in the report).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: iac/hardcoded-secret-in-iac
+detection: hybrid
+tool: checkov
+fallback: grep
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** HIGH — Hardcoded credentials in IaC files are committed to source control, accessible to everyone with repo access, and persist in git history even after removal. Direct credential exposure.
+
+**Confidence rationale:** MEDIUM — Automated pattern matching has false positives on placeholder values and false negatives on obfuscated or non-standard credential field names. LLM confirmation reduces noise.
+
+**Rubric entry:** `iac/hardcoded-secret-in-iac`
+
+#### Fixture
+
+**True positive** (`main.tf`):
+
+```hcl
+# FINDS: hardcoded database password
+resource "aws_db_instance" "main" {
+  engine   = "postgres"
+  password = "supersecret123!"
+}
+```
+
+**True negative** (should produce NO finding):
+
+```hcl
+# OK: password sourced from a variable (not hardcoded)
+resource "aws_db_instance" "main" {
+  engine   = "postgres"
+  password = var.db_password
+}
+```
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/infra-iac/pack.json
+++ b/modules/commands-extra/skills/audit/packs/infra-iac/pack.json
@@ -1,0 +1,51 @@
+{
+  "id": "ccgm/infra-iac",
+  "name": "Infrastructure & IaC Security",
+  "version": "1.0.0",
+  "applies_when": ["has_iac"],
+  "tags": ["security", "iac", "infrastructure", "docker", "terraform", "kubernetes"],
+  "severity_floor": "medium",
+  "tools": ["hadolint", "checkov", "trivy"],
+  "checks": [
+    {
+      "id": "iac/dockerfile-root-user",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "hybrid",
+      "tool": "hadolint",
+      "rule": "DL3002",
+      "fallback": "grep"
+    },
+    {
+      "id": "iac/dockerfile-latest-tag",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "tool",
+      "tool": "hadolint",
+      "rule": "DL3007"
+    },
+    {
+      "id": "iac/public-ingress",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "hybrid",
+      "tool": "checkov",
+      "fallback": "llm"
+    },
+    {
+      "id": "iac/missing-encryption",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "tool",
+      "tool": "checkov"
+    },
+    {
+      "id": "iac/hardcoded-secret-in-iac",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "hybrid",
+      "tool": "checkov",
+      "fallback": "grep"
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/schemas/pack.schema.json
+++ b/modules/commands-extra/skills/audit/schemas/pack.schema.json
@@ -39,7 +39,8 @@
               "has_dockerfile",
               "has_workflows",
               "is_extension",
-              "is_mobile"
+              "is_mobile",
+              "has_iac"
             ]
           },
           {

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -504,6 +504,41 @@
       "severity": "medium",
       "confidence": "medium",
       "fix_confidence": "low"
+    },
+    "iac/dockerfile-root-user": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "iac/dockerfile-latest-tag": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "iac/public-ingress": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "iac/missing-encryption": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "medium"
+    },
+    "iac/hardcoded-secret-in-iac": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "iac/dockerfile-issue": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "iac/checkov-violation": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
     }
   }
 }

--- a/modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh
+++ b/modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh
@@ -15,10 +15,20 @@
 #       "has_dockerfile": bool,
 #       "has_workflows": bool,
 #       "is_extension": bool,
-#       "is_mobile": bool
+#       "is_mobile": bool,
+#       "has_iac": bool
 #     },
 #     "available_tools": [...]
 #   }
+#
+# has_iac detection heuristic (any one of):
+#   - Dockerfile (also sets has_dockerfile)
+#   - *.tf or *.tf.json files (Terraform HCL)
+#   - k8s manifest heuristic: *.yaml under k8s/, manifests/, or .k8s/ dirs
+#     containing both "kind:" and "apiVersion:" lines (grep -l, depth 5)
+#   - CloudFormation template: any YAML/JSON with
+#     AWSTemplateFormatVersion or a top-level "Resources" key alongside
+#     "AWSTemplateFormatVersion" string in the file (depth 4 search)
 #
 # BSD-safe: avoids GNU-only Perl-regex grep flags.
 
@@ -348,6 +358,67 @@ if find_files "*.xcodeproj" 3 || find_files "*.xcworkspace" 3 \
   is_mobile=true
 fi
 
+# --- has_iac ---
+# TRUE when ANY of the following Infrastructure-as-Code signals are present:
+#   1. Dockerfile (already tracked in has_dockerfile — IaC subsumes it)
+#   2. Terraform: *.tf or *.tf.json files
+#   3. Kubernetes manifests: *.yaml files under k8s/, manifests/, or .k8s/
+#      dirs that contain both "kind:" and "apiVersion:" lines
+#   4. CloudFormation: any file containing "AWSTemplateFormatVersion" text
+has_iac=false
+
+# Signal 1: Dockerfile already present
+if [ "$has_dockerfile" = "true" ]; then
+  has_iac=true
+fi
+
+# Signal 2: Terraform HCL files
+if [ "$has_iac" = "false" ]; then
+  if find_ext "tf" 4 || find "$TARGET_DIR" -maxdepth 4 -name "*.tf.json" 2>/dev/null \
+      | head -1 | grep -q .; then
+    has_iac=true
+  fi
+fi
+
+# Signal 3: Kubernetes manifests (yaml files under common k8s dirs that have
+# both "kind:" and "apiVersion:" lines — simple grep heuristic, depth 5)
+if [ "$has_iac" = "false" ]; then
+  for k8s_dir in k8s manifests .k8s; do
+    if has_dir "$k8s_dir"; then
+      # Search for a yaml file containing both "kind:" and "apiVersion:"
+      k8s_hit=$(find "$TARGET_DIR/$k8s_dir" -maxdepth 5 \
+        \( -name "*.yaml" -o -name "*.yml" \) 2>/dev/null \
+        | while IFS= read -r f; do
+            if grep -q "kind:" "$f" 2>/dev/null && \
+               grep -q "apiVersion:" "$f" 2>/dev/null; then
+              echo "$f"
+              break
+            fi
+          done)
+      if [ -n "$k8s_hit" ]; then
+        has_iac=true
+        break
+      fi
+    fi
+  done
+fi
+
+# Signal 4: CloudFormation templates (any file with AWSTemplateFormatVersion)
+if [ "$has_iac" = "false" ]; then
+  cf_hit=$(find "$TARGET_DIR" -maxdepth 4 \
+    \( -name "*.yaml" -o -name "*.yml" -o -name "*.json" \) \
+    -not -path "*/.git/*" 2>/dev/null \
+    | while IFS= read -r f; do
+        if grep -q "AWSTemplateFormatVersion" "$f" 2>/dev/null; then
+          echo "$f"
+          break
+        fi
+      done)
+  if [ -n "$cf_hit" ]; then
+    has_iac=true
+  fi
+fi
+
 # ---------------------------------------------------------------------------
 # Available tools (spine tool list)
 # ---------------------------------------------------------------------------
@@ -432,6 +503,7 @@ jq -n \
   --arg     workflows  "$has_workflows" \
   --arg     extension  "$is_extension" \
   --arg     mobile     "$is_mobile" \
+  --arg     iac        "$has_iac" \
   --argjson tools      "$tools_json" \
   '{
     detected_ecosystems: $ecosystems,
@@ -442,7 +514,8 @@ jq -n \
       has_dockerfile:    ($dockerfile == "true"),
       has_workflows:     ($workflows  == "true"),
       is_extension:      ($extension  == "true"),
-      is_mobile:         ($mobile     == "true")
+      is_mobile:         ($mobile     == "true"),
+      has_iac:           ($iac        == "true")
     },
     available_tools: $tools
   }'

--- a/modules/commands-extra/skills/audit/scripts/registry.py
+++ b/modules/commands-extra/skills/audit/scripts/registry.py
@@ -41,7 +41,8 @@ _VALID_SEVERITIES = {"critical", "high", "medium", "low", "info"}
 _VALID_CONFIDENCES = {"high", "medium", "low"}
 _VALID_DETECTIONS = {"tool", "llm", "hybrid"}
 _VALID_SHAPE_FLAGS = {
-    "has_migrations", "has_dockerfile", "has_workflows", "is_extension", "is_mobile"
+    "has_migrations", "has_dockerfile", "has_workflows", "is_extension", "is_mobile",
+    "has_iac"
 }
 
 

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-checkov.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-checkov.py
@@ -66,7 +66,16 @@ _HIGH_SEVERITY_PREFIXES = {
 
 
 def _severity_for(check_id):
-    """Assign severity based on check_id prefix heuristic."""
+    """Assign severity based on check_id prefix heuristic.
+
+    The heuristic only keys on the check_id string; it does NOT map every
+    possible CKV_* to a precise severity.  That is intentional: pack-level
+    rubric entries (packs/infra-iac/checks.md) are the authoritative severity
+    owners for named check categories (iac/public-ingress, iac/missing-
+    encryption, etc.).  The catch-all "return medium" here is the correct
+    default for the generic iac/checkov-violation check_id — the rubric entry
+    for that check_id specifies medium confidence/severity by design.
+    """
     if check_id in _HIGH_SEVERITY_PREFIXES:
         return "high"
     check_upper = check_id.upper()

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-checkov.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-checkov.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+CCGM audit spine -- parse checkov JSON output -> finding.schema.json JSONL.
+
+Usage: parse-checkov.py <checkov_json_file> <repo_root>
+
+checkov --output json emits one of two shapes:
+
+  Single-framework output (most common):
+    {
+      "check_type": "terraform",
+      "results": {
+        "failed_checks": [
+          {
+            "check_id": "CKV_AWS_20",
+            "check_name": "Ensure the S3 bucket has access control list (ACL) is private",
+            "file_path": "/main.tf",
+            "file_line_range": [1, 10],
+            "resource": "aws_s3_bucket.example",
+            "check_class": "...",
+            ...
+          },
+          ...
+        ],
+        "passed_checks": [...],
+        "skipped_checks": [...]
+      }
+    }
+
+  Multi-framework output (when multiple IaC types are present):
+    [
+      { "check_type": "terraform", "results": { "failed_checks": [...] } },
+      { "check_type": "dockerfile", "results": { "failed_checks": [...] } },
+      ...
+    ]
+
+  NOTE: We only process failed_checks. Passed and skipped checks are ignored.
+  The check_id field (e.g. "CKV_AWS_20") is used as the rule_id. All findings
+  are emitted under the "iac/" check_id namespace.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import normalize  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Severity mapping: checkov does not emit severity in standard JSON output,
+# so we assign "medium" by default.  Known high-severity check IDs override.
+# ---------------------------------------------------------------------------
+
+_HIGH_SEVERITY_PREFIXES = {
+    "CKV_AWS_20",   # S3 bucket public
+    "CKV_AWS_21",   # S3 versioning
+    "CKV_AWS_54",   # S3 public access block
+    "CKV_AWS_55",   # S3 public access block (account level)
+    "CKV_AWS_18",   # CloudTrail logging
+    "CKV_AWS_19",   # CloudTrail encryption
+    "CKV_AWS_7",    # KMS key rotation
+    "CKV_SECRET",   # Secrets in IaC
+    "CKV2_SECRET",  # Secrets in IaC (v2)
+}
+
+
+def _severity_for(check_id):
+    """Assign severity based on check_id prefix heuristic."""
+    if check_id in _HIGH_SEVERITY_PREFIXES:
+        return "high"
+    check_upper = check_id.upper()
+    if "SECRET" in check_upper or "CREDENTIAL" in check_upper or "KEY" in check_upper:
+        return "high"
+    # Public ingress / open to 0.0.0.0
+    if "PUBLIC" in check_upper or "OPEN" in check_upper or "INGRESS" in check_upper:
+        return "high"
+    # Encryption misses
+    if "ENCRYPT" in check_upper:
+        return "medium"
+    return "medium"
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+def _parse_failed_checks(failed_checks, repo_root):
+    """Yield normalized findings from a failed_checks list."""
+    if not isinstance(failed_checks, list):
+        return
+
+    for item in failed_checks:
+        if not isinstance(item, dict):
+            continue
+
+        check_id = item.get("check_id", "CKV_UNKNOWN")
+        check_name = item.get("check_name", "checkov finding")
+        file_path = item.get("file_path", "")
+        resource = item.get("resource", "")
+
+        # Normalize file path: strip leading / and repo_root prefix
+        if file_path.startswith(repo_root + "/"):
+            file_path = file_path[len(repo_root) + 1:]
+        elif file_path.startswith("/"):
+            file_path = file_path.lstrip("/")
+
+        if not file_path:
+            file_path = "."
+
+        # Extract line number from file_line_range: [start, end]
+        line_range = item.get("file_line_range", [1, 1])
+        if isinstance(line_range, list) and len(line_range) >= 1:
+            try:
+                line_no = max(1, int(line_range[0]))
+                end_line = max(line_no, int(line_range[1])) if len(line_range) >= 2 else None
+            except (TypeError, ValueError):
+                line_no = 1
+                end_line = None
+        else:
+            line_no = 1
+            end_line = None
+
+        severity = _severity_for(check_id)
+
+        message = check_name
+        if resource:
+            message = "{0} [{1}]".format(check_name, resource)
+
+        fp = normalize.make_content_fingerprint(
+            "{0}:{1}:{2}".format(file_path, line_no, check_id)
+        )
+
+        finding = normalize.make_finding(
+            check_id="iac/checkov-violation",
+            rule_id=check_id,
+            severity=severity,
+            confidence="medium",
+            path=file_path,
+            line=line_no,
+            message=message,
+            fingerprint=fp,
+            end_line=end_line,
+            properties={"tool": "checkov"},
+        )
+        normalize.emit_finding(finding)
+
+
+def main(argv):
+    if len(argv) < 3:
+        sys.stderr.write("Usage: parse-checkov.py <json_file> <repo_root>\n")
+        sys.exit(1)
+
+    json_file = argv[1]
+    repo_root = argv[2].rstrip("/")
+
+    try:
+        with open(json_file, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.stderr.write("Cannot parse {0}: {1}\n".format(json_file, exc))
+        sys.exit(0)
+
+    # Normalize to a list of framework result objects
+    if isinstance(data, dict):
+        # Single-framework output
+        framework_results = [data]
+    elif isinstance(data, list):
+        # Multi-framework output
+        framework_results = data
+    else:
+        sys.stderr.write("Unexpected checkov output shape\n")
+        sys.exit(0)
+
+    for fw_result in framework_results:
+        if not isinstance(fw_result, dict):
+            continue
+        results = fw_result.get("results", {})
+        if not isinstance(results, dict):
+            continue
+        failed_checks = results.get("failed_checks", [])
+        _parse_failed_checks(failed_checks, repo_root)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/modules/commands-extra/skills/audit/scripts/spine/run.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/run.sh
@@ -12,7 +12,7 @@
 #   --tools <list>   Comma-separated subset of tools to run (default: all)
 #                    Valid: gitleaks,semgrep,dep-audit,knip,eslint,
 #                           govulncheck,bandit,hadolint,actionlint,trivy,
-#                           zizmor,pinact,squawk,sqlfluff
+#                           zizmor,pinact,squawk,sqlfluff,checkov
 #   --output <file>  Write aggregated JSONL to this file instead of stdout
 #
 # Output: JSONL -- one JSON object per line, either a finding or a note.
@@ -33,7 +33,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Defaults
 # ---------------------------------------------------------------------------
 REPO_ROOT=""
-REQUESTED_TOOLS="gitleaks,semgrep,dep-audit,knip,eslint,govulncheck,bandit,hadolint,actionlint,trivy,zizmor,pinact,squawk,sqlfluff"
+REQUESTED_TOOLS="gitleaks,semgrep,dep-audit,knip,eslint,govulncheck,bandit,hadolint,actionlint,trivy,zizmor,pinact,squawk,sqlfluff,checkov"
 OUTPUT_FILE=""
 
 # ---------------------------------------------------------------------------
@@ -90,9 +90,10 @@ TOOL_WRAPPERS["zizmor"]="$SCRIPT_DIR/wrap-zizmor.sh"
 TOOL_WRAPPERS["pinact"]="$SCRIPT_DIR/wrap-pinact.sh"
 TOOL_WRAPPERS["squawk"]="$SCRIPT_DIR/wrap-squawk.sh"
 TOOL_WRAPPERS["sqlfluff"]="$SCRIPT_DIR/wrap-sqlfluff.sh"
+TOOL_WRAPPERS["checkov"]="$SCRIPT_DIR/wrap-checkov.sh"
 
 # Ordered execution list (stable, deterministic)
-TOOL_ORDER=(gitleaks semgrep dep-audit knip eslint govulncheck bandit hadolint actionlint trivy zizmor pinact squawk sqlfluff)
+TOOL_ORDER=(gitleaks semgrep dep-audit knip eslint govulncheck bandit hadolint actionlint trivy zizmor pinact squawk sqlfluff checkov)
 
 # ---------------------------------------------------------------------------
 # Parse requested tools into a set (using associative array for O(1) lookup)

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-checkov.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-checkov.sh
@@ -40,8 +40,15 @@ trap 'rm -f "$TMPFILE"' EXIT
 # --quiet: suppress progress bars and logging
 # --compact: omit passed checks from JSON output (findings only)
 # --soft-fail: exit 0 regardless of findings (we handle them ourselves)
-# Config isolation: --no-guide suppresses network calls;
-# we do NOT load any .checkov.yaml from the repo (no --config-file).
+#
+# Config isolation caveat: checkov auto-discovers .checkov.yaml/.checkov.yml
+# from the scanned --directory, then the process cwd, then ~/.checkov.yaml
+# (via configargparse default_config_files).  There is no CLI flag that
+# suppresses this discovery — --config-file adds to the list rather than
+# replacing it.  A repo-local .checkov.yaml can therefore silently skip or
+# alter checks.  Accepted limitation: the pack rubric and normalizer
+# (parse-checkov.py) own severity/confidence regardless of what the repo
+# config does to the check list.
 set +e
 checkov \
   --directory "$REPO_ROOT" \

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-checkov.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-checkov.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# CCGM audit spine -- checkov wrapper
+# Scans IaC files (Terraform, Dockerfiles, CloudFormation, k8s manifests)
+# for security and compliance misconfigurations.
+#
+# Usage: wrap-checkov.sh <repo_root>
+#
+# Output (stdout): JSONL
+# Exit code: always 0
+
+set -euo pipefail
+
+REPO_ROOT="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NORMALIZE_PY="$SCRIPT_DIR/normalize.py"
+PARSE_PY="$SCRIPT_DIR/parse-checkov.py"
+
+if [[ -z "$REPO_ROOT" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip checkov \
+    "iac/public-ingress:no repo_root argument supplied" \
+    "iac/missing-encryption:no repo_root argument supplied" \
+    "iac/hardcoded-secret-in-iac:no repo_root argument supplied"
+  exit 0
+fi
+
+if ! command -v checkov > /dev/null 2>&1; then
+  python3 "$NORMALIZE_PY" --emit-skip checkov \
+    "iac/public-ingress:checkov not installed -- IaC security scan skipped" \
+    "iac/missing-encryption:checkov not installed -- IaC security scan skipped" \
+    "iac/hardcoded-secret-in-iac:checkov not installed -- IaC security scan skipped"
+  exit 0
+fi
+
+TMPFILE="$(mktemp /tmp/ccgm-checkov-XXXXXX.json)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+# Run checkov on the repo directory.
+# --directory: target path (passed as argv, not interpolated)
+# --output json: machine-readable JSON output
+# --quiet: suppress progress bars and logging
+# --compact: omit passed checks from JSON output (findings only)
+# --soft-fail: exit 0 regardless of findings (we handle them ourselves)
+# Config isolation: --no-guide suppresses network calls;
+# we do NOT load any .checkov.yaml from the repo (no --config-file).
+set +e
+checkov \
+  --directory "$REPO_ROOT" \
+  --output json \
+  --quiet \
+  --compact \
+  --soft-fail \
+  > "$TMPFILE" 2>/dev/null
+CHECKOV_EXIT=$?
+set -e
+
+if [[ $CHECKOV_EXIT -ne 0 && ! -s "$TMPFILE" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip checkov \
+    "iac/public-ingress:checkov exited non-zero with no output"
+  exit 0
+fi
+
+if [[ ! -s "$TMPFILE" ]]; then
+  exit 0
+fi
+
+python3 "$PARSE_PY" "$TMPFILE" "$REPO_ROOT"

--- a/modules/commands-extra/skills/audit/tests/test-detect-ecosystems.sh
+++ b/modules/commands-extra/skills/audit/tests/test-detect-ecosystems.sh
@@ -387,6 +387,70 @@ assert_bool         "seed: has_migrations false" "$SEED_JSON" ".project_shape.ha
 assert_contains     "seed: sql ecosystem present" "$SEED_JSON" ".detected_ecosystems" "sql"
 
 # ---------------------------------------------------------------------------
+# Fixture 13: has_iac via Dockerfile
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: has_iac via Dockerfile ==="
+FIX_IAC_DOCKER=$(make_fixture "iac-docker-repo")
+cat > "$FIX_IAC_DOCKER/Dockerfile" <<'EOF'
+FROM ubuntu:22.04
+RUN apt-get update
+EOF
+
+IAC_DOCKER_JSON=$(run_detector "$FIX_IAC_DOCKER")
+assert_bool "iac-docker: has_iac true"      "$IAC_DOCKER_JSON" ".project_shape.has_iac" "true"
+assert_bool "iac-docker: has_dockerfile true" "$IAC_DOCKER_JSON" ".project_shape.has_dockerfile" "true"
+
+# ---------------------------------------------------------------------------
+# Fixture 14: has_iac via Terraform (.tf file)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: has_iac via Terraform (.tf file) ==="
+FIX_IAC_TF=$(make_fixture "iac-tf-repo")
+cat > "$FIX_IAC_TF/main.tf" <<'EOF'
+resource "aws_s3_bucket" "example" {
+  bucket = "my-tf-test-bucket"
+}
+EOF
+
+IAC_TF_JSON=$(run_detector "$FIX_IAC_TF")
+assert_bool         "iac-tf: has_iac true"        "$IAC_TF_JSON" ".project_shape.has_iac" "true"
+assert_bool         "iac-tf: no dockerfile"       "$IAC_TF_JSON" ".project_shape.has_dockerfile" "false"
+assert_contains     "iac-tf: terraform ecosystem" "$IAC_TF_JSON" ".detected_ecosystems" "terraform"
+
+# ---------------------------------------------------------------------------
+# Fixture 15: has_iac false for a plain JS repo (no IaC signals)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: has_iac false for plain JS repo ==="
+FIX_IAC_NONE=$(make_fixture "no-iac-repo")
+cat > "$FIX_IAC_NONE/package.json" <<'JSON'
+{"name":"no-iac","version":"1.0.0"}
+JSON
+
+IAC_NONE_JSON=$(run_detector "$FIX_IAC_NONE")
+assert_bool "no-iac: has_iac false" "$IAC_NONE_JSON" ".project_shape.has_iac" "false"
+
+# ---------------------------------------------------------------------------
+# Fixture 16: has_iac via k8s manifest directory
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fixture: has_iac via k8s manifest directory ==="
+FIX_IAC_K8S=$(make_fixture "iac-k8s-repo")
+mkdir -p "$FIX_IAC_K8S/k8s"
+cat > "$FIX_IAC_K8S/k8s/deployment.yaml" <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  replicas: 1
+EOF
+
+IAC_K8S_JSON=$(run_detector "$FIX_IAC_K8S")
+assert_bool "iac-k8s: has_iac true" "$IAC_K8S_JSON" ".project_shape.has_iac" "true"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/modules/commands-extra/skills/audit/tests/test-pack-infra.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-infra.sh
@@ -38,6 +38,10 @@ fail() {
   FAIL=$((FAIL + 1))
 }
 
+skip() {
+  printf '  [SKIP] %s\n' "$1"
+}
+
 # ---------------------------------------------------------------------------
 # Temp directory for all runtime fixtures
 # ---------------------------------------------------------------------------
@@ -533,7 +537,7 @@ if command -v shellcheck > /dev/null 2>&1; then
     printf '%s\n' "$SC_OUTPUT" | head -10
   fi
 else
-  fail "shellcheck not installed -- cannot verify shell safety"
+  skip "shellcheck not installed -- wrap-checkov.sh shell-safety check skipped"
 fi
 
 # ---------------------------------------------------------------------------

--- a/modules/commands-extra/skills/audit/tests/test-pack-infra.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-infra.sh
@@ -1,0 +1,554 @@
+#!/usr/bin/env bash
+# CCGM audit -- test suite for infra-iac pack (Epic 4.3)
+#
+# Tests:
+#   1. Pack is SELECTED for a repo with a root-user Dockerfile (has_iac=true)
+#   2. Pack is NOT selected for a plain repo (has_iac=false)
+#   3. wrap-checkov.sh emits graceful coverage-gap when checkov is absent
+#   4. parse-checkov.py unit test: synthetic JSON -> valid JSONL findings
+#   5. pack.json validates against registry.py pack validator
+#   6. severity-rubric.json has iac/* entries
+#   7. shellcheck: wrap-checkov.sh is clean
+#
+# Usage: bash modules/commands-extra/skills/audit/tests/test-pack-infra.sh
+# Exit: 0 = all pass, non-zero = any failure
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$SCRIPT_DIR/.."
+SPINE_DIR="$AUDIT_DIR/scripts/spine"
+REGISTRY_PY="$AUDIT_DIR/scripts/registry.py"
+DETECT_SH="$AUDIT_DIR/scripts/detect-ecosystems.sh"
+RUBRIC_JSON="$AUDIT_DIR/schemas/severity-rubric.json"
+PACK_DIR="$AUDIT_DIR/packs/infra-iac"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+  printf '  [PASS] %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  ERRORS+=("$1")
+  FAIL=$((FAIL + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Temp directory for all runtime fixtures
+# ---------------------------------------------------------------------------
+TESTRUN_TMPDIR="$(mktemp -d /tmp/ccgm-infra-test-XXXXXX)"
+trap 'rm -rf "$TESTRUN_TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Test 1: Pack SELECTED for has_iac repo (root-user Dockerfile)
+# ---------------------------------------------------------------------------
+printf '\nTest 1: infra-iac pack selected for has_iac=true fixture\n'
+
+FIXTURE_IAC="$TESTRUN_TMPDIR/iac-repo"
+mkdir -p "$FIXTURE_IAC"
+
+# Root-user Dockerfile (no USER directive → runs as root)
+cat > "$FIXTURE_IAC/Dockerfile" <<'EOF'
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y nginx
+CMD ["nginx", "-g", "daemon off;"]
+EOF
+
+# Detect ecosystems for this fixture
+DETECTOR_JSON="$TESTRUN_TMPDIR/detector-iac.json"
+if bash "$DETECT_SH" "$FIXTURE_IAC" > "$DETECTOR_JSON" 2>/dev/null; then
+  pass "detector ran successfully on iac fixture"
+else
+  fail "detector failed on iac fixture"
+fi
+
+# Verify has_iac=true in detector output
+HAS_IAC=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d['project_shape'].get('has_iac', False))" \
+  "$DETECTOR_JSON" 2>/dev/null || echo "False")
+if [ "$HAS_IAC" = "True" ]; then
+  pass "detector: has_iac=true for Dockerfile fixture"
+else
+  fail "detector: expected has_iac=true, got: $HAS_IAC"
+fi
+
+# Use registry.py to select packs; verify infra-iac is selected
+SELECTED_JSON="$TESTRUN_TMPDIR/selected-iac.json"
+if python3 "$REGISTRY_PY" "$DETECTOR_JSON" > "$SELECTED_JSON" 2>/dev/null; then
+  pass "registry.py ran successfully"
+else
+  fail "registry.py failed"
+fi
+
+INFRA_SELECTED=$(python3 -c "
+import json, sys
+packs = json.load(open(sys.argv[1]))
+ids = [p['id'] for p in packs]
+print('yes' if 'ccgm/infra-iac' in ids else 'no')
+" "$SELECTED_JSON" 2>/dev/null || echo "no")
+
+if [ "$INFRA_SELECTED" = "yes" ]; then
+  pass "registry: infra-iac pack selected for has_iac=true repo"
+else
+  fail "registry: infra-iac pack NOT selected for has_iac=true repo"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 1b: Public-ingress Terraform fixture also triggers has_iac
+# ---------------------------------------------------------------------------
+printf '\nTest 1b: infra-iac pack selected for Terraform fixture\n'
+
+FIXTURE_TF="$TESTRUN_TMPDIR/tf-repo"
+mkdir -p "$FIXTURE_TF"
+cat > "$FIXTURE_TF/main.tf" <<'EOF'
+resource "aws_security_group" "open" {
+  name = "wide-open"
+  ingress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+EOF
+
+DETECTOR_TF="$TESTRUN_TMPDIR/detector-tf.json"
+bash "$DETECT_SH" "$FIXTURE_TF" > "$DETECTOR_TF" 2>/dev/null
+
+TF_HAS_IAC=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d['project_shape'].get('has_iac', False))" \
+  "$DETECTOR_TF" 2>/dev/null || echo "False")
+if [ "$TF_HAS_IAC" = "True" ]; then
+  pass "detector: has_iac=true for Terraform fixture"
+else
+  fail "detector: expected has_iac=true for .tf fixture, got: $TF_HAS_IAC"
+fi
+
+SELECTED_TF="$TESTRUN_TMPDIR/selected-tf.json"
+python3 "$REGISTRY_PY" "$DETECTOR_TF" > "$SELECTED_TF" 2>/dev/null
+
+TF_INFRA_SELECTED=$(python3 -c "
+import json, sys
+packs = json.load(open(sys.argv[1]))
+ids = [p['id'] for p in packs]
+print('yes' if 'ccgm/infra-iac' in ids else 'no')
+" "$SELECTED_TF" 2>/dev/null || echo "no")
+
+if [ "$TF_INFRA_SELECTED" = "yes" ]; then
+  pass "registry: infra-iac selected for Terraform fixture"
+else
+  fail "registry: infra-iac NOT selected for Terraform fixture"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: Pack NOT selected for plain (no-IaC) repo
+# ---------------------------------------------------------------------------
+printf '\nTest 2: infra-iac pack NOT selected for plain repo\n'
+
+FIXTURE_PLAIN="$TESTRUN_TMPDIR/plain-repo"
+mkdir -p "$FIXTURE_PLAIN"
+printf '{"name":"plain","version":"1.0.0"}\n' > "$FIXTURE_PLAIN/package.json"
+
+DETECTOR_PLAIN="$TESTRUN_TMPDIR/detector-plain.json"
+bash "$DETECT_SH" "$FIXTURE_PLAIN" > "$DETECTOR_PLAIN" 2>/dev/null
+
+PLAIN_HAS_IAC=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d['project_shape'].get('has_iac', False))" \
+  "$DETECTOR_PLAIN" 2>/dev/null || echo "True")
+if [ "$PLAIN_HAS_IAC" = "False" ]; then
+  pass "detector: has_iac=false for plain JS repo"
+else
+  fail "detector: expected has_iac=false for plain JS repo, got: $PLAIN_HAS_IAC"
+fi
+
+SELECTED_PLAIN="$TESTRUN_TMPDIR/selected-plain.json"
+python3 "$REGISTRY_PY" "$DETECTOR_PLAIN" > "$SELECTED_PLAIN" 2>/dev/null
+
+PLAIN_INFRA_SELECTED=$(python3 -c "
+import json, sys
+packs = json.load(open(sys.argv[1]))
+ids = [p['id'] for p in packs]
+print('yes' if 'ccgm/infra-iac' in ids else 'no')
+" "$SELECTED_PLAIN" 2>/dev/null || echo "yes")
+
+if [ "$PLAIN_INFRA_SELECTED" = "no" ]; then
+  pass "registry: infra-iac pack NOT selected for plain repo"
+else
+  fail "registry: infra-iac pack incorrectly selected for plain repo (no IaC)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: wrap-checkov.sh graceful skip when checkov absent
+# ---------------------------------------------------------------------------
+printf '\nTest 3: wrap-checkov.sh graceful coverage-gap when checkov absent\n'
+
+WRAP_CHECKOV="$SPINE_DIR/wrap-checkov.sh"
+
+if [[ ! -f "$WRAP_CHECKOV" ]]; then
+  fail "wrap-checkov.sh not found at: $WRAP_CHECKOV"
+else
+  pass "wrap-checkov.sh file exists"
+fi
+
+# Build a minimal PATH that excludes checkov
+SYSTEM_BINS=""
+for bin in python3 bash find date mktemp cp rm mv printf head grep; do
+  BINPATH="$(command -v "$bin" 2>/dev/null || true)"
+  if [[ -n "$BINPATH" ]]; then
+    BINDIR="$(dirname "$BINPATH")"
+    case ":$SYSTEM_BINS:" in
+      *":$BINDIR:"*) ;;
+      *) SYSTEM_BINS="${SYSTEM_BINS:+$SYSTEM_BINS:}$BINDIR" ;;
+    esac
+  fi
+done
+RESTRICTED_PATH="$SYSTEM_BINS:/usr/bin:/bin"
+
+WRAP_OUTPUT="$TESTRUN_TMPDIR/wrap-checkov-absent.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "$WRAP_CHECKOV" "$FIXTURE_IAC" > "$WRAP_OUTPUT" 2>/dev/null
+WRAP_EXIT=$?
+set -e
+
+if [[ $WRAP_EXIT -eq 0 ]]; then
+  pass "wrap-checkov.sh exits 0 when checkov absent"
+else
+  fail "wrap-checkov.sh exits $WRAP_EXIT (expected 0) when checkov absent"
+fi
+
+if [[ -s "$WRAP_OUTPUT" ]]; then
+  pass "wrap-checkov.sh produced output when checkov absent"
+else
+  fail "wrap-checkov.sh produced no output when checkov absent"
+fi
+
+# Verify output contains a skipped note
+SKIP_COUNT="$(grep -c '"type":"skipped"' "$WRAP_OUTPUT" 2>/dev/null || printf '0')"
+if [[ "$SKIP_COUNT" -gt 0 ]]; then
+  pass "wrap-checkov.sh: found $SKIP_COUNT skipped note(s)"
+else
+  fail "wrap-checkov.sh: no skipped notes found (expected >= 1)"
+fi
+
+# Verify output contains coverage_gap entries
+GAP_COUNT="$(grep -c '"type":"coverage_gap"' "$WRAP_OUTPUT" 2>/dev/null || printf '0')"
+if [[ "$GAP_COUNT" -gt 0 ]]; then
+  pass "wrap-checkov.sh: found $GAP_COUNT coverage-gap entries"
+else
+  fail "wrap-checkov.sh: no coverage_gap entries found (expected >= 1)"
+fi
+
+# All output lines must be valid JSON
+INVALID_JSON=0
+while IFS= read -r line; do
+  if [[ -z "$line" ]]; then continue; fi
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID_JSON=$((INVALID_JSON + 1))
+  fi
+done < "$WRAP_OUTPUT"
+
+if [[ $INVALID_JSON -eq 0 ]]; then
+  pass "wrap-checkov.sh: all output lines are valid JSON"
+else
+  fail "wrap-checkov.sh: $INVALID_JSON output line(s) are invalid JSON"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: parse-checkov.py unit test -- synthetic JSON input
+# ---------------------------------------------------------------------------
+printf '\nTest 4: parse-checkov.py unit test against synthetic JSON\n'
+
+PARSE_CHECKOV="$SPINE_DIR/parse-checkov.py"
+if [[ ! -f "$PARSE_CHECKOV" ]]; then
+  fail "parse-checkov.py not found at: $PARSE_CHECKOV"
+else
+  pass "parse-checkov.py file exists"
+fi
+
+# Synthetic checkov output: single-framework shape
+SYNTHETIC_JSON="$TESTRUN_TMPDIR/synthetic-checkov.json"
+cat > "$SYNTHETIC_JSON" <<'JSON'
+{
+  "check_type": "terraform",
+  "results": {
+    "failed_checks": [
+      {
+        "check_id": "CKV_AWS_20",
+        "check_name": "Ensure the S3 bucket has access control list (ACL) is private",
+        "file_path": "/main.tf",
+        "file_line_range": [1, 10],
+        "resource": "aws_s3_bucket.example"
+      },
+      {
+        "check_id": "CKV_AWS_79",
+        "check_name": "Ensure Instance Metadata Service Version 1 is not enabled",
+        "file_path": "/ec2.tf",
+        "file_line_range": [5, 20],
+        "resource": "aws_instance.web"
+      }
+    ],
+    "passed_checks": [],
+    "skipped_checks": []
+  }
+}
+JSON
+
+PARSE_OUTPUT="$TESTRUN_TMPDIR/parse-checkov-output.jsonl"
+FAKE_REPO="$TESTRUN_TMPDIR/fake-repo"
+mkdir -p "$FAKE_REPO"
+
+set +e
+python3 "$PARSE_CHECKOV" "$SYNTHETIC_JSON" "$FAKE_REPO" > "$PARSE_OUTPUT" 2>/dev/null
+PARSE_EXIT=$?
+set -e
+
+if [[ $PARSE_EXIT -eq 0 ]]; then
+  pass "parse-checkov.py exits 0 on synthetic input"
+else
+  fail "parse-checkov.py exits $PARSE_EXIT on synthetic input (expected 0)"
+fi
+
+# Count findings
+FINDING_COUNT=0
+INVALID_FINDINGS=0
+
+while IFS= read -r line; do
+  if [[ -z "$line" ]]; then continue; fi
+  IS_FINDING=$(python3 -c "
+import json,sys
+try:
+    obj = json.loads(sys.argv[1])
+    if isinstance(obj,dict) and obj.get('type') not in ('skipped','coverage_gap','provenance'):
+        print('yes')
+    else:
+        print('no')
+except Exception:
+    print('no')
+" "$line" 2>/dev/null || echo "no")
+  if [[ "$IS_FINDING" == "yes" ]]; then
+    FINDING_COUNT=$((FINDING_COUNT + 1))
+    # Validate required fields
+    VALID=$(python3 -c "
+import json, re, sys
+obj = json.loads(sys.argv[1])
+required = {'check_id','rule_id','severity','confidence','location','message','fingerprint','detection','source'}
+missing = required - obj.keys()
+if missing:
+    print('missing:' + ','.join(sorted(missing)))
+    sys.exit(0)
+if not re.fullmatch(r'[a-z0-9_-]+/[a-z0-9_.-]+', obj['check_id']):
+    print('bad_check_id')
+    sys.exit(0)
+loc = obj.get('location',{})
+if 'path' not in loc or 'line' not in loc:
+    print('bad_location')
+    sys.exit(0)
+print('ok')
+" "$line" 2>/dev/null || echo "error")
+    if [[ "$VALID" != "ok" ]]; then
+      INVALID_FINDINGS=$((INVALID_FINDINGS + 1))
+    fi
+  fi
+done < "$PARSE_OUTPUT"
+
+if [[ $FINDING_COUNT -ge 2 ]]; then
+  pass "parse-checkov.py: found $FINDING_COUNT findings from synthetic input (expected >= 2)"
+else
+  fail "parse-checkov.py: expected >= 2 findings, got $FINDING_COUNT"
+fi
+
+if [[ $INVALID_FINDINGS -eq 0 ]]; then
+  pass "parse-checkov.py: all findings have required fields and valid structure"
+else
+  fail "parse-checkov.py: $INVALID_FINDINGS finding(s) with invalid structure"
+fi
+
+# Verify check_id is iac/checkov-violation and rule_id is the checkov code
+CHECK_ID_OK=$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    lines = [l.strip() for l in f if l.strip()]
+findings = []
+for l in lines:
+    obj = json.loads(l)
+    if obj.get('type') not in ('skipped','coverage_gap','provenance'):
+        findings.append(obj)
+if not findings:
+    print('no_findings')
+    sys.exit(0)
+for f in findings:
+    if f.get('check_id') != 'iac/checkov-violation':
+        print('wrong_check_id:' + f.get('check_id',''))
+        sys.exit(0)
+    if not f.get('rule_id','').startswith('CKV'):
+        print('wrong_rule_id:' + f.get('rule_id',''))
+        sys.exit(0)
+print('ok')
+" "$PARSE_OUTPUT" 2>/dev/null || echo "error")
+
+if [[ "$CHECK_ID_OK" == "ok" ]]; then
+  pass "parse-checkov.py: check_id=iac/checkov-violation, rule_id=CKV_* as expected"
+else
+  fail "parse-checkov.py: unexpected check_id/rule_id: $CHECK_ID_OK"
+fi
+
+# Verify multi-framework input shape also parses
+printf '\nTest 4b: parse-checkov.py handles multi-framework (array) input\n'
+
+SYNTHETIC_MULTI="$TESTRUN_TMPDIR/synthetic-checkov-multi.json"
+cat > "$SYNTHETIC_MULTI" <<'JSON'
+[
+  {
+    "check_type": "terraform",
+    "results": {
+      "failed_checks": [
+        {
+          "check_id": "CKV_AWS_3",
+          "check_name": "Ensure all data stored in the EBS is securely encrypted",
+          "file_path": "/ebs.tf",
+          "file_line_range": [1, 5],
+          "resource": "aws_ebs_volume.data"
+        }
+      ]
+    }
+  },
+  {
+    "check_type": "dockerfile",
+    "results": {
+      "failed_checks": [
+        {
+          "check_id": "CKV_DOCKER_2",
+          "check_name": "Ensure that HEALTHCHECK instructions have been added to container images",
+          "file_path": "/Dockerfile",
+          "file_line_range": [1, 3],
+          "resource": "Dockerfile"
+        }
+      ]
+    }
+  }
+]
+JSON
+
+PARSE_MULTI_OUTPUT="$TESTRUN_TMPDIR/parse-checkov-multi.jsonl"
+set +e
+python3 "$PARSE_CHECKOV" "$SYNTHETIC_MULTI" "$FAKE_REPO" > "$PARSE_MULTI_OUTPUT" 2>/dev/null
+PARSE_MULTI_EXIT=$?
+set -e
+
+if [[ $PARSE_MULTI_EXIT -eq 0 ]]; then
+  pass "parse-checkov.py exits 0 on multi-framework input"
+else
+  fail "parse-checkov.py exits $PARSE_MULTI_EXIT on multi-framework input"
+fi
+
+MULTI_FINDING_COUNT=$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    lines = [l.strip() for l in f if l.strip()]
+count = sum(1 for l in lines
+    if json.loads(l).get('type') not in ('skipped','coverage_gap','provenance'))
+print(count)
+" "$PARSE_MULTI_OUTPUT" 2>/dev/null || echo "0")
+
+if [[ "$MULTI_FINDING_COUNT" -ge 2 ]]; then
+  pass "parse-checkov.py: multi-framework: $MULTI_FINDING_COUNT findings (expected >= 2)"
+else
+  fail "parse-checkov.py: multi-framework: expected >= 2 findings, got $MULTI_FINDING_COUNT"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: pack.json validates via registry.py validator
+# ---------------------------------------------------------------------------
+printf '\nTest 5: infra-iac pack.json passes registry.py validation\n'
+
+PACK_JSON="$PACK_DIR/pack.json"
+if [[ ! -f "$PACK_JSON" ]]; then
+  fail "pack.json not found at: $PACK_JSON"
+else
+  pass "pack.json file exists"
+fi
+
+PACK_VALIDATE=$(python3 - "$PACK_JSON" "$REGISTRY_PY" << 'PYEOF'
+import json, sys, os
+sys.path.insert(0, os.path.dirname(sys.argv[2]))
+from registry import validate_pack, ValidationError
+
+with open(sys.argv[1]) as f:
+    pack = json.load(f)
+
+try:
+    validate_pack(pack, sys.argv[1])
+    print("ok")
+except ValidationError as e:
+    print("error:" + str(e))
+PYEOF
+)
+
+if [[ "$PACK_VALIDATE" == "ok" ]]; then
+  pass "pack.json passes registry.py validation"
+else
+  fail "pack.json fails registry.py validation: $PACK_VALIDATE"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: severity-rubric.json contains iac/* entries
+# ---------------------------------------------------------------------------
+printf '\nTest 6: severity-rubric.json has iac/* entries\n'
+
+if [[ ! -f "$RUBRIC_JSON" ]]; then
+  fail "severity-rubric.json not found at: $RUBRIC_JSON"
+else
+  pass "severity-rubric.json file exists"
+fi
+
+for CHECK_ID in "iac/dockerfile-root-user" "iac/dockerfile-latest-tag" "iac/public-ingress" \
+                "iac/missing-encryption" "iac/hardcoded-secret-in-iac" \
+                "iac/dockerfile-issue" "iac/checkov-violation"; do
+  HAS_ENTRY=$(python3 -c "
+import json, sys
+rubric = json.load(open(sys.argv[1]))
+checks = rubric.get('checks', {})
+print('yes' if sys.argv[2] in checks else 'no')
+" "$RUBRIC_JSON" "$CHECK_ID" 2>/dev/null || echo "no")
+  if [[ "$HAS_ENTRY" == "yes" ]]; then
+    pass "rubric: $CHECK_ID entry present"
+  else
+    fail "rubric: $CHECK_ID entry MISSING"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Test 7: shellcheck on wrap-checkov.sh
+# ---------------------------------------------------------------------------
+printf '\nTest 7: shellcheck on wrap-checkov.sh\n'
+
+if command -v shellcheck > /dev/null 2>&1; then
+  SC_OUTPUT="$(shellcheck -S warning "$WRAP_CHECKOV" 2>&1 || true)"
+  if [[ -z "$SC_OUTPUT" ]]; then
+    pass "shellcheck clean: wrap-checkov.sh"
+  else
+    fail "shellcheck issues in wrap-checkov.sh:"
+    printf '%s\n' "$SC_OUTPUT" | head -10
+  fi
+else
+  fail "shellcheck not installed -- cannot verify shell safety"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n-------------------------------------------------\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  printf '\nFailed tests:\n'
+  for err in "${ERRORS[@]}"; do
+    printf '  - %s\n' "$err"
+  done
+  exit 1
+fi
+
+printf 'All tests passed.\n'
+exit 0

--- a/modules/commands-extra/skills/audit/tests/test-spine.sh
+++ b/modules/commands-extra/skills/audit/tests/test-spine.sh
@@ -442,6 +442,7 @@ if command -v shellcheck > /dev/null 2>&1; then
     "$SPINE_DIR/wrap-pinact.sh"
     "$SPINE_DIR/wrap-squawk.sh"
     "$SPINE_DIR/wrap-sqlfluff.sh"
+    "$SPINE_DIR/wrap-checkov.sh"
   )
 
   for script in "${SHELL_SCRIPTS[@]}"; do


### PR DESCRIPTION
## Summary

- **`has_iac` detector flag**: `detect-ecosystems.sh` emits `has_iac: true` when a Dockerfile, Terraform `.tf`/`.tf.json`, Kubernetes manifest (yaml with `kind:` + `apiVersion:` under `k8s/`, `manifests/`, `.k8s/`), or CloudFormation template (`AWSTemplateFormatVersion` text) is present. Added to `pack.schema.json` applies_when enum and `registry.py` valid shape flags.
- **checkov spine wrapper**: `wrap-checkov.sh` + `parse-checkov.py` — `command -v checkov` graceful-skip, shellcheck-clean, config-isolated (`--soft-fail --quiet --compact`), repo root passed as argv. Parser handles both single-framework (`{}`) and multi-framework (`[{}, {}]`) JSON shapes. Emits `iac/checkov-violation` check_id with `CKV_*` rule_id. Registered in `run.sh` TOOL_WRAPPERS + TOOL_ORDER + REQUESTED_TOOLS default.
- **`packs/infra-iac`**: `ccgm/infra-iac`, `applies_when: ["has_iac"]`, tools `hadolint+checkov+trivy`. 5 checks: `iac/dockerfile-root-user` (DL3002/hybrid), `iac/dockerfile-latest-tag` (DL3007/tool), `iac/public-ingress` (checkov/llm hybrid), `iac/missing-encryption` (checkov/tool), `iac/hardcoded-secret-in-iac` (checkov/grep hybrid). Full `checks.md` per template with TP/TN fixtures, rationale, and spine wiring docs.
- **`severity-rubric.json`**: 8 new `iac/*` entries for all pack check_ids and parser check_ids.
- **`module.json`**: 4 new files registered.
- **Tests**: `test-detect-ecosystems.sh` +4 fixtures (54 pass), `test-spine.sh` +1 shellcheck entry (30 pass), `tests/test-pack-infra.sh` new 32-test suite (all pass). All 7 verification commands pass.

Closes #630