### PR TITLE
#693: add RED baseline step to skill authoring

### DIFF
--- a/modules/skill-authoring/README.md
+++ b/modules/skill-authoring/README.md
@@ -6,6 +6,7 @@ Discipline for writing skills and slash commands that stay efficient, portable, 
 
 Installs a rule file that governs how new skills and commands are authored:
 
+- **RED baseline (watch it fail first)** - before writing a skill, run a no-skill agent on a representative task, capture its failure modes and rationalizations, write the minimal skill targeting them, then re-run with the skill to confirm the behavior changed (GREEN). The baseline failure is a gate, not optional.
 - **Reference-file inclusion** - when to use backtick CWD-relative paths versus `@` inline embeds
 - **Conditional content extraction** - move late-sequence or conditionally-used blocks into `references/` so they do not live in every subsequent message
 - **Tool selection** - prefer native tools (Glob, Grep, Read) over shell equivalents

--- a/modules/skill-authoring/rules/skill-authoring.md
+++ b/modules/skill-authoring/rules/skill-authoring.md
@@ -17,6 +17,48 @@ This rule governs authoring of:
 
 It does NOT govern rule files (`rules/*.md`), which are loaded once at session start and follow separate conventions in CONTRIBUTING.md.
 
+## The RED Baseline (Watch It Fail First)
+
+**Iron Law:** NO SKILL WITHOUT A CAPTURED BASELINE FAILURE FIRST.
+
+A skill exists to change an agent's behavior. If the behavior was already correct without the skill, the skill is dead weight that taxes every future invocation. The only proof that a skill is needed is a baseline run where an agent *without* the skill produces the wrong behavior. Watch it fail, capture exactly how it failed, then write the minimal skill that targets those failures - and only those.
+
+This is red-green-refactor applied to skills:
+
+1. **RED** - Run a representative task with an agent that does NOT have the skill. Capture the failure modes and the rationalizations it produces.
+2. **GREEN** - Write the smallest skill that targets the captured failures. Re-run the same task with the skill loaded. Confirm the behavior changed.
+3. **REFACTOR** - Trim the skill to context-efficient form (the rest of this rule) while keeping the GREEN result.
+
+A skill written without watching the baseline fail is a guess about what an agent gets wrong. Guesses produce skills full of advice the agent never needed and missing the corrections it did.
+
+### RED: Capture the Baseline Failure
+
+Before writing any skill content:
+
+1. **Pick a representative task** - a concrete instance of the situation the skill is meant to handle. Not a toy; the real kind of task the trigger will match.
+2. **Run an agent without the skill** - a fresh subagent that does not have the skill loaded. Give it the task and nothing else.
+3. **Record the failure modes** - what specifically did it get wrong? Wrong tool, skipped step, bad default, unsafe action, missing verification?
+4. **Record the rationalizations** - the phrases the agent used to justify the wrong behavior ("this is too small to test," "I'll just chain these commands," "the happy path is enough"). These become the left column of the skill's "Rationalizations" table.
+
+If the baseline agent does the task correctly with no skill, **stop**. There is no skill to write. A skill that does not change behavior is bloat, not discipline.
+
+### GREEN: Write the Minimal Skill, Then Confirm
+
+1. **Target only the captured failures** - each section of the skill should correct a specific failure mode or rationalization observed in RED. Do not add advice for failures the baseline agent never produced.
+2. **Re-run the same representative task** with the skill loaded.
+3. **Confirm the behavior changed** - the failure modes from RED no longer appear. If a failure persists, the skill text did not target it sharply enough; revise and re-run, do not declare done.
+
+GREEN is the gate. A skill is not finishable until a skill-loaded run on the RED task demonstrably differs from the baseline.
+
+### Rationalizations That Mean You Are About to Skip the RED Baseline
+
+| You are about to say... | The reality is... |
+|-------------------------|-------------------|
+| "I already know what the agent gets wrong" | If you knew, the baseline run confirms it in two minutes. If you are wrong, you just avoided shipping a skill that targets the wrong failure. |
+| "Running a baseline is slower than just writing the skill" | Writing a skill the agent did not need is the slow path - it taxes every future invocation forever. |
+| "The skill is obviously needed" | "Obvious" is the word that precedes most unnecessary skills. Watch it fail first. |
+| "I'll verify the skill works after I write it" | Verifying against a skill-loaded run with no recorded baseline proves nothing - you cannot see what changed. |
+
 ## Reference File Inclusion
 
 ### Use Backticks for CWD-Relative Reads
@@ -145,6 +187,9 @@ Skills that describe behavior in the abstract ("handle errors appropriately") ar
 
 Before committing a new skill or command file:
 
+- [ ] A RED baseline was captured: a no-skill agent run on a representative task that demonstrably failed
+- [ ] The skill targets only the failure modes and rationalizations observed in RED
+- [ ] A GREEN run (skill loaded, same task) confirmed the behavior changed
 - [ ] Every reference file lives inside the skill's directory
 - [ ] Backticks are used for on-demand reads; `@` is used only for small structural files
 - [ ] Conditional content (~20%+ of the skill, used by some invocations) is extracted to `references/`
@@ -169,6 +214,8 @@ Before committing a new skill or command file:
 
 Stop and restructure the skill if you catch yourself:
 
+- Writing skill content before running a no-skill baseline that failed
+- Declaring a skill done without a GREEN run that differs from the baseline
 - Embedding a schema or long table inline at the top of the skill body
 - Writing a branched procedure (if X do this, if Y do this, if Z do this) where each branch is more than a paragraph
 - Chaining more than two Bash actions in a single instruction

--- a/modules/skillify/README.md
+++ b/modules/skillify/README.md
@@ -6,16 +6,18 @@ Slash command that promotes an ad-hoc session capability into a durable skill.
 
 Installs a `/skillify` command that walks the agent through turning "this just worked" into permanent, tested infrastructure:
 
-1. Identify the capability and its trigger
-2. Classify each step as latent (judgment) vs deterministic (script)
-3. Check for name collisions against existing commands
-4. Write the skill contract (command file with triggers and rules)
-5. Extract deterministic steps into a helper script
-6. Write a pinning test for the script
-7. Register a pointer in the learnings store
-8. Report what was created
+1. Identify the capability and its trigger (and classify each step as latent vs deterministic)
+2. Capture the RED baseline (gate): run a no-skill agent on a representative task and record its failure modes + rationalizations — if it succeeds with no skill, stop, there is nothing to skillify
+3. Decide scope and location
+4. Check for name collisions against existing commands
+5. Write the skill contract, targeting only the RED failures
+6. Extract deterministic steps into a helper script
+7. Write a pinning test for the script
+8. Confirm GREEN (gate): re-run the same RED task with the skill loaded and confirm the behavior changed
+9. Register a pointer in the learnings store
+10. Report what was created (including the RED baseline and GREEN confirmation)
 
-Inspired by the skillify pattern: every repeated failure becomes structurally unreachable by being turned into a tested skill.
+Inspired by the skillify pattern: every repeated failure becomes structurally unreachable by being turned into a tested skill. The RED baseline + GREEN confirmation make this red-green-refactor for skills — a captured baseline failure proves the skill is needed and pins exactly what it must correct.
 
 ## Manual Installation
 
@@ -35,13 +37,13 @@ Make sure `~/.claude/bin` is on `$PATH` so the collision-check helper is discove
 
 - `skill-authoring` — rules governing how skills are written (reference-file inclusion, voice, tool selection)
 - `code-quality` (`rules/latent-vs-deterministic.md`) — the classification the `/skillify` workflow leans on in Phase 1
-- `self-improving` — provides `ccgm-learnings-log` which `/skillify` uses in Phase 7 to register the new skill
+- `self-improving` — provides `ccgm-learnings-log` which `/skillify` uses in Phase 9 to register the new skill
 
 ## Files
 
 | File | Description |
 |------|-------------|
-| `commands/skillify.md` | The `/skillify` slash command — 8-phase workflow from capability to durable skill |
+| `commands/skillify.md` | The `/skillify` slash command — 10-phase red-green-refactor workflow from capability to durable skill |
 | `bin/ccgm-skillify-check` | Deterministic helper: scans `~/.claude/commands/` and `.claude/commands/` for exact and fuzzy name collisions |
 
 ## `ccgm-skillify-check`

--- a/modules/skillify/commands/skillify.md
+++ b/modules/skillify/commands/skillify.md
@@ -29,7 +29,22 @@ Classify every step in the workflow:
 
 If `rules/latent-vs-deterministic.md` is installed, follow it strictly. Deterministic steps must become scripts; latent steps stay in the skill's prose.
 
-### Phase 2: Decide Scope and Location
+### Phase 2: Capture the RED Baseline (Gate)
+
+**Do not write any skill content until a no-skill agent has been watched failing the task.** This is red-green-refactor for skills: the baseline failure proves the skill is needed and pins exactly what it must correct. A skill written without a captured baseline is a guess about what an agent gets wrong.
+
+If `rules/skill-authoring.md` is installed, follow its "RED Baseline" section. The steps:
+
+1. **Pick a representative task** — a concrete instance of the situation the trigger will match, not a toy.
+2. **Run a fresh subagent WITHOUT the skill** — give it only the task. Use the agent-dispatch tool (e.g., Task in Claude Code).
+3. **Record the failure modes** — wrong tool, skipped step, bad default, unsafe action, missing verification.
+4. **Record the rationalizations** — the phrases the baseline agent used to justify the wrong behavior. These become the left column of the skill's "Rationalizations" table in Phase 5.
+
+**Gate:** If the baseline agent does the task correctly with no skill, **stop and do not create the skill.** A skill that does not change behavior is bloat that taxes every future invocation. Report that no skill was warranted and exit.
+
+Keep the captured failure modes and rationalizations — Phase 5 targets them and Phase 8 re-runs against them.
+
+### Phase 3: Decide Scope and Location
 
 Ask (or infer from context):
 
@@ -38,7 +53,7 @@ Ask (or infer from context):
   - Global if the capability is repo-agnostic
 - **Helper code location**: project's existing scripts/lib directory, or `~/.claude/lib/` for global
 
-### Phase 3: Check for Collisions
+### Phase 4: Check for Collisions
 
 Run the deterministic helper:
 
@@ -53,7 +68,7 @@ It scans the user's command directories (`~/.claude/commands/` and any `.claude/
 
 If the check reports a collision, stop and resolve before creating files.
 
-### Phase 4: Write the Skill Contract
+### Phase 5: Write the Skill Contract (Target the RED Failures)
 
 Create the command file with this structure:
 
@@ -80,12 +95,14 @@ Create the command file with this structure:
 ...
 ```
 
+Each section of the skill must correct a specific failure mode or rationalization captured in the Phase 2 RED baseline. Add the captured rationalizations to the skill's "Rationalizations" table. Do not add advice for failures the baseline agent never produced — unprompted advice is the bloat the skill-authoring discipline exists to prevent.
+
 Follow `rules/skill-authoring.md` if installed:
 - Reference files by path, don't inline large content
 - Imperative voice, not second-person
 - One command per bash invocation, no chaining in the runtime shell
 
-### Phase 5: Extract Deterministic Code
+### Phase 6: Extract Deterministic Code
 
 For every deterministic step identified in Phase 1:
 
@@ -94,7 +111,7 @@ For every deterministic step identified in Phase 1:
 3. Make it executable (`chmod +x`).
 4. Have the skill's workflow invoke the script instead of describing the computation in prose.
 
-### Phase 6: Write a Pinning Test
+### Phase 7: Write a Pinning Test
 
 One test per script. Pin the output for a representative input. The goal is a regression guard, not exhaustive coverage.
 
@@ -104,7 +121,16 @@ One test per script. Pin the output for a representative input. The goal is a re
 
 The test must fail if the script's output drifts. Watch it pass before moving on.
 
-### Phase 7: Register with the Learnings Store
+### Phase 8: Confirm GREEN (Re-run the RED Task With the Skill)
+
+Close the red-green loop. Re-run the **same representative task from Phase 2**, this time with the new skill loaded (a fresh subagent that has the skill, or reload and invoke the trigger). Compare against the baseline:
+
+- The failure modes captured in RED no longer appear.
+- The behavior demonstrably differs from the no-skill baseline.
+
+**Gate:** If a captured failure persists, the skill text did not target it sharply enough. Revise the skill (back to Phase 5) and re-run. Do not proceed to Register/Report until the GREEN run differs from the baseline. A skill whose GREEN run matches its RED run changed nothing and should not ship.
+
+### Phase 9: Register with the Learnings Store
 
 If `ccgm-learnings-log` is available, log an entry pointing at the new skill so future `/reflect` runs and searches surface it:
 
@@ -119,10 +145,12 @@ ccgm-learnings-log \
 
 If the learnings store isn't installed, skip this phase without ceremony.
 
-### Phase 8: Report
+### Phase 10: Report
 
-State the result in 3-5 lines:
+State the result in 3-6 lines:
 
+- RED baseline: `<the failure modes the no-skill agent produced>`
+- GREEN confirmation: `<how the skill-loaded run differed from the baseline>`
 - Skill created at: `<path>`
 - Helper script at: `<path>` (or "no script — pure prose workflow")
 - Test at: `<path>` (confirmed passing / pending)
@@ -133,8 +161,11 @@ State the result in 3-5 lines:
 
 Stop and reconsider if you catch yourself:
 
+- Writing skill content before a no-skill baseline (Phase 2) was watched failing the task
+- Creating a skill when the baseline agent did the task correctly with no skill — there is nothing to skillify
+- Shipping the skill without a GREEN re-run (Phase 8) that differs from the baseline
 - Creating a skill before the workflow has actually worked once in this session
-- Skipping Phase 3 (collision check) to save time
+- Skipping Phase 4 (collision check) to save time
 - Writing prose for a deterministic computation instead of a script
 - Shipping the skill without writing the test
 - Naming the skill generically (`helper`, `util`, `fix-stuff`) — the trigger won't match anything
@@ -143,6 +174,9 @@ Stop and reconsider if you catch yourself:
 
 | You are about to say... | The reality is... |
 |-------------------------|-------------------|
+| "I know what the agent gets wrong, skip the baseline" | If you know, the baseline confirms it in two minutes. If you are wrong, you just avoided shipping a skill that targets the wrong failure. |
+| "The baseline run is slower than just writing the skill" | Writing a skill the agent did not need taxes every future invocation forever. The baseline is the cheap path. |
+| "The skill works, I'll skip the GREEN re-run" | Without a re-run against the RED task, you cannot prove the skill changed anything. The GREEN run is the gate. |
 | "The test is trivial, I'll add it later" | Later means never. A skill without a test rots silently. |
 | "It's a one-off, no need to skillify" | If it's one-off, don't skillify. If it might recur, don't cut the test. |
 | "The collision check is paranoid" | The collision check runs in 200ms. Name conflicts are silent and permanent. |


### PR DESCRIPTION
## Summary

Adds a required RED baseline ("watch it fail first") step to skill authoring, applying TDD red-green-refactor discipline to skills (per obra/superpowers writing-skills).

Before writing a skill, run an agent WITHOUT the skill on a representative task, capture the failure modes and rationalizations it produces, write the minimal skill targeting only those, then re-run with the skill to confirm the behavior changed (GREEN). The baseline failure is now a **gate**, not optional.

## Changes

**`modules/skill-authoring/rules/skill-authoring.md`**
- New "The RED Baseline (Watch It Fail First)" section with an Iron Law, framed as red-green-refactor: RED (capture baseline failure) → GREEN (minimal skill + confirm behavior changed) → REFACTOR (trim for context efficiency).
- If the baseline agent succeeds with no skill, stop — there is no skill to write.
- Added RED/GREEN items to the Authoring Checklist, two new Red Flags, and a Rationalizations table for skipping the baseline.

**`modules/skillify/commands/skillify.md`**
- Inserted Phase 2 "Capture the RED Baseline (Gate)" and Phase 8 "Confirm GREEN (Re-run the RED Task With the Skill)"; renumbered all phases (now 10).
- Phase 5 (Write the Skill Contract) now targets only the captured RED failures.
- Phase 10 (Report) surfaces the RED baseline and GREEN confirmation.
- Added Red Flags and Rationalizations entries enforcing the two new gates.

**READMEs** updated for both modules (phase list, phase count, RED/GREEN summary). No files added, so `module.json` `files[]` unchanged.

## Test Plan

- `bash tests/test-modules.sh` → 1374 passed, 0 failed
- `bash tests/test-no-personal-data.sh` → PASS

Closes #693
Part of #659