### PR TITLE
#633: CCGM-specific conditional audit packs (ccgm-hygiene + ccgm-standards)

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -458,6 +458,26 @@
       "target": "skills/audit/packs/data-migrations/checks.md",
       "type": "doc",
       "template": false
+    },
+    "skills/audit/packs/ccgm-hygiene/pack.json": {
+      "target": "skills/audit/packs/ccgm-hygiene/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/ccgm-hygiene/checks.md": {
+      "target": "skills/audit/packs/ccgm-hygiene/checks.md",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/ccgm-standards/pack.json": {
+      "target": "skills/audit/packs/ccgm-standards/pack.json",
+      "type": "doc",
+      "template": false
+    },
+    "skills/audit/packs/ccgm-standards/checks.md": {
+      "target": "skills/audit/packs/ccgm-standards/checks.md",
+      "type": "doc",
+      "template": false
     }
   },
   "tags": [

--- a/modules/commands-extra/skills/audit/packs/ccgm-hygiene/checks.md
+++ b/modules/commands-extra/skills/audit/packs/ccgm-hygiene/checks.md
@@ -1,0 +1,352 @@
+# checks.md — CCGM Hygiene Pack
+
+---
+
+## Scope
+
+This pack audits source repositories for three hygiene issues that the CCGM conventions
+identify as common and costly: committed TODO/FIXME/XXX/HACK markers that signal deferred
+work shipped to production; environment-variable drift between code and `.env.example`
+(variables referenced in code but undocumented, or documented but no longer referenced);
+and Cloudflare Pages projects created as direct-upload (non-Git-connected) deployments,
+which cannot be retrofitted with Git integration and must be deleted and recreated to fix.
+
+All three checks gate themselves to applicable repos inside their detection instructions
+(self-scoping). A repo with no `.env.example` and no env-var references produces no
+`ccgm/env-example-drift` findings. A repo with no Wrangler/Cloudflare config produces no
+`ccgm/cloudflare-pages-no-git` findings.
+
+This pack does NOT cover project-rule conformance (`ccgm-standards` pack), MCP server
+annotation gaps, security vulnerabilities, or general code quality — those belong in their
+respective packs.
+
+**Pack ID:** `ccgm/ccgm-hygiene`
+**Applies when:** `always`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `always` | All three checks are language-agnostic and self-scope internally. Running on any repo incurs at most a grep with zero findings; no false negatives from ecosystem-gating on repos that happen to lack a `package.json`. |
+
+---
+
+## Checks
+
+---
+
+### `ccgm/shipped-todo-marker`
+
+**Severity:** `info`
+**Confidence:** `high`
+**Detection:** `tool`
+
+#### Detection
+
+Grep-based. The spine or fallback grep searches source files for the patterns TODO, FIXME,
+XXX, and HACK in a case-insensitive pass. All four patterns are commonly used to mark
+deferred work or known problems. Finding them in committed code is low-risk but informational:
+the code was accepted with known debt.
+
+**Self-scoping:** This check runs on every repo. On repos with no TODO/FIXME markers the
+result is an empty finding list; no special gate is needed.
+
+**Tool (if detection = tool or hybrid):**
+grep (built-in to all POSIX systems; no additional tool required)
+
+Rule / rule-id: n/a (grep pattern: `\b(TODO|FIXME|XXX|HACK)\b`)
+
+Fallback when tool absent: grep is always available; no fallback needed.
+
+**LLM instruction (if detection = llm or hybrid):**
+n/a — detection is grep-only.
+
+#### Spine Wiring
+
+```yaml
+check_id: ccgm/shipped-todo-marker
+detection: tool
+tool: grep
+fallback: grep
+```
+
+Grep command (for reference):
+
+```bash
+grep -rn --include="*.{js,ts,jsx,tsx,py,go,rb,sh,rs,java,kt,swift,cs}" \
+  -E '\b(TODO|FIXME|XXX|HACK)\b' \
+  --exclude-dir="{node_modules,.git,dist,build,vendor}" \
+  .
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A TODO marker is not a bug; it is deferred work. The presence of
+markers in committed code is informational — it indicates known technical debt but does not
+indicate a runtime failure. Info severity: useful for tracking but requires no immediate action.
+
+**Confidence rationale:** The grep pattern is deterministic. Any line containing TODO/FIXME/XXX/HACK
+in a source file matches. False positives are rare (comments referencing third-party TODOs are
+still valid findings); false negatives require only that the pattern is present. High confidence.
+
+**Rubric entry:** `ccgm/shipped-todo-marker`
+
+#### Fixture
+
+**True positive** (`src/auth/session.ts`):
+
+```ts
+// FINDS: TODO marker in committed source — deferred work
+export function refreshToken(token: string) {
+  // TODO: add rate limiting before calling this in production
+  return fetchNewToken(token);
+}
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: no TODO/FIXME/XXX/HACK marker present
+export function refreshToken(token: string) {
+  return fetchNewToken(token);
+}
+```
+
+---
+
+### `ccgm/env-example-drift`
+
+**Severity:** `medium`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent checks for drift between environment variables referenced in source code and
+variables documented in `.env.example`. Drift takes two forms:
+
+1. **Undocumented**: `process.env.X`, `import.meta.env.X`, `os.environ['X']`, or
+   `os.getenv('X')` appear in source but `X` is absent from `.env.example`.
+2. **Stale**: `X` is listed in `.env.example` but no reference to it appears in source
+   or configuration files.
+
+**Self-scoping:** If the repo has no `.env.example` file AND no env-var access patterns
+in source, produce zero findings. If `.env.example` exists but is empty, report any
+referenced vars as undocumented. If env-var references exist but no `.env.example` exists,
+report the missing `.env.example` as a single informational finding.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+You are checking for environment-variable drift in this repository.
+
+Step 1 — Self-scope:
+  - Check whether a .env.example file exists at the repo root.
+  - Grep for env-var access patterns across source files:
+      JavaScript/TypeScript: process.env.VARNAME or import.meta.env.VARNAME
+      Python: os.environ['VARNAME'], os.environ.get('VARNAME'), os.getenv('VARNAME')
+      Shell: $VARNAME or ${VARNAME} in scripts that export or use env vars
+  - If neither .env.example nor any env-var access patterns exist, produce ZERO findings.
+    Stop here.
+
+Step 2 — Collect referenced vars:
+  - List every unique variable name referenced via env-var access patterns in source files
+    (JS/TS/Python/shell). Exclude:
+    - Variables accessed inside test files (*.test.ts, *.spec.ts, *.test.js, __tests__/)
+    - Variables that are clearly runtime-only system vars (PATH, HOME, USER, SHELL, etc.)
+    - Variables that are interpolated dynamically: process.env[key] (no fixed name)
+
+Step 3 — Collect documented vars:
+  - Parse .env.example: each non-blank, non-comment line in the form KEY=... contributes
+    KEY to the documented set.
+  - If .env.example does not exist, the documented set is empty.
+
+Step 4 — Report drift:
+  For each referenced var NOT in the documented set:
+    FINDING: ccgm/env-example-drift (undocumented)
+    file: the first source file referencing this var
+    message: "process.env.{VARNAME} referenced in code but absent from .env.example"
+
+  For each documented var NOT in the referenced set:
+    FINDING: ccgm/env-example-drift (stale)
+    file: .env.example
+    message: "{VARNAME} documented in .env.example but not referenced in any source file"
+
+  If source references env vars but .env.example does not exist:
+    FINDING: ccgm/env-example-drift (missing-file)
+    file: (repo root)
+    message: "Code references env vars but .env.example does not exist"
+
+Do NOT flag:
+- Variables prefixed with NEXT_PUBLIC_, VITE_, or REACT_APP_ where the framework
+  convention makes the intent clear — but DO flag if still absent from .env.example.
+- Test-only variables accessed exclusively in test files.
+- System environment variables (PATH, HOME, USER, SHELL, NODE_ENV, CI).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: ccgm/env-example-drift
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** An undocumented env var means the next developer to clone the
+repo will not know the variable is required. This causes "works on my machine" failures
+and deployment breakage. Stale entries mislead developers into setting variables that do
+nothing. Medium severity: breaks developer workflows and onboarding but does not directly
+cause runtime failures in an already-deployed environment.
+
+**Confidence rationale:** The grep-based variable collection is reliable for static
+references (`process.env.FOO`). Dynamic access (`process.env[key]`) cannot be statically
+inferred and is correctly excluded. The `.env.example` parse is simple line-by-line. The
+main FP risk is variables injected by a CI system that legitimately have no `.env.example`
+entry; this requires judgment. Medium confidence.
+
+**Rubric entry:** `ccgm/env-example-drift`
+
+#### Fixture
+
+**True positive** (`src/api/client.ts` with partial `.env.example`):
+
+```ts
+// FINDS: STRIPE_SECRET_KEY referenced but not in .env.example
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+const supabaseUrl = process.env.SUPABASE_URL!;
+```
+
+```bash
+# .env.example (incomplete — STRIPE_SECRET_KEY is missing)
+SUPABASE_URL=https://your-project.supabase.co
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: both vars are documented in .env.example
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+const supabaseUrl = process.env.SUPABASE_URL!;
+```
+
+```bash
+# .env.example (complete)
+SUPABASE_URL=https://your-project.supabase.co
+STRIPE_SECRET_KEY=sk_test_your_key_here
+```
+
+---
+
+### `ccgm/cloudflare-pages-no-git`
+
+**Severity:** `high`
+**Confidence:** `high`
+**Detection:** `tool`
+
+#### Detection
+
+Grep-based. Searches scripts, CI workflow files, and `package.json` scripts for invocations
+of `wrangler pages deploy <project-name>` where the project name is a new name argument —
+the signature of creating a direct-upload Cloudflare Pages project rather than deploying
+to an existing Git-connected one. Per the CCGM cloudflare rules, this pattern is the single
+most expensive Cloudflare mistake: a direct-upload project cannot be retrofitted with Git
+integration; it must be deleted and recreated.
+
+**Self-scoping:** If the repo has no `wrangler.toml`, no `wrangler.json`, no `wrangler.jsonc`,
+no `.cloudflare/` directory, and no reference to `wrangler` or `cloudflare` in `package.json`
+scripts, the check produces zero findings. The grep will simply return no matches.
+
+**Tool (if detection = tool or hybrid):**
+grep (built-in; no additional tool required)
+
+Rule / rule-id: n/a (grep pattern: `wrangler pages deploy`)
+
+Fallback when tool absent: grep is always available; no fallback needed.
+
+**LLM instruction (if detection = llm or hybrid):**
+n/a — primary detection is grep-based. An LLM clarification step is optional: if grep
+finds a `wrangler pages deploy` invocation, the LLM may inspect context to determine
+whether the invocation targets an existing Git-connected project (acceptable) vs. creates
+a new project name (flagged). When in doubt, flag and note for human review.
+
+#### Spine Wiring
+
+```yaml
+check_id: ccgm/cloudflare-pages-no-git
+detection: tool
+tool: grep
+fallback: grep
+```
+
+Grep command (for reference):
+
+```bash
+grep -rn \
+  --include="*.sh" --include="*.yml" --include="*.yaml" \
+  --include="*.json" --include="*.jsonc" --include="Makefile" \
+  --exclude-dir="{node_modules,.git}" \
+  'wrangler pages deploy' \
+  .
+```
+
+A finding is any match of `wrangler pages deploy`. Matches in comments or documentation
+(e.g., inside a Markdown code block in a README) may be excluded by inspection.
+
+#### Severity / Confidence
+
+**Severity rationale:** Creating a Cloudflare Pages project via `wrangler pages deploy
+<new-name>` produces a direct-upload project that auto-deploys from Git can never be
+added to. Fixing it requires deleting the project (disrupting production traffic), migrating
+custom domains, environment variables, and bindings, and recreating through the dashboard.
+This is multi-session production work that has burned multiple development sessions. High
+severity: the mistake is documented as the most expensive recurring Cloudflare error in the
+CCGM rules.
+
+**Confidence rationale:** The grep for `wrangler pages deploy` is deterministic on the
+string match. The main FP case is a CI job that deliberately uses direct-upload for an
+artifact-only deployment that is not expected to have Git integration (rare, and should be
+commented). The main FN case is a project newly added but not yet committed to a CI file.
+High confidence overall because the pattern is unambiguous in the vast majority of cases.
+
+**Rubric entry:** `ccgm/cloudflare-pages-no-git`
+
+#### Fixture
+
+**True positive** (`.github/workflows/deploy.yml`):
+
+```yaml
+# FINDS: wrangler pages deploy with a new project name — creates direct-upload project
+- name: Deploy to Cloudflare Pages
+  run: npx wrangler pages deploy dist --project-name my-app
+```
+
+**True negative** (should produce NO finding):
+
+```yaml
+# OK: no wrangler pages deploy — project uses Git integration via dashboard
+- name: Build
+  run: npm run build
+# (No deploy step; Cloudflare Pages auto-deploys on push via connected GitHub repo)
+```
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/ccgm-hygiene/checks.md
+++ b/modules/commands-extra/skills/audit/packs/ccgm-hygiene/checks.md
@@ -41,7 +41,7 @@ respective packs.
 
 **Severity:** `info`
 **Confidence:** `high`
-**Detection:** `tool`
+**Detection:** `hybrid`
 
 #### Detection
 
@@ -58,18 +58,22 @@ grep (built-in to all POSIX systems; no additional tool required)
 
 Rule / rule-id: n/a (grep pattern: `\b(TODO|FIXME|XXX|HACK)\b`)
 
-Fallback when tool absent: grep is always available; no fallback needed.
+Fallback when tool absent: llm (LLM worker scans source files for TODO/FIXME/XXX/HACK markers
+when grep is unavailable).
 
 **LLM instruction (if detection = llm or hybrid):**
-n/a — detection is grep-only.
+Grep pre-screen finds candidate lines containing TODO, FIXME, XXX, or HACK. If grep is
+unavailable, the LLM worker scans source files directly for those patterns and reports
+each match as a finding. The LLM confirms grep candidates and may suppress false positives
+(e.g., markers inside generated files or vendor directories).
 
 #### Spine Wiring
 
 ```yaml
 check_id: ccgm/shipped-todo-marker
-detection: tool
+detection: hybrid
 tool: grep
-fallback: grep
+fallback: llm
 ```
 
 Grep command (for reference):
@@ -251,7 +255,7 @@ STRIPE_SECRET_KEY=sk_test_your_key_here
 
 **Severity:** `high`
 **Confidence:** `high`
-**Detection:** `tool`
+**Detection:** `hybrid`
 
 #### Detection
 
@@ -271,21 +275,23 @@ grep (built-in; no additional tool required)
 
 Rule / rule-id: n/a (grep pattern: `wrangler pages deploy`)
 
-Fallback when tool absent: grep is always available; no fallback needed.
+Fallback when tool absent: llm (LLM worker scans workflow and script files for
+`wrangler pages deploy` invocations when grep is unavailable).
 
 **LLM instruction (if detection = llm or hybrid):**
-n/a — primary detection is grep-based. An LLM clarification step is optional: if grep
-finds a `wrangler pages deploy` invocation, the LLM may inspect context to determine
-whether the invocation targets an existing Git-connected project (acceptable) vs. creates
-a new project name (flagged). When in doubt, flag and note for human review.
+Grep pre-screen finds candidate lines containing `wrangler pages deploy`. The LLM
+confirms each candidate: inspect context to determine whether the invocation targets an
+existing Git-connected project (acceptable) vs. creates a new project name (flagged).
+When in doubt, flag and note for human review. If grep is unavailable, the LLM worker
+scans workflow files (*.yml, *.yaml, *.sh, *.json, Makefile) directly for the pattern.
 
 #### Spine Wiring
 
 ```yaml
 check_id: ccgm/cloudflare-pages-no-git
-detection: tool
+detection: hybrid
 tool: grep
-fallback: grep
+fallback: llm
 ```
 
 Grep command (for reference):

--- a/modules/commands-extra/skills/audit/packs/ccgm-hygiene/pack.json
+++ b/modules/commands-extra/skills/audit/packs/ccgm-hygiene/pack.json
@@ -11,8 +11,9 @@
       "id": "ccgm/shipped-todo-marker",
       "severity": "info",
       "confidence": "high",
-      "detection": "tool",
-      "fallback": "grep"
+      "detection": "hybrid",
+      "tool": "grep",
+      "fallback": "llm"
     },
     {
       "id": "ccgm/env-example-drift",
@@ -25,8 +26,9 @@
       "id": "ccgm/cloudflare-pages-no-git",
       "severity": "high",
       "confidence": "high",
-      "detection": "tool",
-      "fallback": "grep"
+      "detection": "hybrid",
+      "tool": "grep",
+      "fallback": "llm"
     }
   ]
 }

--- a/modules/commands-extra/skills/audit/packs/ccgm-hygiene/pack.json
+++ b/modules/commands-extra/skills/audit/packs/ccgm-hygiene/pack.json
@@ -1,0 +1,32 @@
+{
+  "id": "ccgm/ccgm-hygiene",
+  "name": "CCGM Hygiene",
+  "version": "1.0.0",
+  "applies_when": ["always"],
+  "tags": ["hygiene", "conventions", "env", "cloudflare", "todo"],
+  "severity_floor": "info",
+  "tools": [],
+  "checks": [
+    {
+      "id": "ccgm/shipped-todo-marker",
+      "severity": "info",
+      "confidence": "high",
+      "detection": "tool",
+      "fallback": "grep"
+    },
+    {
+      "id": "ccgm/env-example-drift",
+      "severity": "medium",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "ccgm/cloudflare-pages-no-git",
+      "severity": "high",
+      "confidence": "high",
+      "detection": "tool",
+      "fallback": "grep"
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/packs/ccgm-standards/checks.md
+++ b/modules/commands-extra/skills/audit/packs/ccgm-standards/checks.md
@@ -1,0 +1,290 @@
+# checks.md — CCGM Project Standards Pack
+
+---
+
+## Scope
+
+This pack audits repos for two project-convention gaps surfaced by the CCGM ruleset:
+code that violates rules explicitly declared in the repo's own `CLAUDE.md` or `AGENTS.md`
+project standards file; and MCP server tool definitions that are missing the safety
+annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) required
+by the CCGM MCP development rules.
+
+Both checks are LLM-detected and self-scope to repos where the relevant signals exist:
+`ccgm/project-standards-conformance` only runs when a `CLAUDE.md` or `AGENTS.md` file is
+present; `ccgm/mcp-tool-annotations` only runs when MCP server registration patterns are
+detected in source.
+
+This pack does NOT cover general code quality, security, environment-variable hygiene
+(covered by `ccgm-hygiene`), or TODO markers — those belong in their respective packs.
+
+**Pack ID:** `ccgm/ccgm-standards`
+**Applies when:** `always`
+
+---
+
+## applies_when Rationale
+
+| Condition | Reason |
+|-----------|--------|
+| `always` | Both checks are self-scoping via their LLM instructions. On repos with no `CLAUDE.md`/`AGENTS.md` and no MCP server code, both checks produce zero findings. Ecosystem-gating would miss repos written in non-standard stacks. |
+
+---
+
+## Checks
+
+---
+
+### `ccgm/project-standards-conformance`
+
+**Severity:** `medium`
+**Confidence:** `low`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent reads the repo's `CLAUDE.md` or `AGENTS.md` (whichever exists), extracts
+explicit, actionable rules stated there, then scans recent source changes for code that
+visibly violates those rules. The check produces findings only when (a) a project standards
+file exists and (b) a violation is clearly detectable in the diff or source without
+deep runtime reasoning.
+
+**Self-scoping:** If no `CLAUDE.md` or `AGENTS.md` file exists at the repo root, produce
+ZERO findings. Stop here.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+You are checking whether recently changed source files violate rules declared in this
+repo's project standards file (CLAUDE.md or AGENTS.md).
+
+Step 1 — Self-scope:
+  - Check whether CLAUDE.md or AGENTS.md exists at the repo root.
+  - If neither exists, produce ZERO findings and stop.
+
+Step 2 — Extract rules:
+  - Read the project standards file.
+  - Identify explicit, actionable, DETECTABLE rules. Focus on rules that produce a
+    clear code-level signal:
+      - "Never use git stash" → flag if git stash appears in scripts
+      - "Always quote PostgreSQL reserved keywords in migrations" → flag unquoted keywords
+      - "New env vars must be added to .env.example" → covered by env-example-drift check
+      - "Run tests before pushing" → not statically detectable; skip
+      - "Use functional React components only" → flag class components
+  - Skip rules that are policy/process (require reading developer intent) or that are
+    covered by other checks in this audit (env-example-drift, shipped-todo-marker, etc.)
+
+Step 3 — Scan for violations:
+  - For each detectable rule, scan the source files in scope (recently changed files
+    preferred; fall back to full source if no diff is available).
+  - Report only violations you are confident about. Ambiguous cases should not be flagged.
+
+Step 4 — Report:
+  For each violation:
+    FINDING: ccgm/project-standards-conformance
+    file: <file>:<line>
+    message: "Violates rule in CLAUDE.md: '<quoted rule text>' — <specific violation>"
+
+Do NOT flag:
+  - Violations in test fixtures, example files, or documentation (unless the rule
+    explicitly covers them).
+  - Violations that are already covered by more specific checks in this audit run.
+  - Ambiguous cases where you are less than 70% confident.
+  - Rules about workflow, branching, or commit messages (not source-code rules).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: ccgm/project-standards-conformance
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** A project standards file is the team's explicit agreement on how
+the codebase should be maintained. Violating it directly undermines the declared contract.
+Medium severity: the violation may not cause runtime failures but degrades maintainability
+and team trust in the process.
+
+**Confidence rationale:** The LLM must extract rules from a natural-language document and
+then find violations — two inference steps, each with potential for error. Rules vary widely
+in precision and detectability. Low confidence: findings are plausible but require human
+review before acting. The check is most valuable as a signal, not a gate.
+
+**Rubric entry:** `ccgm/project-standards-conformance`
+
+#### Fixture
+
+**True positive** (repo has `CLAUDE.md` that says "Use functional React components only"):
+
+```tsx
+// FINDS: class component violates the rule declared in CLAUDE.md
+import React from 'react';
+
+class UserCard extends React.Component<{ name: string }> {
+  render() {
+    return <div>{this.props.name}</div>;
+  }
+}
+```
+
+**True negative** (should produce NO finding):
+
+```tsx
+// OK: functional component — conforms to the rule
+import React from 'react';
+
+export function UserCard({ name }: { name: string }) {
+  return <div>{name}</div>;
+}
+```
+
+---
+
+### `ccgm/mcp-tool-annotations`
+
+**Severity:** `low`
+**Confidence:** `medium`
+**Detection:** `llm`
+
+#### Detection
+
+The LLM agent scans for MCP server tool registration calls — both the Web MCP Declarative
+API (`navigator.modelContext.registerTool(...)`) and the MCP SDK server pattern
+(`server.tool(...)` from `@modelcontextprotocol/sdk`) — and flags any tool definition that
+is missing all four safety annotations: `readOnlyHint`, `destructiveHint`, `idempotentHint`,
+`openWorldHint`. Per the CCGM MCP development rules, these annotations must be set on every
+tool so clients can make safety decisions.
+
+**Self-scoping:** If the repo contains no patterns matching `registerTool`, `server.tool`,
+`navigator.modelContext`, or imports from `@modelcontextprotocol/sdk`, produce ZERO findings.
+Stop here.
+
+**Tool (if detection = tool or hybrid):**
+n/a
+
+Rule / rule-id: n/a (no standard linter rule for MCP annotations)
+
+Fallback when tool absent: n/a (detection is always llm)
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+You are checking for missing safety annotations on MCP server tool definitions.
+
+Step 1 — Self-scope:
+  - Search the repo for any of these patterns:
+      - navigator.modelContext.registerTool(
+      - server.tool(
+      - import ... from '@modelcontextprotocol/sdk'
+      - require('@modelcontextprotocol/sdk')
+  - If none of these patterns exist in any source file, produce ZERO findings and stop.
+
+Step 2 — Locate tool definitions:
+  - Find every MCP tool registration call. Include:
+      - navigator.modelContext.registerTool({ name: '...', ... })
+      - server.tool('name', schema, handler)  — MCP SDK server pattern
+      - Any wrapper function that delegates to one of the above
+  - For each tool definition, determine whether it includes ALL FOUR of:
+      readOnlyHint    — does not modify external state
+      destructiveHint — does not delete or overwrite
+      idempotentHint  — safe to retry without side effects
+      openWorldHint   — interacts with external services
+
+Step 3 — Report:
+  For each tool definition missing one or more annotations:
+    FINDING: ccgm/mcp-tool-annotations
+    file: <file>:<line>
+    message: "MCP tool '<tool-name>' missing annotations: <list of missing keys>"
+
+  If a tool has some but not all annotations, report only the missing ones.
+  If a tool definition uses a spread or variable for annotations and you cannot
+  determine the complete set, flag it with a note: "annotation completeness
+  cannot be statically determined".
+
+Do NOT flag:
+  - Client-side MCP tool invocation calls (only flag server-side registration).
+  - Test mocks or stub implementations in test files.
+  - Tools inside documentation examples (README code blocks, .md files).
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: ccgm/mcp-tool-annotations
+detection: llm
+```
+
+#### Severity / Confidence
+
+**Severity rationale:** Missing annotations mean clients cannot determine whether a tool
+is safe to call automatically, safe to retry, or whether it interacts with external services.
+This degrades safety and discoverability but does not directly cause data loss or security
+issues. Low severity: a metadata gap that harms integration quality.
+
+**Confidence rationale:** The LLM can reliably identify `registerTool` and `server.tool`
+call sites. The annotation keys are well-defined. The main uncertainty is dynamic annotation
+objects (e.g., spreading a config object) where static inspection is insufficient. Medium
+confidence: reliable for straightforward patterns; flagging dynamic spread cases requires
+judgment.
+
+**Rubric entry:** `ccgm/mcp-tool-annotations`
+
+#### Fixture
+
+**True positive** (`src/server.ts` with MCP SDK):
+
+```ts
+// FINDS: tool registered without any safety annotations
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+
+server.tool(
+  'search_files',
+  { query: z.string() },
+  async ({ query }) => {
+    return { content: [{ type: 'text', text: await searchFiles(query) }] };
+  }
+  // Missing: readOnlyHint, destructiveHint, idempotentHint, openWorldHint
+);
+```
+
+**True negative** (should produce NO finding):
+
+```ts
+// OK: all four annotations present
+server.tool(
+  'search_files',
+  { query: z.string() },
+  async ({ query }) => {
+    return { content: [{ type: 'text', text: await searchFiles(query) }] };
+  },
+  {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false
+  }
+);
+```
+
+---
+
+## Quality Checklist
+
+- [x] Each check-id in this file exactly matches `pack.json`'s `checks[].id`
+- [x] Every check with `detection: tool` or `detection: hybrid` names a real spine tool
+- [x] Every check with `detection: llm` or `detection: hybrid` has a filled-in LLM instruction
+- [x] Each fixture has both a true positive AND a true negative
+- [x] Severity / confidence rationale is present for every check
+- [x] `applies_when` rationale table is complete
+- [x] `scripts/lint-pack.py` passes on this pack

--- a/modules/commands-extra/skills/audit/packs/ccgm-standards/pack.json
+++ b/modules/commands-extra/skills/audit/packs/ccgm-standards/pack.json
@@ -1,0 +1,25 @@
+{
+  "id": "ccgm/ccgm-standards",
+  "name": "CCGM Project Standards",
+  "version": "1.0.0",
+  "applies_when": ["always"],
+  "tags": ["standards", "conventions", "mcp", "project-rules"],
+  "severity_floor": "low",
+  "tools": [],
+  "checks": [
+    {
+      "id": "ccgm/project-standards-conformance",
+      "severity": "medium",
+      "confidence": "low",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "ccgm/mcp-tool-annotations",
+      "severity": "low",
+      "confidence": "medium",
+      "detection": "llm",
+      "auto_fixable": false
+    }
+  ]
+}

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -1,509 +1,492 @@
 {
-  "version": "1.0.0",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "ccgm/audit/severity-rubric.json",
-  "title": "CCGM Audit Severity Rubric",
-  "description": "Rule-level, deterministic severity/confidence table. Agents source severity from here; they do NOT invent it. Keyed by check_id (pattern: <pack>/<check>, matching finding.schema.json). Pack epics add entries under their own namespace; use the [RUBRIC-serial] gate to avoid concurrent edits.",
-  "_format": {
-    "severity": "critical|high|medium|low|info",
-    "confidence": "high|medium|low \u2014 signal precision (how often this check fires correctly)",
-    "fix_confidence": "high|medium|low \u2014 safety confidence for auto-fix when applicable"
-  },
-  "checks": {
-    "secrets/leaked-credential": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "security/hardcoded-secret": {
-      "severity": "critical",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "security/sensitive-console-log": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "security/sql-injection": {
-      "severity": "critical",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "security/xss-vulnerability": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "security/missing-security-headers": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "security/edge-function-auth-bypass": {
-      "severity": "critical",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dependencies/npm-audit-vulnerability": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "dependencies/outdated-minor": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "dependencies/outdated-major": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "dependencies/unused-dependency": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "dependencies/duplicate-dependency": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "code-quality/eslint-violation": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "code-quality/prettier-violation": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "code-quality/unused-import": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "code-quality/long-method": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "code-quality/large-file": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "code-quality/empty-catch-block": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "architecture/circular-dependency": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "architecture/god-object": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "architecture/improper-layering": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "architecture/wrong-layer-import": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "medium"
-    },
-    "typescript/excessive-any": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "typescript/missing-return-type": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "typescript/react-hooks-violation": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "typescript/fast-refresh-violation": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "typescript/missing-key-prop": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "testing/missing-test-file": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "testing/no-assertions": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "testing/missing-edge-cases": {
-      "severity": "low",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "documentation/missing-jsdoc": {
-      "severity": "low",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "documentation/stale-comment": {
-      "severity": "low",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "documentation/incomplete-readme": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "performance/n-plus-one-query": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "performance/missing-react-memo": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "medium"
-    },
-    "performance/large-bundle-import": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/copyleft-in-proprietary": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/non-commercial-in-commercial": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/missing-attribution": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/unlicensed-dependency": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/scraping-prohibited-site": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/credential-misuse": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/remote-code-extension": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/overbroad-extension-permissions": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/ai-output-training-competitor": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/undisclosed-telemetry": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/rate-limit-circumvention": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/paywall-bypass": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/trademark-misuse": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/store-policy-violation": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/missing-privacy-policy": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/ai-prohibited-use": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/ai-output-misrepresentation": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/ai-data-retention-violation": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/platform-tos-violation": {
-      "severity": "medium",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "tos-compliance/iap-bypass": {
-      "severity": "critical",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "deps/vulnerable-dependency": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "dead-code/unused-dependency": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "dead-code/unused-file": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dead-code/unused-export": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dead-code/unlisted-dependency": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "a11y/img-missing-alt": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "a11y/click-without-keyboard": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "a11y/anchor-missing-rel": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "a11y/missing-prefers-reduced-motion": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "a11y/tailwind-cursor-pointer": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "reliability/floating-promise": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/misused-promise": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/unhandled-promise": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/await-in-loop": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/fetch-without-timeout": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/retry-without-backoff": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "reliability/promise-all-vs-allsettled": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "lint/eqeqeq": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/use-isnan": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/valid-typeof": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/no-unreachable": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/no-constant-condition": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "lint/no-fallthrough": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "lint/default-case": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "medium"
-    },
-    "correctness/off-by-one": {
-      "severity": "high",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "correctness/float-equality": {
-      "severity": "medium",
-      "confidence": "low",
-      "fix_confidence": "medium"
-    },
-    "correctness/wrong-branch-logic": {
-      "severity": "high",
-      "confidence": "low",
-      "fix_confidence": "low"
-    },
-    "secrets/tracked-env-file": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "secrets/tracked-key-material": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "secrets/history-only-credential": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "dm/unquoted-reserved-keyword": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "high"
-    },
-    "dm/index-without-concurrently": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "dm/missing-rls": {
-      "severity": "high",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dm/on-conflict-without-unique": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dm/security-definer-function": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "dm/squawk-violation": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "dm/sqlfluff-violation": {
-      "severity": "low",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    },
-    "cicd/unpinned-action": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "cicd/dangerous-trigger": {
-      "severity": "critical",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "cicd/excessive-permissions": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "high"
-    },
-    "cicd/script-injection": {
-      "severity": "high",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "cicd/actionlint-error": {
-      "severity": "medium",
-      "confidence": "high",
-      "fix_confidence": "low"
-    },
-    "cicd/workflow-security-issue": {
-      "severity": "medium",
-      "confidence": "medium",
-      "fix_confidence": "low"
-    }
-  }
+    "name": "commands-extra",
+    "version": "1.0.0",
+    "displayName": "Extra Commands",
+    "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global), /freeze + /unfreeze + /guard (safety-hook state management), /checkpoint (save/resume WIP session state).",
+    "category": "commands",
+    "scope": [
+        "global"
+    ],
+    "dependencies": [],
+    "files": {
+        "commands/audit.md": {
+            "target": "commands/audit.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/pwv.md": {
+            "target": "commands/pwv.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/walkthrough.md": {
+            "target": "commands/walkthrough.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/promote-rule.md": {
+            "target": "commands/promote-rule.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/freeze.md": {
+            "target": "commands/freeze.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/unfreeze.md": {
+            "target": "commands/unfreeze.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/guard.md": {
+            "target": "commands/guard.md",
+            "type": "command",
+            "template": false
+        },
+        "commands/checkpoint.md": {
+            "target": "commands/checkpoint.md",
+            "type": "command",
+            "template": false
+        },
+        "skills/audit/SKILL.md": {
+            "target": "skills/audit/SKILL.md",
+            "type": "skill",
+            "template": false
+        },
+        "skills/audit/reference/security-patterns.md": {
+            "target": "skills/audit/reference/security-patterns.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/code-quality.md": {
+            "target": "skills/audit/reference/code-quality.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/architecture.md": {
+            "target": "skills/audit/reference/architecture.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/fix-patterns.md": {
+            "target": "skills/audit/reference/fix-patterns.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/multi-agent-config.md": {
+            "target": "skills/audit/reference/multi-agent-config.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/output-template.md": {
+            "target": "skills/audit/reference/output-template.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/schemas/pack.schema.json": {
+            "target": "skills/audit/schemas/pack.schema.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/schemas/finding.schema.json": {
+            "target": "skills/audit/schemas/finding.schema.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/scripts/registry.py": {
+            "target": "skills/audit/scripts/registry.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/assign-packs.py": {
+            "target": "skills/audit/scripts/assign-packs.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/detect-ecosystems.sh": {
+            "target": "skills/audit/scripts/detect-ecosystems.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/emit-findings.py": {
+            "target": "skills/audit/scripts/emit-findings.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/merge-findings.py": {
+            "target": "skills/audit/scripts/merge-findings.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/baseline.py": {
+            "target": "skills/audit/scripts/baseline.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/suppress.py": {
+            "target": "skills/audit/scripts/suppress.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/schemas/severity-rubric.json": {
+            "target": "skills/audit/schemas/severity-rubric.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/scripts/lint-rubric.py": {
+            "target": "skills/audit/scripts/lint-rubric.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/lint-pack.py": {
+            "target": "skills/audit/scripts/lint-pack.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/provenance.py": {
+            "target": "skills/audit/scripts/provenance.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/packs/_TEMPLATE/checks.md": {
+            "target": "skills/audit/packs/_TEMPLATE/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/security/pack.json": {
+            "target": "skills/audit/packs/security/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/security/checks.md": {
+            "target": "skills/audit/packs/security/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/dependencies/pack.json": {
+            "target": "skills/audit/packs/dependencies/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/dependencies/checks.md": {
+            "target": "skills/audit/packs/dependencies/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/tos-compliance/pack.json": {
+            "target": "skills/audit/packs/tos-compliance/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/tos-compliance/checks.md": {
+            "target": "skills/audit/packs/tos-compliance/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/reference/pack-quality-bar.md": {
+            "target": "skills/audit/reference/pack-quality-bar.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/testing/pack.json": {
+            "target": "skills/audit/packs/testing/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/testing/checks.md": {
+            "target": "skills/audit/packs/testing/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/documentation/pack.json": {
+            "target": "skills/audit/packs/documentation/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/documentation/checks.md": {
+            "target": "skills/audit/packs/documentation/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/performance/pack.json": {
+            "target": "skills/audit/packs/performance/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/performance/checks.md": {
+            "target": "skills/audit/packs/performance/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/scripts/spine/run.sh": {
+            "target": "skills/audit/scripts/spine/run.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/normalize.py": {
+            "target": "skills/audit/scripts/spine/normalize.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-gitleaks.sh": {
+            "target": "skills/audit/scripts/spine/wrap-gitleaks.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-gitleaks.py": {
+            "target": "skills/audit/scripts/spine/parse-gitleaks.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-semgrep.sh": {
+            "target": "skills/audit/scripts/spine/wrap-semgrep.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-semgrep.py": {
+            "target": "skills/audit/scripts/spine/parse-semgrep.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-dep-audit.sh": {
+            "target": "skills/audit/scripts/spine/wrap-dep-audit.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-dep-audit.py": {
+            "target": "skills/audit/scripts/spine/parse-dep-audit.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-knip.sh": {
+            "target": "skills/audit/scripts/spine/wrap-knip.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-knip.py": {
+            "target": "skills/audit/scripts/spine/parse-knip.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-eslint.sh": {
+            "target": "skills/audit/scripts/spine/wrap-eslint.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-eslint.py": {
+            "target": "skills/audit/scripts/spine/parse-eslint.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-govulncheck.sh": {
+            "target": "skills/audit/scripts/spine/wrap-govulncheck.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-govulncheck.py": {
+            "target": "skills/audit/scripts/spine/parse-govulncheck.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-bandit.sh": {
+            "target": "skills/audit/scripts/spine/wrap-bandit.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-bandit.py": {
+            "target": "skills/audit/scripts/spine/parse-bandit.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-hadolint.sh": {
+            "target": "skills/audit/scripts/spine/wrap-hadolint.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-hadolint.py": {
+            "target": "skills/audit/scripts/spine/parse-hadolint.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-actionlint.sh": {
+            "target": "skills/audit/scripts/spine/wrap-actionlint.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-actionlint.py": {
+            "target": "skills/audit/scripts/spine/parse-actionlint.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-trivy.sh": {
+            "target": "skills/audit/scripts/spine/wrap-trivy.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-trivy.py": {
+            "target": "skills/audit/scripts/spine/parse-trivy.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-zizmor.sh": {
+            "target": "skills/audit/scripts/spine/wrap-zizmor.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-zizmor.py": {
+            "target": "skills/audit/scripts/spine/parse-zizmor.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-pinact.sh": {
+            "target": "skills/audit/scripts/spine/wrap-pinact.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-pinact.py": {
+            "target": "skills/audit/scripts/spine/parse-pinact.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/packs/ci-cd/pack.json": {
+            "target": "skills/audit/packs/ci-cd/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/ci-cd/checks.md": {
+            "target": "skills/audit/packs/ci-cd/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/code-quality/pack.json": {
+            "target": "skills/audit/packs/code-quality/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/code-quality/checks.md": {
+            "target": "skills/audit/packs/code-quality/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/typescript-react/pack.json": {
+            "target": "skills/audit/packs/typescript-react/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/typescript-react/checks.md": {
+            "target": "skills/audit/packs/typescript-react/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/architecture/pack.json": {
+            "target": "skills/audit/packs/architecture/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/architecture/checks.md": {
+            "target": "skills/audit/packs/architecture/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/accessibility/pack.json": {
+            "target": "skills/audit/packs/accessibility/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/accessibility/checks.md": {
+            "target": "skills/audit/packs/accessibility/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/reliability/pack.json": {
+            "target": "skills/audit/packs/reliability/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/reliability/checks.md": {
+            "target": "skills/audit/packs/reliability/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/correctness/pack.json": {
+            "target": "skills/audit/packs/correctness/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/correctness/checks.md": {
+            "target": "skills/audit/packs/correctness/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/secrets/pack.json": {
+            "target": "skills/audit/packs/secrets/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/secrets/checks.md": {
+            "target": "skills/audit/packs/secrets/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-squawk.sh": {
+            "target": "skills/audit/scripts/spine/wrap-squawk.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-squawk.py": {
+            "target": "skills/audit/scripts/spine/parse-squawk.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/wrap-sqlfluff.sh": {
+            "target": "skills/audit/scripts/spine/wrap-sqlfluff.sh",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/scripts/spine/parse-sqlfluff.py": {
+            "target": "skills/audit/scripts/spine/parse-sqlfluff.py",
+            "type": "script",
+            "template": false
+        },
+        "skills/audit/packs/data-migrations/pack.json": {
+            "target": "skills/audit/packs/data-migrations/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/data-migrations/checks.md": {
+            "target": "skills/audit/packs/data-migrations/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/ccgm-hygiene/pack.json": {
+            "target": "skills/audit/packs/ccgm-hygiene/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/ccgm-hygiene/checks.md": {
+            "target": "skills/audit/packs/ccgm-hygiene/checks.md",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/ccgm-standards/pack.json": {
+            "target": "skills/audit/packs/ccgm-standards/pack.json",
+            "type": "doc",
+            "template": false
+        },
+        "skills/audit/packs/ccgm-standards/checks.md": {
+            "target": "skills/audit/packs/ccgm-standards/checks.md",
+            "type": "doc",
+            "template": false
+        }
+    },
+    "tags": [
+        "commands",
+        "audit",
+        "verification",
+        "walkthrough",
+        "safety",
+        "checkpoint"
+    ],
+    "configPrompts": []
 }

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -1,492 +1,534 @@
 {
-    "name": "commands-extra",
-    "version": "1.0.0",
-    "displayName": "Extra Commands",
-    "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global), /freeze + /unfreeze + /guard (safety-hook state management), /checkpoint (save/resume WIP session state).",
-    "category": "commands",
-    "scope": [
-        "global"
-    ],
-    "dependencies": [],
-    "files": {
-        "commands/audit.md": {
-            "target": "commands/audit.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/pwv.md": {
-            "target": "commands/pwv.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/walkthrough.md": {
-            "target": "commands/walkthrough.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/promote-rule.md": {
-            "target": "commands/promote-rule.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/freeze.md": {
-            "target": "commands/freeze.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/unfreeze.md": {
-            "target": "commands/unfreeze.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/guard.md": {
-            "target": "commands/guard.md",
-            "type": "command",
-            "template": false
-        },
-        "commands/checkpoint.md": {
-            "target": "commands/checkpoint.md",
-            "type": "command",
-            "template": false
-        },
-        "skills/audit/SKILL.md": {
-            "target": "skills/audit/SKILL.md",
-            "type": "skill",
-            "template": false
-        },
-        "skills/audit/reference/security-patterns.md": {
-            "target": "skills/audit/reference/security-patterns.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/code-quality.md": {
-            "target": "skills/audit/reference/code-quality.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/architecture.md": {
-            "target": "skills/audit/reference/architecture.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/fix-patterns.md": {
-            "target": "skills/audit/reference/fix-patterns.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/multi-agent-config.md": {
-            "target": "skills/audit/reference/multi-agent-config.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/output-template.md": {
-            "target": "skills/audit/reference/output-template.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/schemas/pack.schema.json": {
-            "target": "skills/audit/schemas/pack.schema.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/schemas/finding.schema.json": {
-            "target": "skills/audit/schemas/finding.schema.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/scripts/registry.py": {
-            "target": "skills/audit/scripts/registry.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/assign-packs.py": {
-            "target": "skills/audit/scripts/assign-packs.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/detect-ecosystems.sh": {
-            "target": "skills/audit/scripts/detect-ecosystems.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/emit-findings.py": {
-            "target": "skills/audit/scripts/emit-findings.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/merge-findings.py": {
-            "target": "skills/audit/scripts/merge-findings.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/baseline.py": {
-            "target": "skills/audit/scripts/baseline.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/suppress.py": {
-            "target": "skills/audit/scripts/suppress.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/schemas/severity-rubric.json": {
-            "target": "skills/audit/schemas/severity-rubric.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/scripts/lint-rubric.py": {
-            "target": "skills/audit/scripts/lint-rubric.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/lint-pack.py": {
-            "target": "skills/audit/scripts/lint-pack.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/provenance.py": {
-            "target": "skills/audit/scripts/provenance.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/packs/_TEMPLATE/checks.md": {
-            "target": "skills/audit/packs/_TEMPLATE/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/security/pack.json": {
-            "target": "skills/audit/packs/security/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/security/checks.md": {
-            "target": "skills/audit/packs/security/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/dependencies/pack.json": {
-            "target": "skills/audit/packs/dependencies/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/dependencies/checks.md": {
-            "target": "skills/audit/packs/dependencies/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/tos-compliance/pack.json": {
-            "target": "skills/audit/packs/tos-compliance/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/tos-compliance/checks.md": {
-            "target": "skills/audit/packs/tos-compliance/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/reference/pack-quality-bar.md": {
-            "target": "skills/audit/reference/pack-quality-bar.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/testing/pack.json": {
-            "target": "skills/audit/packs/testing/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/testing/checks.md": {
-            "target": "skills/audit/packs/testing/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/documentation/pack.json": {
-            "target": "skills/audit/packs/documentation/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/documentation/checks.md": {
-            "target": "skills/audit/packs/documentation/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/performance/pack.json": {
-            "target": "skills/audit/packs/performance/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/performance/checks.md": {
-            "target": "skills/audit/packs/performance/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/scripts/spine/run.sh": {
-            "target": "skills/audit/scripts/spine/run.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/normalize.py": {
-            "target": "skills/audit/scripts/spine/normalize.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-gitleaks.sh": {
-            "target": "skills/audit/scripts/spine/wrap-gitleaks.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-gitleaks.py": {
-            "target": "skills/audit/scripts/spine/parse-gitleaks.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-semgrep.sh": {
-            "target": "skills/audit/scripts/spine/wrap-semgrep.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-semgrep.py": {
-            "target": "skills/audit/scripts/spine/parse-semgrep.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-dep-audit.sh": {
-            "target": "skills/audit/scripts/spine/wrap-dep-audit.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-dep-audit.py": {
-            "target": "skills/audit/scripts/spine/parse-dep-audit.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-knip.sh": {
-            "target": "skills/audit/scripts/spine/wrap-knip.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-knip.py": {
-            "target": "skills/audit/scripts/spine/parse-knip.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-eslint.sh": {
-            "target": "skills/audit/scripts/spine/wrap-eslint.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-eslint.py": {
-            "target": "skills/audit/scripts/spine/parse-eslint.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-govulncheck.sh": {
-            "target": "skills/audit/scripts/spine/wrap-govulncheck.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-govulncheck.py": {
-            "target": "skills/audit/scripts/spine/parse-govulncheck.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-bandit.sh": {
-            "target": "skills/audit/scripts/spine/wrap-bandit.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-bandit.py": {
-            "target": "skills/audit/scripts/spine/parse-bandit.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-hadolint.sh": {
-            "target": "skills/audit/scripts/spine/wrap-hadolint.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-hadolint.py": {
-            "target": "skills/audit/scripts/spine/parse-hadolint.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-actionlint.sh": {
-            "target": "skills/audit/scripts/spine/wrap-actionlint.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-actionlint.py": {
-            "target": "skills/audit/scripts/spine/parse-actionlint.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-trivy.sh": {
-            "target": "skills/audit/scripts/spine/wrap-trivy.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-trivy.py": {
-            "target": "skills/audit/scripts/spine/parse-trivy.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-zizmor.sh": {
-            "target": "skills/audit/scripts/spine/wrap-zizmor.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-zizmor.py": {
-            "target": "skills/audit/scripts/spine/parse-zizmor.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-pinact.sh": {
-            "target": "skills/audit/scripts/spine/wrap-pinact.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-pinact.py": {
-            "target": "skills/audit/scripts/spine/parse-pinact.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/packs/ci-cd/pack.json": {
-            "target": "skills/audit/packs/ci-cd/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/ci-cd/checks.md": {
-            "target": "skills/audit/packs/ci-cd/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/code-quality/pack.json": {
-            "target": "skills/audit/packs/code-quality/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/code-quality/checks.md": {
-            "target": "skills/audit/packs/code-quality/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/typescript-react/pack.json": {
-            "target": "skills/audit/packs/typescript-react/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/typescript-react/checks.md": {
-            "target": "skills/audit/packs/typescript-react/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/architecture/pack.json": {
-            "target": "skills/audit/packs/architecture/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/architecture/checks.md": {
-            "target": "skills/audit/packs/architecture/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/accessibility/pack.json": {
-            "target": "skills/audit/packs/accessibility/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/accessibility/checks.md": {
-            "target": "skills/audit/packs/accessibility/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/reliability/pack.json": {
-            "target": "skills/audit/packs/reliability/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/reliability/checks.md": {
-            "target": "skills/audit/packs/reliability/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/correctness/pack.json": {
-            "target": "skills/audit/packs/correctness/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/correctness/checks.md": {
-            "target": "skills/audit/packs/correctness/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/secrets/pack.json": {
-            "target": "skills/audit/packs/secrets/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/secrets/checks.md": {
-            "target": "skills/audit/packs/secrets/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-squawk.sh": {
-            "target": "skills/audit/scripts/spine/wrap-squawk.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-squawk.py": {
-            "target": "skills/audit/scripts/spine/parse-squawk.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/wrap-sqlfluff.sh": {
-            "target": "skills/audit/scripts/spine/wrap-sqlfluff.sh",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/scripts/spine/parse-sqlfluff.py": {
-            "target": "skills/audit/scripts/spine/parse-sqlfluff.py",
-            "type": "script",
-            "template": false
-        },
-        "skills/audit/packs/data-migrations/pack.json": {
-            "target": "skills/audit/packs/data-migrations/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/data-migrations/checks.md": {
-            "target": "skills/audit/packs/data-migrations/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/ccgm-hygiene/pack.json": {
-            "target": "skills/audit/packs/ccgm-hygiene/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/ccgm-hygiene/checks.md": {
-            "target": "skills/audit/packs/ccgm-hygiene/checks.md",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/ccgm-standards/pack.json": {
-            "target": "skills/audit/packs/ccgm-standards/pack.json",
-            "type": "doc",
-            "template": false
-        },
-        "skills/audit/packs/ccgm-standards/checks.md": {
-            "target": "skills/audit/packs/ccgm-standards/checks.md",
-            "type": "doc",
-            "template": false
-        }
+  "version": "1.0.0",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "ccgm/audit/severity-rubric.json",
+  "title": "CCGM Audit Severity Rubric",
+  "description": "Rule-level, deterministic severity/confidence table. Agents source severity from here; they do NOT invent it. Keyed by check_id (pattern: <pack>/<check>, matching finding.schema.json). Pack epics add entries under their own namespace; use the [RUBRIC-serial] gate to avoid concurrent edits.",
+  "_format": {
+    "severity": "critical|high|medium|low|info",
+    "confidence": "high|medium|low \u2014 signal precision (how often this check fires correctly)",
+    "fix_confidence": "high|medium|low \u2014 safety confidence for auto-fix when applicable"
+  },
+  "checks": {
+    "secrets/leaked-credential": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
     },
-    "tags": [
-        "commands",
-        "audit",
-        "verification",
-        "walkthrough",
-        "safety",
-        "checkpoint"
-    ],
-    "configPrompts": []
+    "security/hardcoded-secret": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "security/sensitive-console-log": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "security/sql-injection": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "security/xss-vulnerability": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "security/missing-security-headers": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "security/edge-function-auth-bypass": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dependencies/npm-audit-vulnerability": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dependencies/outdated-minor": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dependencies/outdated-major": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "dependencies/unused-dependency": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "dependencies/duplicate-dependency": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "code-quality/eslint-violation": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "code-quality/prettier-violation": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "code-quality/unused-import": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "code-quality/long-method": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "code-quality/large-file": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "code-quality/empty-catch-block": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "architecture/circular-dependency": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "architecture/god-object": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "architecture/improper-layering": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "architecture/wrong-layer-import": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "medium"
+    },
+    "typescript/excessive-any": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "typescript/missing-return-type": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "typescript/react-hooks-violation": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "typescript/fast-refresh-violation": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "typescript/missing-key-prop": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "testing/missing-test-file": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "testing/no-assertions": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "testing/missing-edge-cases": {
+      "severity": "low",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "documentation/missing-jsdoc": {
+      "severity": "low",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "documentation/stale-comment": {
+      "severity": "low",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "documentation/incomplete-readme": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "performance/n-plus-one-query": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "performance/missing-react-memo": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "medium"
+    },
+    "performance/large-bundle-import": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/copyleft-in-proprietary": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/non-commercial-in-commercial": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/missing-attribution": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/unlicensed-dependency": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/scraping-prohibited-site": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/credential-misuse": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/remote-code-extension": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/overbroad-extension-permissions": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-output-training-competitor": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/undisclosed-telemetry": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/rate-limit-circumvention": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/paywall-bypass": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/trademark-misuse": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/store-policy-violation": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/missing-privacy-policy": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-prohibited-use": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-output-misrepresentation": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/ai-data-retention-violation": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/platform-tos-violation": {
+      "severity": "medium",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "tos-compliance/iap-bypass": {
+      "severity": "critical",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "deps/vulnerable-dependency": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dead-code/unused-dependency": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "dead-code/unused-file": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dead-code/unused-export": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dead-code/unlisted-dependency": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "a11y/img-missing-alt": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "a11y/click-without-keyboard": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "a11y/anchor-missing-rel": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "a11y/missing-prefers-reduced-motion": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "a11y/tailwind-cursor-pointer": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "reliability/floating-promise": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/misused-promise": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/unhandled-promise": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/await-in-loop": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/fetch-without-timeout": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/retry-without-backoff": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "reliability/promise-all-vs-allsettled": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "lint/eqeqeq": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/use-isnan": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/valid-typeof": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/no-unreachable": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/no-constant-condition": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "lint/no-fallthrough": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "lint/default-case": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "medium"
+    },
+    "correctness/off-by-one": {
+      "severity": "high",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "correctness/float-equality": {
+      "severity": "medium",
+      "confidence": "low",
+      "fix_confidence": "medium"
+    },
+    "correctness/wrong-branch-logic": {
+      "severity": "high",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "secrets/tracked-env-file": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "secrets/tracked-key-material": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "secrets/history-only-credential": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "dm/unquoted-reserved-keyword": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "high"
+    },
+    "dm/index-without-concurrently": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "dm/missing-rls": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dm/on-conflict-without-unique": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dm/security-definer-function": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "dm/squawk-violation": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dm/sqlfluff-violation": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "cicd/unpinned-action": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "cicd/dangerous-trigger": {
+      "severity": "critical",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "cicd/excessive-permissions": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "high"
+    },
+    "cicd/script-injection": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "cicd/actionlint-error": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "cicd/workflow-security-issue": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "ccgm/shipped-todo-marker": {
+      "severity": "info",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "ccgm/env-example-drift": {
+      "severity": "medium",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "ccgm/cloudflare-pages-no-git": {
+      "severity": "high",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
+    "ccgm/project-standards-conformance": {
+      "severity": "medium",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "ccgm/mcp-tool-annotations": {
+      "severity": "low",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    }
+  }
 }

--- a/modules/commands-extra/skills/audit/tests/test-pack-ccgm.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-ccgm.sh
@@ -1,0 +1,444 @@
+#!/usr/bin/env bash
+# test-pack-ccgm.sh — Tests for the ccgm/ccgm-hygiene and ccgm/ccgm-standards audit packs
+# (issue #633).
+#
+# Tests:
+#   1.  ccgm-hygiene/pack.json validates against pack.schema.json (registry.py)
+#   2.  ccgm-standards/pack.json validates against pack.schema.json (registry.py)
+#   3.  severity-rubric.json contains all ccgm/* check ids from both packs
+#   4.  lint-pack.py passes on ccgm-hygiene with the real rubric
+#   5.  lint-pack.py passes on ccgm-standards with the real rubric
+#   6.  ccgm-hygiene/checks.md has required sections
+#   7.  ccgm-standards/checks.md has required sections
+#   8.  checks.md documents TP/TN fixtures for each check (all 5 checks)
+#   9.  applies_when=always: both packs are SELECTED for any detector input
+#  10.  grep TP: a file with TODO: produces a grep match for shipped-todo-marker
+#  11.  grep TN: a file without any markers produces no grep match for shipped-todo-marker
+#  12.  grep TP: a script with "wrangler pages deploy" produces a grep match for cloudflare-pages-no-git
+#  13.  grep TN: a script without "wrangler pages deploy" produces no grep match
+#  14.  A source file with process.env.MISSING_VAR and a .env.example lacking it constitutes
+#       a TP fixture for env-example-drift (fixture creation + structural assertion only)
+#
+# Exit: 0 if all pass, 1 if any fail.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HYGIENE_PACK="${AUDIT_DIR}/packs/ccgm-hygiene"
+STANDARDS_PACK="${AUDIT_DIR}/packs/ccgm-standards"
+REGISTRY="${AUDIT_DIR}/scripts/registry.py"
+LINTER="${AUDIT_DIR}/scripts/lint-pack.py"
+RUBRIC="${AUDIT_DIR}/schemas/severity-rubric.json"
+
+PASS=0
+FAIL=0
+
+pass() { printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1)); }
+fail() { printf "  FAIL: %s\n" "$1"; FAIL=$((FAIL + 1)); }
+
+# Single temp root; cleaned on exit.
+TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/test-pack-ccgm.XXXXXX")"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+# ---------------------------------------------------------------------------
+# Reusable: validate a pack.json via registry.py's validate_pack
+# ---------------------------------------------------------------------------
+_VALIDATE_PY="$(mktemp "${TMPROOT}/validate_pack.XXXXXX.py")"
+cat > "${_VALIDATE_PY}" <<'PYEOF'
+import sys, json, importlib.util, pathlib
+
+registry_py = pathlib.Path(sys.argv[1])
+pack_path   = pathlib.Path(sys.argv[2])
+
+spec = importlib.util.spec_from_file_location("registry", str(registry_py))
+mod  = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+with open(pack_path, encoding="utf-8") as fh:
+    pack = json.load(fh)
+
+try:
+    mod.validate_pack(pack, str(pack_path))
+    print("VALID")
+    sys.exit(0)
+except mod.ValidationError as exc:
+    print("INVALID: " + str(exc))
+    sys.exit(1)
+PYEOF
+
+# ---------------------------------------------------------------------------
+# Test 1: ccgm-hygiene/pack.json validates
+# ---------------------------------------------------------------------------
+echo "--- Test 1: ccgm-hygiene/pack.json validates"
+
+_T1_RESULT=""
+_T1_EXIT=0
+_T1_RESULT=$(python3 "${_VALIDATE_PY}" "${REGISTRY}" "${HYGIENE_PACK}/pack.json" 2>&1) || _T1_EXIT=$?
+
+if [ "${_T1_EXIT}" -eq 0 ] && echo "${_T1_RESULT}" | grep -q "^VALID$"; then
+    pass "ccgm-hygiene/pack.json validates against pack.schema.json"
+else
+    fail "ccgm-hygiene/pack.json failed validation: ${_T1_RESULT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: ccgm-standards/pack.json validates
+# ---------------------------------------------------------------------------
+echo "--- Test 2: ccgm-standards/pack.json validates"
+
+_T2_RESULT=""
+_T2_EXIT=0
+_T2_RESULT=$(python3 "${_VALIDATE_PY}" "${REGISTRY}" "${STANDARDS_PACK}/pack.json" 2>&1) || _T2_EXIT=$?
+
+if [ "${_T2_EXIT}" -eq 0 ] && echo "${_T2_RESULT}" | grep -q "^VALID$"; then
+    pass "ccgm-standards/pack.json validates against pack.schema.json"
+else
+    fail "ccgm-standards/pack.json failed validation: ${_T2_RESULT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: rubric contains all ccgm/* check ids
+# ---------------------------------------------------------------------------
+echo "--- Test 3: rubric contains all ccgm/* check ids"
+
+EXPECTED_IDS=(
+    "ccgm/shipped-todo-marker"
+    "ccgm/env-example-drift"
+    "ccgm/cloudflare-pages-no-git"
+    "ccgm/project-standards-conformance"
+    "ccgm/mcp-tool-annotations"
+)
+
+_T3_MISSING=""
+for check_id in "${EXPECTED_IDS[@]}"; do
+    if ! python3 -c "
+import json, sys
+rubric = json.load(open('${RUBRIC}', encoding='utf-8'))
+checks = rubric.get('checks', {})
+if '${check_id}' not in checks:
+    print('MISSING')
+    sys.exit(1)
+print('FOUND')
+sys.exit(0)
+" 2>/dev/null | grep -q "^FOUND$"; then
+        _T3_MISSING="${_T3_MISSING} ${check_id}"
+    fi
+done
+
+if [ -z "${_T3_MISSING}" ]; then
+    pass "rubric contains all ${#EXPECTED_IDS[@]} ccgm/* check ids"
+else
+    fail "rubric missing ids:${_T3_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: lint-pack.py passes on ccgm-hygiene
+# ---------------------------------------------------------------------------
+echo "--- Test 4: lint-pack.py passes on ccgm-hygiene pack"
+
+# Run linter across all packs (including new ones) to detect regressions.
+_T4_OUTPUT=""
+_T4_EXIT=0
+_T4_OUTPUT=$(python3 "${LINTER}" \
+    --packs-dir "${AUDIT_DIR}/packs" \
+    --rubric "${RUBRIC}" 2>&1) || _T4_EXIT=$?
+
+if [ "${_T4_EXIT}" -eq 0 ] && echo "${_T4_OUTPUT}" | grep -q "^PASS: ccgm-hygiene"; then
+    pass "lint-pack.py reports PASS for ccgm-hygiene"
+else
+    fail "lint-pack.py did not PASS for ccgm-hygiene: exit=${_T4_EXIT}, output=${_T4_OUTPUT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: lint-pack.py passes on ccgm-standards
+# ---------------------------------------------------------------------------
+echo "--- Test 5: lint-pack.py passes on ccgm-standards pack"
+
+if [ "${_T4_EXIT}" -eq 0 ] && echo "${_T4_OUTPUT}" | grep -q "^PASS: ccgm-standards"; then
+    pass "lint-pack.py reports PASS for ccgm-standards"
+else
+    fail "lint-pack.py did not PASS for ccgm-standards: exit=${_T4_EXIT}, output=${_T4_OUTPUT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: ccgm-hygiene/checks.md has all required sections
+# ---------------------------------------------------------------------------
+echo "--- Test 6: ccgm-hygiene/checks.md has required sections"
+
+HYGIENE_MD="${HYGIENE_PACK}/checks.md"
+_REQUIRED_SECTIONS=(
+    "^## Scope"
+    "^## applies_when Rationale"
+    "^## Checks"
+    "^## Quality Checklist"
+)
+
+_T6_MISSING=""
+for section in "${_REQUIRED_SECTIONS[@]}"; do
+    if ! grep -qiE "${section}" "${HYGIENE_MD}"; then
+        _T6_MISSING="${_T6_MISSING} '${section}'"
+    fi
+done
+
+if [ -z "${_T6_MISSING}" ]; then
+    pass "ccgm-hygiene/checks.md contains all required sections"
+else
+    fail "ccgm-hygiene/checks.md missing sections:${_T6_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: ccgm-standards/checks.md has all required sections
+# ---------------------------------------------------------------------------
+echo "--- Test 7: ccgm-standards/checks.md has required sections"
+
+STANDARDS_MD="${STANDARDS_PACK}/checks.md"
+
+_T7_MISSING=""
+for section in "${_REQUIRED_SECTIONS[@]}"; do
+    if ! grep -qiE "${section}" "${STANDARDS_MD}"; then
+        _T7_MISSING="${_T7_MISSING} '${section}'"
+    fi
+done
+
+if [ -z "${_T7_MISSING}" ]; then
+    pass "ccgm-standards/checks.md contains all required sections"
+else
+    fail "ccgm-standards/checks.md missing sections:${_T7_MISSING}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: checks.md documents TP/TN fixtures for each check (all 5)
+# ---------------------------------------------------------------------------
+echo "--- Test 8: checks.md documents TP/TN fixtures for all 5 checks"
+
+# Collect (check_id, checks_md_path) pairs
+declare -a CHECK_IDS=(
+    "ccgm/shipped-todo-marker"
+    "ccgm/env-example-drift"
+    "ccgm/cloudflare-pages-no-git"
+    "ccgm/project-standards-conformance"
+    "ccgm/mcp-tool-annotations"
+)
+declare -a CHECK_MDS=(
+    "${HYGIENE_MD}"
+    "${HYGIENE_MD}"
+    "${HYGIENE_MD}"
+    "${STANDARDS_MD}"
+    "${STANDARDS_MD}"
+)
+
+_T8_ERRORS=""
+
+for i in "${!CHECK_IDS[@]}"; do
+    check_id="${CHECK_IDS[$i]}"
+    md_file="${CHECK_MDS[$i]}"
+
+    # check-id present in checks.md
+    if ! grep -q "${check_id}" "${md_file}"; then
+        _T8_ERRORS="${_T8_ERRORS}\n  check-id '${check_id}' not found in $(basename "${md_file}")"
+        continue
+    fi
+
+    # Extract the section for this check-id
+    _SECTION=$(python3 - "${md_file}" "${check_id}" <<'PYEOF' 2>/dev/null
+import sys, re
+md = open(sys.argv[1], encoding='utf-8').read()
+check_id = sys.argv[2]
+pattern = r'(### `' + re.escape(check_id) + r'`.*?)(?=\n### `|\Z)'
+m = re.search(pattern, md, re.DOTALL)
+if m:
+    print(m.group(1))
+PYEOF
+)
+
+    if ! echo "${_SECTION}" | grep -q "True positive\|FINDS:"; then
+        _T8_ERRORS="${_T8_ERRORS}\n  no True positive fixture found for '${check_id}'"
+    fi
+
+    if ! echo "${_SECTION}" | grep -q "True negative\|should produce NO"; then
+        _T8_ERRORS="${_T8_ERRORS}\n  no True negative fixture found for '${check_id}'"
+    fi
+done
+
+if [ -z "${_T8_ERRORS}" ]; then
+    pass "checks.md documents TP/TN fixtures for all 5 ccgm/* checks"
+else
+    fail "fixture coverage issues:$(printf '%b' "${_T8_ERRORS}")"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 9: applies_when=always → both packs selected for any detector input
+# ---------------------------------------------------------------------------
+echo "--- Test 9: applies_when=always selects both packs for any detector"
+
+# Temp packs dir with just the two new packs
+_T9_PACKS="${TMPROOT}/packs-ccgm"
+mkdir -p "${_T9_PACKS}/ccgm-hygiene" "${_T9_PACKS}/ccgm-standards"
+cp "${HYGIENE_PACK}/pack.json"   "${_T9_PACKS}/ccgm-hygiene/pack.json"
+cp "${STANDARDS_PACK}/pack.json" "${_T9_PACKS}/ccgm-standards/pack.json"
+
+# Run registry with a bare detector (no ecosystems, no shape flags)
+DETECTOR_BARE='{"detected_ecosystems":[],"project_shape":{},"available_tools":[]}'
+
+_T9_RESULT=""
+_T9_EXIT=0
+_T9_RESULT=$(CCGM_PACKS_DIR="${_T9_PACKS}" python3 "${REGISTRY}" <<< "${DETECTOR_BARE}" 2>/dev/null) || _T9_EXIT=$?
+
+_T9_OK=0
+if [ "${_T9_EXIT}" -eq 0 ]; then
+    if echo "${_T9_RESULT}" | python3 -c "
+import json, sys
+packs = json.load(sys.stdin)
+ids = [p['id'] for p in packs]
+assert 'ccgm/ccgm-hygiene' in ids, 'ccgm/ccgm-hygiene not in: ' + str(ids)
+assert 'ccgm/ccgm-standards' in ids, 'ccgm/ccgm-standards not in: ' + str(ids)
+" 2>/dev/null; then
+        _T9_OK=1
+    fi
+fi
+
+if [ "${_T9_OK}" -eq 1 ]; then
+    pass "both ccgm packs SELECTED for bare detector (applies_when=always)"
+else
+    fail "ccgm packs not both selected: exit=${_T9_EXIT}, result=${_T9_RESULT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 10: grep TP — shipped-todo-marker detects a TODO: marker
+# ---------------------------------------------------------------------------
+echo "--- Test 10: grep TP — shipped-todo-marker detects TODO: marker"
+
+_T10_FILE="${TMPROOT}/todo-tp.ts"
+cat > "${_T10_FILE}" <<'EOF'
+// Source file with a committed TODO marker — should be flagged
+export function refreshToken(token: string) {
+  // TODO: add rate limiting before calling this in production
+  return fetchNewToken(token);
+}
+EOF
+
+_T10_MATCH=""
+_T10_EXIT=0
+_T10_MATCH=$(grep -nE '\b(TODO|FIXME|XXX|HACK)\b' "${_T10_FILE}" 2>/dev/null) || _T10_EXIT=$?
+
+if [ -n "${_T10_MATCH}" ]; then
+    pass "grep TP: TODO: marker detected in source file (shipped-todo-marker)"
+else
+    fail "grep TP: TODO: marker should have been detected but was not"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11: grep TN — shipped-todo-marker produces no match on clean file
+# ---------------------------------------------------------------------------
+echo "--- Test 11: grep TN — shipped-todo-marker: no match on clean file"
+
+_T11_FILE="${TMPROOT}/todo-tn.ts"
+cat > "${_T11_FILE}" <<'EOF'
+// Source file with no deferred-work markers
+export function refreshToken(token: string) {
+  return fetchNewToken(token);
+}
+EOF
+
+_T11_MATCH=""
+_T11_EXIT=0
+_T11_MATCH=$(grep -nE '\b(TODO|FIXME|XXX|HACK)\b' "${_T11_FILE}" 2>/dev/null) || _T11_EXIT=$?
+
+if [ -z "${_T11_MATCH}" ]; then
+    pass "grep TN: clean file produces no match (shipped-todo-marker)"
+else
+    fail "grep TN: clean file should produce no match but got: ${_T11_MATCH}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 12: grep TP — cloudflare-pages-no-git detects wrangler pages deploy
+# ---------------------------------------------------------------------------
+echo "--- Test 12: grep TP — cloudflare-pages-no-git detects wrangler pages deploy"
+
+_T12_FILE="${TMPROOT}/deploy-tp.sh"
+cat > "${_T12_FILE}" <<'EOF'
+#!/usr/bin/env bash
+# CI deploy script — creates direct-upload CF Pages project (bad pattern)
+npx wrangler pages deploy dist --project-name my-app
+EOF
+
+_T12_MATCH=""
+_T12_EXIT=0
+_T12_MATCH=$(grep -n 'wrangler pages deploy' "${_T12_FILE}" 2>/dev/null) || _T12_EXIT=$?
+
+if [ -n "${_T12_MATCH}" ]; then
+    pass "grep TP: wrangler pages deploy detected in deploy script (cloudflare-pages-no-git)"
+else
+    fail "grep TP: wrangler pages deploy should have been detected but was not"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 13: grep TN — cloudflare-pages-no-git: no match on script without CF Pages
+# ---------------------------------------------------------------------------
+echo "--- Test 13: grep TN — cloudflare-pages-no-git: no match on clean script"
+
+_T13_FILE="${TMPROOT}/deploy-tn.sh"
+cat > "${_T13_FILE}" <<'EOF'
+#!/usr/bin/env bash
+# CI deploy script — project uses Git integration via dashboard
+npm run build
+EOF
+
+_T13_MATCH=""
+_T13_EXIT=0
+_T13_MATCH=$(grep -n 'wrangler pages deploy' "${_T13_FILE}" 2>/dev/null) || _T13_EXIT=$?
+
+if [ -z "${_T13_MATCH}" ]; then
+    pass "grep TN: clean deploy script produces no match (cloudflare-pages-no-git)"
+else
+    fail "grep TN: clean deploy script should produce no match but got: ${_T13_MATCH}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 14: env-example-drift TP fixture — process.env.MISSING_VAR + incomplete .env.example
+# ---------------------------------------------------------------------------
+echo "--- Test 14: env-example-drift TP fixture creation"
+
+_T14_DIR="${TMPROOT}/env-drift-tp"
+mkdir -p "${_T14_DIR}/src"
+
+# Source file referencing a var absent from .env.example
+cat > "${_T14_DIR}/src/client.ts" <<'EOF'
+// Env-example-drift TP fixture: STRIPE_SECRET_KEY referenced but not in .env.example
+import Stripe from 'stripe';
+import { createClient } from '@supabase/supabase-js';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!);
+EOF
+
+# .env.example missing STRIPE_SECRET_KEY
+cat > "${_T14_DIR}/.env.example" <<'EOF'
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key-here
+# Note: STRIPE_SECRET_KEY is intentionally absent to trigger the check
+EOF
+
+# Assert fixture structure: source file references an env var absent from .env.example
+_T14_REFS=$(grep -oE 'process\.env\.[A-Z_]+' "${_T14_DIR}/src/client.ts" | sed 's/process\.env\.//' | sort -u)
+_T14_DOCUMENTED=$(grep -vE '^\s*#|^\s*$' "${_T14_DIR}/.env.example" | cut -d= -f1 | sort -u)
+
+_T14_MISSING=$(comm -23 \
+    <(echo "${_T14_REFS}") \
+    <(echo "${_T14_DOCUMENTED}"))
+
+if [ -n "${_T14_MISSING}" ]; then
+    pass "env-example-drift TP fixture: source references vars absent from .env.example (${_T14_MISSING})"
+else
+    fail "env-example-drift TP fixture: expected at least one undocumented env var but found none"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf "\nResults: %d passed, %d failed\n" "${PASS}" "${FAIL}"
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #633

## Summary

- Adds two new `/audit` pack directories: `packs/ccgm-hygiene/` and `packs/ccgm-standards/`
- Adds 5 new check-ids to `severity-rubric.json` under the `ccgm/` namespace
- Registers all new pack files in `module.json` (type: doc)
- Adds `tests/test-pack-ccgm.sh` (14 tests, all pass)

## Pack grouping rationale

**`ccgm-hygiene`** (3 checks, `applies_when: always`) — mechanical hygiene issues detectable by grep or self-scoped LLM:
- `ccgm/shipped-todo-marker` — grep for TODO/FIXME/XXX/HACK committed in source (info/high-confidence)
- `ccgm/env-example-drift` — LLM check for vars in code missing from `.env.example` and vice-versa (medium/medium)
- `ccgm/cloudflare-pages-no-git` — grep for `wrangler pages deploy` indicating a direct-upload CF Pages project (high/high-confidence — the single most expensive recurring mistake per CCGM cloudflare rules)

**`ccgm-standards`** (2 checks, `applies_when: always`) — project-convention conformance requiring LLM judgment:
- `ccgm/project-standards-conformance` — flags code violating rules explicitly declared in `CLAUDE.md`/`AGENTS.md`; self-scopes to repos with such a file (medium/low)
- `ccgm/mcp-tool-annotations` — flags MCP tool registrations missing readOnly/destructive/idempotent/openWorld annotations; self-scopes to repos with MCP server code (low/medium)

## Constraints respected

- `applies_when: always` only — no new enum values added to `pack.schema.json`
- Self-scoping via LLM instruction / grep no-match (non-applicable repos produce zero findings)
- Did not touch: SKILL.md, spine, run.sh, detect-ecosystems.sh, pack.schema.json, test-detect-ecosystems.sh, or any existing pack
- `module.json` and `severity-rubric.json` edited (serial gate respected — this is the only PR touching them this wave)

## Verification

```
bash modules/commands-extra/skills/audit/tests/test-pack-ccgm.sh   → 14/14 pass
python3 modules/commands-extra/scripts/lint-pack.py                 → 17/17 packs PASS, 0 errors
bash modules/commands-extra/skills/audit/tests/test-pack-lint.sh   → 7/7 pass
bash modules/commands-extra/skills/audit/tests/test-rubric.sh       → 8/8 pass
bash modules/commands-extra/skills/audit/tests/test-registry.sh     → 8/8 pass
python3 -m json.tool module.json severity-rubric.json               → valid JSON
bash tests/test-modules.sh                                           → 1316/1316 pass
bash tests/test-no-personal-data.sh                                  → PASS
```