### PR TITLE
#662: scope backups to install target (no cross-scope restore)

### DIFF
--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -1,13 +1,29 @@
 #!/usr/bin/env bash
 # CCGM - Backup and restore
 
+# --- Resolve the backup base for a given install target ---
+# Backups are scoped to the install target so a project-scope (.claude/) install
+# never writes to or restores from the global ~/.claude/backups (and vice-versa).
+# The backups dir sits alongside the target (<target>/backups), so a project
+# target's backups live under that project's .claude/backups.
+# Usage: backup_base_for "/target/dir"
+backup_base_for() {
+  local target_dir="$1"
+  if [ -z "$target_dir" ]; then
+    echo "${HOME}/.claude/backups"
+    return 0
+  fi
+  echo "${target_dir%/}/backups"
+}
+
 # --- Create timestamped backup ---
 # Usage: create_backup "/target/dir"
-# Backs up existing config files to ~/.claude/backups/ccgm-YYYYMMDD-HHMMSS/
+# Backs up existing config files to <target>/backups/ccgm-YYYYMMDD-HHMMSS/
 # Returns the backup directory path on stdout
 create_backup() {
   local target_dir="$1"
-  local backup_base="${HOME}/.claude/backups"
+  local backup_base
+  backup_base=$(backup_base_for "$target_dir")
   local timestamp
   timestamp=$(date '+%Y%m%d-%H%M%S')
   local backup_dir="${backup_base}/ccgm-${timestamp}"
@@ -84,18 +100,21 @@ restore_backup() {
     mkdir -p "$target_dir"
   fi
 
-  # Copy everything from backup to target
-  cp -r "${backup_dir}/"* "$target_dir/" 2>/dev/null
+  # Copy everything from backup to target. The globs may not match (empty
+  # backup, or no hidden files); tolerate that without aborting under `set -e`.
+  cp -r "${backup_dir}/"* "$target_dir/" 2>/dev/null || true
   # Also restore hidden files
-  cp -r "${backup_dir}/".[!.]* "$target_dir/" 2>/dev/null
+  cp -r "${backup_dir}/".[!.]* "$target_dir/" 2>/dev/null || true
 
   return 0
 }
 
 # --- List available backups ---
-# Prints each backup dir, newest first
+# Usage: list_backups ["/target/dir"]
+# Prints each backup dir for the target's scope, newest first.
 list_backups() {
-  local backup_base="${HOME}/.claude/backups"
+  local backup_base
+  backup_base=$(backup_base_for "${1:-}")
   if [ ! -d "$backup_base" ]; then
     return 0
   fi
@@ -113,8 +132,10 @@ list_backups() {
 }
 
 # --- Get most recent backup ---
+# Usage: get_latest_backup ["/target/dir"]
 get_latest_backup() {
-  local backup_base="${HOME}/.claude/backups"
+  local backup_base
+  backup_base=$(backup_base_for "${1:-}")
   if [ ! -d "$backup_base" ]; then
     return 1
   fi
@@ -123,9 +144,11 @@ get_latest_backup() {
 }
 
 # --- Clean old backups (keep N most recent) ---
+# Usage: clean_backups [keep] ["/target/dir"]
 clean_backups() {
   local keep="${1:-5}"
-  local backup_base="${HOME}/.claude/backups"
+  local backup_base
+  backup_base=$(backup_base_for "${2:-}")
 
   if [ ! -d "$backup_base" ]; then
     return 0

--- a/start.sh
+++ b/start.sh
@@ -1025,6 +1025,8 @@ main() {
     if [ -n "$backup_path" ]; then
       BACKUP_DIRS+=("$backup_path")
       ui_success "Global config backed up to: $backup_path"
+      # Bound backup growth: keep the 5 most recent global-scope backups.
+      clean_backups 5 "$global_dir"
     else
       ui_info "No existing global config to back up"
     fi
@@ -1035,6 +1037,8 @@ main() {
     if [ -n "$backup_path" ]; then
       BACKUP_DIRS+=("$backup_path")
       ui_success "Project config backed up to: $backup_path"
+      # Bound backup growth: keep the 5 most recent project-scope backups.
+      clean_backups 5 "$project_dir"
     else
       ui_info "No existing project config to back up"
     fi

--- a/tests/test-backup.sh
+++ b/tests/test-backup.sh
@@ -231,6 +231,94 @@ else
 fi
 echo ""
 
+# --- Test 7: Backups are scoped to the install target (no cross-scope) ---
+echo "--- Test 7: Backup scope isolation (global vs project) ---"
+
+# Global target lives under $HOME/.claude; project target under a project dir.
+GLOBAL_TARGET="$HOME/.claude"
+PROJECT_DIR="$TMPDIR/project"
+PROJECT_TARGET="$PROJECT_DIR/.claude"
+mkdir -p "$PROJECT_TARGET"
+
+# Distinct content per scope so we can detect cross-scope bleed.
+echo '{"scope": "global"}' > "$GLOBAL_TARGET/settings.json"
+echo '{"scope": "project"}' > "$PROJECT_TARGET/settings.json"
+
+global_backup=$(create_backup "$GLOBAL_TARGET")
+project_backup=$(create_backup "$PROJECT_TARGET")
+
+# Each backup must land under its own scope's backups dir.
+if [[ "$global_backup" == "$GLOBAL_TARGET/backups/"* ]]; then
+  pass "Global backup written under global scope ($GLOBAL_TARGET/backups)"
+else
+  fail "Global backup not scoped to global target: $global_backup"
+fi
+
+if [[ "$project_backup" == "$PROJECT_TARGET/backups/"* ]]; then
+  pass "Project backup written under project scope ($PROJECT_TARGET/backups)"
+else
+  fail "Project backup not scoped to project target: $project_backup"
+fi
+
+# A project backup must NOT appear in the global backups dir.
+if [ -d "$GLOBAL_TARGET/backups" ] && ls -1d "$GLOBAL_TARGET/backups"/ccgm-* >/dev/null 2>&1; then
+  # Global backups exist (expected); ensure none of them carry project content.
+  cross_scope=false
+  for b in "$GLOBAL_TARGET/backups"/ccgm-*; do
+    if [ -f "$b/settings.json" ] && grep -q '"scope": "project"' "$b/settings.json"; then
+      cross_scope=true
+    fi
+  done
+  if [ "$cross_scope" = false ]; then
+    pass "Global backups dir contains no project-scope content"
+  else
+    fail "Project content leaked into global backups dir"
+  fi
+else
+  fail "Expected global backups dir to exist after global backup"
+fi
+
+# Restoring a project backup must reproduce project content, not global.
+PROJECT_RESTORE="$TMPDIR/project-restore"
+mkdir -p "$PROJECT_RESTORE"
+restore_backup "$project_backup" "$PROJECT_RESTORE"
+if [ -f "$PROJECT_RESTORE/settings.json" ] && grep -q '"scope": "project"' "$PROJECT_RESTORE/settings.json"; then
+  pass "Project restore reproduces project-scope content"
+else
+  fail "Project restore did not reproduce project-scope content"
+fi
+
+# get_latest_backup must respect scope: project scope sees only project backups.
+latest_project=$(get_latest_backup "$PROJECT_TARGET" 2>/dev/null || true)
+if [ "$latest_project" = "$project_backup" ]; then
+  pass "get_latest_backup scoped to project target returns project backup"
+else
+  fail "get_latest_backup project scope returned '$latest_project', expected '$project_backup'"
+fi
+echo ""
+
+# --- Test 8: clean_backups respects scope ---
+echo "--- Test 8: clean_backups scoped to install target ---"
+
+SCOPE_BASE="$PROJECT_TARGET/backups"
+# Clear and seed project-scope backups.
+rm -rf "$SCOPE_BASE"/ccgm-*
+for i in 1 2 3 4 5; do
+  bdir="$SCOPE_BASE/ccgm-2026050${i}-120000"
+  mkdir -p "$bdir"
+  echo "scoped backup $i" > "$bdir/settings.json"
+done
+
+clean_backups 2 "$PROJECT_TARGET"
+
+scoped_after=$(ls -1d "$SCOPE_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ')
+if [ "$scoped_after" -eq 2 ]; then
+  pass "clean_backups(2) scoped to project kept exactly 2 backups"
+else
+  fail "clean_backups scoped to project kept $scoped_after, expected 2"
+fi
+echo ""
+
 # --- Summary ---
 echo "==================================="
 echo "  Results: $PASS passed, $FAIL failed"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -116,6 +116,8 @@ main() {
   backup_path=$(create_backup "$global_dir")
   if [ -n "$backup_path" ]; then
     ui_success "Safety backup created: $backup_path"
+    # Bound backup growth: keep the 5 most recent global-scope backups.
+    clean_backups 5 "$global_dir"
   else
     ui_info "No files to back up"
   fi
@@ -257,7 +259,7 @@ main() {
   fi
 
   local latest_backup
-  latest_backup=$(get_latest_backup 2>/dev/null || true)
+  latest_backup=$(get_latest_backup "$global_dir" 2>/dev/null || true)
   if [ -n "$latest_backup" ] && [ "$latest_backup" != "${backup_path:-}" ]; then
     echo ""
     ui_info "Previous backups available in ~/.claude/backups/"


### PR DESCRIPTION
## Summary

Project-scope (`.claude/`) backups were always written to and restored from the **global** `~/.claude/backups`, so a project restore could pull global backups and a global restore could pull project backups (cross-scope corruption). This scopes backup/restore to the install target. Also wires up `clean_backups()`, which was implemented and tested but never called (unbounded backup growth).

## Root cause

`lib/backup.sh` hardcoded `backup_base="${HOME}/.claude/backups"` in `create_backup`, `restore_backup` (via `get_latest_backup`/callers), `list_backups`, `get_latest_backup`, and `clean_backups`. `start.sh` calls `create_backup "$project_dir"` for project installs, but the backup still landed under the global base. `clean_backups()` had no caller outside its own test.

## Changes

- `lib/backup.sh`: add `backup_base_for "<target>"` which derives `<target>/backups` (falls back to `~/.claude/backups` when no target is given). `create_backup`, `list_backups`, `get_latest_backup`, and `clean_backups` now resolve their base from the target scope. Hardened `restore_backup` cp globs with `|| true` so a backup with no hidden files does not abort callers running under `set -e`.
- `start.sh`: invoke `clean_backups 5 "<scope>"` after each scoped backup (global and project) to bound growth.
- `uninstall.sh`: invoke `clean_backups 5 "$global_dir"` after the safety backup; pass `$global_dir` to `get_latest_backup` so the "previous backups" hint is scope-correct.
- `tests/test-backup.sh`: new Test 7 (scope isolation — project backup lives under project scope, global backups carry no project content, project restore reproduces project content, `get_latest_backup` is scoped) and Test 8 (`clean_backups` scoped to target).

## Test plan

- `bash tests/test-backup.sh` -> 23 passed, 0 failed (was RED on the 3 new scope assertions before the fix).
- `bash tests/test-no-personal-data.sh` -> PASS.
- `bash -n` on `lib/backup.sh`, `start.sh`, `uninstall.sh` -> all parse.

Closes #662
Part of #659