### PR TITLE
#672: fix macOS CI segfault — Python personal-data scanner

### DIFF
--- a/tests/test-no-personal-data.sh
+++ b/tests/test-no-personal-data.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 #      was never seen before.
 #
 # Design (deliberately robust-by-construction, not heuristic):
-#   * OFFENDERS ARE THE SINGLE SOURCE OF TRUTH. The script builds one offender
+#   * OFFENDERS ARE THE SINGLE SOURCE OF TRUTH. The scanner builds one offender
 #     list (file:line:content) and the exit decision is purely whether that
 #     list is non-empty. It is therefore IMPOSSIBLE to FAIL with blank
 #     offenders -- any future CI failure is self-diagnosing.
@@ -26,24 +26,58 @@ set -euo pipefail
 #     placeholder: the `ccgm-allow-secret` line marker, `__PLACEHOLDER__`, and
 #     reserved/example email domains (RFC 2606 + ccgm.local / github.com).
 #
+# Why Python, not grep:
+#   The previous implementation scanned with BSD/GNU `grep -E`. The large ERE
+#   alternation in the secret pattern segfaulted (SIGSEGV / exit 139) on the
+#   macOS BSD grep build under CI when scanning the whole repo. Python's `re`
+#   engine is already a CI dependency (the suite runs python tests), does not
+#   segfault on this pattern, and behaves identically across Linux and macOS.
+#   The scanning engine therefore lives in an inline python3 heredoc; this bash
+#   file is a thin wrapper preserving the original interface and PASS/FAIL
+#   contract so the workflow needs no change.
+#
 # Self-test:  bash tests/test-no-personal-data.sh --self-test
 #   Plants a fake token in a temp dir, asserts the detector FAILs on it, and
 #   asserts a clean temp file PASSes. Regression-tests the detector itself.
 
-# Deterministic byte semantics for grep/sed across GNU and BSD environments.
-export LC_ALL=C
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# ---------------------------------------------------------------------------
-# Pattern definitions
-# ---------------------------------------------------------------------------
+PYTHON="${PYTHON:-python3}"
+
+# The scanning engine. Reads a mode + paths on argv and prints offenders
+# (file:line:content) to stdout, one per line. Carries no meaning in its exit
+# code; callers decide pass/fail purely from whether stdout is empty. The
+# REPO_ROOT env var anchors relative-path computation.
+#
+# Invocation:
+#   run_scanner identity <target> [<target> ...]   -> identity offenders
+#   run_scanner secret   <root>                    -> secret/PII offenders
+run_scanner() {
+  "$PYTHON" - "$@" <<'PY'
+import os
+import re
+import sys
+
+REPO_ROOT = os.environ["REPO_ROOT"]
 
 # Class 1: maintainer-specific identifiers. Unconditional fail.
 # Covers: usernames, personal paths, Supabase project refs, service URLs,
 # Tailscale hostnames/IPs, and personal device names.
-IDENTITY_PATTERN='lucasmccomb|Lucas McComb|@lucasmccomb|/Users/lem|lem-personal|lem-agent-logs|hyhaowdndehadgcwjxtw|hwoxbllmdqvavxthrlql|eluketronic\.app\.n8n\.cloud|lem-mbp|100\.113\.180\.79|iphone171'
+IDENTITY_PATTERN = (
+    r"lucasmccomb|Lucas McComb|@lucasmccomb|/Users/lem|lem-personal|"
+    r"lem-agent-logs|hyhaowdndehadgcwjxtw|hwoxbllmdqvavxthrlql|"
+    r"eluketronic\.app\.n8n\.cloud|lem-mbp|100\.113\.180\.79|iphone171"
+)
+
+# README.md / postInstall.sh legitimately hold the clone URL (owner handle) and
+# install commands, so the bare username is allowed there but personal paths are
+# not.
+IDENTITY_PATTERN_RELAXED = (
+    r"/Users/lem|lem-personal|lem-agent-logs|hyhaowdndehadgcwjxtw|"
+    r"hwoxbllmdqvavxthrlql|eluketronic\.app\.n8n\.cloud|lem-mbp|"
+    r"100\.113\.180\.79|iphone171"
+)
 
 # Class 2: generic secret / PII shapes.
 #   sk-...            OpenAI / Anthropic style keys
@@ -53,120 +87,183 @@ IDENTITY_PATTERN='lucasmccomb|Lucas McComb|@lucasmccomb|/Users/lem|lem-personal|
 #   AKIA[16]          AWS access key IDs
 #   PRIVATE KEY PEM   private key blocks
 #   email addresses   PII
-SECRET_PATTERN='sk-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{20,}|gho_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|re_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
+SECRET_PATTERN = (
+    r"sk-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{20,}|gho_[A-Za-z0-9]{20,}|"
+    r"github_pat_[A-Za-z0-9_]{20,}|re_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|"
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----|"
+    r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
+)
 
-# A matched secret/PII line is EXEMPT only if it satisfies one of these narrow
-# rules. Intentionally minimal: exclusion-by-location (see scan_paths) handles
-# the bulk; this covers the rare in-scope placeholder.
-allow_line() {
-  local line="$1"
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+# Placeholder / reserved email domains (RFC 2606 + ccgm.local + the public
+# github.com host that appears in git clone URLs).
+PLACEHOLDER_EMAIL_RE = re.compile(
+    r"@(example\.(com|org|net)|test|invalid|.*\.test|.*\.invalid|.*\.example|"
+    r"ccgm\.(local|test)|github\.com|.*\.example\.com)$"
+)
+# Single-letter synthetic placeholder emails like a@b.com.
+TRIVIAL_EMAIL_RE = re.compile(r"^[A-Za-z]@[A-Za-z]\.[A-Za-z]{2,4}$")
 
-  # Explicit opt-out marker for intentional illustrative content.
-  case "$line" in
-    *ccgm-allow-secret*) return 0 ;;
-    *__PLACEHOLDER__*)   return 0 ;;
-  esac
+identity_re = re.compile(IDENTITY_PATTERN)
+identity_relaxed_re = re.compile(IDENTITY_PATTERN_RELAXED)
+secret_re = re.compile(SECRET_PATTERN)
 
-  # Example / reserved / test email domains (RFC 2606 + ccgm.local + the public
-  # github.com host that appears in git clone URLs). Only exempt the line if it
-  # matched solely on email(s), every email is a placeholder domain, and no
-  # other (non-email) token shape remains once the emails are stripped out.
-  local emails real
-  emails=$(printf '%s' "$line" | grep -oE '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' || true)
-  if [ -n "$emails" ]; then
-    real=$(printf '%s\n' "$emails" \
-      | grep -vE '@(example\.(com|org|net)|test|invalid|.*\.test|.*\.invalid|.*\.example|ccgm\.(local|test)|github\.com|.*\.example\.com)$' \
-      | grep -vE '^[A-Za-z]@[A-Za-z]\.[A-Za-z]{2,4}$' \
-      || true)
-    if [ -z "$real" ]; then
-      local stripped
-      stripped=$(printf '%s' "$line" | sed -E 's/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}//g')
-      if printf '%s' "$stripped" | grep -qE "$SECRET_PATTERN"; then
-        return 1   # leftover token shape present; do not exempt
-      fi
-      return 0
-    fi
-    return 1   # a real-looking email is present
-  fi
+TEXT_EXTS = (".md", ".json", ".py", ".sh", ".yml", ".yaml", ".txt")
 
-  return 1
+# Directories pruned from the whole-tree walk for ALL scans.
+PRUNE_DIRS = {
+    ".git",
+    "node_modules",
+    "__pycache__",
+    ".pytest_cache",
+    ".claude",
 }
 
-# Class-2 location exclusions: directories whose contents legitimately contain
-# secret/PII *shapes* by design. Test and fixture trees plant fake tokens to
-# exercise tooling, and the audit skill is itself secret-detection
-# documentation (its packs/fixtures describe and embed these shapes literally).
-# Excluding these by location is robust: it does not depend on telling a fake
-# token from a real one, only on where the file lives.
-secret_path_excluded() {
-  case "$1" in
-    tests/*|*/tests/*)                            return 0 ;;
-    fixtures/*|*/fixtures/*)                       return 0 ;;
-    modules/commands-extra/skills/audit/*)        return 0 ;;
-  esac
-  return 1
-}
 
-# ---------------------------------------------------------------------------
-# Core scan
-# ---------------------------------------------------------------------------
-# scan_paths <mode> <path...>
-#   mode=identity  scan only IDENTITY_PATTERN (unconditional fail)
-#   mode=secret    scan only SECRET_PATTERN, with location + allow_line exemptions
-#
-# Echoes "rel/path:LINENO:matched line" for every offending line, one per line.
-# Carries NO meaning in its return code -- callers decide pass/fail purely from
-# whether the captured offender text is empty.
-list_text_files() {
-  find "$@" -type f \
-    \( -name '*.md' -o -name '*.json' -o -name '*.py' -o -name '*.sh' \
-       -o -name '*.yml' -o -name '*.yaml' -o -name '*.txt' \) \
-    -not -path '*/.git/*' -not -path '*/node_modules/*' \
-    -not -path '*/__pycache__/*' -not -path '*/.pytest_cache/*' \
-    -not -path '*/docs/audits/*' -not -path '*/.claude/*' 2>/dev/null || true
-}
+def is_text_file(path):
+    return path.endswith(TEXT_EXTS)
 
-scan_paths() {
-  local mode="$1"; shift
-  local files f rel
-  files=$(list_text_files "$@")
 
-  while IFS= read -r f; do
-    [ -z "$f" ] && continue
-    rel="${f#"$REPO_ROOT"/}"
+def relpath(path):
+    rp = os.path.relpath(path, REPO_ROOT)
+    return rp.replace(os.sep, "/")
 
-    # This script defines the identity/secret patterns literally; never flag it.
-    case "$rel" in
-      tests/test-no-personal-data.sh) continue ;;
-    esac
 
-    if [ "$mode" = "identity" ]; then
-      # Any README.md and postInstall.sh legitimately hold the clone URL
-      # (owner handle) and install commands, so the bare username is allowed
-      # there but personal paths are not.
-      local idpat="$IDENTITY_PATTERN"
-      case "$rel" in
-        README.md|*/README.md|postInstall.sh|*/postInstall.sh)
-          idpat='/Users/lem|lem-personal|lem-agent-logs|hyhaowdndehadgcwjxtw|hwoxbllmdqvavxthrlql|eluketronic\.app\.n8n\.cloud|lem-mbp|100\.113\.180\.79|iphone171'
-          ;;
-      esac
-      while IFS= read -r hit; do
-        [ -z "$hit" ] && continue
-        echo "$rel:$hit"
-      done < <(grep -nE "$idpat" "$f" 2>/dev/null || true)
-    else
-      # Secret scan: skip files in test/fixture/secret-doc locations wholesale.
-      secret_path_excluded "$rel" && continue
-      while IFS= read -r hit; do
-        [ -z "$hit" ] && continue
-        local content="${hit#*:}"
-        if allow_line "$content"; then
-          continue
-        fi
-        echo "$rel:$hit"
-      done < <(grep -nE "$SECRET_PATTERN" "$f" 2>/dev/null || true)
-    fi
-  done <<< "$files"
+def walk_text_files(root):
+    """Yield text files under root, pruning PRUNE_DIRS and docs/audits."""
+    if os.path.isfile(root):
+        if is_text_file(root):
+            yield root
+        return
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prune unwanted directories in place.
+        dirnames[:] = [d for d in dirnames if d not in PRUNE_DIRS]
+        rel_dir = relpath(dirpath)
+        # docs/audits is excluded for every scan.
+        if rel_dir == "docs/audits" or rel_dir.endswith("/docs/audits"):
+            dirnames[:] = []
+            continue
+        for name in filenames:
+            full = os.path.join(dirpath, name)
+            if is_text_file(full):
+                yield full
+
+
+def read_lines(path):
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            return fh.readlines()
+    except OSError:
+        return []
+
+
+def secret_path_excluded(rel):
+    """Class-2 location exclusions: dirs that legitimately hold secret shapes."""
+    parts = rel.split("/")
+    if "tests" in parts:
+        return True
+    if "fixtures" in parts:
+        return True
+    if rel.startswith("modules/commands-extra/skills/audit/"):
+        return True
+    if "/modules/commands-extra/skills/audit/" in ("/" + rel):
+        return True
+    return False
+
+
+def allow_secret_line(line):
+    """A matched secret/PII line is EXEMPT only under these narrow rules."""
+    # Explicit opt-out marker for intentional illustrative content.
+    if "ccgm-allow-secret" in line:
+        return True
+    if "__PLACEHOLDER__" in line:
+        return True
+
+    emails = EMAIL_RE.findall(line)
+    if emails:
+        real = [
+            e
+            for e in emails
+            if not PLACEHOLDER_EMAIL_RE.search(e)
+            and not TRIVIAL_EMAIL_RE.match(e)
+        ]
+        if not real:
+            # Every email is a placeholder. Exempt only if no other (non-email)
+            # token shape remains once the emails are stripped out.
+            stripped = EMAIL_RE.sub("", line)
+            if secret_re.search(stripped):
+                return False  # leftover token shape present; do not exempt
+            return True
+        return False  # a real-looking email is present
+    return False
+
+
+def emit_offenders(rel, lines, pattern, exempt=None):
+    out = []
+    for idx, raw in enumerate(lines, start=1):
+        line = raw.rstrip("\n").rstrip("\r")
+        if pattern.search(line):
+            if exempt is not None and exempt(line):
+                continue
+            out.append("%s:%d:%s" % (rel, idx, line))
+    return out
+
+
+def scan_identity(targets):
+    offenders = []
+    for target in targets:
+        for path in walk_text_files(target):
+            rel = relpath(path)
+            # This script defines the identity/secret patterns literally.
+            if rel == "tests/test-no-personal-data.sh":
+                continue
+            base = os.path.basename(rel)
+            if base in ("README.md", "postInstall.sh"):
+                pat = identity_relaxed_re
+            else:
+                pat = identity_re
+            offenders.extend(emit_offenders(rel, read_lines(path), pat))
+    return offenders
+
+
+def scan_secret(root):
+    offenders = []
+    for path in walk_text_files(root):
+        rel = relpath(path)
+        if rel == "tests/test-no-personal-data.sh":
+            continue
+        if secret_path_excluded(rel):
+            continue
+        offenders.extend(
+            emit_offenders(rel, read_lines(path), secret_re, exempt=allow_secret_line)
+        )
+    return offenders
+
+
+def main(argv):
+    if len(argv) < 2:
+        sys.stderr.write("usage: scan <identity|secret> <path...>\n")
+        return 2
+    mode = argv[1]
+    paths = argv[2:]
+    if mode == "identity":
+        offenders = scan_identity(paths)
+    elif mode == "secret":
+        if not paths:
+            sys.stderr.write("secret scan requires a root path\n")
+            return 2
+        offenders = scan_secret(paths[0])
+    else:
+        sys.stderr.write("unknown mode: %s\n" % mode)
+        return 2
+    for line in offenders:
+        sys.stdout.write(line + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))
+PY
 }
 
 # ---------------------------------------------------------------------------
@@ -189,7 +286,7 @@ run_self_test() {
 
   local hits
   echo "--- planted-token file (expect DETECT) ---"
-  hits=$(scan_paths secret "$tmp/leak.txt")
+  hits=$(REPO_ROOT="$tmp" run_scanner secret "$tmp/leak.txt")
   if [ -n "$hits" ]; then
     echo "  OK: detector flagged the planted token"
   else
@@ -198,7 +295,7 @@ run_self_test() {
   fi
 
   echo "--- planted-PII-email file (expect DETECT) ---"
-  hits=$(scan_paths secret "$tmp/pii.txt")
+  hits=$(REPO_ROOT="$tmp" run_scanner secret "$tmp/pii.txt")
   if [ -n "$hits" ]; then
     echo "  OK: detector flagged the planted PII email"
   else
@@ -207,7 +304,7 @@ run_self_test() {
   fi
 
   echo "--- clean file (expect PASS) ---"
-  hits=$(scan_paths secret "$tmp/clean.txt")
+  hits=$(REPO_ROOT="$tmp" run_scanner secret "$tmp/clean.txt")
   if [ -z "$hits" ]; then
     echo "  OK: clean file passed"
   else
@@ -262,8 +359,9 @@ echo ""
 
 # Offenders are the single source of truth. Build the combined list; the exit
 # decision below keys off whether it is empty, never off a separate return code.
-identity_hits=$(scan_paths identity "${identity_targets[@]}")
-secret_hits=$(scan_paths secret "$REPO_ROOT")
+export REPO_ROOT
+identity_hits=$(run_scanner identity "${identity_targets[@]}")
+secret_hits=$(run_scanner secret "$REPO_ROOT")
 
 offenders=""
 [ -n "$identity_hits" ] && offenders="$identity_hits"


### PR DESCRIPTION
## Summary

`tests/test-no-personal-data.sh` exited 139 (SIGSEGV) on the GitHub macOS runner during the whole-repo secret/PII scan. The macOS BSD `grep` build segfaults on the large ERE alternation in `SECRET_PATTERN` over the repo's files. It passes on Linux and could not be reproduced with local BSD grep, so CI was the only ground truth.

## Fix

Replaced the grep-based scanning engine with a Python (`re` module) implementation. Python is already a CI dependency and its regex engine does not segfault on this pattern, removing the entire BSD-grep portability/crash class.

## Preserved behavior (unchanged)

- **Class-1 identity scan**: same IDENTITY_PATTERN, same narrow target set (modules, lib, presets, start.sh, update.sh, uninstall.sh, README.md, CONTRIBUTING.md, CLAUDE.md), same README/postInstall relaxation. Unconditional fail.
- **Class-2 secret/PII scan**: same shapes (sk-, ghp_, gho_, github_pat_, re_, AKIA[16], PRIVATE KEY PEM, emails), whole-repo with the same exclusions (.git, node_modules, __pycache__, .pytest_cache, .claude, docs/audits, tests/, fixtures/, audit skill). Same exemptions (`ccgm-allow-secret`, `__PLACEHOLDER__`, RFC-2606 / ccgm.local / github.com email domains).
- Offenders remain the single source of truth: fail iff non-empty, always print file:line:content, never fail blank.
- `--self-test` unchanged; planted token built at runtime.
- Outer interface identical — `.github/workflows/test.yml` needs no change.

## Test plan

- `bash tests/test-no-personal-data.sh` -> PASS
- `bash tests/test-no-personal-data.sh --self-test` -> planted token + planted PII detected, clean passes
- Planted a real-shaped `ghp_` token in README.md -> caught (file:line:content), then removed
- Planted a personal path in a module rule file -> identity scan caught it, then removed

Only `tests/test-no-personal-data.sh` changed. Detection not weakened.

Closes #672
Part of #659