### PR TITLE
#648: fingerprint resilience -- validate tool FP, resilient merge, deterministic test PATH

### DIFF
--- a/modules/commands-extra/skills/audit/scripts/merge-findings.py
+++ b/modules/commands-extra/skills/audit/scripts/merge-findings.py
@@ -392,34 +392,43 @@ def _validate_before_sort(findings: list, emit_mod) -> list:
     """
     Validate findings BEFORE sort and rubric steps (Fix #6).
 
-    Exits 1 with an actionable error message if any finding is malformed
-    (e.g. location.line is a string instead of an int), so the user sees
-    a clear ERROR rather than a bare TypeError traceback from merged.sort().
+    Invalid findings are SKIPPED with a WARNING to stderr so that one bad
+    finding among many (e.g. a tool-supplied fingerprint that fails the schema
+    pattern) does not abort the whole merge run.  Only truly unrecoverable
+    input structure problems (unparseable JSONL, missing CLI args) justify
+    exit 1 -- per-finding validation failures do not.
 
-    Returns validated findings (unchanged list if all pass).
+    Returns the list of valid findings (invalid ones removed).
     """
-    errors = []
+    valid = []
     for idx, f in enumerate(findings):
+        skip_reason = None
+
         loc = f.get("location", {})
         line_val = loc.get("line") if isinstance(loc, dict) else None
         if line_val is not None and not isinstance(line_val, int):
-            errors.append(
-                f"finding[{idx}] ({f.get('check_id','?')}): "
+            skip_reason = (
                 f"location.line must be an integer, got {type(line_val).__name__} "
                 f"value {line_val!r}"
             )
-        # Also run the full validation to catch any other malformed fields early.
-        try:
-            emit_mod.validate_finding(f)
-        except emit_mod.ValidationError as exc:
-            errors.append(f"finding[{idx}] ({f.get('check_id','?')}): {exc}")
 
-    if errors:
-        for err in errors:
-            print(f"merge-findings: VALIDATION ERROR: {err}", file=sys.stderr)
-        sys.exit(1)
+        if skip_reason is None:
+            # Full schema validation
+            try:
+                emit_mod.validate_finding(f)
+            except emit_mod.ValidationError as exc:
+                skip_reason = str(exc)
 
-    return findings
+        if skip_reason is not None:
+            print(
+                f"merge-findings: WARNING: skipping invalid finding[{idx}] "
+                f"({f.get('check_id','?')}): {skip_reason}",
+                file=sys.stderr,
+            )
+        else:
+            valid.append(f)
+
+    return valid
 
 
 # ---------------------------------------------------------------------------
@@ -685,20 +694,21 @@ def main() -> int:
 
     # ------------------------------------------------------------------
     # Final validation pass (post-rubric)
+    # Invalid findings are skipped with a WARNING, not exit 1.  The rubric
+    # step could theoretically produce a bad value; we skip-and-warn so the
+    # rest of the valid output is still emitted.
     # ------------------------------------------------------------------
-    errors = []
     valid_findings = []
     for idx, f in enumerate(merged):
         try:
             emit_mod.validate_finding(f)
             valid_findings.append(f)
         except emit_mod.ValidationError as exc:
-            errors.append(f"finding[{idx}] ({f.get('check_id','?')}): {exc}")
-
-    if errors:
-        for err in errors:
-            print(f"merge-findings: VALIDATION ERROR: {err}", file=sys.stderr)
-        return 1
+            print(
+                f"merge-findings: WARNING: skipping post-rubric invalid finding[{idx}] "
+                f"({f.get('check_id','?')}): {exc}",
+                file=sys.stderr,
+            )
 
     # ------------------------------------------------------------------
     # Step 8: Build output lines

--- a/modules/commands-extra/skills/audit/scripts/spine/normalize.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/normalize.py
@@ -42,13 +42,35 @@ def compute_fingerprint(file_lines, line_no, gen=1):
     return "{0}:{1}".format(digest[:16], gen)
 
 
+_FINGERPRINT_RE = re.compile(r"^[A-Za-z0-9_.:+/=-]{8,128}$")
+
+
+def validate_tool_fingerprint(tool_fp):
+    """
+    Return the stripped tool-supplied fingerprint if it matches the finding
+    schema fingerprint pattern ^[A-Za-z0-9_.:+/=-]{8,128}$, otherwise None.
+
+    Semgrep emits 'requires login' (contains a space) when not authenticated
+    to Semgrep Cloud; that placeholder fails the schema and must be discarded
+    so callers fall back to compute_fingerprint().
+    """
+    stripped = tool_fp.strip() if tool_fp else ""
+    if stripped and _FINGERPRINT_RE.match(stripped):
+        return stripped
+    return None
+
+
 def fingerprint_from_tool(tool_fp):
     """
-    Use a tool-supplied fingerprint verbatim (stripped).
+    Return a validated tool-supplied fingerprint (stripped), or None if the
+    value fails the fingerprint schema pattern ^[A-Za-z0-9_.:+/=-]{8,128}$.
+
     Per plan ss3.7: where a spine tool emits its own partialFingerprints,
-    use the tool's fingerprint verbatim.
+    use the tool's fingerprint -- but only if it is schema-valid.  Invalid
+    values (e.g. semgrep's 'requires login' placeholder when not logged into
+    Semgrep Cloud) are discarded so callers fall back to compute_fingerprint().
     """
-    return tool_fp.strip()
+    return validate_tool_fingerprint(tool_fp)
 
 
 def make_content_fingerprint(content, gen=1):

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-actionlint.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-actionlint.py
@@ -94,12 +94,14 @@ def process_zizmor(data, repo_root):
 
             line_no = max(1, int(region.get("startLine", 1)))
 
-            # Use tool fingerprint if present
+            # Use tool fingerprint when schema-valid;
+            # fingerprint_from_tool returns None for invalid values.
             fps = result.get("partialFingerprints", {})
             tool_fp = fps.get("primaryLocationLineHash", "")
+            fp = None
             if tool_fp:
                 fp = normalize.fingerprint_from_tool(tool_fp)
-            else:
+            if fp is None:
                 fp = normalize.make_content_fingerprint(
                     "{0}:{1}:{2}".format(file_path, line_no, rule_id)
                 )

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-semgrep.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-semgrep.py
@@ -98,10 +98,14 @@ def main(argv):
         severity = map_severity(sev_raw)
         confidence = map_confidence(meta)
 
-        # Fingerprint
+        # Fingerprint: use the tool's fingerprint only when it is schema-valid
+        # (fingerprint_from_tool returns None for invalid values such as
+        # semgrep's 'requires login' placeholder emitted without Semgrep Cloud
+        # authentication). Fall back to content-based fingerprint on None.
+        fp = None
         if tool_fp:
             fp = normalize.fingerprint_from_tool(tool_fp)
-        else:
+        if fp is None:
             fp = normalize.make_content_fingerprint(
                 "{0}:{1}:{2}:{3}".format(path, start_line, rule_id, lines_ctx)
             )

--- a/modules/commands-extra/skills/audit/scripts/spine/parse-zizmor.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/parse-zizmor.py
@@ -151,12 +151,14 @@ def process_zizmor_sarif(data, repo_root):
 
             line_no = max(1, int(region.get("startLine", 1)))
 
-            # Prefer tool-supplied fingerprint
+            # Prefer tool-supplied fingerprint when schema-valid;
+            # fingerprint_from_tool returns None for invalid values.
             fps = result.get("partialFingerprints", {})
             tool_fp = fps.get("primaryLocationLineHash", "")
+            fp = None
             if tool_fp:
                 fp = normalize.fingerprint_from_tool(tool_fp)
-            else:
+            if fp is None:
                 fp = normalize.make_content_fingerprint(
                     "{0}:{1}:{2}".format(file_path, line_no, rule_id_raw)
                 )

--- a/modules/commands-extra/skills/audit/tests/test-merge.sh
+++ b/modules/commands-extra/skills/audit/tests/test-merge.sh
@@ -1012,9 +1012,11 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 8b: invalid finding (string line) -> exit 1 with actionable message
+# Test 8b: invalid finding (string line) -> skipped with WARNING, exit 0
+# (FIX 2: one bad finding must not abort the whole merge run; merge exits 0
+#  and emits a WARNING to stderr so the caller can see what was skipped.)
 # ---------------------------------------------------------------------------
-printf '\nTest 8b: invalid finding (string line) -> exit 1 with actionable message\n'
+printf '\nTest 8b: invalid finding (string line) -> skip+warn, exits 0\n'
 
 T8B_FP="445566778899bbcc:1"
 
@@ -1032,7 +1034,7 @@ with open(out, "w") as fh:
           "detection": "llm",
           "source": "llm",
           "message": "eslint violation",
-          # line is a string instead of int -- malformed input
+          # line is a string instead of int -- malformed but should not abort
           "location": {"path": "src/app.js", "line": "7"},
           "fingerprint": fp
         }
@@ -1049,17 +1051,18 @@ T8B_STDERR="$(python3 "$MERGE_SCRIPT" --spine "$T8_DIR/spine_empty.jsonl" \
 T8B_EXIT=$?
 set -e
 
-if [[ $T8B_EXIT -eq 1 ]]; then
-  pass "t8b: merge exits 1 on string-line finding"
+# Merge must exit 0: one bad finding is skipped, not fatal
+if [[ $T8B_EXIT -eq 0 ]]; then
+  pass "t8b: merge exits 0 (bad finding skipped, not fatal)"
 else
-  fail "t8b: merge exits $T8B_EXIT (expected 1 for malformed input)"
+  fail "t8b: merge exits $T8B_EXIT (expected 0; bad finding should be skipped)"
 fi
 
-# Assert actionable error message (not a bare traceback)
-if echo "$T8B_STDERR" | grep -q "VALIDATION ERROR\|location.line must be"; then
-  pass "t8b: stderr contains actionable error message (not a traceback)"
+# Assert WARNING in stderr mentioning the skipped finding
+if echo "$T8B_STDERR" | grep -q "WARNING.*skipping\|skipping invalid finding"; then
+  pass "t8b: stderr contains skip-warning for the invalid finding"
 else
-  fail "t8b: stderr does not contain actionable error message (got: $T8B_STDERR)"
+  fail "t8b: stderr does not contain skip-warning (got: $T8B_STDERR)"
 fi
 
 # Assert no traceback leaked

--- a/modules/commands-extra/skills/audit/tests/test-pack-ci-cd.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-ci-cd.sh
@@ -405,19 +405,26 @@ jobs:
       - uses: actions/checkout@v4
 YAML
 
-  # Restricted PATH (no zizmor)
-  SYSTEM_BINS=""
-  for bin in python3 bash find date mktemp cp rm mv printf head grep; do
-    BINPATH="$(command -v "$bin" 2>/dev/null || true)"
-    if [[ -n "$BINPATH" ]]; then
-      BINDIR="$(dirname "$BINPATH")"
-      case ":$SYSTEM_BINS:" in
-        *":$BINDIR:"*) ;;
-        *) SYSTEM_BINS="${SYSTEM_BINS:+$SYSTEM_BINS:}$BINDIR" ;;
-      esac
-    fi
+  # Build a deterministic scratch PATH that excludes zizmor and pinact.
+  # bash and python3 are linked from their currently-active location (may be
+  # homebrew on macOS) so bash 4+ and the real python3 are available.
+  # All other tools come from /usr/bin and /bin only, excluding homebrew
+  # audit tools (zizmor, pinact, etc.) from leaking in.
+  SCRATCH_BINDIR="${TESTRUN_TMPDIR}/scratch-bin"
+  mkdir -p "$SCRATCH_BINDIR"
+  for _bin in bash python3; do
+    _src="$(command -v "$_bin" 2>/dev/null || true)"
+    [[ -n "$_src" ]] && ln -sf "$_src" "$SCRATCH_BINDIR/$_bin" 2>/dev/null || true
   done
-  RESTRICTED_PATH="$SYSTEM_BINS:/usr/bin:/bin"
+  for _bin in find dirname date mktemp cp rm mv printf head grep cat; do
+    for _dir in /usr/bin /bin; do
+      if [[ -x "$_dir/$_bin" ]]; then
+        ln -sf "$_dir/$_bin" "$SCRATCH_BINDIR/$_bin" 2>/dev/null || true
+        break
+      fi
+    done
+  done
+  RESTRICTED_PATH="$SCRATCH_BINDIR"
 
   ZI_SKIP_OUT="${TESTRUN_TMPDIR}/zi-skip.jsonl"
   set +e

--- a/modules/commands-extra/skills/audit/tests/test-pack-data-migrations.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-data-migrations.sh
@@ -175,19 +175,29 @@ SECURITY DEFINER
 AS $$ SELECT 1; $$;
 SQLEOF
 
-# Build a PATH that excludes squawk and sqlfluff
-SYSTEM_BINS=""
-for bin in python3 bash find mktemp rm printf head grep; do
-  BINPATH="$(command -v "$bin" 2>/dev/null || true)"
-  if [[ -n "$BINPATH" ]]; then
-    BINDIR="$(dirname "$BINPATH")"
-    case ":$SYSTEM_BINS:" in
-      *":$BINDIR:"*) ;;
-      *) SYSTEM_BINS="${SYSTEM_BINS:+$SYSTEM_BINS:}$BINDIR" ;;
-    esac
-  fi
+# Build a deterministic scratch PATH that excludes squawk and sqlfluff.
+# Strategy: create a tmpdir with symlinks to only the required binaries.
+# For bash and python3, use the currently-active interpreter (may be homebrew
+# on macOS) so that bash 4+ associative arrays and the real python3 are
+# available.  All other tools come from /usr/bin and /bin only so that
+# homebrew-installed audit tools (squawk, sqlfluff, etc.) cannot leak in.
+SCRATCH_BINDIR="$TESTRUN_TMPDIR/scratch-bin"
+mkdir -p "$SCRATCH_BINDIR"
+# bash and python3: use command -v (real version, may be homebrew on macOS)
+for _bin in bash python3; do
+  _src="$(command -v "$_bin" 2>/dev/null || true)"
+  [[ -n "$_src" ]] && ln -sf "$_src" "$SCRATCH_BINDIR/$_bin" 2>/dev/null || true
 done
-RESTRICTED_PATH="$SYSTEM_BINS:/usr/bin:/bin"
+# All other tools: system paths only to exclude homebrew audit tools
+for _bin in find dirname date mktemp rm cp printf head grep cat; do
+  for _dir in /usr/bin /bin; do
+    if [[ -x "$_dir/$_bin" ]]; then
+      ln -sf "$_dir/$_bin" "$SCRATCH_BINDIR/$_bin" 2>/dev/null || true
+      break
+    fi
+  done
+done
+RESTRICTED_PATH="$SCRATCH_BINDIR"
 
 SQUAWK_OUT="$TESTRUN_TMPDIR/squawk-graceful.jsonl"
 set +e

--- a/modules/commands-extra/skills/audit/tests/test-pack-dependencies-deep.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-dependencies-deep.sh
@@ -64,19 +64,26 @@ fail() {
 TESTRUN_TMPDIR="$(mktemp -d /tmp/ccgm-test-deps-deep-XXXXXX)"
 trap 'rm -rf "$TESTRUN_TMPDIR"' EXIT
 
-# Build a restricted PATH that excludes pip-audit, cargo-audit, bundle-audit
-SYSTEM_BINS=""
-for bin in python3 bash find mktemp rm printf head grep; do
-  BINPATH="$(command -v "$bin" 2>/dev/null || true)"
-  if [[ -n "$BINPATH" ]]; then
-    BINDIR="$(dirname "$BINPATH")"
-    case ":$SYSTEM_BINS:" in
-      *":$BINDIR:"*) ;;
-      *) SYSTEM_BINS="${SYSTEM_BINS:+$SYSTEM_BINS:}$BINDIR" ;;
-    esac
-  fi
+# Build a deterministic scratch PATH that excludes pip-audit, cargo-audit,
+# and bundle-audit.  bash and python3 are linked from their currently-active
+# location (may be homebrew on macOS) so bash 4+ and the real python3 are
+# available.  All other tools come from /usr/bin and /bin only, excluding
+# homebrew audit tools from leaking in.
+SCRATCH_BINDIR="$TESTRUN_TMPDIR/scratch-bin"
+mkdir -p "$SCRATCH_BINDIR"
+for _bin in bash python3; do
+  _src="$(command -v "$_bin" 2>/dev/null || true)"
+  [[ -n "$_src" ]] && ln -sf "$_src" "$SCRATCH_BINDIR/$_bin" 2>/dev/null || true
 done
-RESTRICTED_PATH="$SYSTEM_BINS:/usr/bin:/bin"
+for _bin in find dirname date mktemp rm cp printf head grep cat; do
+  for _dir in /usr/bin /bin; do
+    if [[ -x "$_dir/$_bin" ]]; then
+      ln -sf "$_dir/$_bin" "$SCRATCH_BINDIR/$_bin" 2>/dev/null || true
+      break
+    fi
+  done
+done
+RESTRICTED_PATH="$SCRATCH_BINDIR"
 
 # ---------------------------------------------------------------------------
 # Test 1: pack.json validates via lint-pack.py (no rubric)

--- a/modules/commands-extra/skills/audit/tests/test-pack-infra.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-infra.sh
@@ -196,19 +196,26 @@ else
   pass "wrap-checkov.sh file exists"
 fi
 
-# Build a minimal PATH that excludes checkov
-SYSTEM_BINS=""
-for bin in python3 bash find date mktemp cp rm mv printf head grep; do
-  BINPATH="$(command -v "$bin" 2>/dev/null || true)"
-  if [[ -n "$BINPATH" ]]; then
-    BINDIR="$(dirname "$BINPATH")"
-    case ":$SYSTEM_BINS:" in
-      *":$BINDIR:"*) ;;
-      *) SYSTEM_BINS="${SYSTEM_BINS:+$SYSTEM_BINS:}$BINDIR" ;;
-    esac
-  fi
+# Build a deterministic scratch PATH that excludes checkov.
+# bash and python3 are linked from their currently-active location (may be
+# homebrew on macOS) so bash 4+ and the real python3 are available.
+# All other tools come from /usr/bin and /bin only, excluding homebrew
+# audit tools (checkov, etc.) from leaking in.
+SCRATCH_BINDIR="$TESTRUN_TMPDIR/scratch-bin"
+mkdir -p "$SCRATCH_BINDIR"
+for _bin in bash python3; do
+  _src="$(command -v "$_bin" 2>/dev/null || true)"
+  [[ -n "$_src" ]] && ln -sf "$_src" "$SCRATCH_BINDIR/$_bin" 2>/dev/null || true
 done
-RESTRICTED_PATH="$SYSTEM_BINS:/usr/bin:/bin"
+for _bin in find dirname date mktemp cp rm mv printf head grep cat; do
+  for _dir in /usr/bin /bin; do
+    if [[ -x "$_dir/$_bin" ]]; then
+      ln -sf "$_dir/$_bin" "$SCRATCH_BINDIR/$_bin" 2>/dev/null || true
+      break
+    fi
+  done
+done
+RESTRICTED_PATH="$SCRATCH_BINDIR"
 
 WRAP_OUTPUT="$TESTRUN_TMPDIR/wrap-checkov-absent.jsonl"
 set +e


### PR DESCRIPTION
## Summary

- **FIX 1 (normalize.py + parsers)**: Add `_FINGERPRINT_RE` pattern and `fingerprint_from_tool()` to `normalize.py`. Returns `None` for invalid fingerprints (e.g. semgrep's `"requires login"` placeholder which contains a space and fails the `^[A-Za-z0-9_.:+/=-]{8,128}$` schema). `parse-semgrep.py`, `parse-zizmor.py`, and `parse-actionlint.py` now validate-or-compute: if the tool fingerprint is invalid, they fall back to `make_content_fingerprint()`. Fixes the crash where `merge-findings.py` received `"requires login"` as a fingerprint and exited 1.

- **FIX 2 (merge-findings.py)**: `_validate_before_sort()` changed from exit-1-on-any-invalid to skip-with-WARNING. One bad finding among many (e.g. `location.line` as a string) now emits a warning to stderr and skips that finding instead of aborting the entire merge. Exit 1 is reserved for truly malformed input structure (unparseable JSONL, missing CLI args). `test-merge.sh` test `t8b` updated to assert exit 0 + skip-warning.

- **FIX 3 (4 test files)**: Replace the `SYSTEM_BINS` PATH construction (which on macOS with Homebrew included `/opt/homebrew/bin` and leaked all audit tools) with a deterministic scratch bindir. `bash` and `python3` are symlinked from `command -v` (real version, Homebrew on macOS) so that bash 4+ associative arrays and real Python work. All other tools come from `/usr/bin` and `/bin` only, ensuring no homebrew audit tools (`squawk`, `sqlfluff`, `zizmor`, `pinact`, `checkov`, `pip-audit`, `cargo-audit`, `bundler-audit`) can leak in.

## Test plan

- [x] 31/31 audit test suites pass (`tests/run-audit-suite.sh`)
- [x] `grep -nE 'AKIA[A-Z0-9]{12,}'` on all touched test files returns empty (ADV-009 clean)
- [x] FIX 1 verified: semgrep with `"requires login"` fingerprint produces valid computed fingerprint, merge exits 0, finding present
- [x] FIX 2 verified: mix of one invalid + two valid findings produces exit 0, warning on stderr, 2 valid findings in output
- [x] FIX 3 verified: Tests 5/6 in data-migrations, Test 7 in infra, Tests 4/5 in ci-cd, Tests 5-10/21 in dependencies-deep all pass