### PR TITLE
#661: uninstall preserves user settings.json (un-merge, not delete)

### DIFF
--- a/lib/merge.sh
+++ b/lib/merge.sh
@@ -96,6 +96,129 @@ merge_settings() {
   echo "$merged" | jq '.' > "$target"
 }
 
+# --- Record a CCGM-contributed merge partial as a sidecar ---
+# Usage: record_merged_partial "/abs/target/settings.json" "/abs/partial.json" "$global_dir"
+# Persists the exact (already template-expanded) partial that was merged into a
+# merge target so uninstall can later subtract precisely those keys/entries.
+# Sidecars live under "${store_dir}/.ccgm-merged/<sha>.json".
+# Echoes a single-line JSON object: {"target": "...", "partial": "<sidecar>"}.
+# Requires jq.
+record_merged_partial() {
+  local target="$1"
+  local partial_src="$2"
+  local store_dir="$3"
+
+  command -v jq &>/dev/null || return 1
+
+  local merged_dir="${store_dir}/.ccgm-merged"
+  mkdir -p "$merged_dir"
+
+  # Hash target + content so re-merging the same contribution is idempotent and
+  # two different targets never collide.
+  local sha
+  if command -v shasum &>/dev/null; then
+    sha=$( { printf '%s\0' "$target"; cat "$partial_src"; } | shasum -a 256 | awk '{print $1}')
+  elif command -v sha256sum &>/dev/null; then
+    sha=$( { printf '%s\0' "$target"; cat "$partial_src"; } | sha256sum | awk '{print $1}')
+  else
+    # Fallback: derive a stable-ish name from the target path only.
+    sha=$(printf '%s' "$target" | cksum | awk '{print $1}')
+  fi
+
+  local sidecar="${merged_dir}/${sha}.json"
+  cp "$partial_src" "$sidecar"
+
+  jq -n -c --arg target "$target" --arg partial "$sidecar" \
+    '{target: $target, partial: $partial}'
+}
+
+# --- Un-merge a CCGM-contributed partial out of a settings.json ---
+# Usage: unmerge_settings "/target/settings.json" "/path/to/contributed-partial.json"
+# Inverse of merge_settings. Removes ONLY the keys/entries CCGM contributed,
+# leaving any user-authored keys intact. The partial is the exact (template-
+# expanded) JSON that was merged in at install time, recorded in the manifest's
+# mergedFiles[] array.
+#
+# Subtraction rules mirror the merge rules:
+# - permissions.allow / permissions.deny (and other arrays, e.g. hook event
+#     arrays): remove the entries the partial contributed; keep user entries
+# - hooks / enabledPlugins / nested objects: recurse, then drop keys that
+#     become empty objects so empty scaffolding does not linger
+# - scalar / non-array leaf keys: remove only when the live value still equals
+#     the contributed value (a user override is left untouched)
+#
+# After subtraction, if the file reduces to an empty object ({}), it is removed.
+# Returns 0 on success. If the target does not exist, this is a no-op (0).
+unmerge_settings() {
+  local target="$1"
+  local partial="$2"
+
+  _require_jq || return 1
+
+  # Nothing to un-merge from a file that is already gone.
+  [ -f "$target" ] || return 0
+
+  if [ ! -f "$partial" ]; then
+    echo "WARNING: Recorded partial not found, leaving target untouched: $partial" >&2
+    return 0
+  fi
+
+  if ! jq empty "$target" 2>/dev/null; then
+    echo "ERROR: Invalid JSON in target, refusing to un-merge: $target" >&2
+    return 1
+  fi
+  if ! jq empty "$partial" 2>/dev/null; then
+    echo "ERROR: Invalid JSON in recorded partial: $partial" >&2
+    return 1
+  fi
+
+  local result
+  result=$(jq -s '
+    # subtract(live; contributed) -> live with contributed removed
+    def subtract(a; b):
+      a as $a | b as $b |
+      if ($a | type) == "object" and ($b | type) == "object" then
+        # For every key the contribution touched, subtract it from live.
+        reduce ($b | keys[]) as $key ($a;
+          if ($a | has($key) | not) then
+            .
+          elif (($a[$key] | type) == "array") and (($b[$key] | type) == "array") then
+            # Remove contributed array entries (by value). Keeps user entries.
+            ( ($a[$key]) - ($b[$key]) ) as $remaining
+            | if ($remaining | length) == 0 then del(.[$key])
+              else .[$key] = $remaining end
+          elif (($a[$key] | type) == "object") and (($b[$key] | type) == "object") then
+            ( subtract($a[$key]; $b[$key]) ) as $nested
+            | if ($nested | length) == 0 then del(.[$key])
+              else .[$key] = $nested end
+          elif ($a[$key] == $b[$key]) then
+            # Identical leaf the contribution provided: remove it.
+            del(.[$key])
+          else
+            # User overrode the value after install: leave it alone.
+            .
+          end
+        )
+      else
+        $a
+      end;
+    subtract(.[0]; .[1])
+  ' "$target" "$partial" 2>/dev/null)
+
+  if [ -z "$result" ]; then
+    echo "ERROR: Un-merge failed for $target - $partial" >&2
+    return 1
+  fi
+
+  # If the file is now an empty object, the user has nothing left here: remove it.
+  if [ "$(echo "$result" | jq -c '.')" = "{}" ]; then
+    rm -f "$target"
+    return 0
+  fi
+
+  echo "$result" | jq '.' > "$target"
+}
+
 # --- Initialize empty settings.json ---
 # Creates a minimal valid settings.json if none exists
 init_settings() {

--- a/start.sh
+++ b/start.sh
@@ -7,6 +7,12 @@ set -euo pipefail
 # --- Determine script location ---
 CCGM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# --- Global state (declared up front so write_manifest is safe under set -u) ---
+RESOLVED_MODULES=()
+INSTALLED_FILES=()
+MERGED_FILES=()
+BACKUP_DIRS=()
+
 # --- Source libraries ---
 # shellcheck source=lib/ui.sh
 source "${CCGM_ROOT}/lib/ui.sh"
@@ -30,7 +36,7 @@ write_manifest() {
 
   if command -v jq &>/dev/null; then
     # Build proper JSON with jq
-    local modules_json files_json backups_json
+    local modules_json files_json backups_json merged_json
     modules_json=$(printf '%s\n' "${RESOLVED_MODULES[@]}" | jq -R . | jq -s .)
     if [ ${#INSTALLED_FILES[@]} -gt 0 ]; then
       files_json=$(printf '%s\n' "${INSTALLED_FILES[@]}" | jq -R . | jq -s .)
@@ -42,6 +48,12 @@ write_manifest() {
     else
       backups_json="[]"
     fi
+    # mergedFiles[] entries are already-serialized JSON objects ({target,partial}).
+    if [ ${#MERGED_FILES[@]} -gt 0 ]; then
+      merged_json=$(printf '%s\n' "${MERGED_FILES[@]}" | jq -s 'unique_by(.target + "|" + .partial)')
+    else
+      merged_json="[]"
+    fi
 
     jq -n \
       --arg version "1.0.0" \
@@ -51,6 +63,7 @@ write_manifest() {
       --argjson link "$LINK_MODE" \
       --argjson modules "$modules_json" \
       --argjson files "$files_json" \
+      --argjson merged "$merged_json" \
       --argjson backups "$backups_json" \
       --arg ccgm_root "$CCGM_ROOT" \
       '{
@@ -62,6 +75,7 @@ write_manifest() {
         ccgmRoot: $ccgm_root,
         modules: $modules,
         files: $files,
+        mergedFiles: $merged,
         backups: $backups
       }' > "$manifest_file"
   else
@@ -94,6 +108,7 @@ write_manifest() {
       fi
       echo ""
       echo "  ],"
+      echo "  \"mergedFiles\": [],"
       echo "  \"backups\": ["
       first=true
       local backup
@@ -242,7 +257,10 @@ run_add_mode() {
   done
 
   # --- Execute install plan (mirror of main() Step 11) ---
+  # merge targets (e.g. settings.json) are recorded in MERGED_FILES, NOT
+  # INSTALLED_FILES: uninstall un-merges them rather than deleting the file.
   INSTALLED_FILES=()
+  MERGED_FILES=()
   local entry action src target template mod_name
   for entry in ${install_plan[@]+"${install_plan[@]}"}; do
     IFS='|' read -r action src target template mod_name <<< "$entry"
@@ -250,17 +268,23 @@ run_add_mode() {
     case "$action" in
       merge)
         init_settings "$target"
+        local merged_entry
         if [ "$template" = "true" ]; then
           local tmp_merge
           tmp_merge=$(mktemp)
           cp "$src" "$tmp_merge"
           expand_templates "$tmp_merge" "$env_file"
+          merged_entry=$(record_merged_partial "$target" "$tmp_merge" "$global_dir")
           merge_settings "$target" "$tmp_merge"
           rm -f "$tmp_merge"
         else
+          merged_entry=$(record_merged_partial "$target" "$src" "$global_dir")
           merge_settings "$target" "$src"
         fi
+        [ -n "$merged_entry" ] && MERGED_FILES+=("$merged_entry")
         ui_success "Merged: $target"
+        # Note: NOT added to INSTALLED_FILES (un-merged on uninstall, not deleted).
+        continue
         ;;
       link)
         { [ -e "$target" ] || [ -L "$target" ]; } && rm -f "$target"
@@ -299,8 +323,16 @@ run_add_mode() {
     [ -n "$b" ] && existing_backups+=("$b")
   done < <(jq -r '.backups[]?' "$manifest_file")
 
+  # Preserve any mergedFiles[] already recorded by a prior install/add.
+  local existing_merged=()
+  local mf
+  while IFS= read -r mf; do
+    [ -n "$mf" ] && existing_merged+=("$mf")
+  done < <(jq -c '.mergedFiles[]?' "$manifest_file")
+
   RESOLVED_MODULES=("${existing_modules[@]+"${existing_modules[@]}"}" "${to_install[@]}")
   INSTALLED_FILES=("${existing_files[@]+"${existing_files[@]}"}" "${INSTALLED_FILES[@]+"${INSTALLED_FILES[@]}"}")
+  MERGED_FILES=("${existing_merged[@]+"${existing_merged[@]}"}" "${MERGED_FILES[@]+"${MERGED_FILES[@]}"}")
   BACKUP_DIRS=("${existing_backups[@]+"${existing_backups[@]}"}")
 
   echo ""
@@ -1059,7 +1091,10 @@ main() {
   fi
 
   # Process install plan
+  # merge targets (e.g. settings.json) go into MERGED_FILES, NOT INSTALLED_FILES:
+  # uninstall un-merges the CCGM-contributed keys instead of deleting the file.
   INSTALLED_FILES=()
+  MERGED_FILES=()
 
   local entry action src target template mod_name
   for entry in ${install_plan[@]+"${install_plan[@]}"}; do
@@ -1073,20 +1108,26 @@ main() {
         if [ "$has_jq" = true ]; then
           init_settings "$target"
 
+          local merged_entry
           if [ "$template" = "true" ]; then
             local tmp_merge
             tmp_merge=$(mktemp)
             cp "$src" "$tmp_merge"
             expand_templates "$tmp_merge" "$env_file"
+            merged_entry=$(record_merged_partial "$target" "$tmp_merge" "$global_dir")
             merge_settings "$target" "$tmp_merge"
             rm -f "$tmp_merge"
           else
+            merged_entry=$(record_merged_partial "$target" "$src" "$global_dir")
             merge_settings "$target" "$src"
           fi
+          [ -n "$merged_entry" ] && MERGED_FILES+=("$merged_entry")
           ui_success "Merged: $target"
         else
           ui_warn "Skipped merge (no jq): $target"
         fi
+        # merge targets are never added to INSTALLED_FILES (see note above).
+        continue
         ;;
       link)
         [ -e "$target" ] && rm -f "$target"

--- a/tests/test-uninstall-settings.sh
+++ b/tests/test-uninstall-settings.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CCGM Uninstall Settings-Preservation Tests
+#
+# Regression coverage for issue #661 (data-loss bug): uninstall must NOT delete
+# the user's settings.json. settings.json is a MERGE target, not a CCGM-owned
+# file. Uninstall must un-merge only the CCGM-contributed keys/entries and leave
+# user-authored keys intact. The file is removed only if nothing of the user's
+# remains (reduces to {}).
+#
+# These tests exercise unmerge_settings (lib/merge.sh) directly, then run a full
+# install -> uninstall cycle to prove settings.json survives end-to-end.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+ERRORS=()
+TMPDIR=""
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  ERRORS+=("$1")
+  echo "  FAIL: $1"
+}
+
+cleanup() {
+  if [ -n "$TMPDIR" ] && [ -d "$TMPDIR" ]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: jq is required for uninstall settings tests"
+  exit 1
+fi
+
+echo "=== CCGM Uninstall Settings-Preservation Tests ==="
+echo ""
+
+# shellcheck source=../lib/merge.sh
+source "$REPO_ROOT/lib/merge.sh"
+
+TMPDIR=$(mktemp -d)
+
+# ============================================================
+# Unit tests for unmerge_settings
+# ============================================================
+
+# --- Test 1: User scalar keys survive un-merge ---
+echo "--- Test 1: User scalar keys survive un-merge ---"
+
+cat > "$TMPDIR/settings1.json" << 'JSON'
+{
+  "env": { "USER_SECRET": "keep-me" },
+  "model": "opus",
+  "permissions": { "allow": ["Bash(ccgm *)", "Read(user-only)"] }
+}
+JSON
+
+# Exactly what CCGM contributed at install time.
+cat > "$TMPDIR/partial1.json" << 'JSON'
+{
+  "model": "opus",
+  "permissions": { "allow": ["Bash(ccgm *)"] }
+}
+JSON
+
+unmerge_settings "$TMPDIR/settings1.json" "$TMPDIR/partial1.json"
+
+if [ -f "$TMPDIR/settings1.json" ]; then
+  pass "settings.json still exists after un-merge"
+else
+  fail "settings.json was deleted (data loss!) after un-merge"
+fi
+
+if jq -e '.env.USER_SECRET == "keep-me"' "$TMPDIR/settings1.json" >/dev/null 2>&1; then
+  pass "User-authored env.USER_SECRET preserved"
+else
+  fail "User-authored env.USER_SECRET lost"
+fi
+
+if jq -e 'has("model") | not' "$TMPDIR/settings1.json" >/dev/null 2>&1; then
+  pass "CCGM-contributed scalar key 'model' removed"
+else
+  fail "CCGM-contributed scalar key 'model' not removed"
+fi
+
+if jq -e '.permissions.allow == ["Read(user-only)"]' "$TMPDIR/settings1.json" >/dev/null 2>&1; then
+  pass "CCGM allow entry removed, user allow entry preserved"
+else
+  fail "allow array not un-merged correctly: $(jq -c '.permissions.allow' "$TMPDIR/settings1.json")"
+fi
+echo ""
+
+# --- Test 2: File removed only when it reduces to {} ---
+echo "--- Test 2: File removed when nothing user-owned remains ---"
+
+cat > "$TMPDIR/settings2.json" << 'JSON'
+{
+  "permissions": { "allow": ["Bash(ccgm *)"] }
+}
+JSON
+
+cat > "$TMPDIR/partial2.json" << 'JSON'
+{
+  "permissions": { "allow": ["Bash(ccgm *)"] }
+}
+JSON
+
+unmerge_settings "$TMPDIR/settings2.json" "$TMPDIR/partial2.json"
+
+if [ ! -f "$TMPDIR/settings2.json" ]; then
+  pass "Empty-after-unmerge settings.json removed"
+else
+  fail "settings.json should have been removed (only {} left): $(cat "$TMPDIR/settings2.json")"
+fi
+echo ""
+
+# --- Test 3: User override of a CCGM key is preserved ---
+echo "--- Test 3: User override of a CCGM-contributed value is preserved ---"
+
+cat > "$TMPDIR/settings3.json" << 'JSON'
+{ "model": "sonnet" }
+JSON
+
+# CCGM originally contributed model=opus; user later changed it to sonnet.
+cat > "$TMPDIR/partial3.json" << 'JSON'
+{ "model": "opus" }
+JSON
+
+unmerge_settings "$TMPDIR/settings3.json" "$TMPDIR/partial3.json"
+
+if [ -f "$TMPDIR/settings3.json" ] && jq -e '.model == "sonnet"' "$TMPDIR/settings3.json" >/dev/null 2>&1; then
+  pass "User-overridden value left untouched"
+else
+  fail "User override was clobbered or file removed"
+fi
+echo ""
+
+# --- Test 4: deny array + nested hooks un-merge ---
+echo "--- Test 4: deny array and hooks un-merge ---"
+
+cat > "$TMPDIR/settings4.json" << 'JSON'
+{
+  "permissions": {
+    "deny": ["Bash(rm -rf /)", "Bash(user-deny)"]
+  },
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": ["python3 ccgm-hook.py"] },
+      { "matcher": "Bash", "hooks": ["python3 user-hook.py"] }
+    ]
+  }
+}
+JSON
+
+cat > "$TMPDIR/partial4.json" << 'JSON'
+{
+  "permissions": {
+    "deny": ["Bash(rm -rf /)"]
+  },
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": ["python3 ccgm-hook.py"] }
+    ]
+  }
+}
+JSON
+
+unmerge_settings "$TMPDIR/settings4.json" "$TMPDIR/partial4.json"
+
+if jq -e '.permissions.deny == ["Bash(user-deny)"]' "$TMPDIR/settings4.json" >/dev/null 2>&1; then
+  pass "User deny entry preserved, CCGM deny entry removed"
+else
+  fail "deny array un-merge wrong: $(jq -c '.permissions.deny' "$TMPDIR/settings4.json")"
+fi
+
+if jq -e '.hooks.PreToolUse == [{ "matcher": "Bash", "hooks": ["python3 user-hook.py"] }]' "$TMPDIR/settings4.json" >/dev/null 2>&1; then
+  pass "User hook preserved, CCGM hook removed"
+else
+  fail "hooks un-merge wrong: $(jq -c '.hooks.PreToolUse' "$TMPDIR/settings4.json")"
+fi
+echo ""
+
+# --- Test 5: missing target is a no-op (no error) ---
+echo "--- Test 5: missing target is a no-op ---"
+
+set +e
+unmerge_settings "$TMPDIR/does-not-exist.json" "$TMPDIR/partial1.json"
+rc=$?
+set -e
+if [ $rc -eq 0 ]; then
+  pass "Missing target returns 0 (no-op)"
+else
+  fail "Missing target should be a no-op, got rc=$rc"
+fi
+echo ""
+
+# ============================================================
+# End-to-end: install then uninstall preserves user settings.json
+# ============================================================
+echo "--- Test 6: Full install -> uninstall preserves user settings.json ---"
+
+E2E_HOME="$TMPDIR/e2e"
+mkdir -p "$E2E_HOME/.claude"
+
+# User had a pre-existing settings.json with their own keys BEFORE installing CCGM.
+cat > "$E2E_HOME/.claude/settings.json" << 'JSON'
+{
+  "env": { "MY_OWN_KEY": "do-not-delete" },
+  "permissions": { "allow": ["Bash(my-own-tool *)"] }
+}
+JSON
+
+export CCGM_NON_INTERACTIVE=1
+export CCGM_USERNAME=testuser
+export CCGM_CODE_DIR="$E2E_HOME/code"
+export CCGM_TIMEZONE=UTC
+export CCGM_DEFAULT_MODE=ask
+export HOME="$E2E_HOME"
+
+set +e
+"$REPO_ROOT/start.sh" --preset standard --scope global </dev/null >/dev/null 2>&1
+install_exit=$?
+set -e
+
+if [ $install_exit -eq 0 ]; then
+  pass "Installer ran (standard preset)"
+else
+  fail "Installer failed with exit $install_exit"
+fi
+
+# Confirm CCGM merged its keys in alongside the user's.
+if jq -e '.env.MY_OWN_KEY == "do-not-delete"' "$E2E_HOME/.claude/settings.json" >/dev/null 2>&1; then
+  pass "User key survived install merge"
+else
+  fail "User key lost during install merge"
+fi
+
+# Now uninstall non-interactively.
+export CCGM_NON_INTERACTIVE=1
+set +e
+"$REPO_ROOT/uninstall.sh" </dev/null >/dev/null 2>&1
+uninstall_exit=$?
+set -e
+
+if [ -f "$E2E_HOME/.claude/settings.json" ]; then
+  pass "settings.json survived uninstall (not deleted)"
+else
+  fail "settings.json DELETED by uninstall (data loss bug #661)"
+fi
+
+if [ -f "$E2E_HOME/.claude/settings.json" ] && \
+   jq -e '.env.MY_OWN_KEY == "do-not-delete"' "$E2E_HOME/.claude/settings.json" >/dev/null 2>&1; then
+  pass "User key survived uninstall un-merge"
+else
+  fail "User key lost during uninstall"
+fi
+
+if [ -f "$E2E_HOME/.claude/settings.json" ] && \
+   jq -e '.permissions.allow == ["Bash(my-own-tool *)"]' "$E2E_HOME/.claude/settings.json" >/dev/null 2>&1; then
+  pass "User allow entry survived, CCGM allow entries un-merged"
+else
+  fail "User allow entry not preserved cleanly after uninstall: $(jq -c '.permissions.allow // "MISSING"' "$E2E_HOME/.claude/settings.json" 2>/dev/null)"
+fi
+echo ""
+
+# --- Test 7: Legacy manifest (settings.json in files[], no mergedFiles[]) ---
+# Users who installed with a pre-#661 CCGM have settings.json recorded in
+# files[]. Uninstall must still refuse to delete it (defense-in-depth).
+echo "--- Test 7: Legacy manifest does not delete settings.json ---"
+
+LEGACY_HOME="$TMPDIR/legacy"
+mkdir -p "$LEGACY_HOME/.claude/rules"
+echo '{"env":{"LEGACY_USER_KEY":"keep"}}' > "$LEGACY_HOME/.claude/settings.json"
+echo "ccgm rule" > "$LEGACY_HOME/.claude/rules/some-ccgm-rule.md"
+cat > "$LEGACY_HOME/.claude/.ccgm-manifest.json" << JSON
+{
+  "version": "1.0.0",
+  "scope": "global",
+  "modules": ["settings"],
+  "files": [
+    "$LEGACY_HOME/.claude/settings.json",
+    "$LEGACY_HOME/.claude/rules/some-ccgm-rule.md"
+  ]
+}
+JSON
+
+export CCGM_NON_INTERACTIVE=1
+export HOME="$LEGACY_HOME"
+set +e
+"$REPO_ROOT/uninstall.sh" </dev/null >/dev/null 2>&1
+set -e
+
+if [ -f "$LEGACY_HOME/.claude/settings.json" ] && \
+   jq -e '.env.LEGACY_USER_KEY == "keep"' "$LEGACY_HOME/.claude/settings.json" >/dev/null 2>&1; then
+  pass "Legacy settings.json preserved (not deleted)"
+else
+  fail "Legacy settings.json DELETED (data loss for pre-#661 installs)"
+fi
+
+if [ ! -f "$LEGACY_HOME/.claude/rules/some-ccgm-rule.md" ]; then
+  pass "Legacy CCGM-owned rule file still removed"
+else
+  fail "Legacy CCGM-owned rule file not removed"
+fi
+echo ""
+
+# --- Summary ---
+echo "==================================="
+echo "  Results: $PASS passed, $FAIL failed"
+echo "==================================="
+
+if [ $FAIL -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - $err"
+  done
+  exit 1
+fi
+
+exit 0

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -10,6 +10,7 @@ CCGM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # --- Source libraries ---
 source "${CCGM_ROOT}/lib/ui.sh"
 source "${CCGM_ROOT}/lib/backup.sh"
+source "${CCGM_ROOT}/lib/merge.sh"
 
 # ============================================================
 # Main
@@ -72,6 +73,21 @@ main() {
         echo "  - $file (already missing)"
       fi
     done < <(jq -r '.files[]?' "$manifest" 2>/dev/null)
+
+    # Merge targets (e.g. settings.json) are NOT deleted - only CCGM-contributed
+    # keys are un-merged out, preserving the user's own settings.
+    if jq -e '.mergedFiles | length > 0' "$manifest" >/dev/null 2>&1; then
+      echo ""
+      ui_info "Settings to un-merge (file preserved, only CCGM keys removed):"
+      while IFS= read -r mtarget; do
+        [ -z "$mtarget" ] && continue
+        if [ -e "$mtarget" ]; then
+          echo "  - $mtarget"
+        else
+          echo "  - $mtarget (already missing)"
+        fi
+      done < <(jq -r '.mergedFiles[]?.target' "$manifest" 2>/dev/null | sort -u)
+    fi
   else
     ui_info "Found manifest at: $manifest"
     ui_warn "jq not available - will remove known CCGM paths"
@@ -83,7 +99,12 @@ main() {
   ui_info "Your backups (if any) will NOT be removed."
   echo ""
 
-  if ! ui_confirm "Proceed with uninstall?" "no"; then
+  # Interactive default is "no" for safety. An explicit non-interactive run
+  # (CCGM_NON_INTERACTIVE=1) opts in to proceeding, matching the installer's
+  # non-interactive contract.
+  local proceed_default="no"
+  [ "${CCGM_NON_INTERACTIVE:-}" = "1" ] && proceed_default="yes"
+  if ! ui_confirm "Proceed with uninstall?" "$proceed_default"; then
     ui_info "Uninstall cancelled."
     exit 0
   fi
@@ -104,10 +125,47 @@ main() {
 
   local removed_count=0
   local skipped_count=0
+  local unmerged_count=0
 
   if [ "$has_jq" = true ]; then
+    # Collect merge-target paths so we never rm -f a file that is a merge target.
+    # This also protects legacy manifests where a merge target (settings.json)
+    # was incorrectly recorded in files[] - those entries are skipped here and
+    # handled by the un-merge pass below instead of being deleted wholesale.
+    local merge_targets=()
+    local mt
+    while IFS= read -r mt; do
+      [ -n "$mt" ] && merge_targets+=("$mt")
+    done < <(jq -r '.mergedFiles[]?.target' "$manifest" 2>/dev/null | sort -u)
+
+    _is_merge_target() {
+      local candidate="$1" t
+      for t in ${merge_targets[@]+"${merge_targets[@]}"}; do
+        [ "$t" = "$candidate" ] && return 0
+      done
+      return 1
+    }
+
     while IFS= read -r file; do
       [ -z "$file" ] && continue
+
+      # Never delete a merge target - it holds the user's own settings too.
+      if _is_merge_target "$file"; then
+        ui_info "Preserving merge target (will un-merge): $file"
+        skipped_count=$((skipped_count + 1))
+        continue
+      fi
+
+      # Defense-in-depth for legacy manifests written before mergedFiles[]
+      # existed: settings.json is ALWAYS a merge target. If it leaked into
+      # files[] with no recorded partial, we cannot un-merge precisely, so we
+      # refuse to delete it - skipping preserves the user's data over a clean
+      # uninstall. The empty-dir cleanup below will still tidy CCGM-only dirs.
+      if [ "$(basename "$file")" = "settings.json" ]; then
+        ui_warn "Preserving settings.json (no merge record; refusing to delete): $file"
+        skipped_count=$((skipped_count + 1))
+        continue
+      fi
 
       if [ -L "$file" ]; then
         rm -f "$file"
@@ -121,6 +179,30 @@ main() {
         skipped_count=$((skipped_count + 1))
       fi
     done < <(jq -r '.files[]?' "$manifest" 2>/dev/null)
+
+    # Un-merge CCGM-contributed keys from each merge target. The file is left in
+    # place with the user's keys intact; it is removed only if nothing remains.
+    while IFS=$'\t' read -r mtarget mpartial; do
+      [ -z "$mtarget" ] && continue
+      if unmerge_settings "$mtarget" "$mpartial"; then
+        if [ -f "$mtarget" ]; then
+          ui_success "Un-merged CCGM keys from: $mtarget (user settings preserved)"
+        else
+          ui_success "Removed (empty after un-merge): $mtarget"
+        fi
+        unmerged_count=$((unmerged_count + 1))
+      else
+        ui_warn "Could not un-merge $mtarget - left untouched"
+      fi
+      # Clean up the recorded sidecar partial.
+      [ -f "$mpartial" ] && rm -f "$mpartial"
+    done < <(jq -r '.mergedFiles[]? | [.target, .partial] | @tsv' "$manifest" 2>/dev/null)
+
+    # Remove the now-empty sidecar store if nothing else lives there.
+    local merged_dir="${global_dir}/.ccgm-merged"
+    if [ -d "$merged_dir" ] && [ -z "$(ls -A "$merged_dir" 2>/dev/null)" ]; then
+      rmdir "$merged_dir" 2>/dev/null && ui_info "Removed empty dir: $merged_dir"
+    fi
   else
     ui_warn "Cannot parse manifest without jq."
     ui_info "Install jq for precise file removal, or manually remove ~/.claude/ contents."
@@ -164,7 +246,7 @@ main() {
 
   # Step 7: Summary and offer restore
   echo ""
-  ui_info "Removed $removed_count file(s), skipped $skipped_count"
+  ui_info "Removed $removed_count file(s), un-merged $unmerged_count settings file(s), skipped $skipped_count"
   echo ""
 
   if [ -n "$backup_path" ]; then


### PR DESCRIPTION
## Summary

Fixes a **data-loss bug**: `uninstall.sh` ran `rm -f` on every path recorded in the manifest's `files[]`, but `settings.json` is a **merge target** (deep-merged via `lib/merge.sh`), not a CCGM-owned file. Uninstalling therefore deleted the user's own non-CCGM permissions, env vars, hooks, and any other keys they had added.

## Root Cause

Both install paths (`main()` Step 11 and `run_add_mode`) appended **every** install-plan target — including `merge` targets — to `INSTALLED_FILES`, which becomes the manifest `files[]`. `uninstall.sh` then deleted each `files[]` entry wholesale. The merge step never recorded *which* keys CCGM contributed, so there was no way to un-merge them.

## Change (designed as if foundational)

Merge targets are now tracked separately from owned files:

- **Install** records each merge contribution in a new manifest array `mergedFiles[]` as `{ target, partial }`, where `partial` is the exact (template-expanded) JSON CCGM merged in, persisted as a sidecar under `~/.claude/.ccgm-merged/`. Merge targets are **no longer** added to `files[]`.
- **`lib/merge.sh`** gains `record_merged_partial` (write sidecar + manifest entry) and `unmerge_settings` (the inverse of `merge_settings`): it subtracts only the contributed keys/array-entries/hooks, preserves user-authored keys, leaves user overrides untouched, and removes the file only if it reduces to `{}`.
- **`uninstall.sh`** un-merges each `mergedFiles[]` entry via jq instead of deleting the file. It never `rm -f`s a merge target. Defense-in-depth: any `files[]` entry named `settings.json` (from a pre-#661 legacy manifest with no merge record) is **skipped, not deleted**, to preserve user data over a clean uninstall.

## Test Plan

New `tests/test-uninstall-settings.sh` (16 assertions): unit-tests `unmerge_settings` (scalar/array/hooks subtraction, user-override preservation, empty-file removal, missing-target no-op) and a full install -> uninstall cycle proving a user's pre-existing `settings.json` survives intact. Includes a legacy-manifest regression case.

```
test-uninstall-settings.sh -> 16 passed, 0 failed
test-merge.sh              -> 13 passed, 0 failed
test-installer.sh          -> 46 passed, 0 failed
test-no-personal-data.sh   -> PASS
test-modules.sh            -> 1349 passed, 0 failed
```

Closes #661
Part of #659