### PR TITLE
#690: fresh-context reviewer phases + results-in-files return path

### DIFF
--- a/modules/ce-review/README.md
+++ b/modules/ce-review/README.md
@@ -34,13 +34,19 @@ The legacy entry points remain installed. Use them when the stakes are low or wh
 
 ## The Pipeline
 
-1. **Phase 0 - Inputs**: collect diff, PR body, commit messages, issue body
+1. **Phase 0 - Inputs**: collect diff, the requirement clauses of the PR/issue (intent only, not the author's rationale), commit subjects, and fresh build/test output
 2. **Phase 1 - Priors**: dispatch `learnings-researcher` (from `compound-knowledge`) with the diff summary; include returned blocks as grounding for every downstream reviewer
 3. **Phase 2 - Scope-drift**: invoke the `scope-drift` skill (from `pr-review-toolkit`); in interactive mode, a HIGH gating "block" stops the pipeline
 4. **Phase 3 - Tiered fan-out**: dispatch always-on reviewers in parallel, plus conditional reviewers selected from the diff content
-5. **Phase 4 - Adversarial**: dispatch `adversarial-reviewer` with every Phase 3 reviewer's output; five lenses (attack happy path, silent failures, trust assumptions, edge cases, integration boundaries)
+5. **Phase 4 - Adversarial**: dispatch `adversarial-reviewer` with the paths to every Phase 3 reviewer's findings artifact; five lenses (attack happy path, silent failures, trust assumptions, edge cases, integration boundaries)
 6. **Phase 5 - Merge / Dedupe / Route**: confidence-gate at 0.50, dedupe on `(file, line ±3, category)`, route by `autofix_class`
 7. **Phase 6 - Output**: Fix-First format (AUTO-FIXED / NEEDS INPUT / RED-TEAM LENS), plus a full JSON envelope at `.context/ce-review/{timestamp}-{base}-{head}.json`
+
+## Fresh-Context Integrity
+
+Reviewer phases run in **fresh context**. A reviewer receives only the spec/intent, the diff (or changed-file paths), and fresh build/test output - never the implementer's conversation, completion report, or "why I did it this way" rationale. A reviewer who reads the author's justification grades the defense of the change instead of the change, which inflates sign-off. This mirrors the Argus integrity principle (the judge never sees the diff-author's reasoning) and heliohq/ship (review runs in a clean session). The one intended cross-phase context flow is Phase 4: the adversarial reviewer reads the other reviewers' findings, which are independent review output, not author rationale.
+
+**Results stay in files, not in the reply.** Each reviewer writes its JSON findings to `.context/ce-review/reviewers/{run_id}/{reviewer-name}.json` and replies with only that path plus `Findings written.`. The orchestrator merges from the artifacts on disk, not from a reviewer's prose summary in the chat - so every sign-off traces back to a re-readable file rather than a narrative.
 
 ## Modes
 

--- a/modules/ce-review/agents/reviewers/adversarial-reviewer.md
+++ b/modules/ce-review/agents/reviewers/adversarial-reviewer.md
@@ -13,11 +13,11 @@ This agent is dispatched LAST. It receives the findings from every other reviewe
 
 ## Inputs
 
-Same as every reviewer, plus the key addition:
+Same as every reviewer - **only** fresh-context inputs (spec/intent, diff, build/test output, `prior_learnings`, `scope_drift_audit`, and an `output_path`). You do NOT receive the implementer's conversation, completion report, or rationale; judge the change on its own merits. Plus the key addition:
 
-- `prior_findings` - the merged JSON output from correctness, testing, maintainability, project-standards, and any conditional reviewers (security, performance, reliability, api-contract, data-migrations)
+- `prior_findings` - the paths to the other reviewers' findings artifacts under `.context/ce-review/reviewers/{run_id}/`. These are independent **review output**, not the implementer's rationale - reading them is the one intended cross-phase context flow, and the whole point of this reviewer.
 
-Read `prior_findings` first. Note what was covered. Everything below that was covered, skip. Everything not covered is your surface area.
+Read the `prior_findings` artifacts first. Note what was covered. Everything below that was covered, skip. Everything not covered is your surface area.
 
 ## The Five Lenses
 
@@ -124,6 +124,8 @@ Same scale. Do not promote a finding above the severity the code's actual behavi
 - `advisory` - Observation without a clear fix.
 
 ## Output
+
+**Results stay in files, not in the reply.** Write your findings as a JSON array to `output_path` (`.context/ce-review/reviewers/{run_id}/adversarial-reviewer.json`); empty array `[]` if nothing. Reply with only that path plus `Findings written.` - the orchestrator merges from the file, not your narrative.
 
 Standard JSON array. The `reviewer` field must be exactly `adversarial-reviewer`. Include the lens in `category`:
 

--- a/modules/ce-review/agents/reviewers/api-contract-reviewer.md
+++ b/modules/ce-review/agents/reviewers/api-contract-reviewer.md
@@ -11,7 +11,7 @@ Finds changes that will break callers - external clients, other services, other 
 
 ## Inputs
 
-Same as every reviewer. Identify the contract surfaces:
+Same as every reviewer - **only** fresh-context inputs (spec/intent, diff, build/test output, `prior_learnings`, `scope_drift_audit`, and an `output_path`). You do NOT receive the implementer's conversation, completion report, or rationale; judge the change on its own merits. Identify the contract surfaces:
 
 - **HTTP routes** - path, method, query params, request body shape, response shape, status codes, headers
 - **Exported types** - function signatures, exported interfaces, enum values, discriminated unions
@@ -63,6 +63,8 @@ Same as every reviewer. Identify the contract surfaces:
 - `advisory` - Notice of a break that the author has decided is intentional.
 
 ## Output
+
+**Results stay in files, not in the reply.** Write your findings as a JSON array to `output_path` (`.context/ce-review/reviewers/{run_id}/api-contract-reviewer.json`); empty array `[]` if nothing. Reply with only that path plus `Findings written.` - the orchestrator merges from the file, not your narrative.
 
 Standard JSON array. `detail` includes before and after.
 

--- a/modules/ce-review/agents/reviewers/correctness-reviewer.md
+++ b/modules/ce-review/agents/reviewers/correctness-reviewer.md
@@ -11,12 +11,15 @@ Finds bugs in the behavior of the code as written. Not style, not architecture, 
 
 ## Inputs
 
-The orchestrator passes:
+The orchestrator passes **only** fresh-context inputs - the spec/intent, the diff, and build/test output. You do NOT receive the implementer's conversation, completion report, or "why I did it this way" rationale; reviewing that narrative would grade the defense of the change instead of the change. Judge the code on its own merits.
 
 - `base_ref` and `head_ref` - git refs for the diff
 - `diff_files` - list of changed paths
+- `intent` - the requirement statements only (issue / PR acceptance criteria), not the author's justification
+- `build_test_output` - fresh verification-suite output, if the orchestrator captured it
 - `prior_learnings` - block returned by `learnings-researcher`, possibly empty
 - `scope_drift_audit` - summary from the scope-drift skill
+- `output_path` - the file to write your findings to (see Output)
 
 Read files with the native file-read tool, only within `diff_files`. Do not explore the repo beyond the diff and its direct imports - correctness review is focused on changed code, not the whole codebase.
 
@@ -67,7 +70,9 @@ If a finding straddles categories (e.g., an off-by-one that is also a security i
 
 ## Output
 
-Return a JSON array. Empty array if no findings. Each object matches the schema in `skills/ce-review/references/finding.schema.yaml`:
+**Results stay in files, not in the reply.** Write your findings as a JSON array to the `output_path` the orchestrator gave you (`.context/ce-review/reviewers/{run_id}/correctness-reviewer.json`). Write an empty array `[]` if you found nothing. Your reply to the orchestrator is only that path plus the terminal line `Findings written.` - do not paste the findings into the reply. The orchestrator merges from the file, not from your narrative, so a finding that exists only in the chat will be dropped.
+
+Each object matches the schema in `skills/ce-review/references/finding.schema.yaml`:
 
 ```json
 [

--- a/modules/ce-review/agents/reviewers/data-migrations-reviewer.md
+++ b/modules/ce-review/agents/reviewers/data-migrations-reviewer.md
@@ -11,7 +11,7 @@ Finds migration problems that will fail on apply, corrupt data, or block a deplo
 
 ## Inputs
 
-Same as every reviewer. Identify migration files by convention - `supabase/migrations/`, `db/migrate/`, `migrations/`, `prisma/migrations/`, etc. If CLAUDE.md states a local convention, follow it.
+Same as every reviewer - **only** fresh-context inputs (spec/intent, diff, build/test output, `prior_learnings`, `scope_drift_audit`, and an `output_path`). You do NOT receive the implementer's conversation, completion report, or rationale; judge the change on its own merits. Identify migration files by convention - `supabase/migrations/`, `db/migrate/`, `migrations/`, `prisma/migrations/`, etc. If CLAUDE.md states a local convention, follow it.
 
 ## What You Flag
 
@@ -58,6 +58,8 @@ Same as every reviewer. Identify migration files by convention - `supabase/migra
 - `advisory` - Observations about long-term schema design.
 
 ## Output
+
+**Results stay in files, not in the reply.** Write your findings as a JSON array to `output_path` (`.context/ce-review/reviewers/{run_id}/data-migrations-reviewer.json`); empty array `[]` if nothing. Reply with only that path plus `Findings written.` - the orchestrator merges from the file, not your narrative.
 
 Standard JSON array. Quote the SQL fragment in `detail`.
 

--- a/modules/ce-review/agents/reviewers/maintainability-reviewer.md
+++ b/modules/ce-review/agents/reviewers/maintainability-reviewer.md
@@ -11,7 +11,7 @@ Finds code that works today and will be painful to change tomorrow. Not correctn
 
 ## Inputs
 
-Same as every reviewer. Read only files in `diff_files` plus sibling files when duplication needs to be confirmed.
+Same as every reviewer - **only** fresh-context inputs (spec/intent, diff, build/test output, `prior_learnings`, `scope_drift_audit`, and an `output_path`). You do NOT receive the implementer's conversation, completion report, or rationale; judge the change on its own merits. Read only files in `diff_files` plus sibling files when duplication needs to be confirmed.
 
 ## What You Flag
 
@@ -58,6 +58,8 @@ Same as every reviewer. Read only files in `diff_files` plus sibling files when 
 - `advisory` - Nit-level observations.
 
 ## Output
+
+**Results stay in files, not in the reply.** Write your findings as a JSON array to `output_path` (`.context/ce-review/reviewers/{run_id}/maintainability-reviewer.json`); empty array `[]` if nothing. Reply with only that path plus `Findings written.` - the orchestrator merges from the file, not your narrative.
 
 Standard JSON array. Keep each `detail` concise - maintainability findings are easy to over-explain.
 

--- a/modules/ce-review/agents/reviewers/performance-reviewer.md
+++ b/modules/ce-review/agents/reviewers/performance-reviewer.md
@@ -11,7 +11,7 @@ Finds performance problems that would show up at realistic scale or in measured 
 
 ## Inputs
 
-Same as every reviewer. Check for `package.json` scripts or CI config to understand how the code runs (dev server, worker, edge function).
+Same as every reviewer - **only** fresh-context inputs (spec/intent, diff, build/test output, `prior_learnings`, `scope_drift_audit`, and an `output_path`). You do NOT receive the implementer's conversation, completion report, or rationale; judge the change on its own merits. Check for `package.json` scripts or CI config to understand how the code runs (dev server, worker, edge function).
 
 ## What You Flag
 
@@ -56,6 +56,8 @@ Same as every reviewer. Check for `package.json` scripts or CI config to underst
 - `advisory` - Observations without a clear mechanical fix.
 
 ## Output
+
+**Results stay in files, not in the reply.** Write your findings as a JSON array to `output_path` (`.context/ce-review/reviewers/{run_id}/performance-reviewer.json`); empty array `[]` if nothing. Reply with only that path plus `Findings written.` - the orchestrator merges from the file, not your narrative.
 
 Standard JSON array. Always include the scale assumption in `detail`.
 

--- a/modules/ce-review/agents/reviewers/project-standards-reviewer.md
+++ b/modules/ce-review/agents/reviewers/project-standards-reviewer.md
@@ -11,7 +11,7 @@ Finds places where the diff ignores a convention the repo already documents or e
 
 ## Inputs
 
-Same as every reviewer, plus a mandatory first step: locate the convention sources.
+Same as every reviewer - **only** fresh-context inputs (spec/intent, diff, build/test output, `prior_learnings`, `scope_drift_audit`, and an `output_path`). You do NOT receive the implementer's conversation, completion report, or rationale; judge the change on its own merits. Plus a mandatory first step: locate the convention sources.
 
 ### Convention sources (read these first, in order)
 
@@ -66,6 +66,8 @@ Read these with the native file-read tool. If none exist, return a single adviso
 - `advisory` - Inferred patterns surfaced for the author to consider.
 
 ## Output
+
+**Results stay in files, not in the reply.** Write your findings as a JSON array to `output_path` (`.context/ce-review/reviewers/{run_id}/project-standards-reviewer.json`); empty array `[]` if nothing. Reply with only that path plus `Findings written.` - the orchestrator merges from the file, not your narrative.
 
 Standard JSON array. Always include the quoted convention source in `detail` - without a quote, the finding is speculation.
 

--- a/modules/ce-review/agents/reviewers/reliability-reviewer.md
+++ b/modules/ce-review/agents/reviewers/reliability-reviewer.md
@@ -11,7 +11,7 @@ Finds code that will not survive the first production incident. The question: wh
 
 ## Inputs
 
-Same as every reviewer. Look for:
+Same as every reviewer - **only** fresh-context inputs (spec/intent, diff, build/test output, `prior_learnings`, `scope_drift_audit`, and an `output_path`). You do NOT receive the implementer's conversation, completion report, or rationale; judge the change on its own merits. Look for:
 
 - `fetch`, `axios`, `http.request`, gRPC, DB-client calls in the diff
 - Background job definitions (BullMQ, Temporal, Sidekiq, custom queue)
@@ -63,6 +63,8 @@ Same as every reviewer. Look for:
 - `advisory` - Observations for the author to consider.
 
 ## Output
+
+**Results stay in files, not in the reply.** Write your findings as a JSON array to `output_path` (`.context/ce-review/reviewers/{run_id}/reliability-reviewer.json`); empty array `[]` if nothing. Reply with only that path plus `Findings written.` - the orchestrator merges from the file, not your narrative.
 
 Standard JSON array. `detail` names the failure scenario, not just the absence of a mechanism.
 

--- a/modules/ce-review/agents/reviewers/security-reviewer.md
+++ b/modules/ce-review/agents/reviewers/security-reviewer.md
@@ -11,7 +11,7 @@ Finds security-class problems. The threat model is a motivated attacker who read
 
 ## Inputs
 
-Same as every reviewer. Because security findings often depend on caller context, read the touched file's direct callers and its direct imports. Do not explore further.
+Same as every reviewer - **only** fresh-context inputs (spec/intent, diff, build/test output, `prior_learnings`, `scope_drift_audit`, and an `output_path`). You do NOT receive the implementer's conversation, completion report, or rationale; judge the change on its own merits. Because security findings often depend on caller context, read the touched file's direct callers and its direct imports. Do not explore further.
 
 ## What You Flag
 
@@ -56,6 +56,8 @@ Same as every reviewer. Because security findings often depend on caller context
 - `advisory` - Hardening suggestions.
 
 ## Output
+
+**Results stay in files, not in the reply.** Write your findings as a JSON array to `output_path` (`.context/ce-review/reviewers/{run_id}/security-reviewer.json`); empty array `[]` if nothing. Reply with only that path plus `Findings written.` - the orchestrator merges from the file, not your narrative.
 
 Standard JSON array. `detail` includes the attacker input and the path.
 

--- a/modules/ce-review/agents/reviewers/testing-reviewer.md
+++ b/modules/ce-review/agents/reviewers/testing-reviewer.md
@@ -11,11 +11,14 @@ Finds test-coverage gaps and test-quality problems. Not production bugs - that i
 
 ## Inputs
 
-Same as every reviewer:
+Same as every reviewer - **only** fresh-context inputs (spec/intent, diff, build/test output). You do NOT receive the implementer's conversation, completion report, or rationale; judge the change on its own merits.
 
 - `base_ref`, `head_ref`, `diff_files`
+- `intent` - requirement statements only, not the author's justification
+- `build_test_output` - fresh verification-suite output, if captured
 - `prior_learnings`
 - `scope_drift_audit`
+- `output_path` - the file to write your findings to (see Output)
 
 Check the diff for test files (e.g., `**/*.test.ts`, `**/*.spec.ts`, `**/*_test.go`, `tests/**`). If the PR adds production code but no tests, or adds tests but no production code, that is a signal.
 
@@ -64,6 +67,8 @@ Check the diff for test files (e.g., `**/*.test.ts`, `**/*.spec.ts`, `**/*_test.
 - `advisory` - Test-quality concern that does not have a mechanical fix.
 
 ## Output
+
+**Results stay in files, not in the reply.** Write your findings as a JSON array to `output_path` (`.context/ce-review/reviewers/{run_id}/testing-reviewer.json`); empty array `[]` if nothing. Reply with only that path plus `Findings written.` - the orchestrator merges from the file, not your narrative.
 
 JSON array matching `skills/ce-review/references/finding.schema.yaml`. Include a `test_stub` wherever you can - the orchestrator may surface it even without applying.
 

--- a/modules/ce-review/skills/ce-review/SKILL.md
+++ b/modules/ce-review/skills/ce-review/SKILL.md
@@ -52,17 +52,52 @@ The orchestrator is responsible for:
 
 Each reviewer is a separate agent under `agents/reviewers/`. The orchestrator never inlines reviewer logic - agents own their "what you flag / what you don't flag" boundaries.
 
+## Fresh-Context Integrity (read before dispatching anything)
+
+Every reviewer phase runs in **fresh context**. A reviewer must judge the change on its own merits, not inherit the rationale of whoever produced it. A reviewer who has read the author's "here is why I did it this way" narrative grades the *defense* of the change, not the change. That inflates sign-off - the same failure mode the Argus judge avoids by never seeing the diff-author's reasoning, and that heliohq/ship enforces by running review in a clean session.
+
+Concretely, the orchestrator MUST and MUST NOT pass the following to any reviewer subagent:
+
+**Allowed inputs (the only context a reviewer receives):**
+
+- The **spec / intent**: the issue body, the PR title and body's *requirement* statements, the plan items the PR set out to satisfy. This is the target, not the author's justification.
+- The **diff or changed-file paths**: `diff_files`, `diff_stat`, and the refs needed to read them. Reviewers read the files themselves.
+- **Build / test output**: fresh results of the project's verification suite (lint, type-check, tests, build), captured by the orchestrator.
+- Phase 1 prior-learnings and the Phase 2 scope-drift audit (these are independent grounding, not author rationale).
+
+**Forbidden inputs (never forward to a reviewer):**
+
+- The implementer's conversation, chat transcript, or working notes.
+- The implementer's `DONE` self-report, completion summary, or "what I changed and why" narrative.
+- Commit-message **bodies** that explain the author's reasoning (commit *subjects* are fine as a one-line summary of intent; strip the bodies before forwarding).
+- Any "I chose X over Y because…" justification authored by the implementer.
+
+If the only available description of intent is entangled with the author's rationale (e.g., a PR body that mixes "this must do X" with "I did it this way because…"), extract the requirement clauses and discard the justification before passing it on. When in doubt, pass less: the diff plus the issue's acceptance criteria is always a safe reviewer input.
+
+The single intended exception is Phase 4: the adversarial reviewer reads the *other reviewers'* findings (`prior_findings`). Those are independent review output, not the implementer's rationale - reading them is the point.
+
+## Results Stay in Files, Not in the Reply
+
+Reviewer findings are consumed from a **written artifact**, not trusted from the chat narrative. This mirrors Argus: the orchestrator (the judge's caller) routes on the structured result it reads from disk, not on a reviewer's prose summary in the reply.
+
+- Each reviewer writes its JSON findings array to a file under `.context/ce-review/reviewers/{run_id}/{reviewer-name}.json`, and its reply contains only that path plus the terminal line `Findings written.`
+- The orchestrator reads each reviewer's artifact from disk and merges from the files. It does not parse a findings blob pasted into a reply, and it does not let a reviewer's narrative override what the file says.
+- If a reviewer's artifact is missing or unparseable, treat that reviewer as failed (report it per the Coordination Rules in `subagent-patterns`); do not reconstruct its findings from the chat.
+- The merged envelope (Phase 6) is likewise the source of truth for downstream consumers - the human-facing Summary is rendered *from* the envelope, never the other way around.
+
+This keeps the return path auditable: every finding traces back to a file, and no sign-off rests on a narrative that cannot be re-read.
+
 ## Phase 0: Inputs
 
-Collect the inputs once and pass them by path, not content, to the subagents (see `modules/subagent-patterns/rules/subagent-patterns.md`):
+Collect the inputs once and pass them by path, not content, to the subagents (see `modules/subagent-patterns/rules/subagent-patterns.md`). Everything passed to a reviewer must be an **allowed input** per the Fresh-Context Integrity section above - spec/intent, diff, or build/test output, never the implementer's rationale:
 
 - `base_ref` - usually `origin/main`; override from `$ARGUMENTS` if the user said `base:{ref}`
 - `head_ref` - `HEAD` unless specified
 - `diff_files` - paths returned by `git diff --name-only {base_ref}...{head_ref}`
 - `diff_stat` - output of `git diff --stat {base_ref}...{head_ref}` (short; safe to include inline)
-- `pr_body` - `gh pr view --json body,title` if a PR is open
-- `issue_body` - `gh issue view {num}` for any issue the PR closes
-- `commit_messages` - `git log {base_ref}..{head_ref} --pretty=format:"%s%n%b"`
+- `intent` - the **requirement** statements only: the issue body (`gh issue view {num}` for any issue the PR closes) and the PR title plus any acceptance-criteria clauses from `gh pr view --json body,title`. Strip out the author's justification ("I did it this way because…") before forwarding - that is rationale, not intent.
+- `commit_subjects` - `git log {base_ref}..{head_ref} --pretty=format:"%s"` (subjects only). Do **not** collect commit-message bodies; they routinely carry the author's reasoning, which reviewers must not see.
+- `build_test_output` - fresh output of the project's verification suite (lint, type-check, tests, build), captured by the orchestrator. This is the deterministic evidence reviewers ground on instead of the author's "tests pass" claim.
 
 If no base ref resolves (rare; e.g., detached HEAD with no upstream), state that explicitly and fall back to reviewing the last commit only.
 
@@ -70,7 +105,7 @@ If no base ref resolves (rare; e.g., detached HEAD with no upstream), state that
 
 Dispatch the `learnings-researcher` agent (from `modules/compound-knowledge/agents/learnings-researcher.md`). Pass:
 
-- `task_summary` - one paragraph derived from the PR title, PR body first paragraph, and the diff stat
+- `task_summary` - one paragraph derived from the PR title, the `intent` requirement clauses, and the diff stat (not the author's rationale)
 - `files_hint` - `diff_files`
 - `tags_hint` - tags inferred from touched directories (e.g., `supabase` if `supabase/migrations/` changed; `chrome-extension` if `manifest.json` changed; language tags by file extension)
 - `problem_type_filter` - absent (pull both bugs and knowledge priors)
@@ -122,21 +157,28 @@ If none of the conditions fire, run only the always-on set.
 
 ### Dispatch pattern
 
-Use the parallel-research pattern from `modules/subagent-patterns/rules/subagent-patterns.md`. Pass each reviewer:
+Use the parallel-research pattern from `modules/subagent-patterns/rules/subagent-patterns.md`. Pass each reviewer ONLY the allowed inputs (Fresh-Context Integrity above):
 
-- `base_ref`, `head_ref`, `diff_files`, `diff_stat` (inputs)
+- `base_ref`, `head_ref`, `diff_files`, `diff_stat`
+- `intent` - the requirement clauses (not the author's rationale)
+- `build_test_output` from Phase 0
 - The prior-learnings block from Phase 1
 - The scope-drift audit from Phase 2
 - The reviewer's role name
+- `run_id` and the output path `.context/ce-review/reviewers/{run_id}/{reviewer-name}.json` the reviewer must write to
 
-Reviewers are independent. Do not share their drafts between each other in this phase.
+Do NOT pass the implementer's conversation, completion report, or commit-message bodies to any reviewer. If you find yourself about to paste "the author says…" into a reviewer prompt, stop - that is the rationale leak this phase exists to prevent.
+
+Reviewers are independent. Do not share their drafts between each other in this phase. Each reviewer writes its findings to its artifact path and replies with only that path plus `Findings written.`; the orchestrator reads the files (Results Stay in Files, above), not the replies.
 
 ## Phase 4: Adversarial / Red-Team Lens
 
 After Phase 3 completes, dispatch the `adversarial-reviewer` agent with:
 
-- Everything Phase 3 received
-- All Phase 3 reviewer outputs (this is the key difference - the adversarial reviewer reads their findings)
+- Everything Phase 3 received (the allowed inputs only - same fresh-context rule applies; no implementer rationale)
+- The paths to all Phase 3 reviewer artifacts under `.context/ce-review/reviewers/{run_id}/` (this is the key difference - the adversarial reviewer reads their findings from the files, not from a narrative). Reviewer findings are independent review output, not author rationale, so forwarding them is the one intended cross-phase context flow.
+
+The adversarial reviewer writes its own findings to `.context/ce-review/reviewers/{run_id}/adversarial-reviewer.json` and replies with only that path plus `Findings written.`, same as every other reviewer.
 
 The adversarial reviewer runs five lenses (attack the happy path, find silent failures, exploit trust assumptions, break edge cases, find integration-boundary issues) and is specifically told to find what the specialists MISSED. It does not re-state their findings; it augments.
 
@@ -144,7 +186,7 @@ Gating condition - the adversarial reviewer fires in every mode, but its autofix
 
 ## Phase 5: Merge, Dedupe, Score, Route
 
-Collect every finding from Phases 3 and 4. Each finding is a JSON object shaped like:
+Read every reviewer artifact under `.context/ce-review/reviewers/{run_id}/` (one file per Phase 3 and Phase 4 reviewer) and collect the findings from the files - not from the reviewer replies (Results Stay in Files, above). Each finding is a JSON object shaped like:
 
 ```json
 {
@@ -295,6 +337,8 @@ In `headless` mode, the stdout is limited to the envelope path and the terminal 
 
 - **Running reviewers serially.** They are independent; parallelize. Serial execution wastes agent time and inflates the context window with reviewer boilerplate.
 - **Passing content, not paths.** Reviewers should read only the files they need. The orchestrator must not pre-read and inline diffs into every subagent prompt.
+- **Leaking the implementer's rationale into a reviewer.** Forwarding the author's chat, completion report, or "why I did it this way" commit body inflates sign-off - the reviewer grades the defense, not the change. Pass spec/intent, diff, and build/test output only. (Phase 4's `prior_findings` is the one allowed cross-phase context, and it is review output, not author rationale.)
+- **Trusting the reviewer's reply instead of its artifact.** Findings are merged from the files under `.context/ce-review/reviewers/{run_id}/`. A reviewer's prose summary in the reply is not the source of truth; if the file is missing or unparseable, the reviewer failed - do not reconstruct findings from the chat.
 - **Auto-applying adversarial findings.** The red-team lens is an opinion, not a mechanical fix. Even when the confidence is high, route to `gated_auto` or weaker.
 - **Skipping scope-drift.** An in-scope review of out-of-scope code is wasted effort. Phase 2 runs first for a reason.
 - **Inlining reviewer logic.** Every persona has a `what you flag / what you don't flag` boundary; keeping it in the agent file prevents overlap. Do not absorb reviewer prompts into the orchestrator.

--- a/modules/subagent-patterns/agents/code-quality-reviewer.md
+++ b/modules/subagent-patterns/agents/code-quality-reviewer.md
@@ -11,11 +11,12 @@ Stage 2 of the two-stage review. Stage 1 (`spec-compliance-reviewer`) has alread
 
 **Do not run this stage if Stage 1 did not return DONE.** Reviewing the quality of a scope-creeping or incomplete implementation wastes effort - the code may be reverted or heavily modified after the implementer is re-dispatched. Check the upstream status before proceeding.
 
-## Inputs
+You review in **fresh context**. Your inputs are the spec, the artifact, and the project's own conventions - not the implementer's working narrative or rationale. A reviewer who reads the author's "why I did it this way" grades the defense of the change instead of the change, which inflates sign-off. You are not given the implementer's report at all; judge the code on its own merits.
 
 - `spec` - the original spec (read for context, not to re-audit compliance)
 - `stage1_status` - must be `DONE` or `DONE_WITH_CONCERNS`; if `BLOCKED` or `NEEDS_CONTEXT`, refuse to run and return `BLOCKED`
 - `artifact_paths` - paths to the diff and changed files
+- `output_path` - the file to write your findings to (see Output Shape)
 - `project_patterns_hint` (optional) - path to a README, style guide, or example file that represents the project's conventions
 
 ## Review Protocol
@@ -93,6 +94,8 @@ End with exactly one status:
 | **NEEDS_CONTEXT** | You cannot judge a pattern question without seeing more of the project. | Caller supplies the `project_patterns_hint` or points at an authoritative example. |
 
 ## Output Shape
+
+**Results stay in files, not in the reply.** Write your full report (the shape below) to the `output_path` the caller gave you, and reply with only that path plus the terminal line `Findings written.`. The caller routes on the file it reads from disk, not on a prose summary in the chat.
 
 ```
 ## Findings

--- a/modules/subagent-patterns/agents/spec-compliance-reviewer.md
+++ b/modules/subagent-patterns/agents/spec-compliance-reviewer.md
@@ -22,13 +22,16 @@ The implementer finished suspiciously quickly. Do NOT trust their report. Specif
 
 Senior reviewers assume the work is incomplete until each deliverable is individually verified.
 
+You review in **fresh context**. Your inputs are the spec, the artifact, and verification output - not the implementer's working narrative or rationale. A reviewer who reads "I did it this way because…" grades the defense of the change instead of the change, which inflates sign-off. Judge against the spec and the diff alone.
+
 ## Inputs
 
 - `spec` - the original spec passed to the implementer (objective, context, constraints, deliverable)
-- `implementer_report` - the structured output from the `implementer` agent
+- `implementer_report` - the implementer's structured `DONE` output. This is an **audit target, not grounding**: you read it to check its claims against the diff, never to be persuaded by it. A `DONE` is a claim, not evidence. Do not let its reasoning frame your verdict; do not accept any rationale in it as justification for a deviation from the spec.
 - `artifact_paths` - paths to the actual diff, files created, tests run, or other evidence (NOT the contents - you will read what you need)
+- `output_path` - the file to write your findings to (see Output)
 
-The caller passes paths, not content. See `subagent-patterns` > "Pass Paths, Not Contents."
+The caller passes paths, not content. See `subagent-patterns` > "Pass Paths, Not Contents." The caller does NOT pass you the implementer's conversation or chain-of-thought - if you find that in your prompt, ignore it and review from the spec and diff.
 
 ## Review Protocol
 
@@ -90,6 +93,8 @@ End with exactly one status:
 | **NEEDS_CONTEXT** | You cannot verify because the spec is ambiguous or the artifact paths were not provided. | Caller clarifies the spec or resupplies evidence. |
 
 ## Output Shape
+
+**Results stay in files, not in the reply.** Write your full report (the shape below) to the `output_path` the caller gave you, and reply with only that path plus the terminal line `Findings written.`. The caller routes on the file it reads from disk, not on a prose summary in the chat - so your verdict must live in the artifact, not the narrative.
 
 ```
 ## Deliverables

--- a/modules/subagent-patterns/rules/subagent-patterns.md
+++ b/modules/subagent-patterns/rules/subagent-patterns.md
@@ -93,6 +93,22 @@ The only exception: inline a small excerpt (10-30 lines) when the subagent needs
 
 After subagent results come back, review in two passes. **Order matters: Stage 1 gates Stage 2.** Running code-quality review on a scope-creeping or deliverable-incomplete implementation wastes effort polishing code that will be reverted or re-dispatched.
 
+### Fresh Context: Reviewers Do Not Inherit the Implementer's Rationale
+
+Both review stages run in **fresh context**. A reviewer judges the change against the spec and the artifact, not against the implementer's explanation of why they did it that way. A reviewer who reads "I chose X over Y because…" grades the *defense* of the change, not the change - and that inflates sign-off. This is the same integrity property Argus enforces by never showing its judge the diff-author's reasoning.
+
+Pass each reviewer ONLY:
+
+- the **spec** (objective, context, constraints, deliverable) - the target
+- the **diff or changed-file paths** - the artifact
+- fresh **build/test output** - the deterministic evidence
+
+Do NOT pass the implementer's conversation, working notes, or chain-of-thought as grounding. The one nuance for Stage 1: the implementer's `DONE` report is an **audit target**, not grounding - the reviewer reads it to check the claims against the diff, never to be persuaded by it. Stage 2 does not need the report at all.
+
+### Results Stay in Files, Not in the Reply
+
+Each reviewer writes its structured findings (the four-state status plus its itemized checks) to a file the caller named, and replies with only that path plus a terminal line. The caller routes on the artifact it reads from disk, not on a prose summary in the chat. This mirrors Argus: the dispatcher trusts the written result, never a narrative that cannot be re-read. If the artifact is missing or unparseable, treat the reviewer as failed - do not reconstruct its verdict from the reply.
+
 ### Stage 1: Spec Compliance
 
 - Did the agent do what was asked?
@@ -131,6 +147,8 @@ Stop and re-sequence if you catch yourself:
 - Starting Stage 2 before Stage 1 has returned DONE
 - Merging a subagent's output without running either stage because "the code looks fine"
 - Accepting the implementer's self-report as evidence of spec compliance
+- Forwarding the implementer's rationale ("why I did it this way") to a reviewer as grounding - it inflates sign-off; pass spec + diff + verification output only
+- Routing on a reviewer's chat summary instead of the findings artifact it wrote to disk
 - Running Stage 1 and Stage 2 in parallel (they are deliberately serial - Stage 1 gates Stage 2)
 
 ## Coordination Rules


### PR DESCRIPTION
## Summary

Makes CCGM's review phases run in **fresh context** so a reviewer cannot inherit the implementer's rationale (which inflates sign-off, per the Argus integrity principle and heliohq/ship). Encodes two properties across the `ce-review` orchestrator + reviewer agents and the `subagent-patterns` two-stage review:

1. **Fresh-context inputs** - each reviewer phase receives ONLY the spec/intent, the diff or changed-file paths, and build/test output. The implementer's conversation, `DONE` self-report, "why I did it this way" rationale, and rationale-bearing commit-message bodies are explicitly forbidden inputs.
2. **Results stay in files, not in the reply** - reviewers write findings to a structured artifact; the orchestrator/caller routes on the file read from disk, never on the chat narrative. Mirrors Argus (the judge's caller trusts the written result).

## Changes

- `modules/ce-review/skills/ce-review/SKILL.md` - new **Fresh-Context Integrity** and **Results Stay in Files** sections; Phase 0 now collects `intent` (requirement clauses only), `commit_subjects` (no bodies), and `build_test_output` instead of `pr_body` + full commit messages; Phase 3/4/5 dispatch and merge read from per-reviewer artifacts; two new anti-patterns.
- All 11 `modules/ce-review/agents/reviewers/*.md` - Inputs state the fresh-context contract (no implementer rationale); Output sections require writing findings to `.context/ce-review/reviewers/{run_id}/{reviewer}.json` and replying with only the path + `Findings written.`. The adversarial reviewer's `prior_findings` is clarified as the one allowed cross-phase flow (review output, not author rationale).
- `modules/subagent-patterns/rules/subagent-patterns.md` - new fresh-context + results-in-files subsections under Two-Stage Review; two new red flags.
- `modules/subagent-patterns/agents/spec-compliance-reviewer.md` / `code-quality-reviewer.md` - Inputs reframe the implementer report as an audit target (Stage 1) / omit it entirely (Stage 2); Output requires writing to an `output_path`.

No new files; `module.json` `files[]` unchanged.

## Test Plan

- `bash tests/test-modules.sh` - 1374 passed, 0 failed
- `bash tests/test-no-personal-data.sh` - PASS

Closes #690
Part of #659
