### PR TITLE
#675: add start.sh --add mode; data-driven CCGM_MODULE_* expansion with fail-on-leftover

### DIFF
--- a/lib/template.sh
+++ b/lib/template.sh
@@ -17,8 +17,17 @@ expand_templates() {
   # Load env values
   local home_val="" username_val="" code_dir_val="" log_repo_val="" timezone_val="" default_mode_val=""
 
+  # Per-module placeholders are data-driven: any CCGM_MODULE_* env entry whose
+  # name ends in a __PLACEHOLDER__ token contributes one substitution. The env
+  # name is CCGM_MODULE_<module>__<__PLACEHOLDER__> (see start.sh); the module
+  # segment is irrelevant here, only the trailing __UPPER_SNAKE__ token matters.
+  # Stored as parallel arrays (bash 3.2 has no associative arrays).
+  local module_placeholders=()
+  local module_values=()
+
   if [ -f "$env_file" ]; then
-    # Read all values in a single pass instead of 6 separate grep calls
+    # Read all values in a single pass instead of separate grep calls.
+    local key value placeholder
     while IFS='=' read -r key value; do
       case "$key" in
         CCGM_HOME) home_val="$value" ;;
@@ -27,6 +36,17 @@ expand_templates() {
         CCGM_LOG_REPO) log_repo_val="$value" ;;
         CCGM_TIMEZONE) timezone_val="$value" ;;
         CCGM_DEFAULT_MODE) default_mode_val="$value" ;;
+        CCGM_MODULE_*)
+          # Extract the trailing __UPPER_SNAKE__ token as the placeholder. The
+          # body must start and end with an alphanumeric so the match does not
+          # swallow the __ separator that joins <module> to <__PLACEHOLDER__>
+          # (the key is CCGM_MODULE_<module>____PLACEHOLDER__ - four underscores).
+          placeholder=$(printf '%s' "$key" | grep -oE '__[A-Z0-9]([A-Z0-9_]*[A-Z0-9])?__$' || true)
+          if [ -n "$placeholder" ]; then
+            module_placeholders+=("$placeholder")
+            module_values+=("$value")
+          fi
+          ;;
       esac
     done < "$env_file"
   fi
@@ -47,6 +67,13 @@ expand_templates() {
   log_repo_val="$(_escape_sed_replacement "$log_repo_val")"
   timezone_val="$(_escape_sed_replacement "$timezone_val")"
   default_mode_val="$(_escape_sed_replacement "$default_mode_val")"
+
+  # Escape every per-module value the same way.
+  local _i=0
+  while [ $_i -lt ${#module_values[@]} ]; do
+    module_values[$_i]="$(_escape_sed_replacement "${module_values[$_i]}")"
+    _i=$((_i + 1))
+  done
 
   # Perform replacements using sed
   # Use a different delimiter (|) in case paths contain /
@@ -72,6 +99,16 @@ expand_templates() {
     sed_expr+="s|__TIMEZONE__|${timezone_val}|g;"
   fi
   sed_expr+="s|__DEFAULT_MODE__|${default_mode_val}|g;"
+
+  # Append one substitution per declared per-module placeholder. The placeholder
+  # token is fixed UPPER_SNAKE so it needs no escaping; only the value does
+  # (already escaped above). Empty values are still substituted so the literal
+  # __PLACEHOLDER__ never survives in an installed file.
+  _i=0
+  while [ $_i -lt ${#module_placeholders[@]} ]; do
+    sed_expr+="s|${module_placeholders[$_i]}|${module_values[$_i]}|g;"
+    _i=$((_i + 1))
+  done
 
   # Apply sed in-place
   if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/start.sh
+++ b/start.sh
@@ -12,6 +12,10 @@ RESOLVED_MODULES=()
 INSTALLED_FILES=()
 MERGED_FILES=()
 BACKUP_DIRS=()
+# Targets that went through template expansion (template:true). Verification
+# fails hard if any __PLACEHOLDER__ survives in one of these; non-template files
+# (e.g. rule docs that mention __HOME__ in prose) are intentionally excluded.
+EXPANDED_FILES=()
 
 # --- Source libraries ---
 # shellcheck source=lib/ui.sh
@@ -261,6 +265,7 @@ run_add_mode() {
   # INSTALLED_FILES: uninstall un-merges them rather than deleting the file.
   INSTALLED_FILES=()
   MERGED_FILES=()
+  EXPANDED_FILES=()
   local entry action src target template mod_name
   for entry in ${install_plan[@]+"${install_plan[@]}"}; do
     IFS='|' read -r action src target template mod_name <<< "$entry"
@@ -277,6 +282,7 @@ run_add_mode() {
           merged_entry=$(record_merged_partial "$target" "$tmp_merge" "$global_dir")
           merge_settings "$target" "$tmp_merge"
           rm -f "$tmp_merge"
+          EXPANDED_FILES+=("$target")
         else
           merged_entry=$(record_merged_partial "$target" "$src" "$global_dir")
           merge_settings "$target" "$src"
@@ -291,6 +297,7 @@ run_add_mode() {
         if [ "$template" = "true" ]; then
           cp "$src" "$target"
           expand_templates "$target" "$env_file"
+          EXPANDED_FILES+=("$target")
           ui_success "Copied+expanded (template): $target"
         else
           ln -s "$src" "$target"
@@ -301,6 +308,7 @@ run_add_mode() {
         cp "$src" "$target"
         if [ "$template" = "true" ]; then
           expand_templates "$target" "$env_file"
+          EXPANDED_FILES+=("$target")
           ui_success "Copied+expanded: $target"
         else
           ui_success "Copied: $target"
@@ -308,6 +316,17 @@ run_add_mode() {
         ;;
     esac
     INSTALLED_FILES+=("$target")
+  done
+
+  # Fail fast if any declared placeholder survived expansion (broken config).
+  local _add_leftover
+  for f in ${EXPANDED_FILES[@]+"${EXPANDED_FILES[@]}"}; do
+    if [ -f "$f" ] && has_unexpanded_templates "$f"; then
+      _add_leftover=$(list_unexpanded_templates "$f")
+      ui_error "Unexpanded placeholder(s) in $f: $_add_leftover"
+      ui_info "Check the module's configPrompts and re-run with values supplied."
+      exit 1
+    fi
   done
 
   # --- Merge into the manifest (existing entries preserved) ---
@@ -1099,6 +1118,7 @@ main() {
   # uninstall un-merges the CCGM-contributed keys instead of deleting the file.
   INSTALLED_FILES=()
   MERGED_FILES=()
+  EXPANDED_FILES=()
 
   local entry action src target template mod_name
   for entry in ${install_plan[@]+"${install_plan[@]}"}; do
@@ -1121,6 +1141,7 @@ main() {
             merged_entry=$(record_merged_partial "$target" "$tmp_merge" "$global_dir")
             merge_settings "$target" "$tmp_merge"
             rm -f "$tmp_merge"
+            EXPANDED_FILES+=("$target")
           else
             merged_entry=$(record_merged_partial "$target" "$src" "$global_dir")
             merge_settings "$target" "$src"
@@ -1140,6 +1161,7 @@ main() {
           # Templates cannot be symlinked - must copy and expand
           cp "$src" "$target"
           expand_templates "$target" "$env_file"
+          EXPANDED_FILES+=("$target")
           ui_success "Copied+expanded (template): $target"
         else
           ln -s "$src" "$target"
@@ -1150,6 +1172,7 @@ main() {
         cp "$src" "$target"
         if [ "$template" = "true" ]; then
           expand_templates "$target" "$env_file"
+          EXPANDED_FILES+=("$target")
           ui_success "Copied+expanded: $target"
         else
           ui_success "Copied: $target"
@@ -1371,12 +1394,18 @@ TMPL
     fi
   done
 
-  # Check for unexpanded templates
+  # Check for unexpanded templates. A surviving __PLACEHOLDER__ in a file that
+  # was template-expanded means a declared placeholder had no value wired up
+  # (e.g. a module configPrompt that never reached .ccgm.env) - that is a hard
+  # failure, not a warning, because the installed config is broken. Only
+  # template:true targets are checked; rule docs that mention __HOME__ in prose
+  # are not in EXPANDED_FILES and are left alone.
   local remaining
-  for file in ${INSTALLED_FILES[@]+"${INSTALLED_FILES[@]}"}; do
+  for file in ${EXPANDED_FILES[@]+"${EXPANDED_FILES[@]}"}; do
     if [ -f "$file" ] && has_unexpanded_templates "$file"; then
       remaining=$(list_unexpanded_templates "$file")
-      ui_warn "Unexpanded templates in $file: $remaining"
+      ui_error "Unexpanded placeholder(s) in $file: $remaining"
+      verify_errors=$((verify_errors + 1))
     fi
   done
 

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -414,6 +414,106 @@ else
 fi
 echo ""
 
+# ============================================================
+# Test 6: --add a module with per-module placeholders expands them
+# ============================================================
+echo "--- Test 6: --add expands CCGM_MODULE_* placeholders ---"
+
+TEST6_HOME="$TMPDIR/test6"
+mkdir -p "$TEST6_HOME/.claude"
+export HOME="$TEST6_HOME"
+export CCGM_CODE_DIR="$TEST6_HOME/code"
+
+# Base install so a manifest + .ccgm.env exist.
+set +e
+"$REPO_ROOT/start.sh" --preset minimal --scope global </dev/null >/dev/null 2>&1
+base6_exit=$?
+set -e
+if [ $base6_exit -eq 0 ]; then
+  pass "Base minimal install for placeholder --add test"
+else
+  fail "Base minimal install failed (exit $base6_exit)"
+fi
+
+env6="$TEST6_HOME/.claude/.ccgm.env"
+
+# Seed per-module config the way the interactive installer would have. The key
+# shape is CCGM_MODULE_<module>__<__PLACEHOLDER__> (four underscores).
+{
+  echo "CCGM_MODULE_remote-server____REMOTE_HOST__=10.20.30.40"
+  echo "CCGM_MODULE_remote-server____REMOTE_USER__=ops"
+  echo "CCGM_MODULE_remote-server____REMOTE_ALIAS__=lab-box"
+} >> "$env6"
+
+set +e
+"$REPO_ROOT/start.sh" --add remote-server </dev/null >/dev/null 2>&1
+add6_exit=$?
+set -e
+if [ $add6_exit -eq 0 ]; then
+  pass "--add remote-server (with seeded config) exited successfully"
+else
+  fail "--add remote-server exited with code $add6_exit"
+fi
+
+onremote="$TEST6_HOME/.claude/commands/onremote.md"
+if [ -f "$onremote" ]; then
+  pass "commands/onremote.md installed after --add"
+
+  if grep -qE '__[A-Z_]+__' "$onremote"; then
+    fail "onremote.md still has leftover placeholders: $(grep -oE '__[A-Z_]+__' "$onremote" | sort -u | tr '\n' ' ')"
+  else
+    pass "onremote.md has no leftover __PLACEHOLDER__"
+  fi
+
+  if grep -q "10.20.30.40" "$onremote" && grep -q "ops" "$onremote" && grep -q "lab-box" "$onremote"; then
+    pass "onremote.md contains expanded host/user/alias values"
+  else
+    fail "onremote.md missing expected expanded values"
+  fi
+else
+  fail "commands/onremote.md missing after --add"
+fi
+echo ""
+
+# ============================================================
+# Test 7: --add FAILS when a declared placeholder is unwired
+# ============================================================
+echo "--- Test 7: --add fails on leftover placeholder ---"
+
+TEST7_HOME="$TMPDIR/test7"
+mkdir -p "$TEST7_HOME/.claude"
+export HOME="$TEST7_HOME"
+export CCGM_CODE_DIR="$TEST7_HOME/code"
+
+set +e
+"$REPO_ROOT/start.sh" --preset minimal --scope global </dev/null >/dev/null 2>&1
+base7_exit=$?
+set -e
+if [ $base7_exit -eq 0 ]; then
+  pass "Base minimal install for fail-on-leftover test"
+else
+  fail "Base minimal install failed (exit $base7_exit)"
+fi
+
+# Note: NO CCGM_MODULE_remote-server__* entries seeded, so onremote.md's
+# placeholders cannot be expanded -> install must fail.
+set +e
+add7_out=$("$REPO_ROOT/start.sh" --add remote-server </dev/null 2>&1)
+add7_exit=$?
+set -e
+if [ $add7_exit -ne 0 ]; then
+  pass "--add with unwired placeholders fails with non-zero exit"
+else
+  fail "--add with unwired placeholders unexpectedly succeeded"
+fi
+
+if echo "$add7_out" | grep -qiE "unexpanded placeholder"; then
+  pass "Failure message names the unexpanded placeholder"
+else
+  fail "Failure message did not mention unexpanded placeholder"
+fi
+echo ""
+
 # Restore HOME
 export HOME="$TMPDIR/home"
 

--- a/tests/test-templates.sh
+++ b/tests/test-templates.sh
@@ -216,6 +216,113 @@ else
 fi
 echo ""
 
+# --- Test 6: Per-module CCGM_MODULE_* placeholder expansion ---
+echo "--- Test 6: Per-module placeholder expansion ---"
+
+# The installer writes per-module config as CCGM_MODULE_<module>__<__PLACEHOLDER__>
+# (note the four underscores joining the module name to the placeholder token).
+# expand_templates must pick these up data-driven and substitute the trailing
+# __PLACEHOLDER__ token.
+cat > "$TMPDIR/module-template.md" << 'TEMPLATE'
+Host: __REMOTE_HOST__
+User: __REMOTE_USER__
+Alias: __REMOTE_ALIAS__
+Home: __HOME__
+TEMPLATE
+
+cat > "$TMPDIR/module.env" << 'ENV'
+CCGM_HOME=/home/testuser
+CCGM_USERNAME=testuser
+CCGM_MODULE_remote-server____REMOTE_HOST__=192.168.1.50
+CCGM_MODULE_remote-server____REMOTE_USER__=deploy
+CCGM_MODULE_remote-server____REMOTE_ALIAS__=home-server
+ENV
+
+expand_templates "$TMPDIR/module-template.md" "$TMPDIR/module.env"
+mod_content=$(cat "$TMPDIR/module-template.md")
+
+if echo "$mod_content" | grep -q "Host: 192.168.1.50"; then
+  pass "__REMOTE_HOST__ replaced from CCGM_MODULE_* entry"
+else
+  fail "__REMOTE_HOST__ not replaced (got: $(echo "$mod_content" | grep Host))"
+fi
+
+if echo "$mod_content" | grep -q "User: deploy"; then
+  pass "__REMOTE_USER__ replaced from CCGM_MODULE_* entry"
+else
+  fail "__REMOTE_USER__ not replaced"
+fi
+
+if echo "$mod_content" | grep -q "Alias: home-server"; then
+  pass "__REMOTE_ALIAS__ replaced from CCGM_MODULE_* entry"
+else
+  fail "__REMOTE_ALIAS__ not replaced"
+fi
+
+# Core placeholders still expand alongside module ones.
+if echo "$mod_content" | grep -q "Home: /home/testuser"; then
+  pass "Core __HOME__ still expands alongside module placeholders"
+else
+  fail "Core __HOME__ not expanded in module template"
+fi
+
+if has_unexpanded_templates "$TMPDIR/module-template.md"; then
+  remaining=$(list_unexpanded_templates "$TMPDIR/module-template.md")
+  fail "Module template has leftover placeholders: $remaining"
+else
+  pass "No leftover __PLACEHOLDER__ after module expansion"
+fi
+echo ""
+
+# --- Test 7: Values with sed-special characters are escaped ---
+echo "--- Test 7: sed-special chars in module values ---"
+
+cat > "$TMPDIR/special-template.md" << 'TEMPLATE'
+Host: __REMOTE_HOST__
+TEMPLATE
+
+# A value containing & (sed match-reference) and | (the sed delimiter).
+cat > "$TMPDIR/special.env" << 'ENV'
+CCGM_MODULE_remote-server____REMOTE_HOST__=a&b|c
+ENV
+
+expand_templates "$TMPDIR/special-template.md" "$TMPDIR/special.env"
+special_content=$(cat "$TMPDIR/special-template.md")
+
+if echo "$special_content" | grep -qF "Host: a&b|c"; then
+  pass "sed-special characters in module value preserved literally"
+else
+  fail "sed-special characters mangled (got: $special_content)"
+fi
+echo ""
+
+# --- Test 8: Unwired placeholder survives (caller can fail on it) ---
+echo "--- Test 8: Unwired module placeholder is detectable ---"
+
+cat > "$TMPDIR/unwired-template.md" << 'TEMPLATE'
+Host: __REMOTE_HOST__
+Token: __SECRET_TOKEN__
+TEMPLATE
+
+# Only one of the two placeholders is wired in the env file.
+cat > "$TMPDIR/unwired.env" << 'ENV'
+CCGM_MODULE_remote-server____REMOTE_HOST__=10.0.0.1
+ENV
+
+expand_templates "$TMPDIR/unwired-template.md" "$TMPDIR/unwired.env"
+
+if has_unexpanded_templates "$TMPDIR/unwired-template.md"; then
+  remaining=$(list_unexpanded_templates "$TMPDIR/unwired-template.md")
+  if [ "$remaining" = "__SECRET_TOKEN__" ]; then
+    pass "Unwired placeholder __SECRET_TOKEN__ correctly survives for detection"
+  else
+    fail "Expected only __SECRET_TOKEN__ leftover, got: $remaining"
+  fi
+else
+  fail "Unwired placeholder was silently consumed (should remain for fail check)"
+fi
+echo ""
+
 # --- Summary ---
 echo "==================================="
 echo "  Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
Closes #675
Part of #659

## Summary

Two installer fixes from the Wave 1 audit. The audit was partially stale: `start.sh --add` already existed and was already tested, so this PR verifies it and leaves it intact. The real defect was per-module template expansion.

## What was actually broken

`lib/template.sh::expand_templates` only handled six hardcoded placeholders (`__HOME__`, `__USERNAME__`, `__CODE_DIR__`, `__LOG_REPO__`, `__TIMEZONE__`, `__DEFAULT_MODE__`) and silently ignored every `CCGM_MODULE_*` entry. Result: the `remote-server` module's `/onremote` command installed with literal `__REMOTE_HOST__` / `__REMOTE_USER__` / `__REMOTE_ALIAS__` placeholders, since those come from the module's `configPrompts`, not the core set.

## Changes

- **`lib/template.sh`** — data-driven expansion over any `CCGM_MODULE_*` env entry. The env key shape is `CCGM_MODULE_<module>____PLACEHOLDER__`; the module segment is irrelevant, so the trailing `__UPPER_SNAKE__` token is extracted (regex requires alphanumeric boundaries so it doesn't swallow the `__` separator). Values are sed-escaped like the core placeholders; one substitution is appended per placeholder. No per-module hardcoding.
- **`start.sh`** — track template-expanded targets in a new `EXPANDED_FILES` array (main flow + `--add` flow). A surviving `__PLACEHOLDER__` in an expanded file is now a hard verification error (was a silent `ui_warn`). The non-interactive `--add` path `exit 1`s on any leftover. Only `template:true` targets are checked, so rule docs that mention `__HOME__` in prose are untouched.
- **tests** — extended `test-templates.sh` (per-module expansion, sed-special chars in values, unwired-placeholder detection) and `test-installer.sh` (`--add remote-server` expands placeholders end-to-end; `--add` fails non-zero on an unwired placeholder).

## Verification

All run on this branch, exit 0:

- `bash tests/test-templates.sh` — 22 passed, 0 failed
- `bash tests/test-installer.sh` — 54 passed, 0 failed
- `bash tests/test-no-personal-data.sh` — clean
- `bash tests/run-all.sh` — 11 groups + 31 audit suites, 0 failed

Portable bash 3.2 (parallel arrays, no associative arrays) and BSD-grep-safe (`grep -oE` only) for the macOS CI job.