### PR TITLE
#695: opt-in relevance-scoped rule injection + tiered safety core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Instructions for Claude Code when working on the CCGM (Claude Code God Mode) rep
 
 ## What This Repo Is
 
-CCGM is a modular Claude Code configuration system. It contains 69 modules that users can selectively install to configure Claude Code's behavior, hooks, commands, and permissions.
+CCGM is a modular Claude Code configuration system. It contains 70 modules that users can selectively install to configure Claude Code's behavior, hooks, commands, and permissions.
 
 ## Repository Structure
 
@@ -19,7 +19,7 @@ ccgm/
 │   ├── merge.sh        # settings.json merge via jq
 │   ├── modules.sh      # Module discovery + deps
 │   └── backup.sh       # Backup/restore
-├── modules/            # 69 self-contained modules
+├── modules/            # 70 self-contained modules
 │   └── {name}/
 │       ├── module.json # Manifest
 │       ├── README.md   # Module docs

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ The `docs/` directory contains comprehensive documentation:
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
 | [Install via Agent](docs/install-via-agent.md) | Per-preset paste-blocks and how to dry-run them safely |
-| [Module Catalog](docs/modules.md) | Detailed reference for all 69 modules |
+| [Module Catalog](docs/modules.md) | Detailed reference for all 70 modules |
 | [Commands Reference](docs/commands.md) | All 74 slash commands with usage examples |
 | [Hooks Reference](docs/hooks.md) | All 13 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -151,7 +151,7 @@ Removes only CCGM-installed files (tracked via a manifest). Your personal files 
 
 ## Next steps
 
-- [Module Catalog](modules.md) - explore all 69 modules in detail
+- [Module Catalog](modules.md) - explore all 70 modules in detail
 - [Commands Reference](commands.md) - learn every slash command
 - [Hooks Reference](hooks.md) - understand the workflow automation
 - [Configuration](configuration.md) - customize CCGM after installation

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,6 @@
 # Module Catalog
 
-CCGM contains 69 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
+CCGM contains 70 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
 
 ## How modules work
 
@@ -898,6 +898,23 @@ A compact, dependency-free single-line Claude Code statusline.
 Unlike the statusline script bundled in `commands-utility` (which is never wired to the `statusLine` setting), this module ships the script *and* a settings partial, so `--add statusline` produces a working statusline with no manual `settings.json` editing. It is a superset of that script — it adds clone identity, session cost, and the compaction warning. Depends only on `jq`.
 
 **Dependencies**: None
+
+---
+
+### relevance-injection [BETA]
+
+Opt-in, backward-compatible relevance-scoped rule injection plus a tiered always-on safety core.
+
+**Installs**: `rules/relevance-injection.md`, `hooks/relevance-inject.py`, `lib/relevance_select.py`, `lib/applicability-schema.json`, `settings.partial.json` (SessionStart hook)
+
+**What it does**: Addresses the always-on rule-token load without changing default behavior. Two pieces:
+
+- **Tiered safety core**: an authoritative precedence for the always-on Iron Laws (safety/permissions > confusion protocol > TDD/verification > the rest), so they are tiered rather than nine-way flat. Documentation + metadata only.
+- **Opt-in injection**: when `CCGM_RELEVANCE_INJECTION=true` is set in `~/.claude/.ccgm.env`, a `SessionStart` hook emits an `additionalContext` pointer naming the safety core plus the modules relevant to an optional task profile (`CCGM_RELEVANCE_LANGS`, `CCGM_RELEVANCE_TASKTYPES`). When the flag is unset (the default), the hook no-ops and all rules load exactly as before.
+
+Selection lives in a pure, deterministic, tested library (`relevance_select.py`). Modules may add an optional `applicability` field to their `module.json` (absent or `{"always": true}` == always applicable, preserving pre-feature behavior); otherwise `{"langs": [...]}` / `{"taskTypes": [...]}` scope the module to a profile.
+
+**Dependencies**: hooks
 
 ---
 

--- a/modules/cloudflare/module.json
+++ b/modules/cloudflare/module.json
@@ -5,6 +5,7 @@
   "category": "tech-specific",
   "scope": ["global", "project"],
   "dependencies": [],
+  "applicability": { "taskTypes": ["infra", "deployment", "backend"] },
   "files": {
     "rules/cloudflare.md": { "target": "rules/cloudflare.md", "type": "rule", "template": false }
   },

--- a/modules/mcp-development/module.json
+++ b/modules/mcp-development/module.json
@@ -5,6 +5,7 @@
   "category": "tech-specific",
   "scope": ["global", "project"],
   "dependencies": [],
+  "applicability": { "langs": ["typescript", "javascript", "python"], "taskTypes": ["mcp", "backend"] },
   "files": {
     "rules/mcp-development.md": { "target": "rules/mcp-development.md", "type": "rule", "template": false }
   },

--- a/modules/relevance-injection/README.md
+++ b/modules/relevance-injection/README.md
@@ -1,0 +1,65 @@
+# relevance-injection
+
+Opt-in, backward-compatible relevance-scoped rule injection plus a tiered
+always-on safety core.
+
+**Off by default.** With the opt-in flag unset, all rules load exactly as
+before — this module changes nothing about the default install. When enabled,
+a `SessionStart` hook surfaces a pointer to the task-relevant subset of rules
+while always including the safety core.
+
+## What It Does
+
+CCGM auto-loads every installed module's rules on every session. This module
+offers a way to scope *attention* (not access) to the rules relevant to the
+current task, addressing the always-on rule-token load — without ever removing
+a rule file or changing default behavior.
+
+Two pieces:
+
+1. **Tiered safety core** (`rules/relevance-injection.md`): an authoritative
+   precedence for the always-on Iron Laws (safety/permissions > confusion
+   protocol > TDD/verification > the rest), so they are tiered rather than
+   nine-way flat. This is documentation + metadata, not a behavior change.
+
+2. **Opt-in injection** (`hooks/relevance-inject.py` + `lib/relevance_select.py`):
+   when `CCGM_RELEVANCE_INJECTION=true` is set in `~/.claude/.ccgm.env`, the
+   hook emits an `additionalContext` pointer naming the safety core plus the
+   profile-relevant modules. Selection is deterministic and lives in the pure,
+   tested `relevance_select` library. When the flag is unset, the hook no-ops.
+
+## The `applicability` field
+
+Modules may add an optional `applicability` field to their `module.json`
+(schema: `lib/applicability-schema.json`). Absent or `{"always": true}` ==
+always applicable (preserves pre-feature behavior). Otherwise `{"langs": [...]}`
+and/or `{"taskTypes": [...]}` scope the module to a profile.
+
+## Enabling
+
+```bash
+# ~/.claude/.ccgm.env
+CCGM_RELEVANCE_INJECTION=true
+CCGM_RELEVANCE_LANGS=python,typescript        # optional
+CCGM_RELEVANCE_TASKTYPES=backend,testing      # optional
+```
+
+## Manual Installation
+
+```bash
+cp rules/relevance-injection.md   ~/.claude/rules/relevance-injection.md
+cp hooks/relevance-inject.py      ~/.claude/hooks/relevance-inject.py
+cp lib/relevance_select.py        ~/.claude/lib/relevance_select.py
+cp lib/applicability-schema.json  ~/.claude/lib/applicability-schema.json
+# then merge settings.partial.json into ~/.claude/settings.json (SessionStart hook)
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `rules/relevance-injection.md` | Tiered safety-core precedence + how the opt-in feature works |
+| `hooks/relevance-inject.py` | SessionStart hook; no-op unless the opt-in flag is set |
+| `lib/relevance_select.py` | Pure, deterministic selection library (safety core + applicability matching) |
+| `lib/applicability-schema.json` | JSON Schema for the optional `module.json` `applicability` field |
+| `settings.partial.json` | Registers the SessionStart hook |

--- a/modules/relevance-injection/hooks/relevance-inject.py
+++ b/modules/relevance-injection/hooks/relevance-inject.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""SessionStart hook: opt-in relevance-scoped rule injection (issue #695).
+
+PURPOSE
+-------
+CCGM installs every selected module's rules to ~/.claude/rules/, where Claude
+Code auto-loads ALL of them on every session (~53k tokens always-on). This
+hook offers an OPT-IN alternative: at fresh session start, surface a short
+pointer to the SUBSET of rules relevant to the current task profile, while
+guaranteeing the safety core is always surfaced.
+
+CRITICAL SAFETY PROPERTY
+------------------------
+This hook is a strict NO-OP unless an explicit opt-in flag is set:
+
+    CCGM_RELEVANCE_INJECTION=true   in ~/.claude/.ccgm.env
+
+When the flag is unset (the default for every existing and new install), the
+hook reads stdin, finds the flag absent, and returns without emitting
+anything. Claude Code's normal all-rules-always-loaded behavior is completely
+untouched. The feature can only ever ADD a pointer; it never removes a rule
+file from disk and never suppresses the auto-load path.
+
+It additionally fires only on source == "startup" (not resume/compact), and
+only injects a non-authoritative POINTER (additionalContext) — the rule files
+themselves still live in ~/.claude/rules/ and remain loadable. The pointer
+biases attention toward the relevant subset; it does not gate access.
+
+This hook deliberately keeps the latent/deterministic split clean: all
+selection logic lives in the pure relevance_select library (testable), and
+this file only does I/O wiring.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_RELEVANCE_INJECTION"
+LANGS_VAR = "CCGM_RELEVANCE_LANGS"
+TASKS_VAR = "CCGM_RELEVANCE_TASKTYPES"
+
+# The selection library is installed alongside this hook's repo copy, and at
+# ~/.claude/lib/relevance_select.py once CCGM installs it. Make both importable.
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(Path.home() / ".claude" / "lib"))
+sys.path.insert(0, str(_HERE.parent / "lib"))
+
+try:
+    import relevance_select  # type: ignore
+except Exception:  # pragma: no cover - import guard; hook must never crash a session
+    relevance_select = None
+
+
+def _read_env() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _split_csv(val: "str | None") -> "list[str]":
+    if not val:
+        return []
+    return [p.strip() for p in val.replace(";", ",").split(",") if p.strip()]
+
+
+def _installed_modules() -> "list[str]":
+    """Read the installed-module list from the global CCGM manifest."""
+    manifest = Path.home() / ".claude" / ".ccgm-manifest.json"
+    if not manifest.exists():
+        return []
+    try:
+        with open(manifest, encoding="utf-8") as fh:
+            data = json.load(fh)
+        mods = data.get("modules")
+        return [m for m in mods if isinstance(m, str)] if isinstance(mods, list) else []
+    except (OSError, json.JSONDecodeError, ValueError):
+        return []
+
+
+def _modules_dir(env: "dict[str, str]") -> "str | None":
+    """Locate the CCGM repo modules/ dir from the manifest's ccgmRoot."""
+    manifest = Path.home() / ".claude" / ".ccgm-manifest.json"
+    if manifest.exists():
+        try:
+            with open(manifest, encoding="utf-8") as fh:
+                root = json.load(fh).get("ccgmRoot")
+            if isinstance(root, str) and root:
+                cand = os.path.join(root, "modules")
+                if os.path.isdir(cand):
+                    return cand
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return None
+
+
+def build_context(env: "dict[str, str]") -> "str | None":
+    """Build the additionalContext pointer, or None if nothing to emit.
+
+    Pure-ish: depends only on env + filesystem state, no stdin. Returns None
+    when the feature is disabled or the data needed for selection is missing —
+    in every "None" case the caller emits nothing and behavior is unchanged.
+    """
+    if not _truthy(env.get(FLAG)):
+        return None
+    if relevance_select is None:
+        return None
+
+    modules_dir = _modules_dir(env)
+    installed = _installed_modules()
+    if not modules_dir or not installed:
+        return None
+
+    langs = _split_csv(env.get(LANGS_VAR))
+    task_types = _split_csv(env.get(TASKS_VAR))
+
+    selected = relevance_select.select_modules(
+        installed, modules_dir, langs=langs, task_types=task_types
+    )
+    if not selected:
+        return None
+
+    core = [m for m in selected if relevance_select.is_safety_core(m)]
+    situational = [m for m in selected if not relevance_select.is_safety_core(m)]
+
+    lines = [
+        "<ccgm-relevance-injection>",
+        "Relevance-scoped rule injection is ON for this session. The rules in",
+        "~/.claude/rules/ remain loaded; this pointer highlights the subset most",
+        "relevant to the current task profile so you route through them first.",
+        "",
+        "ALWAYS-ON safety core (highest precedence, never scoped away):",
+        "  " + ", ".join(core),
+    ]
+    if situational:
+        lines += [
+            "",
+            "Relevant to this profile"
+            + (f" (langs={','.join(langs)}" if langs else " (")
+            + (f" taskTypes={','.join(task_types)})" if task_types else ")"),
+            "  " + ", ".join(situational),
+        ]
+    lines += [
+        "",
+        "The safety core is non-negotiable regardless of profile. If a task",
+        "touches a discipline not listed above, consult its rule anyway.",
+        "</ccgm-relevance-injection>",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching session-start-enforce.py.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    env = _read_env()
+    context = build_context(env)
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/relevance-injection/lib/applicability-schema.json
+++ b/modules/relevance-injection/lib/applicability-schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ccgm/relevance-injection/applicability-schema.json",
+  "title": "module.json applicability field",
+  "description": "Optional field on a CCGM module.json that scopes when the module's rules are relevant. ABSENT or {\"always\": true} == always applicable (preserves pre-feature behavior where every installed rule loaded unconditionally). This schema documents the field; it is consumed only by the opt-in relevance-injection feature and is ignored by the default install path.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "always": {
+      "type": "boolean",
+      "description": "When true, the module's rules are always surfaced regardless of task profile. Equivalent to omitting the applicability field entirely."
+    },
+    "langs": {
+      "type": "array",
+      "description": "Programming languages / ecosystems this module's rules pertain to. The module is selected when the session's language profile intersects this list. Lowercase, e.g. python, typescript, javascript, ruby, go, rust, css.",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    },
+    "taskTypes": {
+      "type": "array",
+      "description": "Task categories this module's rules pertain to. The module is selected when the session's task profile intersects this list. Lowercase, e.g. frontend, backend, database, infra, testing, debugging, docs, design.",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    }
+  },
+  "examples": [
+    { "always": true },
+    { "langs": ["python"] },
+    { "taskTypes": ["frontend", "design"] },
+    { "langs": ["typescript", "javascript"], "taskTypes": ["frontend"] }
+  ]
+}

--- a/modules/relevance-injection/lib/relevance_select.py
+++ b/modules/relevance-injection/lib/relevance_select.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Deterministic relevance-scoped rule selection for CCGM.
+
+This is the pure, side-effect-free core of the opt-in relevance-injection
+feature (issue #695). It answers one question:
+
+    Given the installed modules and an (optional) task profile, which rule
+    files should be surfaced for this session?
+
+It does NOT read stdin, write files, or touch the network. The SessionStart
+hook (relevance-inject.py) wires this library to Claude Code; everything that
+can be tested in isolation lives here.
+
+Design invariants (each pinned by a test in tests/):
+
+  1. SAFETY CORE IS ALWAYS INCLUDED. Regardless of profile, the always-on
+     minimal core (safety/permissions, confusion-protocol, TDD, verification,
+     autonomy, ...) is selected. A bad profile can never drop an Iron Law.
+
+  2. ABSENT `applicability` == ALWAYS. A module with no `applicability` field
+     in its module.json is treated as always-applicable. This preserves
+     today's behavior: before this feature, every installed rule loaded
+     unconditionally, so the default for an unclassified module must remain
+     "load it."
+
+  3. EXPLICIT {"always": true} == ALWAYS. Same as absent, but declared.
+
+  4. SELECTION IS DETERMINISTIC. Same inputs -> same ordered output. No
+     randomness, no clock, no filesystem ordering leaking through. Output is
+     sorted by (tier, module, file) so two runs are byte-identical.
+
+The hook only ever calls this library when an explicit opt-in flag is set.
+When the flag is unset the hook no-ops and Claude Code's normal
+all-rules-always-loaded path is completely untouched. This library is dead
+code in the default configuration; it cannot change default behavior.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Iterable
+
+
+# ---------------------------------------------------------------------------
+# Safety core tiering.
+#
+# The tier ordering is the AUTHORITATIVE precedence for the always-on minimal
+# core. It is documented in rules/relevance-injection.md as well; keep the two
+# in sync. Lower tier number == higher precedence == surfaced first.
+#
+# These modules are ALWAYS selected, regardless of their module.json
+# `applicability` field and regardless of the task profile. They are the Iron
+# Laws that must hold in every session. Listing a module here is a deliberate
+# statement that the rule is non-negotiable safety/discipline, not
+# situational guidance.
+# ---------------------------------------------------------------------------
+SAFETY_CORE_TIERS: "list[list[str]]" = [
+    # Tier 0 — safety / permissions / git-history protection. Highest precedence.
+    ["git-workflow", "hooks"],
+    # Tier 1 — confusion protocol: stop and ask at architectural forks.
+    ["autonomy"],
+    # Tier 2 — TDD + verification: no code without a failing test; no claim
+    #          without fresh evidence.
+    ["test-driven-development", "verification"],
+    # Tier 3 — everything else in the core that should never be scoped away.
+    ["systematic-debugging", "subagent-patterns"],
+]
+
+
+def safety_core_modules() -> "list[str]":
+    """Flat, precedence-ordered list of the always-on core module names."""
+    flat: "list[str]" = []
+    for tier in SAFETY_CORE_TIERS:
+        flat.extend(tier)
+    return flat
+
+
+def safety_core_tier(module: str) -> int:
+    """Tier index for a core module, or a large sentinel for non-core.
+
+    Used as the primary sort key so core rules sort ahead of situational
+    rules and in their declared precedence order.
+    """
+    for idx, tier in enumerate(SAFETY_CORE_TIERS):
+        if module in tier:
+            return idx
+    return len(SAFETY_CORE_TIERS) + 1
+
+
+def is_safety_core(module: str) -> bool:
+    """True iff `module` is part of the always-on safety core."""
+    return safety_core_tier(module) <= len(SAFETY_CORE_TIERS)
+
+
+# ---------------------------------------------------------------------------
+# Applicability matching.
+# ---------------------------------------------------------------------------
+def _as_lower_set(values: "Iterable[str] | None") -> "set[str]":
+    if not values:
+        return set()
+    return {str(v).strip().lower() for v in values if str(v).strip()}
+
+
+def module_is_applicable(
+    applicability: "dict | None",
+    langs: "Iterable[str] | None" = None,
+    task_types: "Iterable[str] | None" = None,
+) -> bool:
+    """Decide whether a module's rules apply to a given task profile.
+
+    Rules (in order):
+
+      * `applicability` is None or {} or {"always": true}  -> ALWAYS applies.
+        (Backward-compat: an unclassified module loaded unconditionally
+        before this feature, so it must continue to.)
+
+      * Otherwise the module declares `langs` and/or `taskTypes` constraints.
+        The module applies if the profile INTERSECTS any declared dimension:
+          - if `langs` is declared, a profile lang in it makes it applicable;
+          - if `taskTypes` is declared, a profile task type in it makes it
+            applicable.
+        Matching is OR across dimensions: a Python file (lang match) pulls in
+        a module even if the task type does not match its taskTypes, and vice
+        versa. This is deliberately permissive — over-inclusion is safe
+        (you see a rule you did not strictly need); under-inclusion risks
+        dropping a relevant discipline.
+
+      * A module that declares constraints but matches NOTHING in the profile
+        is excluded. This is the only case where a rule is dropped, and it can
+        only ever apply to a module that explicitly opted out of "always".
+
+    `applicability` shape:
+        {"always": true}
+        {"langs": ["python", "typescript"]}
+        {"taskTypes": ["frontend", "css"]}
+        {"langs": ["python"], "taskTypes": ["backend"]}
+    """
+    if not applicability:
+        return True
+    if applicability.get("always") is True:
+        return True
+
+    declared_langs = _as_lower_set(applicability.get("langs"))
+    declared_tasks = _as_lower_set(applicability.get("taskTypes"))
+
+    # A malformed entry with neither dimension is treated as "always" rather
+    # than silently dropping the rule — fail safe toward inclusion.
+    if not declared_langs and not declared_tasks:
+        return True
+
+    profile_langs = _as_lower_set(langs)
+    profile_tasks = _as_lower_set(task_types)
+
+    if declared_langs and (profile_langs & declared_langs):
+        return True
+    if declared_tasks and (profile_tasks & declared_tasks):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# module.json reading (the only filesystem touch; still no stdin/network).
+# ---------------------------------------------------------------------------
+def read_module_manifest(modules_dir: str, module: str) -> "dict | None":
+    """Load modules/<module>/module.json, or None if absent/unparseable."""
+    path = os.path.join(modules_dir, module, "module.json")
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def rule_files_for_module(manifest: "dict | None") -> "list[str]":
+    """Return the target paths of all type=='rule' files in a manifest."""
+    if not manifest:
+        return []
+    files = manifest.get("files")
+    if not isinstance(files, dict):
+        return []
+    out: "list[str]" = []
+    for entry in files.values():
+        if isinstance(entry, dict) and entry.get("type") == "rule":
+            target = entry.get("target")
+            if isinstance(target, str) and target:
+                out.append(target)
+    return sorted(out)
+
+
+# ---------------------------------------------------------------------------
+# Top-level selection.
+# ---------------------------------------------------------------------------
+def select_modules(
+    installed_modules: "Iterable[str]",
+    modules_dir: str,
+    langs: "Iterable[str] | None" = None,
+    task_types: "Iterable[str] | None" = None,
+) -> "list[str]":
+    """Return the deterministic, precedence-ordered set of selected modules.
+
+    A module is selected if EITHER:
+      * it is part of the safety core (always), OR
+      * its `applicability` matches the profile (absent/always counts as
+        matching everything).
+
+    Output ordering: safety-core tier first (by precedence), then everything
+    else alphabetically. Always deduplicated.
+    """
+    installed = list(dict.fromkeys(installed_modules))  # de-dup, keep order
+    selected: "set[str]" = set()
+
+    for module in installed:
+        if is_safety_core(module):
+            selected.add(module)
+            continue
+        manifest = read_module_manifest(modules_dir, module)
+        applicability = None
+        if manifest:
+            ap = manifest.get("applicability")
+            applicability = ap if isinstance(ap, dict) else None
+        if module_is_applicable(applicability, langs=langs, task_types=task_types):
+            selected.add(module)
+
+    return sorted(
+        selected,
+        key=lambda m: (safety_core_tier(m), m),
+    )
+
+
+def select_rule_files(
+    installed_modules: "Iterable[str]",
+    modules_dir: str,
+    langs: "Iterable[str] | None" = None,
+    task_types: "Iterable[str] | None" = None,
+) -> "list[tuple[str, str]]":
+    """Return [(module, rule_target_path), ...] for the selected modules.
+
+    Deterministic: ordered by (safety-core tier, module, rule file).
+    """
+    out: "list[tuple[str, str]]" = []
+    for module in select_modules(
+        installed_modules, modules_dir, langs=langs, task_types=task_types
+    ):
+        manifest = read_module_manifest(modules_dir, module)
+        for target in rule_files_for_module(manifest):
+            out.append((module, target))
+    return out

--- a/modules/relevance-injection/module.json
+++ b/modules/relevance-injection/module.json
@@ -1,0 +1,19 @@
+{
+  "name": "relevance-injection",
+  "displayName": "Relevance-Scoped Rule Injection",
+  "description": "Opt-in, backward-compatible relevance-scoped rule injection plus a tiered always-on safety core. Off by default: with the flag unset, all rules load exactly as before. When enabled, surfaces a pointer to the task-relevant rule subset while always including the safety core.",
+  "category": "workflow",
+  "scope": ["global"],
+  "status": "beta",
+  "dependencies": ["hooks"],
+  "applicability": { "always": true },
+  "files": {
+    "rules/relevance-injection.md": { "target": "rules/relevance-injection.md", "type": "rule", "template": false },
+    "hooks/relevance-inject.py": { "target": "hooks/relevance-inject.py", "type": "hook", "template": false },
+    "lib/relevance_select.py": { "target": "lib/relevance_select.py", "type": "lib", "template": false },
+    "lib/applicability-schema.json": { "target": "lib/applicability-schema.json", "type": "lib", "template": false },
+    "settings.partial.json": { "target": "settings.json", "type": "settings", "merge": true, "template": false }
+  },
+  "tags": ["rules", "tokens", "context", "safety-core", "opt-in", "session-start"],
+  "configPrompts": []
+}

--- a/modules/relevance-injection/rules/relevance-injection.md
+++ b/modules/relevance-injection/rules/relevance-injection.md
@@ -1,0 +1,70 @@
+# Relevance-Scoped Rule Injection + Tiered Safety Core
+
+CCGM installs every selected module's rule files to `~/.claude/rules/`, where
+Claude Code auto-loads all of them on every session. With a full install that
+is a large, always-on token load. This module provides an **opt-in,
+backward-compatible** way to scope rule attention to the current task while
+guaranteeing the safety core is always present.
+
+**This is opt-in. With the feature off (the default), nothing changes.** All
+rules load exactly as before.
+
+## The Tiered Safety Core (authoritative precedence)
+
+The Iron Laws are not a flat list. When two disciplines could conflict, this
+ordering is authoritative. The always-on minimal core is surfaced in this
+precedence and is **never** scoped away by relevance selection, regardless of
+task profile:
+
+| Tier | Modules | Why it is non-negotiable |
+|------|---------|--------------------------|
+| 0 — safety / permissions | `git-workflow`, `hooks` | History-altering git safety, protected-branch enforcement, permission gating. A breach here is irreversible or destructive. |
+| 1 — confusion protocol | `autonomy` | Stop and ask at architectural forks; do not guess on high-stakes ambiguity. Prevents wrong-direction work that the lower tiers would then faithfully execute. |
+| 2 — TDD + verification | `test-driven-development`, `verification` | No production code without a failing test; no completion claim without fresh evidence. These gate correctness. |
+| 3 — debugging + delegation discipline | `systematic-debugging`, `subagent-patterns` | Root cause before fix; spec + status protocol for delegated work. |
+
+Read top-down: a Tier-0 safety rule wins over a Tier-2 convenience. "Violating
+the letter of a rule is violating the spirit" applies most strongly at the top
+of this table.
+
+The machine-readable form of this ordering lives in
+`lib/relevance_select.py` (`SAFETY_CORE_TIERS`). Keep the two in sync.
+
+## How selection works
+
+Each module's `module.json` may carry an optional `applicability` field
+(schema: `lib/applicability-schema.json`):
+
+- **Absent** or `{"always": true}` — the module's rules are always surfaced.
+  This is the backward-compatible default: a module that does not declare
+  applicability behaves exactly as it did before this feature existed.
+- `{"langs": [...]}` and/or `{"taskTypes": [...]}` — the module is surfaced
+  only when the session's profile intersects a declared dimension. Matching is
+  OR across dimensions and deliberately permissive: over-inclusion is safe,
+  under-inclusion would risk dropping a relevant discipline.
+
+The safety core (above) is always selected even if a core module declared an
+`applicability` constraint — core membership wins.
+
+## Enabling the feature
+
+Strictly opt-in via `~/.claude/.ccgm.env`:
+
+```
+CCGM_RELEVANCE_INJECTION=true
+CCGM_RELEVANCE_LANGS=python,typescript      # optional task profile
+CCGM_RELEVANCE_TASKTYPES=backend,testing    # optional task profile
+```
+
+With the flag set, the `SessionStart` hook emits a short pointer
+(`additionalContext`) listing the safety core plus the profile-relevant
+modules. The rule files themselves remain on disk and loadable — the pointer
+biases routing, it does not gate access. With the flag unset, the hook is a
+no-op.
+
+## Why a pointer, not file removal
+
+This module never deletes or relocates rule files and never disables the
+auto-load path. It is additive: the most it can do is inject one extra block
+of context. That property is what makes the feature safe to ship without
+changing default behavior or risking an existing install.

--- a/modules/relevance-injection/settings.partial.json
+++ b/modules/relevance-injection/settings.partial.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/relevance-inject.py",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/modules/relevance-injection/tests/test_relevance_hook.sh
+++ b/modules/relevance-injection/tests/test_relevance_hook.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# test_relevance_hook.sh — verify the SessionStart hook is a strict no-op
+# unless the opt-in flag is set, and emits the safety core when enabled.
+#
+# Property (a) at the hook level: default (no flag) => zero output, behavior
+# unchanged. Properties (c)/(d) reinforced: when enabled, the safety core is
+# always present in the emitted pointer.
+#
+# Portable: bash 3.2, no GNU-only flags. Builds a fake HOME so the test never
+# touches the developer's real ~/.claude.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$MODULE_DIR/../.." && pwd)"
+HOOK="$MODULE_DIR/hooks/relevance-inject.py"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+FAKE_HOME="$(mktemp -d)"
+trap 'rm -rf "$FAKE_HOME"' EXIT
+
+mkdir -p "$FAKE_HOME/.claude/lib"
+# Make the selection library importable at the installed location.
+cp "$MODULE_DIR/lib/relevance_select.py" "$FAKE_HOME/.claude/lib/"
+
+# A manifest that points ccgmRoot at the real repo (so module.json files load)
+# and lists a small installed set including safety-core + a scoped module.
+cat > "$FAKE_HOME/.claude/.ccgm-manifest.json" <<EOF
+{
+  "version": "1.0.0",
+  "ccgmRoot": "$REPO_ROOT",
+  "modules": ["git-workflow", "verification", "tailwind", "code-quality"]
+}
+EOF
+
+STARTUP_INPUT='{"source":"startup"}'
+
+# --- Test 1: no flag, no .ccgm.env => no-op (empty output) ---
+out=$(printf '%s' "$STARTUP_INPUT" | HOME="$FAKE_HOME" python3 "$HOOK" 2>/dev/null)
+if [ -z "$out" ]; then
+  pass "no .ccgm.env => hook emits nothing (default behavior unchanged)"
+else
+  fail "expected empty output with no flag, got: $out"
+fi
+
+# --- Test 2: flag explicitly false => still no-op ---
+cat > "$FAKE_HOME/.claude/.ccgm.env" <<'EOF'
+CCGM_RELEVANCE_INJECTION=false
+EOF
+out=$(printf '%s' "$STARTUP_INPUT" | HOME="$FAKE_HOME" python3 "$HOOK" 2>/dev/null)
+if [ -z "$out" ]; then
+  pass "flag=false => hook emits nothing"
+else
+  fail "expected empty output with flag=false, got: $out"
+fi
+
+# --- Test 3: flag true => emits pointer including the safety core ---
+cat > "$FAKE_HOME/.claude/.ccgm.env" <<'EOF'
+CCGM_RELEVANCE_INJECTION=true
+CCGM_RELEVANCE_LANGS=css
+CCGM_RELEVANCE_TASKTYPES=frontend
+EOF
+out=$(printf '%s' "$STARTUP_INPUT" | HOME="$FAKE_HOME" python3 "$HOOK" 2>/dev/null)
+if printf '%s' "$out" | grep -q "ccgm-relevance-injection"; then
+  pass "flag=true => emits relevance-injection block"
+else
+  fail "expected relevance-injection block, got: $out"
+fi
+# Safety core (git-workflow, verification) must be present regardless of profile.
+if printf '%s' "$out" | grep -q "git-workflow" && printf '%s' "$out" | grep -q "verification"; then
+  pass "flag=true => safety core present in output"
+else
+  fail "expected safety core in output, got: $out"
+fi
+# Profile-matched situational module (tailwind: css/frontend) present.
+if printf '%s' "$out" | grep -q "tailwind"; then
+  pass "flag=true => profile-matched module (tailwind) present"
+else
+  fail "expected tailwind in output, got: $out"
+fi
+
+# --- Test 4: non-startup source => no-op even with flag on ---
+out=$(printf '%s' '{"source":"resume"}' | HOME="$FAKE_HOME" python3 "$HOOK" 2>/dev/null)
+if [ -z "$out" ]; then
+  pass "source=resume => no-op even with flag on"
+else
+  fail "expected no-op on resume, got: $out"
+fi
+
+# --- Test 5: flag on but no manifest => no-op (cannot select, fail safe) ---
+rm -f "$FAKE_HOME/.claude/.ccgm-manifest.json"
+out=$(printf '%s' "$STARTUP_INPUT" | HOME="$FAKE_HOME" python3 "$HOOK" 2>/dev/null)
+if [ -z "$out" ]; then
+  pass "flag on but no manifest => no-op"
+else
+  fail "expected no-op without manifest, got: $out"
+fi
+
+echo ""
+echo "test_relevance_hook.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/modules/relevance-injection/tests/test_relevance_select.py
+++ b/modules/relevance-injection/tests/test_relevance_select.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Unit tests for the relevance_select selection library (issue #695).
+
+Pins the four required correctness properties:
+
+  (a) default / no profile == every applicable module selected (no behavior change)
+  (b) with a profile, only applicable situational rules are selected
+  (c) the safety core is ALWAYS included regardless of profile
+  (d) absent `applicability` == treated as always
+
+Plus determinism and helper-level checks. Pure library; no I/O beyond reading
+a temp modules/ tree we build per test.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+import relevance_select as rs  # noqa: E402
+
+
+def _write_module(modules_dir, name, *, applicability=None, rule_files=None):
+    """Create modules/<name>/module.json with optional applicability + rules."""
+    mod_dir = os.path.join(modules_dir, name)
+    os.makedirs(mod_dir, exist_ok=True)
+    files = {}
+    for rf in rule_files or []:
+        files[rf] = {"target": rf, "type": "rule", "template": False}
+    manifest = {"name": name, "files": files}
+    if applicability is not None:
+        manifest["applicability"] = applicability
+    with open(os.path.join(mod_dir, "module.json"), "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh)
+
+
+class SafetyCoreTests(unittest.TestCase):
+    def test_core_membership_and_tiers(self):
+        self.assertTrue(rs.is_safety_core("git-workflow"))
+        self.assertTrue(rs.is_safety_core("autonomy"))
+        self.assertTrue(rs.is_safety_core("verification"))
+        self.assertFalse(rs.is_safety_core("tailwind"))
+        # git-workflow (tier 0) outranks verification (tier 2).
+        self.assertLess(rs.safety_core_tier("git-workflow"), rs.safety_core_tier("verification"))
+
+    def test_safety_core_modules_is_precedence_ordered(self):
+        core = rs.safety_core_modules()
+        self.assertEqual(core[0:2], ["git-workflow", "hooks"])
+        self.assertIn("autonomy", core)
+        self.assertIn("test-driven-development", core)
+
+
+class ApplicabilityTests(unittest.TestCase):
+    def test_absent_applicability_is_always(self):  # property (d)
+        self.assertTrue(rs.module_is_applicable(None, langs=["python"]))
+        self.assertTrue(rs.module_is_applicable(None))
+        self.assertTrue(rs.module_is_applicable({}))
+
+    def test_explicit_always(self):
+        self.assertTrue(rs.module_is_applicable({"always": True}, langs=["go"]))
+
+    def test_lang_match_and_miss(self):
+        ap = {"langs": ["python", "typescript"]}
+        self.assertTrue(rs.module_is_applicable(ap, langs=["python"]))
+        self.assertTrue(rs.module_is_applicable(ap, langs=["PYTHON"]))  # case-insensitive
+        self.assertFalse(rs.module_is_applicable(ap, langs=["ruby"]))
+        self.assertFalse(rs.module_is_applicable(ap, langs=[]))
+
+    def test_tasktype_match_and_miss(self):
+        ap = {"taskTypes": ["frontend"]}
+        self.assertTrue(rs.module_is_applicable(ap, task_types=["frontend"]))
+        self.assertFalse(rs.module_is_applicable(ap, task_types=["backend"]))
+
+    def test_or_across_dimensions(self):
+        ap = {"langs": ["python"], "taskTypes": ["frontend"]}
+        # lang matches, task does not -> still applicable
+        self.assertTrue(rs.module_is_applicable(ap, langs=["python"], task_types=["backend"]))
+        # task matches, lang does not -> still applicable
+        self.assertTrue(rs.module_is_applicable(ap, langs=["ruby"], task_types=["frontend"]))
+        # neither matches -> excluded
+        self.assertFalse(rs.module_is_applicable(ap, langs=["ruby"], task_types=["backend"]))
+
+    def test_malformed_constraints_fail_safe_to_always(self):
+        # declares the key but with empty dimensions -> include rather than drop
+        self.assertTrue(rs.module_is_applicable({"langs": []}))
+
+
+class SelectionTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.modules_dir = self._tmp.name
+        # Safety-core modules present.
+        _write_module(self.modules_dir, "git-workflow", rule_files=["rules/git-workflow.md"])
+        _write_module(self.modules_dir, "verification", rule_files=["rules/verification.md"])
+        _write_module(self.modules_dir, "test-driven-development",
+                      rule_files=["rules/test-driven-development.md"])
+        # Situational modules.
+        _write_module(self.modules_dir, "tailwind",
+                      applicability={"langs": ["css", "typescript"], "taskTypes": ["frontend"]},
+                      rule_files=["rules/tailwind.md"])
+        _write_module(self.modules_dir, "supabase",
+                      applicability={"langs": ["sql"], "taskTypes": ["database"]},
+                      rule_files=["rules/supabase.md"])
+        # Unclassified situational module (no applicability) -> always.
+        _write_module(self.modules_dir, "code-quality",
+                      rule_files=["rules/code-quality.md"])
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    @property
+    def installed(self):
+        return ["git-workflow", "verification", "test-driven-development",
+                "tailwind", "supabase", "code-quality"]
+
+    def test_no_profile_selects_all_applicable(self):  # property (a)
+        sel = rs.select_modules(self.installed, self.modules_dir)
+        # With no profile: core + all unclassified-always + no scoped (scoped miss empty profile)
+        self.assertIn("code-quality", sel)        # unclassified -> always
+        self.assertIn("git-workflow", sel)        # core
+        # Scoped modules with empty profile do NOT match -> excluded.
+        self.assertNotIn("tailwind", sel)
+        self.assertNotIn("supabase", sel)
+
+    def test_profile_selects_only_applicable(self):  # property (b)
+        sel = rs.select_modules(self.installed, self.modules_dir,
+                                langs=["css"], task_types=["frontend"])
+        self.assertIn("tailwind", sel)            # css/frontend match
+        self.assertNotIn("supabase", sel)         # sql/database miss
+
+    def test_safety_core_always_present(self):  # property (c)
+        # An adversarial profile that matches nothing situational.
+        sel = rs.select_modules(self.installed, self.modules_dir,
+                                langs=["brainfuck"], task_types=["nonsense"])
+        for core in ("git-workflow", "verification", "test-driven-development"):
+            self.assertIn(core, sel)
+        # Situational scoped modules excluded.
+        self.assertNotIn("tailwind", sel)
+        self.assertNotIn("supabase", sel)
+
+    def test_core_module_with_constraint_still_always(self):
+        # If a core module somehow declared a constraint, core membership wins.
+        _write_module(self.modules_dir, "git-workflow",
+                      applicability={"langs": ["nonexistent"]},
+                      rule_files=["rules/git-workflow.md"])
+        sel = rs.select_modules(self.installed, self.modules_dir, langs=["ruby"])
+        self.assertIn("git-workflow", sel)
+
+    def test_output_is_deterministic(self):  # property: determinism
+        a = rs.select_modules(self.installed, self.modules_dir, langs=["css"])
+        b = rs.select_modules(list(reversed(self.installed)), self.modules_dir, langs=["css"])
+        self.assertEqual(a, b)
+
+    def test_core_sorts_ahead_of_situational(self):
+        sel = rs.select_modules(self.installed, self.modules_dir)
+        core_positions = [sel.index(m) for m in ("git-workflow", "verification") if m in sel]
+        situational_positions = [sel.index("code-quality")]
+        self.assertTrue(max(core_positions) < min(situational_positions))
+
+    def test_select_rule_files_returns_targets(self):
+        pairs = rs.select_rule_files(self.installed, self.modules_dir,
+                                     langs=["css"], task_types=["frontend"])
+        mods = {m for m, _ in pairs}
+        self.assertIn("tailwind", mods)
+        self.assertIn(("tailwind", "rules/tailwind.md"), pairs)
+        # deterministic ordering
+        self.assertEqual(pairs, rs.select_rule_files(self.installed, self.modules_dir,
+                                                     langs=["css"], task_types=["frontend"]))
+
+    def test_missing_manifest_treated_as_always(self):
+        sel = rs.select_modules(self.installed + ["ghost-module"], self.modules_dir)
+        # ghost-module has no manifest -> applicability None -> always-applicable
+        self.assertIn("ghost-module", sel)
+
+
+class RealRepoApplicabilityTests(unittest.TestCase):
+    """Validate that the real repo's module.json applicability fields parse and
+    that the safety-core modules exist in the repo."""
+
+    def setUp(self):
+        self.repo_modules = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..")
+        )
+
+    def test_safety_core_modules_exist_in_repo(self):
+        for mod in rs.safety_core_modules():
+            self.assertTrue(
+                os.path.isdir(os.path.join(self.repo_modules, mod)),
+                f"safety-core module {mod} missing from repo",
+            )
+
+    def test_all_applicability_fields_are_valid(self):
+        for name in os.listdir(self.repo_modules):
+            manifest = rs.read_module_manifest(self.repo_modules, name)
+            if not manifest:
+                continue
+            ap = manifest.get("applicability")
+            if ap is None:
+                continue
+            self.assertIsInstance(ap, dict, f"{name}: applicability must be an object")
+            allowed = {"always", "langs", "taskTypes"}
+            self.assertTrue(
+                set(ap.keys()) <= allowed,
+                f"{name}: applicability has unknown keys {set(ap.keys()) - allowed}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/shadcn/module.json
+++ b/modules/shadcn/module.json
@@ -5,6 +5,7 @@
   "category": "tech-specific",
   "scope": ["global", "project"],
   "dependencies": [],
+  "applicability": { "langs": ["typescript", "javascript"], "taskTypes": ["frontend", "design"] },
   "files": {
     "rules/shadcn.md": { "target": "rules/shadcn.md", "type": "rule", "template": false }
   },

--- a/modules/supabase/module.json
+++ b/modules/supabase/module.json
@@ -5,6 +5,7 @@
   "category": "tech-specific",
   "scope": ["global", "project"],
   "dependencies": [],
+  "applicability": { "langs": ["sql", "typescript", "javascript"], "taskTypes": ["database", "backend"] },
   "files": {
     "rules/supabase.md": { "target": "rules/supabase.md", "type": "rule", "template": false }
   },

--- a/modules/tailwind/module.json
+++ b/modules/tailwind/module.json
@@ -5,6 +5,7 @@
   "category": "tech-specific",
   "scope": ["global", "project"],
   "dependencies": [],
+  "applicability": { "langs": ["css", "typescript", "javascript"], "taskTypes": ["frontend", "design"] },
   "files": {
     "rules/tailwind.md": { "target": "rules/tailwind.md", "type": "rule", "template": false },
     "rules/frontend-css.md": { "target": "rules/frontend-css.md", "type": "rule", "template": false }


### PR DESCRIPTION
Closes #695. Part of #659 (Wave 3).

## Summary

Reduces the always-on rule-token load via an **opt-in, backward-compatible** relevance-scoped rule injection mechanism plus a documented tiered safety core. **Default behavior is unchanged**: with the feature flag unset, every rule loads exactly as today. The feature is additive — it never removes or relocates a rule file and never disables Claude Code's auto-load path.

## Changes

1. **Schema** — optional `applicability` field on `module.json` (`{"always": true}` | `{"langs": [...]}` | `{"taskTypes": [...]}`). Absent/`always` == always applicable, preserving the pre-feature load-everything behavior. Populated for the confidently-classifiable tech-specific modules: `tailwind`, `shadcn`, `supabase`, `cloudflare`, `mcp-development`. JSON Schema documented in `lib/applicability-schema.json`.

2. **Tiered safety core** — an authoritative precedence for the always-on Iron Laws, so they are tiered rather than nine-way flat:
   `safety/permissions (git-workflow, hooks) > confusion-protocol (autonomy) > TDD/verification > systematic-debugging/subagent-patterns`.
   Documented in `rules/relevance-injection.md` and pinned in `lib/relevance_select.py` (`SAFETY_CORE_TIERS`). The safety core is **always** selected regardless of task profile.

3. **Opt-in injection** — new `relevance-injection` module (beta). A `SessionStart` hook (`relevance-inject.py`) that, **only** when `CCGM_RELEVANCE_INJECTION=true` is set in `~/.claude/.ccgm.env`, emits an `additionalContext` pointer naming the safety core plus the profile-relevant modules. When the flag is unset the hook is a strict no-op. Optional task profile via `CCGM_RELEVANCE_LANGS` / `CCGM_RELEVANCE_TASKTYPES`. All selection logic lives in the pure, deterministic, testable `relevance_select` library (no stdin/network in the library).

## How default behavior is guaranteed unchanged

- The module is opt-in and **beta** (excluded from all presets; not installed unless explicitly chosen).
- The hook self-gates on the flag and returns empty output when it is unset — verified by tests.
- The hook only injects a **pointer**; rule files remain on disk and loadable. Nothing is removed or suppressed.
- `applicability` is consumed only by this feature; the default installer ignores it. Absent `applicability` == always (matches old load-everything semantics).

## Test Plan

New tests (all green):
- `tests/test_relevance_select.py` — 18 unit tests pinning: (a) no profile selects all applicable, (b) profile selects only applicable, (c) **safety core always present** regardless of profile, (d) **absent applicability == always**, plus determinism, core-precedence ordering, and real-repo applicability-field validity.
- `tests/test_relevance_hook.sh` — 7 tests pinning: no-flag/`false`-flag no-op (default behavior unchanged), enabled-flag emits the safety core, non-startup source no-op, no-manifest fail-safe no-op.

Full suite:
- `bash tests/test-modules.sh` — 1422 passed
- `bash tests/test-doc-counts.sh` — all checks passed (counts 69 -> 70)
- `bash tests/test-no-personal-data.sh` — pass
- `bash tests/run-all.sh` — 12/12 suites passed (218 pytest, all shell)