### PR TITLE
#650: statusline: render Fable as flagship (F-{ver})

### DIFF
--- a/lib/statusline.sh
+++ b/lib/statusline.sh
@@ -5,15 +5,22 @@
 input=$(cat)
 
 # --- Model: render as "{family}-{version}" with a tier that drives color/emoji.
-# Family and version are parsed from display_name generically, so NEW MODEL
-# RELEASES NEED NO EDITS HERE. Examples:
-#   "Opus 4.8 (1M context)" -> 🧠 O-4.8   "Sonnet 4.6" -> 🐢 S-4.6   "Haiku 4.5" -> ⚠️ H-4.5
+# Family and version are parsed from display_name generically, so new VERSIONS
+# of known families need no edits here; a new FAMILY needs one case branch.
+# Examples:
+#   "Fable 5" -> 🧠 F-5   "Opus 4.8 (1M context)" -> 🧠 O-4.8
+#   "Sonnet 4.6" -> 🐢 S-4.6   "Haiku 4.5" -> ⚠️ H-4.5
 model_raw=$(echo "$input" | jq -r '.model.display_name // ""')
 
 # First version token in the name, e.g. "4.8" (empty when the name has none).
 model_ver=$(printf '%s' "$model_raw" | grep -oE '[0-9]+(\.[0-9]+)?' | head -n1)
 
 case "$model_raw" in
+  *Fable*)
+    # Fable is the tier above Opus — always flagship.
+    model_abbr="F${model_ver:+-$model_ver}"
+    model_tier="flagship"
+    ;;
   *Opus*)
     model_abbr="O${model_ver:+-$model_ver}"
     # Opus is flagship (🧠) at 4.6 or newer, plain below. The check is numeric
@@ -21,7 +28,7 @@ case "$model_raw" in
     ver_major=${model_ver%%.*}; ver_minor=${model_ver#*.}
     [ "$ver_minor" = "$model_ver" ] && ver_minor=0
     if [ "${ver_major:-0}" -gt 4 ] || { [ "${ver_major:-0}" -eq 4 ] && [ "${ver_minor:-0}" -ge 6 ]; }; then
-      model_tier="opus-best"
+      model_tier="flagship"
     else
       model_tier="opus-other"
     fi
@@ -145,7 +152,7 @@ if [ -n "$model_abbr" ]; then
     fi
   fi
   case "$model_tier" in
-    opus-best)
+    flagship)
       sections+=("$(printf "${BLUE}🧠 %s${RESET}%s" "$model_abbr" "$effort_suffix")")
       ;;
     sonnet)

--- a/modules/commands-utility/tests/test_statusline.sh
+++ b/modules/commands-utility/tests/test_statusline.sh
@@ -43,7 +43,18 @@ check() {  # $1 = display_name, $2 = expected model field
 
 echo "=== statusline model rendering ==="
 
+# --- Source parity: the installed module copy must match lib/statusline.sh ---
+# Both files ship the same script; an edit to one without the other silently
+# desyncs the installed statusline from the tested one.
+if diff -q "$STATUSLINE" "$REPO_ROOT/modules/commands-utility/statusline-command.sh" >/dev/null 2>&1; then
+  PASS=$((PASS + 1)); echo "  PASS: lib/statusline.sh == modules/commands-utility/statusline-command.sh"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: lib/statusline.sh and modules/commands-utility/statusline-command.sh differ"
+fi
+
 # --- Current models (must match prior behavior exactly) ---
+check "Fable 5"               "🧠 F-5"
+check "Fable 5 (1M context)"  "🧠 F-5"
 check "Opus 4.8 (1M context)" "🧠 O-4.8"
 check "Opus 4.8"              "🧠 O-4.8"
 check "Opus 4.7"              "🧠 O-4.7"
@@ -57,6 +68,8 @@ check "Haiku 4.5"             "⚠️ H-4.5"
 check "Haiku"                 "⚠️ H"
 
 # --- Future models: NO code edit should ever be needed for these ---
+check "Fable 5.1"             "🧠 F-5.1"
+check "Fable 6"               "🧠 F-6"
 check "Opus 4.9"              "🧠 O-4.9"
 check "Opus 4.10"             "🧠 O-4.10"
 check "Opus 5"                "🧠 O-5"
@@ -94,6 +107,10 @@ M='{"model":{"display_name":"Opus 4.8"},"cwd":"'"$TMPHOME"'"'
 # Baseline effort labels (no ultracode) — must be unchanged.
 check_effort "max"               "$M,\"effort\":{\"level\":\"max\"}}"                     "$TMPHOME" "🧠 O-4.8 Max"
 check_effort "xhigh"             "$M,\"effort\":{\"level\":\"xhigh\"}}"                   "$TMPHOME" "🧠 O-4.8 XH"
+# Fable at xhigh — the exact scenario from the "Fable Max" bug report. stdin
+# effort must win over any stale persisted/env source and render XH, not Max.
+F='{"model":{"display_name":"Fable 5"},"cwd":"'"$TMPHOME"'"'
+check_effort "fable xhigh"       "$F,\"effort\":{\"level\":\"xhigh\"}}"                   "$TMPHOME" "🧠 F-5 XH"
 # Ultracode keeps the accurate effort (always xhigh -> XH) and bookends with ✨.
 # Via stdin .effort.level=="ultracode" (defensive: no effort case -> forced XH).
 check_effort "effort=ultracode"  "$M,\"effort\":{\"level\":\"ultracode\"}}"               "$TMPHOME" "🧠 O-4.8 ✨XH✨"


### PR DESCRIPTION
Closes #650

## Summary
- Add `*Fable*` case branch to `lib/statusline.sh`: renders `F-{ver}` (e.g. `🧠 F-5`) with flagship tier — previously fell through to the unknown-family fallback and rendered plain "Fable" with no version, emoji, or color.
- Rename internal tier `opus-best` -> `flagship` since it now covers Fable + Opus >= 4.6.
- `modules/commands-utility/statusline-command.sh` is a repo symlink to `lib/statusline.sh`, so the installed statusline picks this up on canonical sync.

Context: surfaced while debugging a "Fable Max" effort-display report. The effort half was config, not code — a stale `CLAUDE_CODE_EFFORT_LEVEL=max` in the settings.json `env` block was overriding the persisted `effortLevel: xhigh` per session (CC honors that env var as a per-session effort override). Fixed locally by removing the env entry; this PR covers the rendering half.

## Test Plan
- `test_statusline.sh`: 33/33 pass — adds Fable current ("Fable 5", "Fable 5 (1M context)") and future ("Fable 5.1", "Fable 6") render cases, a Fable+xhigh effort end-to-end case (`🧠 F-5 XH`), and a lib/module source-parity assertion.
- `tests/test-no-personal-data.sh`: pass.