### PR TITLE
#663: remove personal data from session-history/remote-server/multi-agent

### DIFF
--- a/modules/multi-agent/commands/mawf.md
+++ b/modules/multi-agent/commands/mawf.md
@@ -149,10 +149,10 @@ Compare the output CWDs against the clone directories. Any clone directory that 
 In the execution plan presentation, mark occupied clones clearly:
 ```
 Wave 1 (parallel):
-  agent-w0-c0 (habitpro-ai-w0-c0): #42 - Add dark mode toggle
-  agent-w0-c1 (habitpro-ai-w0-c1): #43 - Fix login redirect
-  agent-w0-c2 (habitpro-ai-w0-c2): [OCCUPIED - PID 78859, up 2h, branch: 166-api-native] - SKIPPED
-  agent-w0-c3 (habitpro-ai-w0-c3): #44 - Update onboarding flow
+  agent-w0-c0 (myrepo-w0-c0): #42 - Add dark mode toggle
+  agent-w0-c1 (myrepo-w0-c1): #43 - Fix login redirect
+  agent-w0-c2 (myrepo-w0-c2): [OCCUPIED - PID 78859, up 2h, branch: 166-api-native] - SKIPPED
+  agent-w0-c3 (myrepo-w0-c3): #44 - Update onboarding flow
 ```
 
 If all available clones are occupied, report this and ask the user:

--- a/modules/multi-agent/commands/workspace-setup.md
+++ b/modules/multi-agent/commands/workspace-setup.md
@@ -29,13 +29,13 @@ $ARGUMENTS
 ### Phase 1: Parse Arguments
 
 Extract from `$ARGUMENTS`:
-- **repo-name** (required): The GitHub repo name (e.g., `habitpro-ai`)
+- **repo-name** (required): The GitHub repo name (e.g., `my-multi-word-repo`)
 - **workspace-count** (optional, default: 3): Number of workspaces (w0 through wN-1)
 - **clone-count** (optional, default: 4): Number of clones per workspace (c0 through cN-1)
 
 If repo-name is missing, ask:
 
-> "What GitHub repo should I set up workspaces for? (e.g., `habitpro-ai`)"
+> "What GitHub repo should I set up workspaces for? (e.g., `my-multi-word-repo`)"
 
 ### Phase 2: Detect GitHub Info
 

--- a/modules/multi-agent/multi-agent-system.md
+++ b/modules/multi-agent/multi-agent-system.md
@@ -62,15 +62,15 @@ Derived from the directory name pattern `{repo}-w{X}-c{Y}`:
 
 ```bash
 AGENT_ID=$(basename "$PWD" | grep -oP 'w\d+-c\d+$' | sed 's/^/agent-/')
-# habitpro-ai-w1-c2 -> agent-w1-c2
+# myrepo-w1-c2 -> agent-w1-c2
 ```
 
 | Directory | Agent ID |
 |-----------|----------|
-| `habitpro-ai-w0-c0` | agent-w0-c0 |
-| `habitpro-ai-w0-c3` | agent-w0-c3 |
-| `habitpro-ai-w1-c0` | agent-w1-c0 |
-| `habitpro-ai-w2-c3` | agent-w2-c3 |
+| `myrepo-w0-c0` | agent-w0-c0 |
+| `myrepo-w0-c3` | agent-w0-c3 |
+| `myrepo-w1-c0` | agent-w1-c0 |
+| `myrepo-w2-c3` | agent-w2-c3 |
 
 ### .env.clone File (Workspaces)
 
@@ -112,7 +112,7 @@ PORT_OFFSET=6
 
 ### Coordinator Role
 
-The coordinator agent runs in the workspace directory (e.g., `~/code/habitpro-ai-workspaces/habitpro-ai-w0/`). It:
+The coordinator agent runs in the workspace directory (e.g., `~/code/myrepo-workspaces/myrepo-w0/`). It:
 
 1. Receives a set of issues or a task from the human
 2. Discovers available clones by listing subdirectories
@@ -366,14 +366,11 @@ Each clone gets isolated ports to prevent collisions. Ports are assigned per-rep
 
 | Repo | Frontend Base | Backend Base |
 |------|--------------|-------------|
-| habitpro-ai | 5173 | 8787 |
-| openslide-ai | 5189 | 8803 |
-| lem-photo | 5205 | 8819 |
-| lem-work | 5221 | 8835 |
-| techenable | 5237 | 8851 |
-| lem-fyi | 5253 | 8867 |
-| nadaproof | 5269 | 8883 |
-| darkly-suite | 5285 | 8899 |
+| example-app | 5173 | 8787 |
+| example-monorepo | 5189 | 8803 |
+| ccgm | 5301 | 8915 |
+
+The entries shipped in `port-registry.json` are examples — add a row per repo you run, keeping each repo's base ports at least 16 apart so blocks do not overlap.
 
 Within each block, offset = `(workspace * clones_per_workspace) + clone` (workspace model) or `clone_number` (flat model).
 

--- a/modules/multi-agent/port-registry.json
+++ b/modules/multi-agent/port-registry.json
@@ -1,79 +1,24 @@
 {
-  "_comment": "Port allocation registry for multi-agent development. Each repo gets a block of 16 ports per service type. Within a block, offset = (workspace * clones_per_workspace) + clone. For flat clone repos, offset = clone_number.",
+  "_comment": "Port allocation registry for multi-agent development. Each repo gets a block of 16 ports per service type. Within a block, offset = (workspace * clones_per_workspace) + clone. For flat clone repos, offset = clone_number. The entries below are EXAMPLES showing the schema - replace them with your own repos. Keep each repo's base ports at least 16 apart so blocks do not overlap.",
   "_block_size": 16,
   "_formula": "port = base_port + PORT_OFFSET (from .env.clone)",
   "repos": {
-    "habitpro-ai": {
+    "example-app": {
       "frontend": 5173,
       "backend": 8787,
-      "notes": "Vite + Wrangler API"
+      "notes": "Vite frontend + Wrangler API (example entry)"
     },
-    "openslide-ai": {
+    "example-monorepo": {
       "frontend": 5189,
       "backend": 8803,
-      "notes": "Vite editor + Wrangler worker"
-    },
-    "lem-photo": {
-      "frontend": 5205,
-      "backend": 8819,
-      "notes": "Vite client + tsx server"
-    },
-    "lem-work": {
-      "frontend": 5221,
-      "backend": 8835,
-      "notes": "Vite client + Wrangler worker"
-    },
-    "techenable": {
-      "frontend": 5237,
-      "backend": 8851,
       "extra": {
-        "blog": 4321
+        "docs": 4321
       },
-      "notes": "Vite web + Wrangler worker + Astro blog"
-    },
-    "lem-fyi": {
-      "frontend": 5253,
-      "backend": 8867,
-      "notes": "browser-sync / static build"
-    },
-    "nadaproof": {
-      "frontend": 5269,
-      "backend": 8883,
-      "notes": "Supabase-backed"
-    },
-    "darkly-suite": {
-      "frontend": 5285,
-      "backend": 8899,
-      "notes": "Chrome extension monorepo"
+      "notes": "Frontend + worker + extra docs port (example entry)"
     },
     "ccgm": {
       "frontend": 5301,
       "backend": 8915,
-      "notes": "TBD"
-    },
-    "human-of-habit": {
-      "frontend": 5317,
-      "backend": 8931,
-      "notes": "TBD"
-    },
-    "sightagent": {
-      "frontend": 5333,
-      "backend": 8947,
-      "notes": "TBD"
-    },
-    "luke-stream": {
-      "frontend": 5349,
-      "backend": 8963,
-      "notes": "TBD"
-    },
-    "revisionary": {
-      "frontend": 5365,
-      "backend": 8979,
-      "notes": "TBD"
-    },
-    "rootstead": {
-      "frontend": 5381,
-      "backend": 8995,
       "notes": "TBD"
     }
   }

--- a/modules/remote-server/commands/onremote.md
+++ b/modules/remote-server/commands/onremote.md
@@ -33,7 +33,7 @@ Run a health check and present a brief status report:
 ```bash
 ssh __REMOTE_USER__@__REMOTE_HOST__ "uptime"
 ssh __REMOTE_USER__@__REMOTE_HOST__ "df -h /"
-ssh __REMOTE_USER__@__REMOTE_HOST__ "ps -u openclaw -o pid,command | grep -Ev '/System/|/usr/lib|/usr/sbin|Contents/MacOS|\.framework' | grep -v PID"
+ssh __REMOTE_USER__@__REMOTE_HOST__ "ps -u __REMOTE_USER__ -o pid,command | grep -Ev '/System/|/usr/lib|/usr/sbin|Contents/MacOS|\.framework' | grep -v PID"
 ```
 
 Present as:
@@ -57,10 +57,10 @@ The arguments are a natural language description of what to do on the remote ser
 4. Report back in plain language - what you did and what the result was
 
 Examples of how to interpret input:
-- "check if openclaw is running" → `ps aux | grep openclaw-gateway`
+- "check if myservice is running" → `ps aux | grep myservice`
 - "how much disk space is left" → `df -h /`
 - "restart ollama" → `brew services restart ollama` (or find the right command)
-- "show the last 50 lines of the openclaw log" → find the log file and tail it
+- "show the last 50 lines of the myservice log" → find the log file and tail it
 - "what processes are using the most CPU" → `ps aux | sort -rk3 | head -10`
 
 Use multiple SSH calls if needed. Interpret the task fully - do not ask clarifying questions unless the intent is genuinely ambiguous.

--- a/modules/session-history/README.md
+++ b/modules/session-history/README.md
@@ -66,7 +66,7 @@ chmod +x ~/.claude/scripts/add-agents-md-symlinks.sh
 /recall                     # Last 7 days, current repo, all clones, summary
 /recall migration           # Last 7 days, filter turns by "migration"
 /recall --days 30 auth      # Custom window + filter
-/recall --repo voxter       # Different repo (canonical name required)
+/recall --repo other-repo   # Different repo (canonical name required)
 /recall --session 65b57a04  # Dump a specific session
 /recall --summary --limit 3 # Top 3 most recent sessions, compact format
 ```
@@ -89,7 +89,7 @@ Ask directly in a session:
 
 ```
 Dispatch the session-historian agent. Find out what I tried when I
-debugged the Vite CSS preflight issue in habitpro-ai this past week.
+debugged the Vite CSS preflight issue in my-app this past week.
 ```
 
 ### Scripts directly
@@ -98,12 +98,12 @@ The discovery and metadata scripts are usable on their own if you want to inspec
 
 ```bash
 # List Claude Code + Codex sessions for this repo from the last 7 days
-bash ~/.claude/scripts/discover-sessions.sh habitpro-ai 7
+bash ~/.claude/scripts/discover-sessions.sh my-app 7
 
 # Get metadata for all of them in one pipeline
-bash ~/.claude/scripts/discover-sessions.sh habitpro-ai 7 \
+bash ~/.claude/scripts/discover-sessions.sh my-app 7 \
   | tr '\n' '\0' \
-  | xargs -0 python3 ~/.claude/scripts/extract-metadata.py --cwd-filter habitpro-ai
+  | xargs -0 python3 ~/.claude/scripts/extract-metadata.py --cwd-filter my-app
 ```
 
 Output is one JSON object per session plus a final `_meta` line with `files_processed` and `parse_errors` counts.
@@ -136,4 +136,4 @@ This module does **not**:
 
 ## Source
 
-Ported from EveryInc/compound-engineering-plugin's `agents/research/session-historian.md` and companion `session-history-scripts/`. The CCGM port drops Cursor (Lucas does not use Cursor), folds skeleton/error extraction back into the agent itself (using native Read + Grep rather than additional Python scripts - keeping the surface minimal), and uses absolute `~/.claude/scripts/` paths matching CCGM's install convention rather than the plugin-relative paths the original assumes.
+Ported from EveryInc/compound-engineering-plugin's `agents/research/session-historian.md` and companion `session-history-scripts/`. The CCGM port drops Cursor (out of scope for the typical CCGM workflow), folds skeleton/error extraction back into the agent itself (using native Read + Grep rather than additional Python scripts - keeping the surface minimal), and uses absolute `~/.claude/scripts/` paths matching CCGM's install convention rather than the plugin-relative paths the original assumes.

--- a/modules/session-history/commands/recall.md
+++ b/modules/session-history/commands/recall.md
@@ -20,7 +20,7 @@ It does NOT maintain a separate index or database — transcripts are the source
 | `/recall <query>` | Last 7 days, filtered to turns matching `<query>` (case-insensitive regex) |
 | `/recall --days N` | Custom time window |
 | `/recall --days N <query>` | Custom window + query filter |
-| `/recall --repo <name>` | Different repo. Pass the canonical name (e.g. `ccgm`, `habitpro-ai`) as returned by `git remote get-url origin` — substring matching is NOT supported |
+| `/recall --repo <name>` | Different repo. Pass the canonical name (e.g. `ccgm`, `my-multi-word-repo`) as returned by `git remote get-url origin` — substring matching is NOT supported |
 | `/recall --summary` | Force summary mode even when a query is given |
 | `/recall --full <query>` | Do not truncate matched turn content |
 | `/recall --limit N` | Maximum sessions/results to display (default 50) |
@@ -32,7 +32,7 @@ It does NOT maintain a separate index or database — transcripts are the source
 /recall                       # What have I been doing in this repo this week?
 /recall migration             # What did I try with that migration?
 /recall --days 30 auth        # Broader lookback on auth work
-/recall --repo voxter         # Switch to voxter sessions
+/recall --repo other-repo     # Switch to another repo's sessions
 /recall --session 65b57a04    # Read a specific session
 ```
 

--- a/modules/session-history/scripts/add-agents-md-symlinks.sh
+++ b/modules/session-history/scripts/add-agents-md-symlinks.sh
@@ -8,8 +8,10 @@
 # duplicating content.
 #
 # Behavior:
-# - Accepts a list of repo paths as arguments. If none provided, scans
-#   sensible defaults under $CODE_DIR (default $HOME/code).
+# - Accepts a list of repo paths as arguments. If none provided, auto-discovers
+#   candidate repos under $CODE_DIR (default $HOME/code): any immediate
+#   subdirectory containing a CLAUDE.md, plus the first clone of common
+#   multi-clone layouts (-repos/-N and -workspaces/-wX/-wX-cY).
 # - Skips any path that is not a directory containing CLAUDE.md.
 # - Skips any path where AGENTS.md already exists as a non-symlink (warns).
 # - If AGENTS.md is already a symlink, leaves it alone.
@@ -19,22 +21,31 @@ set -u
 
 CODE_DIR="${CODE_DIR:-$HOME/code}"
 
-DEFAULT_TARGETS=(
-  "$CODE_DIR/ccgm"
-  "$CODE_DIR/voxstr-repos/voxstr-0"
-  "$CODE_DIR/voxstr-site-repos/voxstr-site-0"
-  "$CODE_DIR/habitpro-ai-workspaces/habitpro-ai-w0/habitpro-ai-w0-c0"
-  "$CODE_DIR/openslide-ai-repos/openslide-ai-0"
-  "$CODE_DIR/lem-photo-repos/lem-photo-0"
-  "$CODE_DIR/darkly-suite-repos/darkly-suite-0"
-  "$CODE_DIR/lem-work-repos/lem-work-0"
-  "$CODE_DIR/nadaproof"
-)
+# Discover repos under $CODE_DIR that have a CLAUDE.md. Pass explicit paths as
+# arguments to override discovery. No personal repo names are hardcoded here.
+discover_targets() {
+  [ -d "$CODE_DIR" ] || return 0
+  # Single-clone repos: $CODE_DIR/<repo>/CLAUDE.md
+  for d in "$CODE_DIR"/*/; do
+    [ -f "${d}CLAUDE.md" ] && printf '%s\n' "${d%/}"
+  done
+  # Flat-clone repos: $CODE_DIR/<repo>-repos/<repo>-0/CLAUDE.md
+  for d in "$CODE_DIR"/*-repos/*-0/; do
+    [ -f "${d}CLAUDE.md" ] && printf '%s\n' "${d%/}"
+  done
+  # Workspace repos: $CODE_DIR/<repo>-workspaces/<repo>-w0/<repo>-w0-c0/CLAUDE.md
+  for d in "$CODE_DIR"/*-workspaces/*-w0/*-w0-c0/; do
+    [ -f "${d}CLAUDE.md" ] && printf '%s\n' "${d%/}"
+  done
+}
 
 if [ "$#" -gt 0 ]; then
   TARGETS=("$@")
 else
-  TARGETS=("${DEFAULT_TARGETS[@]}")
+  TARGETS=()
+  while IFS= read -r line; do
+    [ -n "$line" ] && TARGETS+=("$line")
+  done < <(discover_targets)
 fi
 
 CREATED=0

--- a/modules/session-history/scripts/repo_detect.py
+++ b/modules/session-history/scripts/repo_detect.py
@@ -12,9 +12,9 @@ from pathlib import Path
 CLAUDE_PROJECTS = Path.home() / ".claude" / "projects"
 
 # Regex matches a clone suffix on a path basename:
-#   flat clone:     "ccgm-0", "ccgm-1", "habitpro-ai-0"
-#   workspace:      "ccgm-w0", "habitpro-ai-w1"
-#   workspace+clone: "ccgm-w0-c2", "habitpro-ai-w1-c3"
+#   flat clone:     "myrepo-0", "myrepo-1", "my-multi-word-repo-0"
+#   workspace:      "myrepo-w0", "my-multi-word-repo-w1"
+#   workspace+clone: "myrepo-w0-c2", "my-multi-word-repo-w1-c3"
 CLONE_SUFFIX = re.compile(r"-(?:w\d+(?:-c\d+)?|\d+)$")
 
 
@@ -41,7 +41,7 @@ def detect_repo(cwd: str | None = None) -> str | None:
         if out.returncode == 0:
             url = out.stdout.strip()
             # Handle git@github.com:user/repo.git and https://github.com/user/repo.git
-            name = url.rstrip("/").rsplit("/", 1)[-1].rstrip(".git")
+            name = url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
             if name:
                 return name
     except (subprocess.TimeoutExpired, FileNotFoundError):
@@ -93,9 +93,9 @@ def clone_label(project_dir: Path, repo: str) -> str:
     """Short label identifying which clone this project dir represents.
 
     Example mappings (based on trailing encoded-path segment):
-      repo='ccgm', project_dir=-Users-lem-code-ccgm-repos-ccgm-1   → 'ccgm-1'
-      repo='ccgm', -Users-lem-code-ccgm-workspaces-ccgm-w0-c2      → 'ccgm-w0-c2'
-      repo='ccgm', -Users-lem-code-ccgm                            → 'ccgm'
+      repo='ccgm', project_dir=-home-alice-code-ccgm-repos-ccgm-1   → 'ccgm-1'
+      repo='ccgm', -home-alice-code-ccgm-workspaces-ccgm-w0-c2      → 'ccgm-w0-c2'
+      repo='ccgm', -home-alice-code-ccgm                            → 'ccgm'
 
     Requires the canonical repo name to disambiguate (since encoded path names
     cannot be uniquely reversed when repo names contain hyphens).

--- a/modules/session-history/tests/test_repo_detect.py
+++ b/modules/session-history/tests/test_repo_detect.py
@@ -4,11 +4,50 @@ import os
 import sys
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 import repo_detect  # noqa: E402
+
+
+def _fake_git_remote(url):
+    """Return a function mimicking subprocess.run for `git remote get-url origin`."""
+
+    def runner(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout=url + "\n", stderr="")
+
+    return runner
+
+
+def test_detect_repo_strips_only_dot_git_suffix(monkeypatch):
+    """Regression: must use removesuffix('.git'), NOT rstrip('.git').
+
+    rstrip('.git') strips any trailing chars in the set {'.', 'g', 'i', 't'},
+    so a repo whose name ends in one of those chars would be truncated.
+    'digit' would become 'd', 'widget' would become 'widge', etc.
+    """
+    with patch.object(
+        repo_detect.subprocess, "run",
+        _fake_git_remote("git@github.com:owner/digit.git"),
+    ):
+        assert repo_detect.detect_repo() == "digit"
+
+    with patch.object(
+        repo_detect.subprocess, "run",
+        _fake_git_remote("https://github.com/owner/widget.git"),
+    ):
+        assert repo_detect.detect_repo() == "widget"
+
+
+def test_detect_repo_no_dot_git_suffix(monkeypatch):
+    """A remote URL without a .git suffix returns the name unchanged."""
+    with patch.object(
+        repo_detect.subprocess, "run",
+        _fake_git_remote("https://github.com/owner/myrepo"),
+    ):
+        assert repo_detect.detect_repo() == "myrepo"
 
 
 def test_detect_repo_from_ccgm_flat_clone_basename(tmp_path, monkeypatch):
@@ -21,10 +60,10 @@ def test_detect_repo_from_ccgm_flat_clone_basename(tmp_path, monkeypatch):
 
 def test_detect_repo_from_workspace_clone_basename(tmp_path, monkeypatch):
     """Workspace clone suffix 'w0-c2' is stripped to return the canonical name."""
-    clone_dir = tmp_path / "habitpro-ai-w0-c2"
+    clone_dir = tmp_path / "multi-word-repo-w0-c2"
     clone_dir.mkdir()
     monkeypatch.chdir(clone_dir)
-    assert repo_detect.detect_repo() == "habitpro-ai"
+    assert repo_detect.detect_repo() == "multi-word-repo"
 
 
 def test_detect_repo_workspace_root_suffix(tmp_path, monkeypatch):
@@ -55,13 +94,13 @@ def test_list_project_dirs_matches_exact_repo_only(tmp_path):
     fake_projects = tmp_path / "projects"
     fake_projects.mkdir()
     for name in [
-        "-Users-lem-code-ccgm-repos-ccgm-0",
-        "-Users-lem-code-ccgm-repos-ccgm-1",
-        "-Users-lem-code-ccgm-workspaces-ccgm-w0",
-        "-Users-lem-code-ccgm-workspaces-ccgm-w0-c2",
-        "-Users-lem-code-ccgm-agent-learning",  # different repo, same prefix
-        "-Users-lem-code-ccgm-agent-learning-0",  # clone of different repo
-        "-Users-lem-code-voxter",  # unrelated
+        "-home-dev-code-ccgm-repos-ccgm-0",
+        "-home-dev-code-ccgm-repos-ccgm-1",
+        "-home-dev-code-ccgm-workspaces-ccgm-w0",
+        "-home-dev-code-ccgm-workspaces-ccgm-w0-c2",
+        "-home-dev-code-ccgm-agent-learning",  # different repo, same prefix
+        "-home-dev-code-ccgm-agent-learning-0",  # clone of different repo
+        "-home-dev-code-unrelated-repo",  # unrelated
     ]:
         (fake_projects / name).mkdir()
 
@@ -69,17 +108,17 @@ def test_list_project_dirs_matches_exact_repo_only(tmp_path):
         matches = repo_detect.list_project_dirs("ccgm")
         names = sorted(m.name for m in matches)
     assert names == [
-        "-Users-lem-code-ccgm-repos-ccgm-0",
-        "-Users-lem-code-ccgm-repos-ccgm-1",
-        "-Users-lem-code-ccgm-workspaces-ccgm-w0",
-        "-Users-lem-code-ccgm-workspaces-ccgm-w0-c2",
+        "-home-dev-code-ccgm-repos-ccgm-0",
+        "-home-dev-code-ccgm-repos-ccgm-1",
+        "-home-dev-code-ccgm-workspaces-ccgm-w0",
+        "-home-dev-code-ccgm-workspaces-ccgm-w0-c2",
     ]
 
 
 def test_list_project_dirs_empty_when_no_matches(tmp_path):
     fake_projects = tmp_path / "projects"
     fake_projects.mkdir()
-    (fake_projects / "-Users-lem-code-voxter").mkdir()
+    (fake_projects / "-home-dev-code-unrelated-repo").mkdir()
     with patch.object(repo_detect, "CLAUDE_PROJECTS", fake_projects):
         assert repo_detect.list_project_dirs("ccgm") == []
 
@@ -91,25 +130,25 @@ def test_list_project_dirs_empty_when_projects_missing(tmp_path):
 
 
 def test_clone_label_flat_clone():
-    project_dir = Path("/fake/-Users-lem-code-ccgm-repos-ccgm-1")
+    project_dir = Path("/fake/-home-dev-code-ccgm-repos-ccgm-1")
     assert repo_detect.clone_label(project_dir, "ccgm") == "ccgm-1"
 
 
 def test_clone_label_workspace_clone():
-    project_dir = Path("/fake/-Users-lem-code-ccgm-workspaces-ccgm-w0-c2")
+    project_dir = Path("/fake/-home-dev-code-ccgm-workspaces-ccgm-w0-c2")
     assert repo_detect.clone_label(project_dir, "ccgm") == "ccgm-w0-c2"
 
 
 def test_clone_label_no_suffix():
-    project_dir = Path("/fake/-Users-lem-code-ccgm")
+    project_dir = Path("/fake/-home-dev-code-ccgm")
     assert repo_detect.clone_label(project_dir, "ccgm") == "ccgm"
 
 
 def test_clone_label_repo_with_hyphens():
-    project_dir = Path("/fake/-Users-lem-code-habitpro-ai-workspaces-habitpro-ai-w0-c2")
-    assert repo_detect.clone_label(project_dir, "habitpro-ai") == "habitpro-ai-w0-c2"
+    project_dir = Path("/fake/-home-dev-code-multi-word-repo-workspaces-multi-word-repo-w0-c2")
+    assert repo_detect.clone_label(project_dir, "multi-word-repo") == "multi-word-repo-w0-c2"
 
 
 def test_clone_label_repo_flat_clone_with_hyphens():
-    project_dir = Path("/fake/-Users-lem-code-habitpro-ai-repos-habitpro-ai-0")
-    assert repo_detect.clone_label(project_dir, "habitpro-ai") == "habitpro-ai-0"
+    project_dir = Path("/fake/-home-dev-code-multi-word-repo-repos-multi-word-repo-0")
+    assert repo_detect.clone_label(project_dir, "multi-word-repo") == "multi-word-repo-0"


### PR DESCRIPTION
## Summary

Removes hardcoded personal repo/host/username strings from the `session-history`, `remote-server`, and `multi-agent` modules, replacing them with generic placeholders or neutral example names. Also fixes a latent repo-name detection bug.

## Changes

### session-history
- **Bug fix (`repo_detect.py`)**: `git remote` repo-name parsing used `rstrip('.git')`, which strips any trailing chars in the set `{'.', 'g', 'i', 't'}` rather than the literal suffix. A repo named `digit` became `d`, `widget` became `widge`. Switched to `.removesuffix('.git')`.
- Added regression tests covering the `.git` suffix edge case (repo names ending in `.git`-set characters) and a no-suffix URL.
- Replaced `habitpro-ai`/`voxter` examples with neutral names (`my-multi-word-repo`, `my-app`, `other-repo`); replaced `/Users/lem` docstring/test paths with `/home/dev` and `/home/alice`; removed "Lucas does not use Cursor" wording.
- `add-agents-md-symlinks.sh`: removed the hardcoded list of personal repo paths (`voxstr`, `habitpro-ai`, `openslide-ai`, `lem-photo`, `lem-work`, etc.) used as default targets. Default behavior now auto-discovers repos under `$CODE_DIR` that contain a `CLAUDE.md` (single-clone, flat-clone `-repos/-0`, and workspace `-workspaces/-w0/-w0-c0` layouts). Explicit path args still override.

### remote-server
- `onremote.md`: `ps -u openclaw` hardcoded a personal username; now uses the existing `__REMOTE_USER__` placeholder (the SSH login user, also the process owner). Replaced `openclaw`/`openclaw-gateway` example service names with generic `myservice`.

### multi-agent
- `port-registry.json`: replaced the maintainer's full personal repo list with two generic example entries plus `ccgm`, and documented that the entries are examples.
- `multi-agent-system.md`, `mawf.md`, `workspace-setup.md`: replaced `habitpro-ai`/`openslide-ai`/`lem-*` examples and the port table with neutral placeholders (`myrepo`, `my-multi-word-repo`, `example-app`, `example-monorepo`).

## Test Plan
- `bash tests/test-no-personal-data.sh` → PASS
- `bash tests/test-modules.sh` → 1349 passed, 0 failed
- `python3 -m pytest modules/session-history/tests/ modules/multi-agent/tests/` → 38 passed
- Broad grep for personal strings across the three modules → zero matches
- Smoke-tested `add-agents-md-symlinks.sh` discovery against a fixture tree (single-clone, flat-clone, workspace) → correct
- `__pycache__`/`*.pyc`/`.pytest_cache` under these modules are untracked and already gitignored (`__pycache__/`, `.pytest_cache/` in root `.gitignore`); none committed

Closes #663
Part of #659