### PR TITLE
#654: fix stale module/preset counts in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ ccgm/
 │   ├── merge.sh        # settings.json merge via jq
 │   ├── modules.sh      # Module discovery + deps
 │   └── backup.sh       # Backup/restore
-├── modules/            # 66 self-contained modules
+├── modules/            # 68 self-contained modules
 │   └── {name}/
 │       ├── module.json # Manifest
 │       ├── README.md   # Module docs

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,14 +33,15 @@ The interactive installer handles everything from here.
 
 ### 2. Choose a preset (or pick modules individually)
 
-The installer offers four presets, or you can select modules one by one:
+The installer offers five presets, or you can select modules one by one:
 
 | Preset | What you get | Best for |
 |--------|-------------|----------|
 | **minimal** | Core autonomy + git workflow rules | Trying CCGM for the first time |
 | **standard** | Minimal + hooks, settings, core commands | Most individual developers |
 | **team** | Standard + github-protocols, code-quality, debugging, verification | Teams with shared repos |
-| **full** | 48 modules | Power users who want everything |
+| **full** | 50 modules | Power users who want everything |
+| **cloud-agent** | Full minus desktop-only modules, plus agent orchestration | Headless cloud VMs dispatching parallel agents |
 
 See [Presets](presets.md) for detailed breakdowns.
 


### PR DESCRIPTION
Closes #654

## Summary

Post-merge `/docupdate` sweep after #653 caught pre-existing count drift the module-add PR didn't touch.

## Changes

- `CLAUDE.md` structure diagram: 66 → 68 self-contained modules
- `docs/getting-started.md` preset table: full 48 → 50 modules, added the missing `cloud-agent` row, "four presets" → "five presets"

## Test Plan

- `bash tests/test-no-personal-data.sh` — PASS
- Counts verified against `ls modules/*/module.json | wc -l` (68) and `presets/full.json` length (50)