### PR TITLE
#677: drop tracked pycache; correct Task->Agent dispatch tool references

### DIFF
--- a/modules/agent-native/skills/agent-native-audit/SKILL.md
+++ b/modules/agent-native/skills/agent-native-audit/SKILL.md
@@ -82,7 +82,7 @@ for design guidance.
 
 ## Phase 1: Parallel Analysis
 
-Dispatch **eight Task agents in parallel** - two per principle. One agent per pair measures (counts, inventory); the other critiques (examples, violations, fixes). Use `subagent_type: "Explore"` and launch all eight in a single message so they run concurrently.
+Dispatch **eight agents in parallel** - two per principle. One agent per pair measures (counts, inventory); the other critiques (examples, violations, fixes). Use `subagent_type: "Explore"` and launch all eight in a single message so they run concurrently.
 
 Pass paths, not file contents (see `modules/subagent-patterns/rules/subagent-patterns.md`). Each agent gets the triage summary, the principle text verbatim from `modules/agent-native/rules/agent-native.md`, and the scoped paths to analyze.
 

--- a/modules/ce-review/skills/ce-review/SKILL.md
+++ b/modules/ce-review/skills/ce-review/SKILL.md
@@ -95,7 +95,7 @@ In `autofix`, `report-only`, and `headless` modes, record the scope-drift findin
 
 ## Phase 3: Tiered Reviewer Fan-Out
 
-Dispatch reviewer agents in parallel using the Task tool. Each reviewer returns a JSON array of findings matching `references/finding.schema.yaml`.
+Dispatch reviewer agents in parallel using the Agent tool. Each reviewer returns a JSON array of findings matching `references/finding.schema.yaml`.
 
 ### Always-on reviewers (every run)
 

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -103,7 +103,7 @@ Options:
 
 **Question 2** - header: "Execution", question: "How should the audit run?"
 Options:
-1. **Parallel worktrees (Recommended)** - description: "Task agents in isolated git worktrees within this repo. Good balance of depth and speed. Your working directory is never touched."
+1. **Parallel worktrees (Recommended)** - description: "Agents in isolated git worktrees within this repo. Good balance of depth and speed. Your working directory is never touched."
 2. **Single session** - description: "Lightweight read-only subagents in the current session. One subagent per selected pack. Fastest but least thorough."
 3. **Multi-clone** - description: "Agents across sibling clone directories. Deepest analysis with full context per agent. WARNING: Requires all clones to be on clean branches with no active work."
 4. **Manual setup** - description: "Set up worktrees and task files, then output launch commands so you can run each agent yourself in separate terminals."
@@ -681,7 +681,7 @@ PYEOF
 
 ### Phase M5: Launch Audit Workers
 
-**CRITICAL**: Determine which workers have non-empty pack assignments, then launch only those workers — in a SINGLE message with parallel Task tool calls (`subagent_type: "general-purpose"`, `run_in_background: true`).
+**CRITICAL**: Determine which workers have non-empty pack assignments, then launch only those workers — in a SINGLE message with parallel Agent tool calls (`subagent_type: "general-purpose"`, `run_in_background: true`).
 
 ```bash
 # Determine active worker ids
@@ -704,7 +704,7 @@ Display progress summary before launching:
 Running {N} audit workers in parallel...
 ```
 
-**Prompt template for each Task agent (read-only mode):**
+**Prompt template for each agent (read-only mode):**
 
 ```
 You are audit worker {WORKER_ID} performing a READ-ONLY codebase audit using the pack registry.
@@ -1080,7 +1080,7 @@ Notes:
 
 ## Worker Mode: `--worker` (Phases W1-W5)
 
-Run from a worktree (manual mode) or invoked as a Task agent (autonomous mode). Reads its pack-based task file and performs the audit of assigned packs.
+Run from a worktree (manual mode) or invoked as an agent (autonomous mode). Reads its pack-based task file and performs the audit of assigned packs.
 
 ### Phase W1: Self-ID & Task Load
 
@@ -1298,7 +1298,7 @@ wait
 
 ### M5-fix: Worker Prompts Include Fix Instructions
 
-The Task agent prompts are extended with strategy-specific instructions:
+The agent prompts are extended with strategy-specific instructions:
 
 **Worktree strategy** (default `--fix` path):
 ```
@@ -1604,8 +1604,8 @@ Then produce per-pack spine slices using the same slicing logic as Phase M4.
 
 ### Phase 4: Dispatch Read-Only Pack Subagents
 
-Launch **one Task agent per SELECTED pack** (not a fixed 9) in a SINGLE message with parallel
-Task tool calls (`subagent_type: "Explore"`, `run_in_background: true`).
+Launch **one Agent per SELECTED pack** (not a fixed 9) in a SINGLE message with parallel
+Agent tool calls (`subagent_type: "Explore"`, `run_in_background: true`).
 
 For each pack, the subagent receives:
 - The absolute path to the pack's `checks.md` (`$SKILL_ROOT/packs/<pack-dir>/checks.md`)
@@ -1709,8 +1709,8 @@ flag on the specific check. A check is eligible for autonomous fix only when:
 | `.audit/current/` already exists | Coordinator asks: clean start, resume, or cancel. |
 | Worktree already exists | Remove stale worktree first, then create fresh. |
 | Task file missing | Worker errors with message to run `/audit` first. |
-| Task agent times out | Collect proceeds with completed workers, reports incomplete ones. |
-| All Task agents fail | Report failure, suggest `--manual` mode. |
+| Agent times out | Collect proceeds with completed workers, reports incomplete ones. |
+| All agents fail | Report failure, suggest `--manual` mode. |
 | `--single` with `--fix` | Print note: `--single is read-only; --fix ignored`. Proceed read-only. |
 | `--staged` with `--fix` | Print note: `--staged is read-only; --fix ignored`. Proceed read-only. |
 

--- a/modules/copycat/commands/copycat.md
+++ b/modules/copycat/commands/copycat.md
@@ -119,7 +119,7 @@ Build a mental model of:
 
 ## Phase 2: Deep Analysis (Parallel Agents)
 
-Launch analysis agents in parallel using the Task tool. Set model to **sonnet** for all agents.
+Launch analysis agents in parallel using the Agent tool. Set model to **sonnet** for all agents.
 
 Each agent receives:
 1. The target repo path

--- a/modules/design-review/skills/design-review/SKILL.md
+++ b/modules/design-review/skills/design-review/SKILL.md
@@ -104,7 +104,7 @@ JSON.stringify(results, null, 2)
 
 ### Step 3: Run Parallel Analysis Passes
 
-Launch **6 Task agents in parallel** (single message, all `subagent_type: "Explore"`, `run_in_background: true`). Each agent receives the CSS source, computed styles JSON, and DOM structure extract. They analyze from one design lens.
+Launch **6 agents in parallel** (single message, all `subagent_type: "Explore"`, `run_in_background: true`). Each agent receives the CSS source, computed styles JSON, and DOM structure extract. They analyze from one design lens.
 
 Include the collected data directly in each agent's prompt (not file paths).
 

--- a/modules/documentation/commands/docupdate.md
+++ b/modules/documentation/commands/docupdate.md
@@ -42,7 +42,7 @@ Build a **repo manifest** from the output - a mental model of:
 
 ## Phase 1: Parallel Audit
 
-Launch all applicable audit agents in parallel using the Task tool. Each agent returns a structured list of **gaps** - things that are wrong, missing, or stale.
+Launch all applicable audit agents in parallel using the Agent tool. Each agent returns a structured list of **gaps** - things that are wrong, missing, or stale.
 
 Pass each agent: the repo manifest from Phase 0.
 

--- a/modules/editorial-critique/skills/editorial-critique/SKILL.md
+++ b/modules/editorial-critique/skills/editorial-critique/SKILL.md
@@ -27,7 +27,7 @@ Read the full file content. Strip frontmatter (everything between the opening an
 
 ### Step 2: Run Parallel Editorial Passes
 
-Launch **8 Task agents in parallel** (single message, all `subagent_type: "Explore"`). Do **NOT** use `run_in_background: true` - the agents must run in the foreground so the system waits for all 8 to complete before returning results. Launching all 8 in a single message ensures they execute concurrently while still blocking until all finish.
+Launch **8 agents in parallel** (single message, all `subagent_type: "Explore"`). Do **NOT** use `run_in_background: true` - the agents must run in the foreground so the system waits for all 8 to complete before returning results. Launching all 8 in a single message ensures they execute concurrently while still blocking until all finish.
 
 Each agent receives the full text and analyzes it from one lens.
 

--- a/modules/multi-agent/commands/mawf.md
+++ b/modules/multi-agent/commands/mawf.md
@@ -9,7 +9,7 @@ Takes unstructured feedback, feature requests, or bug reports, splits them into 
 
 ## Sub-Agent Model Optimization
 
-When spawning execution agents to implement issues in Phase 5, set model to **sonnet** in the Agent/Task tool call. Coding and implementation tasks work well on Sonnet. The orchestrator remains on the current model for issue parsing and agent coordination.
+When spawning execution agents to implement issues in Phase 5, set model to **sonnet** in the Agent tool call. Coding and implementation tasks work well on Sonnet. The orchestrator remains on the current model for issue parsing and agent coordination.
 
 ---
 
@@ -200,7 +200,7 @@ For each wave:
 
 #### 5.1 Spawn Agents
 
-Use the Task tool to launch one agent per assigned issue, each in its own clone directory:
+Use the Agent tool to launch one agent per assigned issue, each in its own clone directory:
 
 Each agent should:
 1. Navigate to its assigned clone directory

--- a/modules/multi-agent/multi-agent-system.md
+++ b/modules/multi-agent/multi-agent-system.md
@@ -116,7 +116,7 @@ The coordinator agent runs in the workspace directory (e.g., `~/code/myrepo-work
 
 1. Receives a set of issues or a task from the human
 2. Discovers available clones by listing subdirectories
-3. Spawns sub-agents into specific clone directories using the Task tool
+3. Spawns sub-agents into specific clone directories using the Agent tool
 4. Monitors progress and merges PRs
 5. Reports back to the human
 

--- a/modules/multi-agent/rules/multi-agent.md
+++ b/modules/multi-agent/rules/multi-agent.md
@@ -1,13 +1,13 @@
 # Parallel Work Preference
 
-When a task involves multiple independent issues or work items, prefer spawning parallel agents in separate clones to complete them simultaneously. Use the Task tool to launch agents, each working in its own clone directory.
+When a task involves multiple independent issues or work items, prefer spawning parallel agents in separate clones to complete them simultaneously. Use the Agent tool to launch agents, each working in its own clone directory.
 
 **When to parallelize:**
 - Multiple independent GitHub issues need to be completed
 - A project has issues that do not block each other
 - The repo has a multi-clone setup (workspace model: `~/code/{repo}-workspaces/` or flat model: `~/code/{repo}-repos/`)
 
-**How:** Launch Task agents pointed at different clone directories. Each agent claims its own issue via the tracking CSV (auto-registered by hooks on branch creation) and works independently. See `~/.claude/multi-agent-system.md` for the full coordination guide.
+**How:** Launch agents pointed at different clone directories. Each agent claims its own issue via the tracking CSV (auto-registered by hooks on branch creation) and works independently. See `~/.claude/multi-agent-system.md` for the full coordination guide.
 
 **Issue tracking**: Uses `~/code/{log-repo-name}/{repo}/tracking.csv`. Hooks auto-update tracking on branch creation, commits, PR creation, merge, and issue close. See `~/.claude/multi-agent-system.md` for details.
 

--- a/modules/research/commands/research.md
+++ b/modules/research/commands/research.md
@@ -17,7 +17,7 @@ For deeper, higher-quality research with a local pipeline, install `/deepresearc
 
 ## Sub-Agent Model Optimization
 
-When spawning research agents (Domain, Technical, Competitive, Adjacent, UX, Data, Monetization, Codebase), set model to **sonnet** in the Agent/Task tool call. Research synthesis and web queries work well on Sonnet. The orchestrator remains on the current model for final synthesis and verification.
+When spawning research agents (Domain, Technical, Competitive, Adjacent, UX, Data, Monetization, Codebase), set model to **sonnet** in the Agent tool call. Research synthesis and web queries work well on Sonnet. The orchestrator remains on the current model for final synthesis and verification.
 
 ---
 
@@ -137,7 +137,7 @@ Pass these targeted sub-questions to each agent instead of (or alongside) the br
 
 ## Phase 2: Spawn Research Agents
 
-Launch the selected research agents in **parallel** using the Task tool. Each agent gets:
+Launch the selected research agents in **parallel** using the Agent tool. Each agent gets:
 1. The topic/concept to research
 2. Its targeted sub-questions from Phase 1.5
 3. The Internet Research Tools reference (below)

--- a/modules/session-history/README.md
+++ b/modules/session-history/README.md
@@ -21,7 +21,7 @@ Files installed globally to `~/.claude/`:
 Two consumption patterns:
 
 1. **`/recall` slash command** — fast, deterministic summary / query over the last N days of sessions for the current repo (unified across all clones). Default 7 days. No agent dispatch, no LLM calls.
-2. **`session-historian` agent** — heavier synthesis via Task tool dispatch when you need "what was tried, what failed, what was decided" analysis across platforms (Claude Code + Codex).
+2. **`session-historian` agent** — heavier synthesis via Agent tool dispatch when you need "what was tried, what failed, what was decided" analysis across platforms (Claude Code + Codex).
 
 Use `/recall` for quick lookups. Use the agent when you need the history interpreted, not just listed.
 
@@ -75,7 +75,7 @@ chmod +x ~/.claude/scripts/add-agents-md-symlinks.sh
 
 ### From another skill or command
 
-Dispatch the agent via the Task tool. Pass:
+Dispatch the agent via the Agent tool. Pass:
 
 - A one-paragraph `task_summary` describing the current problem.
 - An optional `time_range` hint (`today`, `this week`, `last month`, ...).

--- a/modules/session-lifecycle/commands/sds.md
+++ b/modules/session-lifecycle/commands/sds.md
@@ -40,7 +40,7 @@ Use TaskList to see active background tasks the agent owns. For each running tas
 - If it's stalled or long-running, report it and ask once: "Background task `<id>` is still running. Wait, kill, or leave it?"
 - If nothing is running, say so in one line and move on.
 
-Sub-agents spawned via the Task tool that have already returned are out of scope — they don't need shutdown. Only `run_in_background` work and persistent background shells matter here.
+Sub-agents spawned via the Agent tool that have already returned are out of scope — they don't need shutdown. Only `run_in_background` work and persistent background shells matter here.
 
 ### Phase 2 — Working tree commit
 

--- a/modules/subagent-patterns/rules/subagent-patterns.md
+++ b/modules/subagent-patterns/rules/subagent-patterns.md
@@ -1,6 +1,6 @@
 # Subagent Patterns
 
-Methodology for decomposing work and delegating to subagents (Task tool) effectively.
+Methodology for decomposing work and delegating to subagents (Agent tool) effectively.
 
 ## When to Use Subagents
 

--- a/modules/test-vision/README.md
+++ b/modules/test-vision/README.md
@@ -94,7 +94,7 @@ The generated test suite supports building features test-first:
 ## Dependencies
 
 - `browser-automation` - Chrome MCP tool permissions for visual discovery
-- `multi-agent` - Task agent dispatch for parallel spec generation
+- `multi-agent` - agent dispatch for parallel spec generation
 
 ## Manual Installation
 

--- a/modules/test-vision/commands/test-vision.md
+++ b/modules/test-vision/commands/test-vision.md
@@ -353,7 +353,7 @@ For repos with >12 feature domains, split into two dispatch waves of 6-8 agents 
 
 ### 4.3 Dispatch Agents
 
-For each feature domain, spawn a Task agent (model: sonnet) with the following prompt:
+For each feature domain, spawn an agent (model: sonnet) with the following prompt:
 
 ```
 Read the file ~/.claude/commands/e2e.md and follow its instructions exactly.

--- a/modules/xplan/commands/xplan.md
+++ b/modules/xplan/commands/xplan.md
@@ -42,7 +42,7 @@ Specify cheaper models when spawning sub-agents to conserve usage without sacrif
 | Phase 4 | Review agents (security, architecture, business) | sonnet |
 | Phase 7 | Execution agents (epic implementation) | sonnet |
 
-The orchestrator (this session) stays on the current model for all synthesis, architecture, and interactive decisions. Simple background tasks (file checks, directory setup, issue creation) can use haiku if spawned as Task agents.
+The orchestrator (this session) stays on the current model for all synthesis, architecture, and interactive decisions. Simple background tasks (file checks, directory setup, issue creation) can use haiku if spawned as agents.
 
 ---
 
@@ -286,7 +286,7 @@ Wait for explicit selection. Do not auto-select.
 
 ### D.5 Dispatch Targeted Deepening Passes
 
-For each selected candidate, spawn a focused Task agent (model: sonnet) whose entire job is to close that one gap. The agent's brief:
+For each selected candidate, spawn a focused agent (model: sonnet) whose entire job is to close that one gap. The agent's brief:
 
 ```
 You are deepening one section of an existing plan.
@@ -499,9 +499,9 @@ Store the selection for Phase 1.1. Do not re-ask in Phase 1.0.
 
 ### 1.1 Delegate to /deepresearch
 
-Spawn a single Task agent (model: sonnet) that executes the `/deepresearch` skill with the concept, depth selection, plan directory, and repo (if provided).
+Spawn a single agent (model: sonnet) that executes the `/deepresearch` skill with the concept, depth selection, plan directory, and repo (if provided).
 
-The Task agent's prompt should be:
+The agent's prompt should be:
 
 ```
 Read the file ~/.claude/commands/deepresearch.md and follow its instructions exactly.
@@ -523,7 +523,7 @@ SOURCE FRESHNESS — repo facts:
 
 ### 1.2 Verify Research Output
 
-After the Task agent completes:
+After the agent completes:
 
 ```bash
 ls -la ~/code/plans/{concept-name}/research.md
@@ -624,7 +624,7 @@ If yes or "I already have a name":
 
 ### 2.1 Spawn Naming Agent
 
-Launch a Task agent (model: sonnet) that:
+Launch an agent (model: sonnet) that:
 1. Generates 15-25 name candidates based on research and concept
 2. Considers: memorability, brandability, brevity, relevance, uniqueness
 3. Checks for conflicts with existing apps/products (web search)
@@ -999,7 +999,7 @@ options:
 
 ### 4.1 Spawn Review Agents
 
-Launch chosen review agents in parallel using the Task tool (model: sonnet).
+Launch chosen review agents in parallel using the Agent tool (model: sonnet).
 
 1. **Security Review Agent** - Output: `~/code/plans/{concept-name}/reviews/security.md`
 2. **Architecture Review Agent** - Output: `~/code/plans/{concept-name}/reviews/architecture.md`
@@ -1385,7 +1385,7 @@ Read `~/code/plans/{concept-name}/comments.json`. It contains:
 - The "target section" for D.5 is the comment's `section_title` in the comment's `file`.
 - The "gap description" is the comment's `text`.
 - Derive the gap bucket heuristically: ambiguity / pattern / test / tech-assumption based on the comment's wording; default to ambiguity if unclear. This feeds the D.5 agent prompt.
-- Dispatch one Task agent per comment (model: sonnet), in parallel when comments target different sections, serialized when they touch the same section.
+- Dispatch one agent per comment (model: sonnet), in parallel when comments target different sections, serialized when they touch the same section.
 
 After the deepening agents return, integrate their results into plan.md via D.6 **without** re-prompting the user per section (the user already stated their intent in the comment - applying the proposed replacement is the direct implementation of that intent). If a deepening pass produces ambiguous or conflicting output, fall back to D.6's interactive AskUserQuestion for that single comment only.
 
@@ -1601,7 +1601,7 @@ For each wave:
 
 #### 7.3.1 Spawn Agents
 
-Spawn Task agents in parallel (model: sonnet), one per epic, assigned to different clones.
+Spawn agents in parallel (model: sonnet), one per epic, assigned to different clones.
 
 #### 7.3.2 Agent Work Loop
 


### PR DESCRIPTION
Closes #677. Part of #659 (Wave 1 hygiene).

## Summary

Two hygiene fixes:

**A. Python caches.** Verified no `__pycache__/`, `*.pyc`, or `.pytest_cache/` artifacts are tracked (`git ls-files` returned nothing). Root `.gitignore` already covers all three patterns (`__pycache__/`, `*.py[cod]`, `.pytest_cache/`) — no changes needed.

**B. Dispatch tool-name corrections.** Claude Code dispatches subagents via the **Agent** tool (the older name was `Task`). Confirmed the canonical convention from 18 existing up-to-date "Agent tool" references across the repo. Corrected every stale dispatch-tool reference:

- `Task tool` / `Agent/Task tool` -> `Agent tool` (genuine dispatch references in research, copycat, docupdate, xplan, session-history, multi-agent, mawf, sds, subagent-patterns, ce-review, audit)
- `Task agent(s)` -> `agent(s)` (the canonical bare form; "Task" was acting as the old tool-name qualifier — in xplan, editorial-critique, multi-agent, test-vision, agent-native-audit, design-review, audit)

Only genuine dispatch-tool references were changed. The 171 generic uses of "task" (todos, task decomposition, status-protocol "Task completed", hook filenames, "subagent task") were left untouched.

## Verification

- `tests/test-modules.sh`: 1349 passed, 0 failed (exit 0)
- `tests/run-all.sh`: all suites pass (Python 200 passed; shell 2 suites; audit 31/0) (exit 0)
- `tests/test-no-personal-data.sh`: PASS (exit 0)
- Re-grep `Task agents?|Task tool|Task\(` over `modules/`: 0 hits remaining