### PR TITLE
#676: order-preserving allow/deny dedup in merge.sh

### DIFF
--- a/lib/merge.sh
+++ b/lib/merge.sh
@@ -49,6 +49,11 @@ merge_settings() {
   # Perform the merge
   local merged
   merged=$(jq -s '
+    # Order-preserving dedup: keep first occurrence, preserve input order.
+    # (jq builtin `unique` sorts, which reshuffles human-curated allow/deny lists.)
+    def dedup_ordered:
+      reduce .[] as $x ([]; if any(.[]; . == $x) then . else . + [$x] end);
+
     # Custom deep merge function
     def deep_merge(a; b):
       a as $a | b as $b |
@@ -58,8 +63,9 @@ merge_settings() {
           if ($key == "allow" or $key == "deny") and
              (($a[$key] | type) == "array") and
              (($b[$key] | type) == "array") then
-            # Array merge with deduplication for allow/deny
-            { ($key): (($a[$key] + $b[$key]) | unique) }
+            # Array merge with order-preserving deduplication for allow/deny.
+            # Base entries keep their curated order; new unique entries are appended.
+            { ($key): (($a[$key] + $b[$key]) | dedup_ordered) }
           elif ($key == "hooks" or $key == "enabledPlugins") and
                (($a[$key] | type) == "object") and
                (($b[$key] | type) == "object") then
@@ -71,8 +77,9 @@ merge_settings() {
             { ($key): deep_merge($a[$key]; $b[$key]) }
           elif (($a[$key] | type) == "array") and
                (($b[$key] | type) == "array") then
-            # For hook event arrays (PreToolUse, etc.), concatenate and deduplicate
-            { ($key): ([$a[$key] + $b[$key] | .[] | tojson] | unique | [.[] | fromjson]) }
+            # For hook event arrays (PreToolUse, etc.), concatenate and
+            # deduplicate while preserving first-seen order.
+            { ($key): ([$a[$key] + $b[$key] | .[] | tojson] | dedup_ordered | [.[] | fromjson]) }
           elif $b | has($key) then
             { ($key): $b[$key] }
           else

--- a/tests/test-merge.sh
+++ b/tests/test-merge.sh
@@ -131,6 +131,56 @@ else
 fi
 echo ""
 
+# --- Test 2b: Allow/deny dedup preserves base order (no alphabetic reshuffle) ---
+echo "--- Test 2b: Allow/deny order preservation ---"
+
+# Intentionally non-alphabetical base list to detect any sort-on-merge.
+cat > "$TMPDIR/target2b.json" << 'JSON'
+{
+  "permissions": {
+    "allow": ["Zebra", "Apple", "Bash(git *)", "Read"],
+    "deny": ["Bash(rm -rf *)", "Bash(sudo *)"]
+  }
+}
+JSON
+
+cat > "$TMPDIR/partial2b.json" << 'JSON'
+{
+  "permissions": {
+    "allow": ["Read", "Mango"],
+    "deny": ["Bash(sudo *)", "Alpha"]
+  }
+}
+JSON
+
+merge_settings "$TMPDIR/target2b.json" "$TMPDIR/partial2b.json"
+result2b=$(cat "$TMPDIR/target2b.json")
+
+# Base order must be preserved exactly, with new unique entries appended.
+expected_allow='["Zebra","Apple","Bash(git *)","Read","Mango"]'
+actual_allow=$(echo "$result2b" | jq -c '.permissions.allow')
+if [ "$actual_allow" = "$expected_allow" ]; then
+  pass "Allow list preserves base order and appends new entries"
+else
+  fail "Allow order reshuffled: got $actual_allow, expected $expected_allow"
+fi
+
+expected_deny='["Bash(rm -rf *)","Bash(sudo *)","Alpha"]'
+actual_deny=$(echo "$result2b" | jq -c '.permissions.deny')
+if [ "$actual_deny" = "$expected_deny" ]; then
+  pass "Deny list preserves base order and appends new entries"
+else
+  fail "Deny order reshuffled: got $actual_deny, expected $expected_deny"
+fi
+
+# Guard against regression to a sorted-output implementation.
+if [ "$actual_allow" != "$(echo "$result2b" | jq -c '.permissions.allow | sort')" ]; then
+  pass "Allow output is not alphabetically sorted (curated order intact)"
+else
+  fail "Allow output equals its sorted form (curated order destroyed)"
+fi
+echo ""
+
 # --- Test 3: Hooks arrays are concatenated ---
 echo "--- Test 3: Hooks array concatenation ---"
 


### PR DESCRIPTION
## Summary

`merge_settings` deduplicated `permissions.allow` / `permissions.deny` with jq's `unique`, which **sorts** its input. Every install/merge therefore reshuffled the human-curated allow/deny lists into alphabetical order, destroying the intentional grouping.

## Root cause

`lib/merge.sh` line 62: `(($a[$key] + $b[$key]) | unique)`. `unique` in jq sorts then dedupes. Demonstrated on a non-alphabetical base list:

- Before: base `["Zebra","Apple","Bash(git *)","Read"]` + `["Read","Mango"]` → `["Apple","Bash(git *)","Mango","Read","Zebra"]` (alphabetized)
- After: → `["Zebra","Apple","Bash(git *)","Read","Mango"]` (base order kept, new entry appended)

## Changes

- Added a `dedup_ordered` jq helper: `reduce .[] as $x ([]; if any(.[]; . == $x) then . else . + [$x] end)` — keeps first occurrence, preserves input order.
- Applied it to `allow`, `deny`, and the hook event arrays (which had the identical `unique`-sort reshuffle). Dedup behavior is otherwise unchanged.
- Added test 2b in `tests/test-merge.sh` asserting base order is preserved and new unique entries are appended (with a guard that the output is not its sorted form).

## Test plan

- `bash tests/test-merge.sh` — 16 passed, 0 failed
- `bash tests/test-installer.sh` — 46 passed, 0 failed
- `bash tests/test-no-personal-data.sh` — pass
- `bash tests/run-all.sh` — 11 suites passed, 0 failed

Closes #676. Part of #659.