### PR TITLE
#644: make /audit spine bash-3.2 portable

### DIFF
--- a/modules/commands-extra/skills/audit/scripts/spine/run.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/run.sh
@@ -75,39 +75,52 @@ fi
 # ---------------------------------------------------------------------------
 # Tool registry -- ordered list of (tool_name, wrapper_script) pairs.
 # Paths are absolute, never derived from user input.
+# Bash-3.2-portable: case dispatch instead of associative array
+# (declare -A requires bash 4+).
 # ---------------------------------------------------------------------------
-declare -A TOOL_WRAPPERS
-TOOL_WRAPPERS["gitleaks"]="$SCRIPT_DIR/wrap-gitleaks.sh"
-TOOL_WRAPPERS["semgrep"]="$SCRIPT_DIR/wrap-semgrep.sh"
-TOOL_WRAPPERS["dep-audit"]="$SCRIPT_DIR/wrap-dep-audit.sh"
-TOOL_WRAPPERS["knip"]="$SCRIPT_DIR/wrap-knip.sh"
-TOOL_WRAPPERS["eslint"]="$SCRIPT_DIR/wrap-eslint.sh"
-TOOL_WRAPPERS["govulncheck"]="$SCRIPT_DIR/wrap-govulncheck.sh"
-TOOL_WRAPPERS["bandit"]="$SCRIPT_DIR/wrap-bandit.sh"
-TOOL_WRAPPERS["hadolint"]="$SCRIPT_DIR/wrap-hadolint.sh"
-TOOL_WRAPPERS["actionlint"]="$SCRIPT_DIR/wrap-actionlint.sh"
-TOOL_WRAPPERS["trivy"]="$SCRIPT_DIR/wrap-trivy.sh"
-TOOL_WRAPPERS["zizmor"]="$SCRIPT_DIR/wrap-zizmor.sh"
-TOOL_WRAPPERS["pinact"]="$SCRIPT_DIR/wrap-pinact.sh"
-TOOL_WRAPPERS["squawk"]="$SCRIPT_DIR/wrap-squawk.sh"
-TOOL_WRAPPERS["sqlfluff"]="$SCRIPT_DIR/wrap-sqlfluff.sh"
-TOOL_WRAPPERS["checkov"]="$SCRIPT_DIR/wrap-checkov.sh"
-TOOL_WRAPPERS["pip-audit"]="$SCRIPT_DIR/wrap-pip-audit.sh"
-TOOL_WRAPPERS["cargo-audit"]="$SCRIPT_DIR/wrap-cargo-audit.sh"
-TOOL_WRAPPERS["bundler-audit"]="$SCRIPT_DIR/wrap-bundler-audit.sh"
 
 # Ordered execution list (stable, deterministic)
 TOOL_ORDER=(gitleaks semgrep dep-audit knip eslint govulncheck bandit hadolint actionlint trivy zizmor pinact squawk sqlfluff checkov pip-audit cargo-audit bundler-audit)
 
+# Resolve wrapper path for a given tool name.
+# Sets WRAPPER to the script path, or empty string if unknown.
+_get_wrapper() {
+  local _tool="$1"
+  case "$_tool" in
+    gitleaks)       WRAPPER="$SCRIPT_DIR/wrap-gitleaks.sh" ;;
+    semgrep)        WRAPPER="$SCRIPT_DIR/wrap-semgrep.sh" ;;
+    dep-audit)      WRAPPER="$SCRIPT_DIR/wrap-dep-audit.sh" ;;
+    knip)           WRAPPER="$SCRIPT_DIR/wrap-knip.sh" ;;
+    eslint)         WRAPPER="$SCRIPT_DIR/wrap-eslint.sh" ;;
+    govulncheck)    WRAPPER="$SCRIPT_DIR/wrap-govulncheck.sh" ;;
+    bandit)         WRAPPER="$SCRIPT_DIR/wrap-bandit.sh" ;;
+    hadolint)       WRAPPER="$SCRIPT_DIR/wrap-hadolint.sh" ;;
+    actionlint)     WRAPPER="$SCRIPT_DIR/wrap-actionlint.sh" ;;
+    trivy)          WRAPPER="$SCRIPT_DIR/wrap-trivy.sh" ;;
+    zizmor)         WRAPPER="$SCRIPT_DIR/wrap-zizmor.sh" ;;
+    pinact)         WRAPPER="$SCRIPT_DIR/wrap-pinact.sh" ;;
+    squawk)         WRAPPER="$SCRIPT_DIR/wrap-squawk.sh" ;;
+    sqlfluff)       WRAPPER="$SCRIPT_DIR/wrap-sqlfluff.sh" ;;
+    checkov)        WRAPPER="$SCRIPT_DIR/wrap-checkov.sh" ;;
+    pip-audit)      WRAPPER="$SCRIPT_DIR/wrap-pip-audit.sh" ;;
+    cargo-audit)    WRAPPER="$SCRIPT_DIR/wrap-cargo-audit.sh" ;;
+    bundler-audit)  WRAPPER="$SCRIPT_DIR/wrap-bundler-audit.sh" ;;
+    *)              WRAPPER="" ;;
+  esac
+}
+
 # ---------------------------------------------------------------------------
-# Parse requested tools into a set (using associative array for O(1) lookup)
+# Parse requested tools into a colon-delimited string for membership testing.
+# Bash-3.2-portable: no associative arrays (declare -A requires bash 4+).
+# Membership test pattern: case ":$_REQUESTED_CSV_NORM:" in *":$TOOL:"*) ...
 # ---------------------------------------------------------------------------
-declare -A REQUESTED_SET
+_REQUESTED_CSV_NORM=""
 IFS=',' read -ra _REQ_TOOLS <<< "$REQUESTED_TOOLS"
 for _t in "${_REQ_TOOLS[@]}"; do
   _t="${_t// /}"  # strip spaces
-  REQUESTED_SET["$_t"]=1
+  _REQUESTED_CSV_NORM="${_REQUESTED_CSV_NORM}:${_t}"
 done
+_REQUESTED_CSV_NORM="${_REQUESTED_CSV_NORM}:"  # trailing colon for uniform matching
 
 # ---------------------------------------------------------------------------
 # Aggregation: collect all output to a temp file if --output is set,
@@ -144,11 +157,14 @@ PYEOF
 # ---------------------------------------------------------------------------
 for TOOL in "${TOOL_ORDER[@]}"; do
   # Skip tools not in the requested set
-  if [[ -z "${REQUESTED_SET[$TOOL]:-}" ]]; then
-    continue
-  fi
+  # Bash-3.2-portable membership test via case pattern on colon-delimited string.
+  # _REQUESTED_CSV_NORM has the form ":tool1:tool2:...:toolN:" (leading+trailing colon).
+  case "${_REQUESTED_CSV_NORM}" in
+    *":${TOOL}:"*) ;;  # present -- fall through
+    *) continue ;;     # not requested -- skip
+  esac
 
-  WRAPPER="${TOOL_WRAPPERS[$TOOL]:-}"
+  _get_wrapper "$TOOL"
   if [[ -z "$WRAPPER" || ! -f "$WRAPPER" ]]; then
     printf '{"type":"coverage_gap","tool":"%s","check_id":"spine/missing-wrapper","description":"wrapper script not found: %s"}\n' \
       "$TOOL" "$WRAPPER" >> "$SINK"

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-actionlint.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-actionlint.sh
@@ -29,8 +29,12 @@ if [[ ! -d "$WORKFLOWS_DIR" ]]; then
   exit 0
 fi
 
-# Collect workflow files safely
-mapfile -d '' WORKFLOW_FILES < <(
+# Collect workflow files safely using a NUL-delimited read loop.
+# Bash-3.2-portable: mapfile -d '' requires bash 4+; use while-read instead.
+WORKFLOW_FILES=()
+while IFS= read -r -d '' f; do
+  WORKFLOW_FILES+=("$f")
+done < <(
   find "$WORKFLOWS_DIR" \
     -maxdepth 1 \
     -type f \

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-hadolint.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-hadolint.sh
@@ -31,9 +31,12 @@ TMPFILES_LIST="$(mktemp /tmp/ccgm-hadolint-files-XXXXXX.txt)"
 TMPFILE="$(mktemp /tmp/ccgm-hadolint-XXXXXX.json)"
 trap 'rm -f "$TMPFILES_LIST" "$TMPFILE"' EXIT
 
-# Collect Dockerfiles via find -- paths null-delimited internally, then
-# read into array safely
-mapfile -d '' DOCKERFILES < <(
+# Collect Dockerfiles via find -- NUL-delimited read loop.
+# Bash-3.2-portable: mapfile -d '' requires bash 4+; use while-read instead.
+DOCKERFILES=()
+while IFS= read -r -d '' f; do
+  DOCKERFILES+=("$f")
+done < <(
   find "$REPO_ROOT" \
     -type f \
     \( -name "Dockerfile" -o -name "Dockerfile.*" \) \

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-pinact.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-pinact.sh
@@ -29,8 +29,12 @@ if [[ ! -d "$WORKFLOWS_DIR" ]]; then
   exit 0
 fi
 
-# Collect workflow files safely
-mapfile -d '' WORKFLOW_FILES < <(
+# Collect workflow files safely using a NUL-delimited read loop.
+# Bash-3.2-portable: mapfile -d '' requires bash 4+; use while-read instead.
+WORKFLOW_FILES=()
+while IFS= read -r -d '' f; do
+  WORKFLOW_FILES+=("$f")
+done < <(
   find "$WORKFLOWS_DIR" \
     -maxdepth 1 \
     -type f \

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-sqlfluff.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-sqlfluff.sh
@@ -78,8 +78,12 @@ if ! command -v sqlfluff > /dev/null 2>&1; then
   exit 0
 fi
 
-# Collect .sql files from migration directories using find + null-delimited output
-mapfile -d '' SQL_FILES < <(
+# Collect .sql files from migration directories using a NUL-delimited read loop.
+# Bash-3.2-portable: mapfile -d '' requires bash 4+; use while-read instead.
+SQL_FILES=()
+while IFS= read -r -d '' f; do
+  SQL_FILES+=("$f")
+done < <(
   for dir in "${MIGRATION_DIRS[@]}"; do
     find "$dir" \
       -type f \

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-squawk.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-squawk.sh
@@ -75,8 +75,12 @@ if ! command -v squawk > /dev/null 2>&1; then
   exit 0
 fi
 
-# Collect .sql files from migration directories using find + null-delimited output
-mapfile -d '' SQL_FILES < <(
+# Collect .sql files from migration directories using a NUL-delimited read loop.
+# Bash-3.2-portable: mapfile -d '' requires bash 4+; use while-read instead.
+SQL_FILES=()
+while IFS= read -r -d '' f; do
+  SQL_FILES+=("$f")
+done < <(
   for dir in "${MIGRATION_DIRS[@]}"; do
     find "$dir" \
       -type f \

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-zizmor.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-zizmor.sh
@@ -35,8 +35,12 @@ if [[ ! -d "$WORKFLOWS_DIR" ]]; then
   exit 0
 fi
 
-# Collect workflow files safely
-mapfile -d '' WORKFLOW_FILES < <(
+# Collect workflow files safely using a NUL-delimited read loop.
+# Bash-3.2-portable: mapfile -d '' requires bash 4+; use while-read instead.
+WORKFLOW_FILES=()
+while IFS= read -r -d '' f; do
+  WORKFLOW_FILES+=("$f")
+done < <(
   find "$WORKFLOWS_DIR" \
     -maxdepth 1 \
     -type f \

--- a/modules/commands-extra/skills/audit/tests/test-orchestration.sh
+++ b/modules/commands-extra/skills/audit/tests/test-orchestration.sh
@@ -570,15 +570,8 @@ if [ -z "$ABSENT_TOOL" ]; then
   echo "  SKIP: coverage_gap sub-test: no absent tool found"
   echo "  SKIP: coverage_gap sub-test: merge with coverage-only spine"
   echo "  SKIP: coverage_gap sub-test: coverage_gap in merged output"
-elif [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
-  # run.sh uses declare -A which requires bash 4+.
-  # Skip the spine invocation on bash 3.2 (macOS system shell);
-  # ubuntu CI (bash 5) will exercise these assertions.
-  echo "  Spine invocation skipped -- bash < 4 (spine requires bash 4+; ubuntu CI will run this)"
-  pass "coverage_gap sub-test skipped -- bash < 4 (spine requires bash 4+)"
-  pass "merge-findings.py coverage_gap test skipped -- bash < 4"
-  pass "coverage_gap fold-through test skipped -- bash < 4"
 else
+  # run.sh is bash-3.2-portable; no version guard needed.
   echo "  Using absent tool '$ABSENT_TOOL' for coverage_gap sub-test"
 
   set +e

--- a/modules/commands-extra/skills/audit/tests/test-pack-ci-cd.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-ci-cd.sh
@@ -387,16 +387,11 @@ fi
 # ---------------------------------------------------------------------------
 printf '\nTest 4: wrap-zizmor.sh graceful skip when zizmor absent\n'
 
-# wrap-zizmor.sh uses mapfile -d '' which requires bash 4+.
-# On bash 3.2 (macOS system shell), skip these wrapper invocation tests;
-# ubuntu CI (bash 5) will exercise them.
-if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
-  pass "Test 4: wrap-zizmor.sh wrapper skip test skipped -- bash < 4 (wrapper requires bash 4+; ubuntu CI will run this)"
-else
-  # Build a minimal repo with a workflows dir
-  WRAP_REPO="${TESTRUN_TMPDIR}/repo-with-workflows"
-  mkdir -p "${WRAP_REPO}/.github/workflows"
-  cat > "${WRAP_REPO}/.github/workflows/ci.yml" << 'YAML'
+# wrap-zizmor.sh is bash-3.2-portable (uses while-read instead of mapfile); no version guard needed.
+# Build a minimal repo with a workflows dir
+WRAP_REPO="${TESTRUN_TMPDIR}/repo-with-workflows"
+mkdir -p "${WRAP_REPO}/.github/workflows"
+cat > "${WRAP_REPO}/.github/workflows/ci.yml" << 'YAML'
 on: [push]
 jobs:
   build:
@@ -405,60 +400,61 @@ jobs:
       - uses: actions/checkout@v4
 YAML
 
-  # Restricted PATH (no zizmor)
-  SYSTEM_BINS=""
-  for bin in python3 bash find date mktemp cp rm mv printf head grep; do
-    BINPATH="$(command -v "$bin" 2>/dev/null || true)"
-    if [[ -n "$BINPATH" ]]; then
-      BINDIR="$(dirname "$BINPATH")"
-      case ":$SYSTEM_BINS:" in
-        *":$BINDIR:"*) ;;
-        *) SYSTEM_BINS="${SYSTEM_BINS:+$SYSTEM_BINS:}$BINDIR" ;;
-      esac
-    fi
-  done
-  RESTRICTED_PATH="$SYSTEM_BINS:/usr/bin:/bin"
-
-  ZI_SKIP_OUT="${TESTRUN_TMPDIR}/zi-skip.jsonl"
-  set +e
-  PATH="$RESTRICTED_PATH" bash "${SPINE_DIR}/wrap-zizmor.sh" "$WRAP_REPO" > "$ZI_SKIP_OUT" 2>/dev/null
-  ZI_SKIP_EXIT=$?
-  set -e
-
-  if [[ $ZI_SKIP_EXIT -eq 0 ]]; then
-    pass "wrap-zizmor.sh exits 0 when zizmor absent"
-  else
-    fail "wrap-zizmor.sh exits $ZI_SKIP_EXIT (expected 0) when zizmor absent"
+# Restricted PATH (no zizmor)
+SYSTEM_BINS=""
+for bin in python3 bash find date mktemp cp rm mv printf head grep; do
+  BINPATH="$(command -v "$bin" 2>/dev/null || true)"
+  if [[ -n "$BINPATH" ]]; then
+    BINDIR="$(dirname "$BINPATH")"
+    case ":$SYSTEM_BINS:" in
+      *":$BINDIR:"*) ;;
+      *) SYSTEM_BINS="${SYSTEM_BINS:+$SYSTEM_BINS:}$BINDIR" ;;
+    esac
   fi
+done
+RESTRICTED_PATH="$SYSTEM_BINS:/usr/bin:/bin"
 
-  SKIP_COUNT="$(grep -c '"type":"skipped"' "$ZI_SKIP_OUT" 2>/dev/null || printf '0')"
-  GAP_COUNT="$(grep -c '"type":"coverage_gap"' "$ZI_SKIP_OUT" 2>/dev/null || printf '0')"
+ZI_SKIP_OUT="${TESTRUN_TMPDIR}/zi-skip.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "${SPINE_DIR}/wrap-zizmor.sh" "$WRAP_REPO" > "$ZI_SKIP_OUT" 2>/dev/null
+ZI_SKIP_EXIT=$?
+set -e
 
-  if [[ $SKIP_COUNT -ge 1 ]]; then
-    pass "wrap-zizmor.sh emits skipped note when absent"
-  else
-    fail "wrap-zizmor.sh emitted no skipped note"
+if [[ $ZI_SKIP_EXIT -eq 0 ]]; then
+  pass "wrap-zizmor.sh exits 0 when zizmor absent"
+else
+  fail "wrap-zizmor.sh exits $ZI_SKIP_EXIT (expected 0) when zizmor absent"
+fi
+
+# Use { grep ... || true; } so a zero-match exit-1 doesn't fire the ||, preventing
+# double-output under bash 3.2 when grep exits non-zero (no matches).
+SKIP_COUNT="$({ grep -c '"type":"skipped"' "$ZI_SKIP_OUT" || true; } 2>/dev/null)"
+GAP_COUNT="$({ grep -c '"type":"coverage_gap"' "$ZI_SKIP_OUT" || true; } 2>/dev/null)"
+
+if [[ ${SKIP_COUNT:-0} -ge 1 ]]; then
+  pass "wrap-zizmor.sh emits skipped note when absent"
+else
+  fail "wrap-zizmor.sh emitted no skipped note"
+fi
+
+if [[ ${GAP_COUNT:-0} -ge 1 ]]; then
+  pass "wrap-zizmor.sh emits coverage_gap entries when absent"
+else
+  fail "wrap-zizmor.sh emitted no coverage_gap entries"
+fi
+
+# Verify all output lines are valid JSON
+INVALID_JSON_ZI=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID_JSON_ZI=$((INVALID_JSON_ZI + 1))
   fi
-
-  if [[ $GAP_COUNT -ge 1 ]]; then
-    pass "wrap-zizmor.sh emits coverage_gap entries when absent"
-  else
-    fail "wrap-zizmor.sh emitted no coverage_gap entries"
-  fi
-
-  # Verify all output lines are valid JSON
-  INVALID_JSON_ZI=0
-  while IFS= read -r line; do
-    [[ -z "$line" ]] && continue
-    if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
-      INVALID_JSON_ZI=$((INVALID_JSON_ZI + 1))
-    fi
-  done < "$ZI_SKIP_OUT"
-  if [[ $INVALID_JSON_ZI -eq 0 ]]; then
-    pass "all wrap-zizmor.sh skip output lines are valid JSON"
-  else
-    fail "$INVALID_JSON_ZI invalid JSON lines from wrap-zizmor.sh skip"
-  fi
+done < "$ZI_SKIP_OUT"
+if [[ $INVALID_JSON_ZI -eq 0 ]]; then
+  pass "all wrap-zizmor.sh skip output lines are valid JSON"
+else
+  fail "$INVALID_JSON_ZI invalid JSON lines from wrap-zizmor.sh skip"
 fi
 
 # ---------------------------------------------------------------------------
@@ -466,49 +462,45 @@ fi
 # ---------------------------------------------------------------------------
 printf '\nTest 5: wrap-pinact.sh graceful skip when pinact absent\n'
 
-# wrap-pinact.sh uses mapfile -d '' which requires bash 4+; skip on bash 3.2.
-if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
-  pass "Test 5: wrap-pinact.sh wrapper skip test skipped -- bash < 4 (wrapper requires bash 4+; ubuntu CI will run this)"
+# wrap-pinact.sh is bash-3.2-portable (uses while-read instead of mapfile); no version guard needed.
+PI_SKIP_OUT="${TESTRUN_TMPDIR}/pi-skip.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "${SPINE_DIR}/wrap-pinact.sh" "$WRAP_REPO" > "$PI_SKIP_OUT" 2>/dev/null
+PI_SKIP_EXIT=$?
+set -e
+
+if [[ $PI_SKIP_EXIT -eq 0 ]]; then
+  pass "wrap-pinact.sh exits 0 when pinact absent"
 else
-  PI_SKIP_OUT="${TESTRUN_TMPDIR}/pi-skip.jsonl"
-  set +e
-  PATH="$RESTRICTED_PATH" bash "${SPINE_DIR}/wrap-pinact.sh" "$WRAP_REPO" > "$PI_SKIP_OUT" 2>/dev/null
-  PI_SKIP_EXIT=$?
-  set -e
+  fail "wrap-pinact.sh exits $PI_SKIP_EXIT (expected 0) when pinact absent"
+fi
 
-  if [[ $PI_SKIP_EXIT -eq 0 ]]; then
-    pass "wrap-pinact.sh exits 0 when pinact absent"
-  else
-    fail "wrap-pinact.sh exits $PI_SKIP_EXIT (expected 0) when pinact absent"
+PI_SKIP_COUNT="$({ grep -c '"type":"skipped"' "$PI_SKIP_OUT" || true; } 2>/dev/null)"
+PI_GAP_COUNT="$({ grep -c '"type":"coverage_gap"' "$PI_SKIP_OUT" || true; } 2>/dev/null)"
+
+if [[ ${PI_SKIP_COUNT:-0} -ge 1 ]]; then
+  pass "wrap-pinact.sh emits skipped note when absent"
+else
+  fail "wrap-pinact.sh emitted no skipped note"
+fi
+
+if [[ ${PI_GAP_COUNT:-0} -ge 1 ]]; then
+  pass "wrap-pinact.sh emits coverage_gap entries when absent"
+else
+  fail "wrap-pinact.sh emitted no coverage_gap entries"
+fi
+
+INVALID_JSON_PI=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID_JSON_PI=$((INVALID_JSON_PI + 1))
   fi
-
-  PI_SKIP_COUNT="$(grep -c '"type":"skipped"' "$PI_SKIP_OUT" 2>/dev/null || printf '0')"
-  PI_GAP_COUNT="$(grep -c '"type":"coverage_gap"' "$PI_SKIP_OUT" 2>/dev/null || printf '0')"
-
-  if [[ $PI_SKIP_COUNT -ge 1 ]]; then
-    pass "wrap-pinact.sh emits skipped note when absent"
-  else
-    fail "wrap-pinact.sh emitted no skipped note"
-  fi
-
-  if [[ $PI_GAP_COUNT -ge 1 ]]; then
-    pass "wrap-pinact.sh emits coverage_gap entries when absent"
-  else
-    fail "wrap-pinact.sh emitted no coverage_gap entries"
-  fi
-
-  INVALID_JSON_PI=0
-  while IFS= read -r line; do
-    [[ -z "$line" ]] && continue
-    if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
-      INVALID_JSON_PI=$((INVALID_JSON_PI + 1))
-    fi
-  done < "$PI_SKIP_OUT"
-  if [[ $INVALID_JSON_PI -eq 0 ]]; then
-    pass "all wrap-pinact.sh skip output lines are valid JSON"
-  else
-    fail "$INVALID_JSON_PI invalid JSON lines from wrap-pinact.sh skip"
-  fi
+done < "$PI_SKIP_OUT"
+if [[ $INVALID_JSON_PI -eq 0 ]]; then
+  pass "all wrap-pinact.sh skip output lines are valid JSON"
+else
+  fail "$INVALID_JSON_PI invalid JSON lines from wrap-pinact.sh skip"
 fi
 
 # ---------------------------------------------------------------------------

--- a/modules/commands-extra/skills/audit/tests/test-pack-data-migrations.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-data-migrations.sh
@@ -479,8 +479,10 @@ else
   fail "spine exits $SPINE_EXIT (expected 0)"
 fi
 
-SKIP_OR_GAP="$(grep -c '"type":"skipped"\|"type":"coverage_gap"' "$SPINE_OUT" 2>/dev/null || printf '0')"
-if [[ "$SKIP_OR_GAP" -gt 0 ]]; then
+# Use { grep ... || true; } so a zero-match exit-1 doesn't fire the ||, preventing
+# double-output under bash 3.2 when grep exits non-zero (no matches).
+SKIP_OR_GAP="$({ grep -c '"type":"skipped"\|"type":"coverage_gap"' "$SPINE_OUT" || true; } 2>/dev/null)"
+if [[ ${SKIP_OR_GAP:-0} -gt 0 ]]; then
   pass "spine emits $SKIP_OR_GAP skip/gap note(s) for absent tools on fixture repo"
 else
   fail "spine emits no skip/gap notes for absent tools on fixture repo"

--- a/modules/commands-extra/skills/audit/tests/test-pack-data-migrations.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-data-migrations.sh
@@ -462,31 +462,28 @@ fi
 # ---------------------------------------------------------------------------
 printf '\nTest 14: Fixture repo graceful-degradation (tools absent)\n'
 
-if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
-  pass "Test 14: spine fixture run skipped -- bash < 4 (spine requires bash 4+; ubuntu CI will run this)"
+# run.sh is bash-3.2-portable; no version guard needed.
+SPINE_OUT="$TESTRUN_TMPDIR/spine-dm-graceful.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "${SPINE_DIR}/run.sh" \
+  --repo "$FIXTURE_REPO" \
+  --tools "squawk,sqlfluff" \
+  --output "$SPINE_OUT" \
+  2>/dev/null
+SPINE_EXIT=$?
+set -e
+
+if [[ $SPINE_EXIT -eq 0 ]]; then
+  pass "spine exits 0 for squawk,sqlfluff on fixture repo (tools absent)"
 else
-  SPINE_OUT="$TESTRUN_TMPDIR/spine-dm-graceful.jsonl"
-  set +e
-  PATH="$RESTRICTED_PATH" bash "${SPINE_DIR}/run.sh" \
-    --repo "$FIXTURE_REPO" \
-    --tools "squawk,sqlfluff" \
-    --output "$SPINE_OUT" \
-    2>/dev/null
-  SPINE_EXIT=$?
-  set -e
+  fail "spine exits $SPINE_EXIT (expected 0)"
+fi
 
-  if [[ $SPINE_EXIT -eq 0 ]]; then
-    pass "spine exits 0 for squawk,sqlfluff on fixture repo (tools absent)"
-  else
-    fail "spine exits $SPINE_EXIT (expected 0)"
-  fi
-
-  SKIP_OR_GAP="$(grep -c '"type":"skipped"\|"type":"coverage_gap"' "$SPINE_OUT" 2>/dev/null || printf '0')"
-  if [[ "$SKIP_OR_GAP" -gt 0 ]]; then
-    pass "spine emits $SKIP_OR_GAP skip/gap note(s) for absent tools on fixture repo"
-  else
-    fail "spine emits no skip/gap notes for absent tools on fixture repo"
-  fi
+SKIP_OR_GAP="$(grep -c '"type":"skipped"\|"type":"coverage_gap"' "$SPINE_OUT" 2>/dev/null || printf '0')"
+if [[ "$SKIP_OR_GAP" -gt 0 ]]; then
+  pass "spine emits $SKIP_OR_GAP skip/gap note(s) for absent tools on fixture repo"
+else
+  fail "spine emits no skip/gap notes for absent tools on fixture repo"
 fi
 
 # ---------------------------------------------------------------------------

--- a/modules/commands-extra/skills/audit/tests/test-pack-dependencies-deep.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-dependencies-deep.sh
@@ -590,45 +590,42 @@ version = "0.1.0"
 serde = "1.0"
 CARGO
 
-if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
-  pass "Test 21: spine fixture run skipped -- bash < 4 (spine requires bash 4+; ubuntu CI will run this)"
+# run.sh is bash-3.2-portable; no version guard needed.
+SPINE_OUT="$TESTRUN_TMPDIR/spine-multi-eco.jsonl"
+set +e
+PATH="$RESTRICTED_PATH" bash "${SPINE_DIR}/run.sh" \
+  --repo "$FIXTURE_REPO" \
+  --tools "pip-audit,cargo-audit,bundler-audit" \
+  --output "$SPINE_OUT" \
+  2>/dev/null
+SPINE_EXIT=$?
+set -e
+
+if [[ $SPINE_EXIT -eq 0 ]]; then
+  pass "spine exits 0 for pip-audit,cargo-audit,bundler-audit on fixture repo (tools absent)"
 else
-  SPINE_OUT="$TESTRUN_TMPDIR/spine-multi-eco.jsonl"
-  set +e
-  PATH="$RESTRICTED_PATH" bash "${SPINE_DIR}/run.sh" \
-    --repo "$FIXTURE_REPO" \
-    --tools "pip-audit,cargo-audit,bundler-audit" \
-    --output "$SPINE_OUT" \
-    2>/dev/null
-  SPINE_EXIT=$?
-  set -e
+  fail "spine exits $SPINE_EXIT (expected 0)"
+fi
 
-  if [[ $SPINE_EXIT -eq 0 ]]; then
-    pass "spine exits 0 for pip-audit,cargo-audit,bundler-audit on fixture repo (tools absent)"
-  else
-    fail "spine exits $SPINE_EXIT (expected 0)"
-  fi
+SKIP_OR_GAP="$(grep -c '"type":"skipped"\|"type":"coverage_gap"' "$SPINE_OUT" 2>/dev/null || printf '0')"
+if [[ "$SKIP_OR_GAP" -gt 0 ]]; then
+  pass "spine emits $SKIP_OR_GAP skip/gap note(s) for absent tools on multi-ecosystem fixture"
+else
+  fail "spine emits no skip/gap notes for absent tools on multi-ecosystem fixture"
+fi
 
-  SKIP_OR_GAP="$(grep -c '"type":"skipped"\|"type":"coverage_gap"' "$SPINE_OUT" 2>/dev/null || printf '0')"
-  if [[ "$SKIP_OR_GAP" -gt 0 ]]; then
-    pass "spine emits $SKIP_OR_GAP skip/gap note(s) for absent tools on multi-ecosystem fixture"
-  else
-    fail "spine emits no skip/gap notes for absent tools on multi-ecosystem fixture"
+# All output should be valid JSON
+INVALID_JSON=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID_JSON=$((INVALID_JSON + 1))
   fi
-
-  # All output should be valid JSON
-  INVALID_JSON=0
-  while IFS= read -r line; do
-    [[ -z "$line" ]] && continue
-    if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
-      INVALID_JSON=$((INVALID_JSON + 1))
-    fi
-  done < "$SPINE_OUT"
-  if [[ $INVALID_JSON -eq 0 ]]; then
-    pass "spine output for multi-ecosystem fixture is valid JSONL"
-  else
-    fail "spine output has $INVALID_JSON invalid JSON lines"
-  fi
+done < "$SPINE_OUT"
+if [[ $INVALID_JSON -eq 0 ]]; then
+  pass "spine output for multi-ecosystem fixture is valid JSONL"
+else
+  fail "spine output has $INVALID_JSON invalid JSON lines"
 fi
 
 # ---------------------------------------------------------------------------

--- a/modules/commands-extra/skills/audit/tests/test-pack-dependencies-deep.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-dependencies-deep.sh
@@ -607,8 +607,10 @@ else
   fail "spine exits $SPINE_EXIT (expected 0)"
 fi
 
-SKIP_OR_GAP="$(grep -c '"type":"skipped"\|"type":"coverage_gap"' "$SPINE_OUT" 2>/dev/null || printf '0')"
-if [[ "$SKIP_OR_GAP" -gt 0 ]]; then
+# Use { grep ... || true; } so a zero-match exit-1 doesn't fire the ||, preventing
+# double-output under bash 3.2 when grep exits non-zero (no matches).
+SKIP_OR_GAP="$({ grep -c '"type":"skipped"\|"type":"coverage_gap"' "$SPINE_OUT" || true; } 2>/dev/null)"
+if [[ ${SKIP_OR_GAP:-0} -gt 0 ]]; then
   pass "spine emits $SKIP_OR_GAP skip/gap note(s) for absent tools on multi-ecosystem fixture"
 else
   fail "spine emits no skip/gap notes for absent tools on multi-ecosystem fixture"

--- a/modules/commands-extra/skills/audit/tests/test-smoke-audits.sh
+++ b/modules/commands-extra/skills/audit/tests/test-smoke-audits.sh
@@ -102,11 +102,7 @@ if command -v gitleaks >/dev/null 2>&1; then
   GITLEAKS_AVAILABLE=true
 fi
 
-# Check bash version (spine requires bash 4+ for declare -A)
-BASH_GE4=true
-if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
-  BASH_GE4=false
-fi
+# run.sh is bash-3.2-portable; BASH_GE4 guard removed.
 
 # ---------------------------------------------------------------------------
 # ADV-009: assemble the fake AWS key from fragments at runtime.
@@ -153,7 +149,7 @@ PYEOF
 # ---------------------------------------------------------------------------
 # Helper: run the full deterministic pipeline for a fixture repo.
 # Returns paths to spine output and merged findings via env vars.
-# Spine step gated on BASH_GE4 (bash 4+ required for declare -A in run.sh).
+# Spine step -- run.sh is bash-3.2-portable; no version gate needed.
 # ---------------------------------------------------------------------------
 run_pipeline() {
   local fixture_name="$1"   # human label for messages
@@ -193,25 +189,19 @@ run_pipeline() {
     return 1
   fi
 
-  # Step 3: spine/run.sh (bash-4 gate)
-  if [ "$BASH_GE4" = "false" ]; then
-    skip "$fixture_name: spine invocation skipped -- bash ${BASH_VERSINFO[0]} < 4 (spine requires bash 4+; ubuntu CI will run this)"
-    # Create an empty spine file so merge step is also skipped cleanly below
-    printf '{"type":"provenance","tool":"ccgm-spine-skipped","version":"1.0"}\n' > "$spine_jsonl"
+  # Step 3: spine/run.sh (bash-3.2-portable; no version gate needed)
+  set +e
+  bash "$SPINE" \
+    --repo   "$repo_abs" \
+    --tools  "$tools" \
+    --output "$spine_jsonl" 2>/dev/null
+  SPINE_EC=$?
+  set -e
+  if [ "$SPINE_EC" -eq 0 ] && [ -f "$spine_jsonl" ]; then
+    pass "$fixture_name: spine/run.sh exited 0"
   else
-    set +e
-    bash "$SPINE" \
-      --repo   "$repo_abs" \
-      --tools  "$tools" \
-      --output "$spine_jsonl" 2>/dev/null
-    SPINE_EC=$?
-    set -e
-    if [ "$SPINE_EC" -eq 0 ] && [ -f "$spine_jsonl" ]; then
-      pass "$fixture_name: spine/run.sh exited 0"
-    else
-      fail "$fixture_name: spine/run.sh failed (exit $SPINE_EC) or output missing"
-      return 1
-    fi
+    fail "$fixture_name: spine/run.sh failed (exit $SPINE_EC) or output missing"
+    return 1
   fi
 
   # Step 4: merge-findings.py
@@ -239,17 +229,12 @@ run_pipeline() {
 
 # ---------------------------------------------------------------------------
 # Helper: assert the critical secrets finding is present in findings.jsonl.
-# Gated on both GITLEAKS_AVAILABLE and BASH_GE4.
+# Gated on GITLEAKS_AVAILABLE only (spine is bash-3.2-portable, always runs).
 # ---------------------------------------------------------------------------
 assert_critical_finding() {
   local fixture_name="$1"
   local findings_jsonl="$2"
   local fake_key="$3"
-
-  if [ "$BASH_GE4" = "false" ]; then
-    skip "$fixture_name: gitleaks finding asserts skipped -- bash < 4 (spine not run)"
-    return
-  fi
 
   if [ "$GITLEAKS_AVAILABLE" = "false" ]; then
     skip "$fixture_name: gitleaks not installed -- critical-finding asserts skipped (SKIP, not FAIL)"
@@ -295,16 +280,11 @@ PYEOF
 # ---------------------------------------------------------------------------
 # Helper: assert a coverage_gap record exists in findings.jsonl for an
 # absent tool (verifies the spine coverage-gap passthrough).
-# Gated on BASH_GE4 (spine must have run).
+# Spine is bash-3.2-portable; no version guard needed.
 # ---------------------------------------------------------------------------
 assert_coverage_gap() {
   local fixture_name="$1"
   local findings_jsonl="$2"
-
-  if [ "$BASH_GE4" = "false" ]; then
-    skip "$fixture_name: coverage_gap assert skipped -- bash < 4 (spine not run)"
-    return
-  fi
 
   # Check for at least one coverage_gap record (tool absent = gap emitted by spine)
   GAP_COUNT="$(python3 - "$findings_jsonl" << 'PYEOF'

--- a/modules/commands-extra/skills/audit/tests/test-spine.sh
+++ b/modules/commands-extra/skills/audit/tests/test-spine.sh
@@ -141,83 +141,73 @@ printf 'hello world\n' > "$TMPDIR_REPO/hello.txt"
 # ---------------------------------------------------------------------------
 printf '\nTest 1: All tools forced-absent -> graceful skip\n'
 
-# run.sh uses declare -A which requires bash 4+.
-# On bash 3.2 (macOS system shell), skip spine invocation tests;
-# ubuntu CI (bash 5) will exercise them.
-if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
-  pass "Test 1: spine graceful-skip test skipped -- bash < 4 (spine requires bash 4+; ubuntu CI will run this)"
-  pass "Test 1: spine output check skipped -- bash < 4"
-  pass "Test 1: skipped notes check skipped -- bash < 4"
-  pass "Test 1: coverage_gap entries check skipped -- bash < 4"
-  pass "Test 1: valid JSON output check skipped -- bash < 4"
+# run.sh is bash-3.2-portable (no declare -A / mapfile); runs on all bash versions.
+# Build a PATH containing only essential non-audit binaries
+SYSTEM_BINS=""
+for bin in python3 bash find date mktemp cp rm mv printf head grep; do
+  BINPATH="$(command -v "$bin" 2>/dev/null || true)"
+  if [[ -n "$BINPATH" ]]; then
+    BINDIR="$(dirname "$BINPATH")"
+    case ":$SYSTEM_BINS:" in
+      *":$BINDIR:"*) ;;  # already present
+      *) SYSTEM_BINS="${SYSTEM_BINS:+$SYSTEM_BINS:}$BINDIR" ;;
+    esac
+  fi
+done
+# Always include standard system paths
+RESTRICTED_PATH="$SYSTEM_BINS:/usr/bin:/bin"
+
+SPINE_OUTPUT="$TESTRUN_TMPDIR/test1-output.jsonl"
+
+set +e
+PATH="$RESTRICTED_PATH" bash "$SPINE_DIR/run.sh" \
+  --repo "$TMPDIR_REPO" \
+  --output "$SPINE_OUTPUT" \
+  2>/dev/null
+T1_EXIT=$?
+set -e
+
+if [[ $T1_EXIT -eq 0 ]]; then
+  pass "run.sh exits 0 when tools absent"
 else
-  # Build a PATH containing only essential non-audit binaries
-  SYSTEM_BINS=""
-  for bin in python3 bash find date mktemp cp rm mv printf head grep; do
-    BINPATH="$(command -v "$bin" 2>/dev/null || true)"
-    if [[ -n "$BINPATH" ]]; then
-      BINDIR="$(dirname "$BINPATH")"
-      case ":$SYSTEM_BINS:" in
-        *":$BINDIR:"*) ;;  # already present
-        *) SYSTEM_BINS="${SYSTEM_BINS:+$SYSTEM_BINS:}$BINDIR" ;;
-      esac
-    fi
-  done
-  # Always include standard system paths
-  RESTRICTED_PATH="$SYSTEM_BINS:/usr/bin:/bin"
+  fail "run.sh exits $T1_EXIT (expected 0) when tools absent"
+fi
 
-  SPINE_OUTPUT="$TESTRUN_TMPDIR/test1-output.jsonl"
+if [[ -s "$SPINE_OUTPUT" ]]; then
+  pass "run.sh produced output (provenance + skip notes)"
+else
+  fail "run.sh produced no output (expected at least provenance record)"
+fi
 
-  set +e
-  PATH="$RESTRICTED_PATH" bash "$SPINE_DIR/run.sh" \
-    --repo "$TMPDIR_REPO" \
-    --output "$SPINE_OUTPUT" \
-    2>/dev/null
-  T1_EXIT=$?
-  set -e
+# Check for skipped notes
+SKIP_COUNT="$(grep -c '"type":"skipped"' "$SPINE_OUTPUT" 2>/dev/null || printf '0')"
+if [[ "$SKIP_COUNT" -gt 0 ]]; then
+  pass "found $SKIP_COUNT skipped note(s) for absent tools"
+else
+  fail "no skipped notes found for absent tools (expected >= 1)"
+fi
 
-  if [[ $T1_EXIT -eq 0 ]]; then
-    pass "run.sh exits 0 when tools absent"
-  else
-    fail "run.sh exits $T1_EXIT (expected 0) when tools absent"
+# Check for coverage-gap entries
+GAP_COUNT="$(grep -c '"type":"coverage_gap"' "$SPINE_OUTPUT" 2>/dev/null || printf '0')"
+if [[ "$GAP_COUNT" -gt 0 ]]; then
+  pass "found $GAP_COUNT coverage-gap entries for absent tools"
+else
+  fail "no coverage_gap entries found for absent tools (expected >= 1)"
+fi
+
+# All lines should be valid JSON
+INVALID_JSON=0
+while IFS= read -r line; do
+  if [[ -z "$line" ]]; then continue; fi
+  if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
+    INVALID_JSON=$((INVALID_JSON + 1))
   fi
+done < "$SPINE_OUTPUT"
 
-  if [[ -s "$SPINE_OUTPUT" ]]; then
-    pass "run.sh produced output (provenance + skip notes)"
-  else
-    fail "run.sh produced no output (expected at least provenance record)"
-  fi
-
-  # Check for skipped notes
-  SKIP_COUNT="$(grep -c '"type":"skipped"' "$SPINE_OUTPUT" 2>/dev/null || printf '0')"
-  if [[ "$SKIP_COUNT" -gt 0 ]]; then
-    pass "found $SKIP_COUNT skipped note(s) for absent tools"
-  else
-    fail "no skipped notes found for absent tools (expected >= 1)"
-  fi
-
-  # Check for coverage-gap entries
-  GAP_COUNT="$(grep -c '"type":"coverage_gap"' "$SPINE_OUTPUT" 2>/dev/null || printf '0')"
-  if [[ "$GAP_COUNT" -gt 0 ]]; then
-    pass "found $GAP_COUNT coverage-gap entries for absent tools"
-  else
-    fail "no coverage_gap entries found for absent tools (expected >= 1)"
-  fi
-
-  # All lines should be valid JSON
-  INVALID_JSON=0
-  while IFS= read -r line; do
-    if [[ -z "$line" ]]; then continue; fi
-    if ! python3 -c "import json,sys; json.loads(sys.argv[1])" "$line" 2>/dev/null; then
-      INVALID_JSON=$((INVALID_JSON + 1))
-    fi
-  done < "$SPINE_OUTPUT"
-
-  if [[ $INVALID_JSON -eq 0 ]]; then
-    pass "all output lines are valid JSON"
-  else
-    fail "$INVALID_JSON output line(s) are invalid JSON"
-  fi
+if [[ $INVALID_JSON -eq 0 ]]; then
+  pass "all output lines are valid JSON"
+else
+  fail "$INVALID_JSON output line(s) are invalid JSON"
 fi
 
 # ---------------------------------------------------------------------------
@@ -226,33 +216,30 @@ fi
 # ---------------------------------------------------------------------------
 printf '\nTest 1b: Adversarial repo path -> provenance line is valid JSON\n'
 
-if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
-  pass "Test 1b: adversarial path test skipped -- bash < 4 (spine requires bash 4+; ubuntu CI will run this)"
-  pass "Test 1b: provenance JSON validity check skipped -- bash < 4"
+# run.sh is bash-3.2-portable; no version guard needed.
+WEIRD_DIR="$TESTRUN_TMPDIR/repo-with-quote\"-and space"
+mkdir -p "$WEIRD_DIR"
+printf '{"name":"weird"}\n' > "$WEIRD_DIR/package.json"
+
+WEIRD_OUTPUT="$TESTRUN_TMPDIR/test1b-output.jsonl"
+set +e
+bash "$SPINE_DIR/run.sh" \
+  --repo "$WEIRD_DIR" \
+  --tools "gitleaks" \
+  --output "$WEIRD_OUTPUT" \
+  2>/dev/null
+WEIRD_EXIT=$?
+set -e
+
+if [[ $WEIRD_EXIT -eq 0 ]]; then
+  pass "spine exits 0 on adversarial repo path"
 else
-  WEIRD_DIR="$TESTRUN_TMPDIR/repo-with-quote\"-and space"
-  mkdir -p "$WEIRD_DIR"
-  printf '{"name":"weird"}\n' > "$WEIRD_DIR/package.json"
+  fail "spine exits $WEIRD_EXIT on adversarial repo path (expected 0)"
+fi
 
-  WEIRD_OUTPUT="$TESTRUN_TMPDIR/test1b-output.jsonl"
-  set +e
-  bash "$SPINE_DIR/run.sh" \
-    --repo "$WEIRD_DIR" \
-    --tools "gitleaks" \
-    --output "$WEIRD_OUTPUT" \
-    2>/dev/null
-  WEIRD_EXIT=$?
-  set -e
-
-  if [[ $WEIRD_EXIT -eq 0 ]]; then
-    pass "spine exits 0 on adversarial repo path"
-  else
-    fail "spine exits $WEIRD_EXIT on adversarial repo path (expected 0)"
-  fi
-
-  # Extract and validate the provenance line using python3 (grep patterns vary by
-  # platform; json.dumps adds spaces after ":" so a no-space grep would miss it).
-  PROV_VALID="$(python3 - "$WEIRD_OUTPUT" << 'PYEOF'
+# Extract and validate the provenance line using python3 (grep patterns vary by
+# platform; json.dumps adds spaces after ":" so a no-space grep would miss it).
+PROV_VALID="$(python3 - "$WEIRD_OUTPUT" << 'PYEOF'
 import json, sys
 with open(sys.argv[1]) as f:
     for raw in f:
@@ -270,14 +257,13 @@ with open(sys.argv[1]) as f:
             sys.exit(0)
 print("missing")
 PYEOF
-  )"
-  if [[ "$PROV_VALID" == "valid" ]]; then
-    pass "provenance line is valid JSON for adversarial repo path (contains quote + space)"
-  elif [[ "$PROV_VALID" == "missing" ]]; then
-    fail "no provenance line found in output for adversarial repo path"
-  else
-    fail "provenance line is NOT valid JSON for adversarial repo path -- printf escaping bug?"
-  fi
+)"
+if [[ "$PROV_VALID" == "valid" ]]; then
+  pass "provenance line is valid JSON for adversarial repo path (contains quote + space)"
+elif [[ "$PROV_VALID" == "missing" ]]; then
+  fail "no provenance line found in output for adversarial repo path"
+else
+  fail "provenance line is NOT valid JSON for adversarial repo path -- printf escaping bug?"
 fi
 
 # ---------------------------------------------------------------------------
@@ -294,10 +280,7 @@ rm -f "/tmp/PWNED"
 
 pass "precondition: cleaned any stale PWNED file"
 
-if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
-  pass "Test 2: spine injection test skipped -- bash < 4 (spine requires bash 4+; ubuntu CI will run this)"
-  pass "Test 2: PWNED check still runs -- injection safety is filesystem-level"
-else
+# run.sh is bash-3.2-portable; no version guard needed.
 INJECTION_OUTPUT="$TESTRUN_TMPDIR/test2-output.jsonl"
 
 set +e
@@ -312,7 +295,6 @@ if [[ $INJECT_EXIT -eq 0 ]]; then
   pass "spine exits 0 on injection fixture"
 else
   fail "spine exits $INJECT_EXIT on injection fixture (expected 0)"
-fi
 fi
 
 # The critical check: no PWNED file should exist anywhere


### PR DESCRIPTION
## Summary

- Replace `declare -A TOOL_WRAPPERS` and `declare -A REQUESTED_SET` in `run.sh` with a `case`-dispatch helper (`_get_wrapper`) and a colon-delimited membership string — behavior-identical for all 18 tools, works under bash 3.2
- Replace `mapfile -d ''` in `wrap-zizmor.sh`, `wrap-pinact.sh`, `wrap-hadolint.sh`, `wrap-actionlint.sh`, `wrap-squawk.sh`, and `wrap-sqlfluff.sh` with `while IFS= read -r -d '' f; do ... done < <(find ... -print0)` — preserves NUL-delimiter safety, works under bash 3.2
- Remove `BASH_VERSINFO` guards from 6 test files that were added to skip spine tests on bash < 4; now that the spine is portable those guards suppress coverage on macOS

## Pre-existing failures (not introduced by this PR)

The full test suite shows 5 failures on both `main` and this branch under bash 3.2 and 5.2. All 5 trace to `zizmor` and `pinact` being installed in `/opt/homebrew/bin`, which overlaps with the `RESTRICTED_PATH` because `python3` is also there. Confirmed identical failure counts on `main` baseline.

## Verification

```
# bash 3.2 proof
/bin/bash --version   # GNU bash, version 3.2.57(1)-release

# Spine runs clean under 3.2
/bin/bash run.sh --repo /tmp/proof --tools gitleaks --output /tmp/out.jsonl
# exit 0, valid provenance JSONL

# No residual bash-4 constructs
grep -rn 'declare -A\|mapfile\|readarray' modules/commands-extra/skills/audit/scripts/spine/

# Full suite: 26 pass / 5 pre-existing failures under bash 3.2 and 5.2
```

Closes #644