### PR TITLE
#703: native plugin marketplace (generated; bash stays canonical)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,954 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "description": "Claude Code God Mode - modular rules, commands, agents, and skills. The bash installer (start.sh) remains the canonical full-fidelity path; this marketplace is an additive native-plugin projection of the same modules.",
+  "metadata": {
+    "pluginRoot": "./modules"
+  },
+  "name": "ccgm",
+  "owner": {
+    "name": "CCGM"
+  },
+  "plugins": [
+    {
+      "category": "workflow",
+      "description": "/adrev - adversarial review of a plan or any entity (file, doc, PR, issue, directory, or stated concept). Dispatches a separate adrev-reviewer agent that attacks premises, hunts failure modes, and steelmans the case against. Plan targets get findings incorporated into the plan automatically unless told not to; all other targets get a report.",
+      "name": "adversarial-review",
+      "source": "./adversarial-review",
+      "tags": [
+        "adversarial",
+        "planning",
+        "quality-gate",
+        "red-team",
+        "review"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "[DEPRECATED] Go-based terminal UI for managing Claude Code agent processes via tmux panes. Unmaintained and no longer offered for new installs; a GUI-based replacement is being pursued instead. Kept in-repo for existing users.",
+      "keywords": [
+        "status:deprecated"
+      ],
+      "name": "agent-manager",
+      "source": "./agent-manager",
+      "tags": [
+        "agents",
+        "monitoring",
+        "multi-agent",
+        "process-management",
+        "tui"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "Principles and audit skill for building applications where an agent is a first-class user. Four principles (parity, granularity, composability, emergent capability) as a rule file, a self-eval / red-team rubric that scores a surface against those principles, plus /agent-native-audit that scores a codebase with specific counts and a reviewer persona for the unified review orchestrator.",
+      "name": "agent-native",
+      "source": "./agent-native",
+      "tags": [
+        "agent-native",
+        "ai-first",
+        "architecture",
+        "audit",
+        "evaluation",
+        "red-team",
+        "review",
+        "rubric",
+        "tools"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "/argus - a closed-loop visual-ATDD harness where the agent develops UI against a per-feature design spec and signs off on its own work (functional AND visual) by grounding every judgment in deterministic gates plus a SEPARATE judge subagent that scores the render against the spec, a reference image, and the design system — never the diff. Loops to two consecutive passes, then commits a snapshot baseline. Platform-agnostic via a pluggable sensor+gates adapter (web built in; iOS/macOS via a project adapter). Ships the loop skill, the argus-judge agent, the spec/verdict/gate/rubric schemas, six dependency-free deterministic gate scripts, and an adapter-authoring contract.",
+      "name": "argus",
+      "source": "./argus",
+      "tags": [
+        "accessibility",
+        "anti-reward-hacking",
+        "argus",
+        "convergence-loop",
+        "design",
+        "judge",
+        "orchestrator",
+        "snapshot",
+        "visual-atdd",
+        "wcag"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Spec-driven development where E2E vision specs define target behavior. /atdd reads Playwright specs, iteratively builds app code until all tests pass, then ships.",
+      "name": "atdd",
+      "source": "./atdd",
+      "tags": [
+        "development",
+        "e2e",
+        "playwright",
+        "tdd",
+        "testing"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Captures permission events, tool failures, and user-correction signals; runs a daily analyzer via direct Anthropic API call; produces a local digest + opt-in Resend email; opt-in real-time security alerts and opt-in confidence-gated auto-apply. Cross-clone-safe via fcntl file locks. Webhook publisher seam is dormant by default.",
+      "name": "autoheal",
+      "source": "./autoheal",
+      "tags": [
+        "autoheal",
+        "hooks",
+        "jsonl",
+        "observability",
+        "permissions",
+        "self-healing",
+        "telemetry"
+      ]
+    },
+    {
+      "category": "core",
+      "description": "Configure Claude as a fully autonomous Staff-level engineer who executes tasks end-to-end without asking unnecessary questions.",
+      "name": "autonomy",
+      "source": "./autonomy",
+      "tags": [
+        "autonomy",
+        "productivity",
+        "workflow"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/brainstorm - hard gate that forbids code, scaffolding, or implementation until a design spec is written and user-approved. Proposes 2-3 approaches with tradeoffs, writes a design doc, self-reviews for TBDs and contradictions, then hands off to /xplan. Pairs with /ideate (which refines the concept) to enforce spec-before-plan-before-code.",
+      "name": "brainstorm",
+      "source": "./brainstorm",
+      "tags": [
+        "brainstorming",
+        "commands",
+        "design",
+        "gate",
+        "planning",
+        "spec"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "Slash commands for brand naming research: /brand (full naming pipeline with word exploration, domain/trademark/app store checks) and /brand-check (single-name deep verification). Optionally adds Instant Domain Search MCP server for fast domain availability checks.",
+      "name": "brand-naming",
+      "source": "./brand-naming",
+      "tags": [
+        "branding",
+        "commands",
+        "domains",
+        "naming",
+        "research"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "Rules for browser automation tool selection: Chrome extension, Playwright, and WebMCP. Includes verification priority order and UI verification workflow.",
+      "name": "browser-automation",
+      "source": "./browser-automation",
+      "tags": [
+        "automation",
+        "browser",
+        "chrome",
+        "playwright",
+        "webmcp"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/capabilities - a decision map for CCGM's overlapping command/skill clusters. Answers \"which one do I use?\" for research, review, planning/execution, debugging, and knowledge/memory. A tight always-on rule points at the on-demand command so the full map costs zero idle tokens.",
+      "name": "capability-router",
+      "source": "./capability-router",
+      "tags": [
+        "commands",
+        "decision-map",
+        "discoverability",
+        "navigation",
+        "router"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Audit tool for Claude Code installs. Three subcommands: check-resolvable (hook refs, command descriptions, script refs), dry (lexical overlap between command descriptions), and resolver-eval (runs a routing suite of {intent, expected} assertions against keyword-overlap scoring). Ships a default routing suite covering common slash commands.",
+      "name": "ccgm-doctor",
+      "source": "./ccgm-doctor",
+      "tags": [
+        "audit",
+        "evals",
+        "health-check",
+        "reachability",
+        "resolver"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "Unified code-review orchestrator. Composes scope-drift, learnings-researcher, tiered reviewer personas (correctness, testing, maintainability, project-standards + conditional security, performance, reliability, api-contract, data-migrations), and an adversarial/red-team lens that runs AFTER the specialists with access to their findings. Confidence-gated autofix routing with safe_auto / gated_auto / manual / advisory classes. Modes - interactive / autofix / report-only / headless.",
+      "name": "ce-review",
+      "source": "./ce-review",
+      "tags": [
+        "adversarial",
+        "autofix",
+        "confidence",
+        "orchestrator",
+        "pr",
+        "red-team",
+        "review",
+        "tiered"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Delegate Claude Code agent work to Hetzner Cloud VMs. Provides golden image pipeline, VM lifecycle management, secret injection, workspace provisioning, and /dispatch command for one-command multi-agent dispatch.",
+      "name": "cloud-dispatch",
+      "source": "./cloud-dispatch",
+      "tags": [
+        "agents",
+        "cloud",
+        "dispatch",
+        "hetzner",
+        "infrastructure",
+        "packer"
+      ]
+    },
+    {
+      "category": "tech-specific",
+      "description": "Cloudflare-specific rules: Pages vs Workers selection, deployment methods, Git integration requirements.",
+      "name": "cloudflare",
+      "source": "./cloudflare",
+      "tags": [
+        "cloudflare",
+        "deployment",
+        "pages",
+        "workers"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "Code standards, testing requirements, error handling patterns, security practices, build verification, and living documents maintenance.",
+      "name": "code-quality",
+      "source": "./code-quality",
+      "tags": [
+        "code-quality",
+        "security",
+        "standards",
+        "testing"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "Essential slash commands: /commit, /pr, /cpm (commit-PR-merge), /gs (git status), /ghi (create issue).",
+      "name": "commands-core",
+      "source": "./commands-core",
+      "tags": [
+        "commands",
+        "git",
+        "github",
+        "workflow"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global), /freeze + /unfreeze + /guard (safety-hook state management), /checkpoint (save/resume WIP session state).",
+      "name": "commands-extra",
+      "source": "./commands-extra",
+      "tags": [
+        "audit",
+        "checkpoint",
+        "commands",
+        "safety",
+        "verification",
+        "walkthrough"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Experimental UserPromptSubmit hook that injects a compact preamble of iron-law principles (Confusion Protocol, Completeness, Evidence Before Claims, Root Cause Before Fix) at the start of slash-command invocations. Opt-in, disabled by default.",
+      "name": "commands-preamble",
+      "source": "./commands-preamble",
+      "tags": [
+        "commands",
+        "experimental",
+        "hooks",
+        "preamble",
+        "principles"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "Utility commands and scripts: /cws-submit, /ccgm-sync (reverse-sync local config to CCGM + lem-deepresearch), /user-test, statusline, agent-team launcher.",
+      "name": "commands-utility",
+      "source": "./commands-utility",
+      "tags": [
+        "browser",
+        "commands",
+        "git",
+        "statusline",
+        "testing",
+        "tmux",
+        "utility"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "8 battle-tested anti-patterns to avoid: shallow directory exploration, dependency blindness, ESLint Fast Refresh, and more.",
+      "name": "common-mistakes",
+      "source": "./common-mistakes",
+      "tags": [
+        "anti-patterns",
+        "best-practices",
+        "debugging",
+        "mistakes"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Team-shared learnings in docs/solutions/. After solving a non-trivial problem, /compound writes a structured markdown doc with YAML frontmatter that later /xplan and /review runs re-inject as grounding. Counterpart to self-improving's personal MEMORY.md.",
+      "name": "compound-knowledge",
+      "source": "./compound-knowledge",
+      "tags": [
+        "compound",
+        "docs-solutions",
+        "knowledge",
+        "learnings",
+        "planning",
+        "review",
+        "team"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/copycat - analyze external Claude Code config repos to find useful patterns, rules, and techniques worth adopting into CCGM",
+      "name": "copycat",
+      "source": "./copycat",
+      "tags": [
+        "ccgm",
+        "commands",
+        "config-analysis",
+        "research"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/debug - structured root-cause debugging with Opus delegation. 7-phase workflow: gather context, reproduce, hypothesize, instrument, diagnose, fix, verify.",
+      "name": "debugging",
+      "source": "./debugging",
+      "tags": [
+        "commands",
+        "debugging"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/deepresearch - Multi-query semantic research using the Exa MCP server. Claude generates diverse queries from your topic, fans them out via parallel Exa MCP tool calls, and synthesizes a structured research.md from full page contents. Requires the Exa MCP server registered via `claude mcp add` and an Exa API key.",
+      "name": "deepresearch",
+      "source": "./deepresearch",
+      "tags": [
+        "commands",
+        "exa",
+        "external-api",
+        "mcp",
+        "research",
+        "web-search"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/design-review - visual design review for web pages. Screenshots at 3 viewports, 6 parallel analysis passes: spacing, typography, responsive, visual hierarchy, accessibility, component consistency. Scored report with optional auto-fix.",
+      "name": "design-review",
+      "source": "./design-review",
+      "tags": [
+        "accessibility",
+        "commands",
+        "css",
+        "design",
+        "frontend",
+        "review"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "Rule and template for shipping machine-readable docs alongside human docs. Any project an agent will install, build, test, deploy, or debug should have an AGENTS.md with copy-pasteable command blocks — not prose, not dashboard instructions.",
+      "name": "docs-for-agents",
+      "source": "./docs-for-agents",
+      "tags": [
+        "AGENTS.md",
+        "agents",
+        "documentation",
+        "dx",
+        "llms.txt"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Seven-lens plan-quality gate. Before a plan, spec, or requirements doc ships to execution, /document-review fans out to 7 role-specific reviewer agents (coherence, feasibility, product-lens, scope-guardian, design-lens, security-lens, adversarial) and merges structured JSON findings with severity and confidence. Each lens has tight what-you-flag boundaries so they do not overlap.",
+      "name": "document-review",
+      "source": "./document-review",
+      "tags": [
+        "adversarial",
+        "document-review",
+        "plan-review",
+        "planning",
+        "quality-gate",
+        "review",
+        "scope",
+        "yagni"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/docupdate - comprehensive documentation audit and update. Checks README, TOC, onboarding flows, package lists, and module coverage against actual codebase state.",
+      "name": "documentation",
+      "source": "./documentation",
+      "tags": [
+        "commands",
+        "documentation",
+        "maintenance"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/editorial-critique - deep editorial review of long-form writing. 8 parallel analysis passes: prose craft, AI-tell detection, argument architecture, conciseness, data verification, structure, impact, grammar. Scored report with optional auto-fix.",
+      "name": "editorial-critique",
+      "source": "./editorial-critique",
+      "tags": [
+        "commands",
+        "editing",
+        "prose",
+        "review",
+        "writing"
+      ]
+    },
+    {
+      "category": "core",
+      "description": "Git workflow rules: sync before history changes, rebase by default, post-merge cleanup, PR template detection, no AI attribution in commits.",
+      "name": "git-workflow",
+      "source": "./git-workflow",
+      "tags": [
+        "branching",
+        "git",
+        "pr",
+        "workflow"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Solo-agent worktree-based isolation for feature work. Lighter alternative to multi-clone setup when only one agent is active.",
+      "name": "git-worktrees",
+      "source": "./git-worktrees",
+      "tags": [
+        "git",
+        "isolation",
+        "workflow",
+        "worktree"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "GitHub repository management protocols: issue-first workflow, PR conventions, label taxonomy, code review standards.",
+      "name": "github-protocols",
+      "source": "./github-protocols",
+      "tags": [
+        "code-review",
+        "github",
+        "issues",
+        "pr",
+        "protocols"
+      ]
+    },
+    {
+      "category": "core",
+      "description": "Slim global CLAUDE.md that serves as the root configuration reference. Points to rules, commands, hooks, and settings without duplicating their content.",
+      "name": "global-claude-md",
+      "source": "./global-claude-md",
+      "tags": [
+        "claude-md",
+        "config",
+        "core"
+      ]
+    },
+    {
+      "category": "core",
+      "description": "Python hooks that enforce git workflow rules: issue-first workflow, commit message format, branch protection, and auto-approval for file operations.",
+      "name": "hooks",
+      "source": "./hooks",
+      "tags": [
+        "auto-approve",
+        "git",
+        "hooks",
+        "workflow"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/ideate - structured ideation framework. Interviews you to refine a loose idea into a concrete concept using Socratic questioning, confidence tracking, and progressive refinement. Delegates to /deepresearch for validation and /xplan for planning.",
+      "name": "ideate",
+      "source": "./ideate",
+      "tags": [
+        "brainstorming",
+        "commands",
+        "ideation",
+        "interview",
+        "planning"
+      ]
+    },
+    {
+      "category": "core",
+      "description": "Two foundational context files that give Claude Code a persistent identity: soul.md (AI personality and philosophy) and human-context.md (who you are, your goals, and how you work).",
+      "name": "identity",
+      "source": "./identity",
+      "tags": [
+        "context",
+        "identity",
+        "personality",
+        "soul"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "A /launch skill that takes a one-page spec and reaches a deployed Cloudflare Pages site without further human input — except for the unavoidable Connect-to-Git dashboard step, which the skill stops to ask for. Inspired by Karpathy's Sequoia talk: 'I would hope that I could give a prompt to an LLM, build menu gen, and then I didn't have to touch anything and it's deployed in that same way on the internet.' The skill is the forcing function that surfaces every place CCGM/CF infra is still human-shaped.",
+      "name": "launch",
+      "source": "./launch",
+      "tags": [
+        "agent-native",
+        "cloudflare-pages",
+        "deployment",
+        "one-prompt",
+        "skills",
+        "spec-driven"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "Design-engineering details that compound into polished interfaces. Model-invoked skill with references on design direction (aesthetic identity, typeface/color/spacing choices, avoiding generic AI aesthetics), typography (text-wrap, tabular nums, font smoothing), surfaces (concentric radii, shadows over borders, optical alignment, image outlines), animations (interruptible transitions, enter/exit, icon micro-interactions), and performance (transition specificity, will-change).",
+      "name": "make-interfaces-feel-better",
+      "source": "./make-interfaces-feel-better",
+      "tags": [
+        "aesthetics",
+        "animation",
+        "color",
+        "css",
+        "design",
+        "frontend",
+        "micro-interactions",
+        "typography",
+        "ui"
+      ]
+    },
+    {
+      "category": "tech-specific",
+      "description": "Guide for building Model Context Protocol servers: project structure, tool design, error handling, testing with MCP Inspector, and evaluation patterns.",
+      "name": "mcp-development",
+      "source": "./mcp-development",
+      "tags": [
+        "mcp",
+        "model-context-protocol",
+        "servers",
+        "tools"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Multi-clone architecture for parallel agent work with issue claiming, port allocation, and the /mawf workflow command.",
+      "name": "multi-agent",
+      "source": "./multi-agent",
+      "tags": [
+        "coordination",
+        "multi-agent",
+        "parallel",
+        "workflow"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/onboarding - analyzes a repository and generates a structured ONBOARDING.md (architecture, dev setup, key commands, test workflow, glossary). Runs an inventory script to build a language-aware structural map, reads only the files that map surfaces, and writes prose with strict voice rules so the output reads like a knowledgeable teammate rather than generated documentation.",
+      "name": "onboarding",
+      "source": "./onboarding",
+      "tags": [
+        "command",
+        "documentation",
+        "inventory",
+        "onboarding",
+        "skill"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "Formatting rules for user-facing output: copy-pasteable content (drafts, messages, prompts, config snippets) is delivered in fenced code blocks, never blockquotes, so it pastes clean anywhere.",
+      "name": "output-formatting",
+      "source": "./output-formatting",
+      "tags": [
+        "communication",
+        "copy-paste",
+        "formatting",
+        "output"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "Packages the always-on TONE rules (terse communication, autonomous execution, copy-paste formatting) as a Claude Code output style — a system-prompt layer fixed at session start and prompt-cached — instead of always-loaded rules/*.md. Opt-in alternative; does not remove the source rules.",
+      "name": "output-styles",
+      "source": "./output-styles",
+      "tags": [
+        "output-style",
+        "prompt-caching",
+        "tokens",
+        "tone"
+      ]
+    },
+    {
+      "category": "core",
+      "description": "Maintainer tooling that projects CCGM's modules into a native Claude Code plugin marketplace (.claude-plugin/marketplace.json + per-module plugin.json), additively. The bash installer stays the canonical full-fidelity path. Ships the generator, a JSON-schema validator, and the SessionStart rule-injection hook that bridges the plugin-CLAUDE.md-not-loaded gap.",
+      "keywords": [
+        "status:beta"
+      ],
+      "name": "plugin-marketplace",
+      "source": "./plugin-marketplace",
+      "tags": [
+        "distribution",
+        "generator",
+        "marketplace",
+        "opt-in",
+        "plugin",
+        "session-start"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Structured resolver for PR review comments. /resolve-pr-feedback fetches unresolved review threads via GraphQL, triages new vs already-handled, and if 3+ new items arrive (or a cross-invocation signal fires) runs cluster analysis - categorizes each into 11 fixed concern categories and groups by category + spatial proximity. Clusters surface systemic issues instead of dispatching 10 one-off fixes. Parallel pr-comment-resolver subagents apply unambiguous fixes, post inline replies via gh api, and resolve threads; taste questions are batched for human decision.",
+      "name": "pr-feedback",
+      "source": "./pr-feedback",
+      "tags": [
+        "cluster",
+        "comments",
+        "feedback",
+        "github",
+        "graphql",
+        "pr",
+        "resolver",
+        "review"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "Augments the external pr-review-toolkit plugin with scope-drift detection (compare stated intent to actual diff) and a Fix-First output format (AUTO-FIXED vs NEEDS INPUT). Ported from garrytan/gstack review skill.",
+      "name": "pr-review-toolkit",
+      "source": "./pr-review-toolkit",
+      "tags": [
+        "commands",
+        "fix-first",
+        "pr",
+        "review",
+        "scope-drift"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Opt-in, backward-compatible relevance-scoped rule injection plus a tiered always-on safety core. Off by default: with the flag unset, all rules load exactly as before. When enabled, surfaces a pointer to the task-relevant rule subset while always including the safety core.",
+      "keywords": [
+        "status:beta"
+      ],
+      "name": "relevance-injection",
+      "source": "./relevance-injection",
+      "tags": [
+        "context",
+        "opt-in",
+        "rules",
+        "safety-core",
+        "session-start",
+        "tokens"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "SSH access to a remote server. Adds /onremote command for health checks and remote command execution. Delegates to Haiku.",
+      "name": "remote-server",
+      "source": "./remote-server",
+      "tags": [
+        "infrastructure",
+        "remote",
+        "server",
+        "ssh"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/research - multi-channel research using parallel agents with WebSearch, WebFetch, GitHub, and Reddit. Zero external dependencies. For deeper research backed by Exa neural search, see the deepresearch module.",
+      "name": "research",
+      "source": "./research",
+      "tags": [
+        "commands",
+        "research",
+        "web-search"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "Discipline for writing rules that hold up under pressure. Treats rule authoring as TDD: pressure-test a candidate rule with adversarial scenarios, capture the rationalizations agents use to bypass it, and rewrite until the rule closes those loopholes.",
+      "name": "rule-authoring",
+      "source": "./rule-authoring",
+      "tags": [
+        "authoring",
+        "discipline",
+        "pressure-testing",
+        "rules",
+        "tdd-for-rules"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Meta-learning system with a structured JSONL learnings store (confidence decay, staleness, prompt-injection-filtered), automated reflection triggers, and hooks that fire at key moments (PR merge, context compaction, debugging failures). Replaces narrative MEMORY.md with a queryable, token-budgeted store while keeping MEMORY.md as a rendered index.",
+      "name": "self-improving",
+      "source": "./self-improving",
+      "tags": [
+        "confidence-decay",
+        "hooks",
+        "improvement",
+        "jsonl",
+        "learnings",
+        "memory",
+        "meta-learning",
+        "reflection"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Cross-platform session historian agent. Searches prior Claude Code and Codex session transcripts for what was tried, what failed, and what was decided in earlier sessions on the same repo. Invoked by other skills (/compound, /xplan, /debug) to surface institutional knowledge a fresh session cannot see.",
+      "name": "session-history",
+      "source": "./session-history",
+      "tags": [
+        "agent",
+        "claude-code",
+        "codex",
+        "cross-platform",
+        "history",
+        "recall",
+        "retrieval",
+        "session"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Structured session shutdown via /sds. Autonomous wrap-up sweep: commit dirty work, update referenced issues, run /reflect, write a handoff, broadcast to sibling clones. Complements /startup at the other end of the session.",
+      "name": "session-lifecycle",
+      "source": "./session-lifecycle",
+      "tags": [
+        "handoff",
+        "session",
+        "shutdown",
+        "workflow"
+      ]
+    },
+    {
+      "category": "core",
+      "description": "Base settings.json with comprehensive tool permissions (800+ allow entries), deny list for dangerous operations, and plugin configuration. Defaults to 'ask' mode for safety.",
+      "name": "settings",
+      "source": "./settings",
+      "tags": [
+        "permissions",
+        "security",
+        "settings"
+      ]
+    },
+    {
+      "category": "tech-specific",
+      "description": "shadcn/ui component patterns: composition over custom builds, semantic theming tokens, proper form architecture, accessibility, and CLI workflow.",
+      "name": "shadcn",
+      "source": "./shadcn",
+      "tags": [
+        "components",
+        "radix",
+        "react",
+        "shadcn",
+        "ui"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/ship-ready command: at-a-glance dashboard of what gates a merge on the current branch (failing tests, open PR count, stale branches, outdated deps, merge velocity, review freshness, unresolved risks from docs/solutions/). Reads ce-review envelopes for commit-hash staleness detection.",
+      "name": "ship-readiness",
+      "source": "./ship-readiness",
+      "tags": [
+        "dashboard",
+        "gating",
+        "pre-merge",
+        "review",
+        "ship",
+        "staleness"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "Discipline for writing skills and slash commands that stay efficient, portable, and context-safe. Covers reference-file inclusion, conditional content extraction, tool selection, and writing style.",
+      "name": "skill-authoring",
+      "source": "./skill-authoring",
+      "tags": [
+        "authoring",
+        "commands",
+        "context-window",
+        "discipline",
+        "skills"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Slash command that promotes an ad-hoc session capability into a durable skill: a command file with triggers and rules, optional deterministic helper script, a pinning test, and a learnings-store entry pointing at the new skill. Inspired by the 'skillify' pattern where every repeated failure becomes structurally unreachable by being turned into a tested skill.",
+      "name": "skillify",
+      "source": "./skillify",
+      "tags": [
+        "authoring",
+        "durability",
+        "meta-learning",
+        "skills"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Plain-text /startup dashboard for Claude Code sessions. Surfaces git state, live sessions, tracking.csv claims, and recent activity (via session-history /recall). No agent-log writes; session transcripts are captured by Claude Code natively.",
+      "name": "startup-dashboard",
+      "source": "./startup-dashboard",
+      "tags": [
+        "dashboard",
+        "session",
+        "startup"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Compact single-line Claude Code statusline: model + effort, multi-clone identity (.env.clone), dir + git branch, context-used % with a compaction warning, session cost, and 5h/7d rate-limit bars. Installs the script and wires the statusLine setting.",
+      "name": "statusline",
+      "source": "./statusline",
+      "tags": [
+        "context",
+        "cost",
+        "multi-clone",
+        "statusline",
+        "ui"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Subagent dispatch methodology: task decomposition, spec-driven delegation, pass-paths-not-contents, two-stage review (spec compliance then code quality), parallel coordination, and skill invocation modes.",
+      "name": "subagent-patterns",
+      "source": "./subagent-patterns",
+      "tags": [
+        "agents",
+        "coordination",
+        "delegation",
+        "parallel",
+        "review",
+        "subagents"
+      ]
+    },
+    {
+      "category": "tech-specific",
+      "description": "Supabase-specific rules: API key terminology (publishable/secret), environment variable naming, migration validation, and database change workflow.",
+      "name": "supabase",
+      "source": "./supabase",
+      "tags": [
+        "auth",
+        "database",
+        "migrations",
+        "supabase"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "4-phase root cause investigation methodology: investigate, analyze patterns, test hypotheses, implement fix. Prevents random fix attempts.",
+      "name": "systematic-debugging",
+      "source": "./systematic-debugging",
+      "tags": [
+        "debugging",
+        "methodology",
+        "root-cause",
+        "troubleshooting"
+      ]
+    },
+    {
+      "category": "tech-specific",
+      "description": "Tailwind CSS v4 design system patterns: CSS-first configuration, design token hierarchy, CVA component variants, dark mode, and responsive grid systems.",
+      "name": "tailwind",
+      "source": "./tailwind",
+      "tags": [
+        "css",
+        "design-system",
+        "tailwind",
+        "theming",
+        "tokens"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "Strict red-green-refactor TDD discipline. No production code without a failing test first. Enforces test-first methodology for all new features and bug fixes.",
+      "name": "test-driven-development",
+      "source": "./test-driven-development",
+      "tags": [
+        "methodology",
+        "red-green-refactor",
+        "tdd",
+        "testing"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Vision-driven e2e test suite generation. /test-vision for full repo analysis + parallel test suite creation. /e2e for single-feature spec generation. Composes /e2e as the atomic unit within /test-vision orchestration.",
+      "name": "test-vision",
+      "source": "./test-vision",
+      "tags": [
+        "browser-automation",
+        "e2e",
+        "parallel",
+        "playwright",
+        "testing"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "File-based review-finding tracker. Review findings, PR nitpicks, and tech debt that does not merit a full GitHub issue go to .claude/todos/NNN-{status}-{priority}-{description}.md with YAML frontmatter. Three skills compose - /todo-create (canonical writer), /todo-triage (interactive pending->ready), /todo-resolve (batch-resolve ready todos via parallel subagents). Fills the gap between review-found-it and cut-an-issue with a lightweight, in-repo third option.",
+      "name": "todos",
+      "source": "./todos",
+      "tags": [
+        "pr-feedback",
+        "review",
+        "tech-debt",
+        "todos",
+        "tracker",
+        "triage"
+      ]
+    },
+    {
+      "category": "patterns",
+      "description": "Evidence-before-claims methodology. Requires fresh execution of verification commands, reading full output, and confirming results before asserting completion.",
+      "name": "verification",
+      "source": "./verification",
+      "tags": [
+        "completion",
+        "evidence",
+        "quality",
+        "verification"
+      ]
+    },
+    {
+      "category": "workflow",
+      "description": "Deep research + planning + execution framework. Spawns parallel research/review agents, creates comprehensive plans, and executes via parallel agent waves.",
+      "name": "xplan",
+      "source": "./xplan",
+      "tags": [
+        "execution",
+        "parallel",
+        "planning",
+        "research"
+      ]
+    },
+    {
+      "category": "commands",
+      "description": "/transcript <url> grabs a YouTube transcript via yt-dlp AND dispatches a subagent to produce an opinionated implications doc against your project memory. Saves both files with matching slug+date so the pair correlates by name. --no-analysis flag for extraction only.",
+      "name": "youtube-transcripts",
+      "source": "./youtube-transcripts",
+      "tags": [
+        "analysis",
+        "commands",
+        "subagent",
+        "transcripts",
+        "youtube"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Check doc counts + preset coverage
         run: bash tests/test-doc-counts.sh
 
+      - name: Plugin marketplace in sync (generator --check)
+        run: python3 modules/plugin-marketplace/lib/gen_marketplace.py --check
+
+      - name: Validate plugin marketplace + manifests
+        run: python3 modules/plugin-marketplace/lib/validate_marketplace.py
+
       - name: Personal-data detector self-test
         run: bash tests/test-no-personal-data.sh --self-test
 
@@ -52,6 +58,12 @@ jobs:
 
       - name: Check doc counts + preset coverage
         run: bash tests/test-doc-counts.sh
+
+      - name: Plugin marketplace in sync (generator --check)
+        run: python3 modules/plugin-marketplace/lib/gen_marketplace.py --check
+
+      - name: Validate plugin marketplace + manifests
+        run: python3 modules/plugin-marketplace/lib/validate_marketplace.py
 
       - name: Personal-data detector self-test
         run: bash tests/test-no-personal-data.sh --self-test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Instructions for Claude Code when working on the CCGM (Claude Code God Mode) rep
 
 ## What This Repo Is
 
-CCGM is a modular Claude Code configuration system. It contains 70 modules that users can selectively install to configure Claude Code's behavior, hooks, commands, and permissions.
+CCGM is a modular Claude Code configuration system. It contains 71 modules that users can selectively install to configure Claude Code's behavior, hooks, commands, and permissions.
 
 ## Repository Structure
 
@@ -19,7 +19,7 @@ ccgm/
 │   ├── merge.sh        # settings.json merge via jq
 │   ├── modules.sh      # Module discovery + deps
 │   └── backup.sh       # Backup/restore
-├── modules/            # 70 self-contained modules
+├── modules/            # 71 self-contained modules
 │   └── {name}/
 │       ├── module.json # Manifest
 │       ├── README.md   # Module docs

--- a/README.md
+++ b/README.md
@@ -150,6 +150,25 @@ For a quick install with a preset:
 ./uninstall.sh   # Remove only CCGM-installed files
 ```
 
+### Install as a native plugin marketplace
+
+CCGM is also published as a [Claude Code plugin marketplace](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces). This is an **additive** path — the bash installer above remains canonical.
+
+```bash
+claude plugin marketplace add lucasmccomb/ccgm
+claude plugin install code-quality@ccgm     # install any module as a plugin
+```
+
+**The bash installer is canonical; the marketplace is a projection.** A plugin's `CLAUDE.md` is not auto-loaded and a plugin can only contribute the `agent`/`subagentStatusLine` settings keys, so the marketplace path does **not** perform CCGM's deep `settings.json` merge or write the always-on global `CLAUDE.md` context. Use the bash installer when those matter.
+
+| Component | Bash installer | Marketplace |
+|-----------|----------------|-------------|
+| Commands / agents / skills / output styles | `~/.claude/` | Native plugin components |
+| Rules (`rules/*.md`) | Auto-loaded | Injected by a SessionStart hook, opt-in via `CCGM_PLUGIN_RULE_INJECTION=true` |
+| Deep `settings.json` merge + global `CLAUDE.md` | Yes | No |
+
+The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plugin.json` files are **generated** from `modules/*/module.json` by `modules/plugin-marketplace/lib/gen_marketplace.py` — never hand-edited. See the [plugin-marketplace module](modules/plugin-marketplace/README.md).
+
 ## Module Catalog
 
 | Module | Category | Description | Dependencies |
@@ -320,7 +339,7 @@ The `docs/` directory contains comprehensive documentation:
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
 | [Install via Agent](docs/install-via-agent.md) | Per-preset paste-blocks and how to dry-run them safely |
-| [Module Catalog](docs/modules.md) | Detailed reference for all 70 modules |
+| [Module Catalog](docs/modules.md) | Detailed reference for all 71 modules |
 | [Commands Reference](docs/commands.md) | All 74 slash commands with usage examples |
 | [Hooks Reference](docs/hooks.md) | All 13 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -151,7 +151,7 @@ Removes only CCGM-installed files (tracked via a manifest). Your personal files 
 
 ## Next steps
 
-- [Module Catalog](modules.md) - explore all 70 modules in detail
+- [Module Catalog](modules.md) - explore all 71 modules in detail
 - [Commands Reference](commands.md) - learn every slash command
 - [Hooks Reference](hooks.md) - understand the workflow automation
 - [Configuration](configuration.md) - customize CCGM after installation

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,6 @@
 # Module Catalog
 
-CCGM contains 70 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
+CCGM contains 71 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
 
 ## How modules work
 

--- a/modules/adversarial-review/.claude-plugin/plugin.json
+++ b/modules/adversarial-review/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/adrev - adversarial review of a plan or any entity (file, doc, PR, issue, directory, or stated concept). Dispatches a separate adrev-reviewer agent that attacks premises, hunts failure modes, and steelmans the case against. Plan targets get findings incorporated into the plan automatically unless told not to; all other targets get a report.",
+  "displayName": "Adversarial Review",
+  "keywords": [
+    "adversarial",
+    "planning",
+    "quality-gate",
+    "red-team",
+    "review"
+  ],
+  "license": "MIT",
+  "name": "adversarial-review"
+}

--- a/modules/agent-manager/.claude-plugin/plugin.json
+++ b/modules/agent-manager/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "[DEPRECATED] Go-based terminal UI for managing Claude Code agent processes via tmux panes. Unmaintained and no longer offered for new installs; a GUI-based replacement is being pursued instead. Kept in-repo for existing users.",
+  "displayName": "Agent Manager TUI",
+  "keywords": [
+    "agents",
+    "monitoring",
+    "multi-agent",
+    "process-management",
+    "tui"
+  ],
+  "license": "MIT",
+  "name": "agent-manager"
+}

--- a/modules/agent-native/.claude-plugin/plugin.json
+++ b/modules/agent-native/.claude-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Principles and audit skill for building applications where an agent is a first-class user. Four principles (parity, granularity, composability, emergent capability) as a rule file, a self-eval / red-team rubric that scores a surface against those principles, plus /agent-native-audit that scores a codebase with specific counts and a reviewer persona for the unified review orchestrator.",
+  "displayName": "Agent-Native Architecture",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "agent-native",
+    "ai-first",
+    "architecture",
+    "audit",
+    "evaluation",
+    "red-team",
+    "review",
+    "rubric",
+    "tools"
+  ],
+  "license": "MIT",
+  "name": "agent-native"
+}

--- a/modules/agent-native/hooks/plugin-rule-inject.py
+++ b/modules/agent-native/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/argus/.claude-plugin/plugin.json
+++ b/modules/argus/.claude-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/argus - a closed-loop visual-ATDD harness where the agent develops UI against a per-feature design spec and signs off on its own work (functional AND visual) by grounding every judgment in deterministic gates plus a SEPARATE judge subagent that scores the render against the spec, a reference image, and the design system — never the diff. Loops to two consecutive passes, then commits a snapshot baseline. Platform-agnostic via a pluggable sensor+gates adapter (web built in; iOS/macOS via a project adapter). Ships the loop skill, the argus-judge agent, the spec/verdict/gate/rubric schemas, six dependency-free deterministic gate scripts, and an adapter-authoring contract.",
+  "displayName": "Argus: Visual-ATDD Convergence Loop",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "accessibility",
+    "anti-reward-hacking",
+    "argus",
+    "convergence-loop",
+    "design",
+    "judge",
+    "orchestrator",
+    "snapshot",
+    "visual-atdd",
+    "wcag"
+  ],
+  "license": "MIT",
+  "name": "argus"
+}

--- a/modules/argus/hooks/plugin-rule-inject.py
+++ b/modules/argus/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/atdd/.claude-plugin/plugin.json
+++ b/modules/atdd/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Spec-driven development where E2E vision specs define target behavior. /atdd reads Playwright specs, iteratively builds app code until all tests pass, then ships.",
+  "displayName": "Agentic Test-Driven Development",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "development",
+    "e2e",
+    "playwright",
+    "tdd",
+    "testing"
+  ],
+  "license": "MIT",
+  "name": "atdd"
+}

--- a/modules/atdd/hooks/plugin-rule-inject.py
+++ b/modules/atdd/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/autoheal/.claude-plugin/plugin.json
+++ b/modules/autoheal/.claude-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Captures permission events, tool failures, and user-correction signals; runs a daily analyzer via direct Anthropic API call; produces a local digest + opt-in Resend email; opt-in real-time security alerts and opt-in confidence-gated auto-apply. Cross-clone-safe via fcntl file locks. Webhook publisher seam is dormant by default.",
+  "displayName": "Autoheal: Self-Healing Observability Loop",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "autoheal",
+    "hooks",
+    "jsonl",
+    "observability",
+    "permissions",
+    "self-healing",
+    "telemetry"
+  ],
+  "license": "MIT",
+  "name": "autoheal"
+}

--- a/modules/autoheal/hooks/plugin-rule-inject.py
+++ b/modules/autoheal/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/autonomy/.claude-plugin/plugin.json
+++ b/modules/autonomy/.claude-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Configure Claude as a fully autonomous Staff-level engineer who executes tasks end-to-end without asking unnecessary questions.",
+  "displayName": "Full Autonomy",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "autonomy",
+    "productivity",
+    "workflow"
+  ],
+  "license": "MIT",
+  "name": "autonomy"
+}

--- a/modules/autonomy/hooks/plugin-rule-inject.py
+++ b/modules/autonomy/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/brainstorm/.claude-plugin/plugin.json
+++ b/modules/brainstorm/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/brainstorm - hard gate that forbids code, scaffolding, or implementation until a design spec is written and user-approved. Proposes 2-3 approaches with tradeoffs, writes a design doc, self-reviews for TBDs and contradictions, then hands off to /xplan. Pairs with /ideate (which refines the concept) to enforce spec-before-plan-before-code.",
+  "displayName": "Brainstorm (Design-Before-Implementation Gate)",
+  "keywords": [
+    "brainstorming",
+    "commands",
+    "design",
+    "gate",
+    "planning",
+    "spec"
+  ],
+  "license": "MIT",
+  "name": "brainstorm"
+}

--- a/modules/brand-naming/.claude-plugin/plugin.json
+++ b/modules/brand-naming/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Slash commands for brand naming research: /brand (full naming pipeline with word exploration, domain/trademark/app store checks) and /brand-check (single-name deep verification). Optionally adds Instant Domain Search MCP server for fast domain availability checks.",
+  "displayName": "Brand Naming Research",
+  "keywords": [
+    "branding",
+    "commands",
+    "domains",
+    "naming",
+    "research"
+  ],
+  "license": "MIT",
+  "name": "brand-naming"
+}

--- a/modules/browser-automation/.claude-plugin/plugin.json
+++ b/modules/browser-automation/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Rules for browser automation tool selection: Chrome extension, Playwright, and WebMCP. Includes verification priority order and UI verification workflow.",
+  "displayName": "Browser Automation",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "automation",
+    "browser",
+    "chrome",
+    "playwright",
+    "webmcp"
+  ],
+  "license": "MIT",
+  "name": "browser-automation"
+}

--- a/modules/browser-automation/hooks/plugin-rule-inject.py
+++ b/modules/browser-automation/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/capability-router/.claude-plugin/plugin.json
+++ b/modules/capability-router/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/capabilities - a decision map for CCGM's overlapping command/skill clusters. Answers \"which one do I use?\" for research, review, planning/execution, debugging, and knowledge/memory. A tight always-on rule points at the on-demand command so the full map costs zero idle tokens.",
+  "displayName": "Capability Router",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "commands",
+    "decision-map",
+    "discoverability",
+    "navigation",
+    "router"
+  ],
+  "license": "MIT",
+  "name": "capability-router"
+}

--- a/modules/capability-router/hooks/plugin-rule-inject.py
+++ b/modules/capability-router/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/ccgm-doctor/.claude-plugin/plugin.json
+++ b/modules/ccgm-doctor/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Audit tool for Claude Code installs. Three subcommands: check-resolvable (hook refs, command descriptions, script refs), dry (lexical overlap between command descriptions), and resolver-eval (runs a routing suite of {intent, expected} assertions against keyword-overlap scoring). Ships a default routing suite covering common slash commands.",
+  "displayName": "CCGM Doctor",
+  "keywords": [
+    "audit",
+    "evals",
+    "health-check",
+    "reachability",
+    "resolver"
+  ],
+  "license": "MIT",
+  "name": "ccgm-doctor"
+}

--- a/modules/ce-review/.claude-plugin/plugin.json
+++ b/modules/ce-review/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Unified code-review orchestrator. Composes scope-drift, learnings-researcher, tiered reviewer personas (correctness, testing, maintainability, project-standards + conditional security, performance, reliability, api-contract, data-migrations), and an adversarial/red-team lens that runs AFTER the specialists with access to their findings. Confidence-gated autofix routing with safe_auto / gated_auto / manual / advisory classes. Modes - interactive / autofix / report-only / headless.",
+  "displayName": "CE Review Orchestrator",
+  "keywords": [
+    "adversarial",
+    "autofix",
+    "confidence",
+    "orchestrator",
+    "pr",
+    "red-team",
+    "review",
+    "tiered"
+  ],
+  "license": "MIT",
+  "name": "ce-review"
+}

--- a/modules/cloud-dispatch/.claude-plugin/plugin.json
+++ b/modules/cloud-dispatch/.claude-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Delegate Claude Code agent work to Hetzner Cloud VMs. Provides golden image pipeline, VM lifecycle management, secret injection, workspace provisioning, and /dispatch command for one-command multi-agent dispatch.",
+  "displayName": "Cloud Dispatch",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "agents",
+    "cloud",
+    "dispatch",
+    "hetzner",
+    "infrastructure",
+    "packer"
+  ],
+  "license": "MIT",
+  "name": "cloud-dispatch"
+}

--- a/modules/cloud-dispatch/hooks/plugin-rule-inject.py
+++ b/modules/cloud-dispatch/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/cloudflare/.claude-plugin/plugin.json
+++ b/modules/cloudflare/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Cloudflare-specific rules: Pages vs Workers selection, deployment methods, Git integration requirements.",
+  "displayName": "Cloudflare Rules",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "cloudflare",
+    "deployment",
+    "pages",
+    "workers"
+  ],
+  "license": "MIT",
+  "name": "cloudflare"
+}

--- a/modules/cloudflare/hooks/plugin-rule-inject.py
+++ b/modules/cloudflare/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/code-quality/.claude-plugin/plugin.json
+++ b/modules/code-quality/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Code standards, testing requirements, error handling patterns, security practices, build verification, and living documents maintenance.",
+  "displayName": "Code Quality Standards",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "code-quality",
+    "security",
+    "standards",
+    "testing"
+  ],
+  "license": "MIT",
+  "name": "code-quality"
+}

--- a/modules/code-quality/hooks/plugin-rule-inject.py
+++ b/modules/code-quality/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/commands-core/.claude-plugin/plugin.json
+++ b/modules/commands-core/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Essential slash commands: /commit, /pr, /cpm (commit-PR-merge), /gs (git status), /ghi (create issue).",
+  "displayName": "Core Commands",
+  "keywords": [
+    "commands",
+    "git",
+    "github",
+    "workflow"
+  ],
+  "license": "MIT",
+  "name": "commands-core"
+}

--- a/modules/commands-extra/.claude-plugin/plugin.json
+++ b/modules/commands-extra/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Additional slash commands: /audit (codebase audit), /pwv (Playwright visual verify), /walkthrough (step-by-step guide), /promote-rule (promote repo rules to global), /freeze + /unfreeze + /guard (safety-hook state management), /checkpoint (save/resume WIP session state).",
+  "displayName": "Extra Commands",
+  "keywords": [
+    "audit",
+    "checkpoint",
+    "commands",
+    "safety",
+    "verification",
+    "walkthrough"
+  ],
+  "license": "MIT",
+  "name": "commands-extra"
+}

--- a/modules/commands-preamble/.claude-plugin/plugin.json
+++ b/modules/commands-preamble/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Experimental UserPromptSubmit hook that injects a compact preamble of iron-law principles (Confusion Protocol, Completeness, Evidence Before Claims, Root Cause Before Fix) at the start of slash-command invocations. Opt-in, disabled by default.",
+  "displayName": "Command Preamble Injection (Experimental)",
+  "keywords": [
+    "commands",
+    "experimental",
+    "hooks",
+    "preamble",
+    "principles"
+  ],
+  "license": "MIT",
+  "name": "commands-preamble"
+}

--- a/modules/commands-utility/.claude-plugin/plugin.json
+++ b/modules/commands-utility/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Utility commands and scripts: /cws-submit, /ccgm-sync (reverse-sync local config to CCGM + lem-deepresearch), /user-test, statusline, agent-team launcher.",
+  "displayName": "Utility Commands",
+  "keywords": [
+    "browser",
+    "commands",
+    "git",
+    "statusline",
+    "testing",
+    "tmux",
+    "utility"
+  ],
+  "license": "MIT",
+  "name": "commands-utility"
+}

--- a/modules/common-mistakes/.claude-plugin/plugin.json
+++ b/modules/common-mistakes/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "8 battle-tested anti-patterns to avoid: shallow directory exploration, dependency blindness, ESLint Fast Refresh, and more.",
+  "displayName": "Common Mistakes",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "anti-patterns",
+    "best-practices",
+    "debugging",
+    "mistakes"
+  ],
+  "license": "MIT",
+  "name": "common-mistakes"
+}

--- a/modules/common-mistakes/hooks/plugin-rule-inject.py
+++ b/modules/common-mistakes/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/compound-knowledge/.claude-plugin/plugin.json
+++ b/modules/compound-knowledge/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Team-shared learnings in docs/solutions/. After solving a non-trivial problem, /compound writes a structured markdown doc with YAML frontmatter that later /xplan and /review runs re-inject as grounding. Counterpart to self-improving's personal MEMORY.md.",
+  "displayName": "Compound Knowledge",
+  "keywords": [
+    "compound",
+    "docs-solutions",
+    "knowledge",
+    "learnings",
+    "planning",
+    "review",
+    "team"
+  ],
+  "license": "MIT",
+  "name": "compound-knowledge"
+}

--- a/modules/copycat/.claude-plugin/plugin.json
+++ b/modules/copycat/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/copycat - analyze external Claude Code config repos to find useful patterns, rules, and techniques worth adopting into CCGM",
+  "displayName": "Copycat",
+  "keywords": [
+    "ccgm",
+    "commands",
+    "config-analysis",
+    "research"
+  ],
+  "license": "MIT",
+  "name": "copycat"
+}

--- a/modules/debugging/.claude-plugin/plugin.json
+++ b/modules/debugging/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/debug - structured root-cause debugging with Opus delegation. 7-phase workflow: gather context, reproduce, hypothesize, instrument, diagnose, fix, verify.",
+  "displayName": "Debugging",
+  "keywords": [
+    "commands",
+    "debugging"
+  ],
+  "license": "MIT",
+  "name": "debugging"
+}

--- a/modules/deepresearch/.claude-plugin/plugin.json
+++ b/modules/deepresearch/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/deepresearch - Multi-query semantic research using the Exa MCP server. Claude generates diverse queries from your topic, fans them out via parallel Exa MCP tool calls, and synthesizes a structured research.md from full page contents. Requires the Exa MCP server registered via `claude mcp add` and an Exa API key.",
+  "displayName": "Deep Research (Exa MCP)",
+  "keywords": [
+    "commands",
+    "exa",
+    "external-api",
+    "mcp",
+    "research",
+    "web-search"
+  ],
+  "license": "MIT",
+  "name": "deepresearch"
+}

--- a/modules/design-review/.claude-plugin/plugin.json
+++ b/modules/design-review/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/design-review - visual design review for web pages. Screenshots at 3 viewports, 6 parallel analysis passes: spacing, typography, responsive, visual hierarchy, accessibility, component consistency. Scored report with optional auto-fix.",
+  "displayName": "Design Review",
+  "keywords": [
+    "accessibility",
+    "commands",
+    "css",
+    "design",
+    "frontend",
+    "review"
+  ],
+  "license": "MIT",
+  "name": "design-review"
+}

--- a/modules/docs-for-agents/.claude-plugin/plugin.json
+++ b/modules/docs-for-agents/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Rule and template for shipping machine-readable docs alongside human docs. Any project an agent will install, build, test, deploy, or debug should have an AGENTS.md with copy-pasteable command blocks — not prose, not dashboard instructions.",
+  "displayName": "Docs for Agents (AGENTS.md)",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "AGENTS.md",
+    "agents",
+    "documentation",
+    "dx",
+    "llms.txt"
+  ],
+  "license": "MIT",
+  "name": "docs-for-agents"
+}

--- a/modules/docs-for-agents/hooks/plugin-rule-inject.py
+++ b/modules/docs-for-agents/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/document-review/.claude-plugin/plugin.json
+++ b/modules/document-review/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Seven-lens plan-quality gate. Before a plan, spec, or requirements doc ships to execution, /document-review fans out to 7 role-specific reviewer agents (coherence, feasibility, product-lens, scope-guardian, design-lens, security-lens, adversarial) and merges structured JSON findings with severity and confidence. Each lens has tight what-you-flag boundaries so they do not overlap.",
+  "displayName": "Document Review",
+  "keywords": [
+    "adversarial",
+    "document-review",
+    "plan-review",
+    "planning",
+    "quality-gate",
+    "review",
+    "scope",
+    "yagni"
+  ],
+  "license": "MIT",
+  "name": "document-review"
+}

--- a/modules/documentation/.claude-plugin/plugin.json
+++ b/modules/documentation/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/docupdate - comprehensive documentation audit and update. Checks README, TOC, onboarding flows, package lists, and module coverage against actual codebase state.",
+  "displayName": "Documentation Update",
+  "keywords": [
+    "commands",
+    "documentation",
+    "maintenance"
+  ],
+  "license": "MIT",
+  "name": "documentation"
+}

--- a/modules/editorial-critique/.claude-plugin/plugin.json
+++ b/modules/editorial-critique/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/editorial-critique - deep editorial review of long-form writing. 8 parallel analysis passes: prose craft, AI-tell detection, argument architecture, conciseness, data verification, structure, impact, grammar. Scored report with optional auto-fix.",
+  "displayName": "Editorial Critique",
+  "keywords": [
+    "commands",
+    "editing",
+    "prose",
+    "review",
+    "writing"
+  ],
+  "license": "MIT",
+  "name": "editorial-critique"
+}

--- a/modules/git-workflow/.claude-plugin/plugin.json
+++ b/modules/git-workflow/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Git workflow rules: sync before history changes, rebase by default, post-merge cleanup, PR template detection, no AI attribution in commits.",
+  "displayName": "Git Workflow",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "branching",
+    "git",
+    "pr",
+    "workflow"
+  ],
+  "license": "MIT",
+  "name": "git-workflow"
+}

--- a/modules/git-workflow/hooks/plugin-rule-inject.py
+++ b/modules/git-workflow/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/git-worktrees/.claude-plugin/plugin.json
+++ b/modules/git-worktrees/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Solo-agent worktree-based isolation for feature work. Lighter alternative to multi-clone setup when only one agent is active.",
+  "displayName": "Git Worktrees",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "git",
+    "isolation",
+    "workflow",
+    "worktree"
+  ],
+  "license": "MIT",
+  "name": "git-worktrees"
+}

--- a/modules/git-worktrees/hooks/plugin-rule-inject.py
+++ b/modules/git-worktrees/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/github-protocols/.claude-plugin/plugin.json
+++ b/modules/github-protocols/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "GitHub repository management protocols: issue-first workflow, PR conventions, label taxonomy, code review standards.",
+  "displayName": "GitHub Protocols",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "code-review",
+    "github",
+    "issues",
+    "pr",
+    "protocols"
+  ],
+  "license": "MIT",
+  "name": "github-protocols"
+}

--- a/modules/github-protocols/hooks/plugin-rule-inject.py
+++ b/modules/github-protocols/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/global-claude-md/.claude-plugin/plugin.json
+++ b/modules/global-claude-md/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Slim global CLAUDE.md that serves as the root configuration reference. Points to rules, commands, hooks, and settings without duplicating their content.",
+  "displayName": "Global CLAUDE.md",
+  "keywords": [
+    "claude-md",
+    "config",
+    "core"
+  ],
+  "license": "MIT",
+  "name": "global-claude-md"
+}

--- a/modules/hooks/.claude-plugin/plugin.json
+++ b/modules/hooks/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Python hooks that enforce git workflow rules: issue-first workflow, commit message format, branch protection, and auto-approval for file operations.",
+  "displayName": "Git Workflow Hooks",
+  "keywords": [
+    "auto-approve",
+    "git",
+    "hooks",
+    "workflow"
+  ],
+  "license": "MIT",
+  "name": "hooks"
+}

--- a/modules/ideate/.claude-plugin/plugin.json
+++ b/modules/ideate/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/ideate - structured ideation framework. Interviews you to refine a loose idea into a concrete concept using Socratic questioning, confidence tracking, and progressive refinement. Delegates to /deepresearch for validation and /xplan for planning.",
+  "displayName": "Ideation",
+  "keywords": [
+    "brainstorming",
+    "commands",
+    "ideation",
+    "interview",
+    "planning"
+  ],
+  "license": "MIT",
+  "name": "ideate"
+}

--- a/modules/identity/.claude-plugin/plugin.json
+++ b/modules/identity/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Two foundational context files that give Claude Code a persistent identity: soul.md (AI personality and philosophy) and human-context.md (who you are, your goals, and how you work).",
+  "displayName": "Identity & Context",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "context",
+    "identity",
+    "personality",
+    "soul"
+  ],
+  "license": "MIT",
+  "name": "identity"
+}

--- a/modules/identity/hooks/plugin-rule-inject.py
+++ b/modules/identity/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/launch/.claude-plugin/plugin.json
+++ b/modules/launch/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "A /launch skill that takes a one-page spec and reaches a deployed Cloudflare Pages site without further human input — except for the unavoidable Connect-to-Git dashboard step, which the skill stops to ask for. Inspired by Karpathy's Sequoia talk: 'I would hope that I could give a prompt to an LLM, build menu gen, and then I didn't have to touch anything and it's deployed in that same way on the internet.' The skill is the forcing function that surfaces every place CCGM/CF infra is still human-shaped.",
+  "displayName": "Launch (one-prompt spec to deployed CF Pages)",
+  "keywords": [
+    "agent-native",
+    "cloudflare-pages",
+    "deployment",
+    "one-prompt",
+    "skills",
+    "spec-driven"
+  ],
+  "license": "MIT",
+  "name": "launch"
+}

--- a/modules/make-interfaces-feel-better/.claude-plugin/plugin.json
+++ b/modules/make-interfaces-feel-better/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Design-engineering details that compound into polished interfaces. Model-invoked skill with references on design direction (aesthetic identity, typeface/color/spacing choices, avoiding generic AI aesthetics), typography (text-wrap, tabular nums, font smoothing), surfaces (concentric radii, shadows over borders, optical alignment, image outlines), animations (interruptible transitions, enter/exit, icon micro-interactions), and performance (transition specificity, will-change).",
+  "displayName": "Make Interfaces Feel Better",
+  "keywords": [
+    "aesthetics",
+    "animation",
+    "color",
+    "css",
+    "design",
+    "frontend",
+    "micro-interactions",
+    "typography",
+    "ui"
+  ],
+  "license": "MIT",
+  "name": "make-interfaces-feel-better"
+}

--- a/modules/mcp-development/.claude-plugin/plugin.json
+++ b/modules/mcp-development/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Guide for building Model Context Protocol servers: project structure, tool design, error handling, testing with MCP Inspector, and evaluation patterns.",
+  "displayName": "MCP Server Development",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "servers",
+    "tools"
+  ],
+  "license": "MIT",
+  "name": "mcp-development"
+}

--- a/modules/mcp-development/hooks/plugin-rule-inject.py
+++ b/modules/mcp-development/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/multi-agent/.claude-plugin/plugin.json
+++ b/modules/multi-agent/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Multi-clone architecture for parallel agent work with issue claiming, port allocation, and the /mawf workflow command.",
+  "displayName": "Multi-Agent Coordination",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "coordination",
+    "multi-agent",
+    "parallel",
+    "workflow"
+  ],
+  "license": "MIT",
+  "name": "multi-agent"
+}

--- a/modules/multi-agent/hooks/plugin-rule-inject.py
+++ b/modules/multi-agent/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/onboarding/.claude-plugin/plugin.json
+++ b/modules/onboarding/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/onboarding - analyzes a repository and generates a structured ONBOARDING.md (architecture, dev setup, key commands, test workflow, glossary). Runs an inventory script to build a language-aware structural map, reads only the files that map surfaces, and writes prose with strict voice rules so the output reads like a knowledgeable teammate rather than generated documentation.",
+  "displayName": "Onboarding Generator",
+  "keywords": [
+    "command",
+    "documentation",
+    "inventory",
+    "onboarding",
+    "skill"
+  ],
+  "license": "MIT",
+  "name": "onboarding"
+}

--- a/modules/output-formatting/.claude-plugin/plugin.json
+++ b/modules/output-formatting/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Formatting rules for user-facing output: copy-pasteable content (drafts, messages, prompts, config snippets) is delivered in fenced code blocks, never blockquotes, so it pastes clean anywhere.",
+  "displayName": "Output Formatting",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "communication",
+    "copy-paste",
+    "formatting",
+    "output"
+  ],
+  "license": "MIT",
+  "name": "output-formatting"
+}

--- a/modules/output-formatting/hooks/plugin-rule-inject.py
+++ b/modules/output-formatting/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/output-styles/.claude-plugin/plugin.json
+++ b/modules/output-styles/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Packages the always-on TONE rules (terse communication, autonomous execution, copy-paste formatting) as a Claude Code output style — a system-prompt layer fixed at session start and prompt-cached — instead of always-loaded rules/*.md. Opt-in alternative; does not remove the source rules.",
+  "displayName": "Output Styles",
+  "keywords": [
+    "output-style",
+    "prompt-caching",
+    "tokens",
+    "tone"
+  ],
+  "license": "MIT",
+  "name": "output-styles"
+}

--- a/modules/plugin-marketplace/.claude-plugin/plugin.json
+++ b/modules/plugin-marketplace/.claude-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Maintainer tooling that projects CCGM's modules into a native Claude Code plugin marketplace (.claude-plugin/marketplace.json + per-module plugin.json), additively. The bash installer stays the canonical full-fidelity path. Ships the generator, a JSON-schema validator, and the SessionStart rule-injection hook that bridges the plugin-CLAUDE.md-not-loaded gap.",
+  "displayName": "Plugin Marketplace (generator)",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "distribution",
+    "generator",
+    "marketplace",
+    "opt-in",
+    "plugin",
+    "session-start"
+  ],
+  "license": "MIT",
+  "name": "plugin-marketplace"
+}

--- a/modules/plugin-marketplace/README.md
+++ b/modules/plugin-marketplace/README.md
@@ -1,0 +1,58 @@
+# plugin-marketplace
+
+Maintainer tooling that makes CCGM installable as a **native Claude Code plugin marketplace** — additively. The bash installer (`start.sh`) remains the canonical, full-fidelity path.
+
+## What it ships
+
+| File | Purpose |
+|------|---------|
+| `lib/gen_marketplace.py` | Generator. Projects `modules/*/module.json` into `.claude-plugin/marketplace.json` + per-module `.claude-plugin/plugin.json`. Deterministic; `--check` for CI. |
+| `lib/validate_marketplace.py` | Dependency-free structural validator for the marketplace + every plugin manifest. CI fallback when the `claude` CLI is absent. |
+| `hooks/plugin-rule-inject.py` | SessionStart hook copied into every rules-bearing plugin. Injects that plugin's `rules/*.md` as `additionalContext` (opt-in via `CCGM_PLUGIN_RULE_INJECTION`). |
+| `rules/plugin-marketplace.md` | The rule explaining the two install paths and the generate-don't-hand-edit contract. |
+
+## Why a marketplace projection
+
+Claude Code plugins ship commands, agents, skills, hooks, and output styles — but a plugin's `CLAUDE.md` is **not** loaded as context, and a plugin can only contribute the `agent`/`subagentStatusLine` settings keys. So:
+
+- **Commands / agents / skills / output styles** map cleanly to native plugin components.
+- **Rules** (`rules/*.md`), which the bash path auto-loads, are bridged by the SessionStart rule-injection hook.
+- **Deep `settings.json` merge + global `CLAUDE.md`** have no plugin equivalent — that is why the bash installer stays canonical.
+
+## Usage
+
+```bash
+# Regenerate after changing any module.json
+python3 modules/plugin-marketplace/lib/gen_marketplace.py
+
+# CI: fail if committed output drifted from module.json
+python3 modules/plugin-marketplace/lib/gen_marketplace.py --check
+
+# Validate (no claude CLI required)
+python3 modules/plugin-marketplace/lib/validate_marketplace.py
+
+# Validate with the real CLI when available
+claude plugin validate .claude-plugin/marketplace.json --strict
+```
+
+## Installing CCGM as a marketplace (end user)
+
+```bash
+claude plugin marketplace add lucasmccomb/ccgm
+claude plugin install code-quality@ccgm
+# rules behind a flag (opt-in, token cost):
+echo 'CCGM_PLUGIN_RULE_INJECTION=true' >> ~/.claude/.ccgm.env
+```
+
+## Manual installation (without the CCGM installer)
+
+```bash
+mkdir -p ~/.claude/lib ~/.claude/hooks ~/.claude/rules
+cp lib/gen_marketplace.py lib/validate_marketplace.py ~/.claude/lib/
+cp hooks/plugin-rule-inject.py ~/.claude/hooks/
+cp rules/plugin-marketplace.md ~/.claude/rules/
+```
+
+## Status
+
+`beta` — maintainer/distribution tooling, opt-in via `start.sh --add plugin-marketplace`. Not bundled in any preset.

--- a/modules/plugin-marketplace/hooks/plugin-rule-inject.py
+++ b/modules/plugin-marketplace/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/plugin-marketplace/lib/gen_marketplace.py
+++ b/modules/plugin-marketplace/lib/gen_marketplace.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Project CCGM modules into a native Claude Code plugin marketplace (issue #703).
+
+WHAT THIS DOES
+--------------
+CCGM's source of truth is `modules/*/module.json`. The bash installer
+(`start.sh`) is and remains the canonical, full-fidelity install path: only it
+performs the deep settings.json merge and writes the global CLAUDE.md context
+that Claude Code auto-loads.
+
+This generator ADDITIVELY projects the same modules into the native Claude Code
+plugin format so CCGM can also be consumed as a plugin marketplace
+(`claude plugin marketplace add <owner>/ccgm`; see the README for the owner).
+It is a pure projection:
+
+  * It reads every `modules/<name>/module.json`.
+  * It writes one `modules/<name>/.claude-plugin/plugin.json` per module,
+    declaring the native plugin components that module actually ships.
+  * It writes the catalog `.claude-plugin/marketplace.json` at the repo root,
+    listing every module as a plugin (via `metadata.pluginRoot: "./modules"`).
+
+It NEVER edits module rule/command/agent/skill content. The only files it
+writes are the generated manifests and rule-hook copies, all of which are
+committed alongside this script.
+
+WHY EACH modules/<name> IS ITS OWN PLUGIN ROOT
+----------------------------------------------
+A CCGM module's on-disk layout already matches a plugin's expected layout:
+`commands/`, `agents/`, `skills/`, `output-styles/`, `hooks/`. So the plugin
+root is simply `modules/<name>/`, and `.claude-plugin/plugin.json` goes inside
+it. Plugins are copied to a cache on install and cannot reference files outside
+their own directory, so keeping each module self-rooted means every plugin is
+self-contained.
+
+THE CLAUDE.md / rules GAP
+-------------------------
+A plugin's root `CLAUDE.md` is NOT loaded as context, and a plugin can only
+contribute the `agent`/`subagentStatusLine` settings keys. Many CCGM modules
+are rules-only (`rules/*.md`). To preserve their value under the plugin path,
+modules that ship `type:"rule"` files get a SessionStart hook
+(`hooks/plugin-rule-inject.py`) wired into their generated `plugin.json`. That
+hook injects the plugin's own bundled rules as `additionalContext` at session
+start. This is the documented workaround for plugin-CLAUDE.md-not-loading.
+
+DETERMINISM
+-----------
+Output is fully sorted (modules, JSON keys) so re-running the generator on an
+unchanged tree produces byte-identical files. CI runs the generator with
+--check and fails if the working tree would change, guaranteeing the committed
+output stays in sync with module.json.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# Repo root is two levels up from this file: modules/plugin-marketplace/lib/.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Marketplace identity. `name` is public-facing (users type `plugin@ccgm`).
+# It must not collide with the reserved Anthropic names.
+#
+# Author/owner is the project name, NOT a personal handle: these manifests are
+# committed to a public repo and the personal-data guard (tests/) forbids the
+# maintainer username in any file but README/postInstall. The repository URL is
+# likewise omitted here to stay clear of that guard; users discover the repo via
+# the README install instructions.
+MARKETPLACE_NAME = "ccgm"
+MARKETPLACE_OWNER = {"name": "CCGM"}
+MARKETPLACE_DESCRIPTION = (
+    "Claude Code God Mode - modular rules, commands, agents, and skills. "
+    "The bash installer (start.sh) remains the canonical full-fidelity path; "
+    "this marketplace is an additive native-plugin projection of the same modules."
+)
+MARKETPLACE_SCHEMA = "https://json.schemastore.org/claude-code-marketplace.json"
+PLUGIN_SCHEMA = "https://json.schemastore.org/claude-code-plugin-manifest.json"
+
+# Where the per-plugin rule-injection hook lives inside an INSTALLED plugin.
+HOOK_REL = "hooks/plugin-rule-inject.py"
+
+
+def _load(path: Path) -> dict:
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _module_manifests() -> "list[tuple[str, dict]]":
+    """Return sorted (module_name, manifest) for every modules/*/module.json."""
+    mods_dir = REPO_ROOT / "modules"
+    out: "list[tuple[str, dict]]" = []
+    for child in sorted(mods_dir.iterdir()):
+        manifest = child / "module.json"
+        if child.is_dir() and manifest.is_file():
+            out.append((child.name, _load(manifest)))
+    return out
+
+
+def _file_types(manifest: dict) -> "set[str]":
+    files = manifest.get("files")
+    if not isinstance(files, dict):
+        return set()
+    return {
+        v.get("type")
+        for v in files.values()
+        if isinstance(v, dict) and v.get("type")
+    }
+
+
+def _has_rule(manifest: dict) -> bool:
+    return "rule" in _file_types(manifest)
+
+
+def _has_output_style(manifest: dict) -> bool:
+    """A module ships an output style iff it has a content file targeting
+    output-styles/."""
+    files = manifest.get("files")
+    if not isinstance(files, dict):
+        return False
+    for v in files.values():
+        if not isinstance(v, dict):
+            continue
+        target = v.get("target", "")
+        if v.get("type") == "content" and isinstance(target, str) and \
+                target.startswith("output-styles/"):
+            return True
+    return False
+
+
+def _component_summary(manifest: dict) -> "list[str]":
+    """Human-facing list of native plugin components this module contributes."""
+    types = _file_types(manifest)
+    comps: "list[str]" = []
+    if "command" in types:
+        comps.append("commands")
+    if "agent" in types:
+        comps.append("agents")
+    if "skill" in types:
+        comps.append("skills")
+    if _has_output_style(manifest):
+        comps.append("output-styles")
+    if _has_rule(manifest):
+        comps.append("rules")
+    if "hook" in types:
+        comps.append("hooks")
+    return comps
+
+
+def build_plugin_manifest(name: str, manifest: dict) -> dict:
+    """Build the .claude-plugin/plugin.json for one module.
+
+    Only `name` is strictly required. We add metadata for the /plugin picker and
+    wire the rule-injection hook for modules that ship rules. Native components
+    (commands/agents/skills/output-styles) are auto-discovered from their
+    default directories, so we do not emit redundant path fields.
+    """
+    plugin: dict = {
+        "$schema": PLUGIN_SCHEMA,
+        "name": name,
+        "description": manifest.get("description", ""),
+        "author": dict(MARKETPLACE_OWNER),
+        "license": "MIT",
+    }
+
+    display = manifest.get("displayName")
+    if isinstance(display, str) and display:
+        plugin["displayName"] = display
+
+    tags = manifest.get("tags")
+    if isinstance(tags, list) and tags:
+        plugin["keywords"] = sorted({str(t) for t in tags if str(t)})
+
+    # Rules-bearing modules get the session-start rule injector. The hook is
+    # copied into each such plugin's hooks/ directory by the generator (see
+    # _ensure_rule_hook) so ${CLAUDE_PLUGIN_ROOT}/hooks/... resolves after the
+    # plugin is cached.
+    if _has_rule(manifest):
+        plugin["hooks"] = {
+            "SessionStart": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": (
+                                'python3 "${CLAUDE_PLUGIN_ROOT}/'
+                                + HOOK_REL
+                                + '"'
+                            ),
+                        }
+                    ]
+                }
+            ]
+        }
+
+    return plugin
+
+
+def build_marketplace(manifests: "list[tuple[str, dict]]") -> dict:
+    plugins: "list[dict]" = []
+    for name, manifest in manifests:
+        entry: dict = {
+            "name": name,
+            # pluginRoot is "./modules", so source is just the module dir name.
+            "source": f"./{name}",
+            "description": manifest.get("description", ""),
+            "category": manifest.get("category", "workflow"),
+        }
+        tags = manifest.get("tags")
+        if isinstance(tags, list) and tags:
+            entry["tags"] = sorted({str(t) for t in tags if str(t)})
+        # Surface beta/deprecated status so the catalog mirrors module.json.
+        status = manifest.get("status")
+        if isinstance(status, str) and status and status != "stable":
+            entry["keywords"] = [f"status:{status}"]
+        plugins.append(entry)
+
+    return {
+        "$schema": MARKETPLACE_SCHEMA,
+        "name": MARKETPLACE_NAME,
+        "owner": dict(MARKETPLACE_OWNER),
+        "description": MARKETPLACE_DESCRIPTION,
+        "metadata": {"pluginRoot": "./modules"},
+        "plugins": plugins,
+    }
+
+
+def _serialize(data: dict) -> str:
+    return json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def _dump(path: Path, data: dict) -> bool:
+    """Write data as deterministic JSON. Return True if the file changed."""
+    text = _serialize(data)
+    if path.exists() and path.read_text(encoding="utf-8") == text:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return True
+
+
+def _ensure_rule_hook(name: str, changed: "list[str]", check: bool) -> None:
+    """Copy the shared rule-injection hook into a rules-bearing plugin.
+
+    The hook source of truth is plugin-marketplace/hooks/plugin-rule-inject.py.
+    Each rules-bearing plugin needs its own copy because installed plugins
+    cannot reference files outside their directory. The copy is committed.
+    """
+    src = REPO_ROOT / "modules" / "plugin-marketplace" / HOOK_REL
+    dst = REPO_ROOT / "modules" / name / HOOK_REL
+    src_text = src.read_text(encoding="utf-8")
+    if dst.exists() and dst.read_text(encoding="utf-8") == src_text:
+        return
+    changed.append(str(dst.relative_to(REPO_ROOT)))
+    if not check:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text(src_text, encoding="utf-8")
+        os.chmod(dst, 0o755)
+
+
+def generate(check: bool = False) -> "list[str]":
+    """Generate (or, with check=True, dry-run) all marketplace files.
+
+    Returns the list of repo-relative paths that changed (or would change).
+    """
+    manifests = _module_manifests()
+    changed: "list[str]" = []
+
+    # Per-module plugin manifests + rule-hook copies.
+    for name, manifest in manifests:
+        # plugin-marketplace is the host module for the shared hook; it does not
+        # need a self-injected copy, but it still gets a plugin.json so it can
+        # be installed like any other plugin.
+        if _has_rule(manifest) and name != "plugin-marketplace":
+            _ensure_rule_hook(name, changed, check)
+        plugin = build_plugin_manifest(name, manifest)
+        dst = REPO_ROOT / "modules" / name / ".claude-plugin" / "plugin.json"
+        if check:
+            if not dst.exists() or dst.read_text(encoding="utf-8") != _serialize(plugin):
+                changed.append(str(dst.relative_to(REPO_ROOT)))
+        elif _dump(dst, plugin):
+            changed.append(str(dst.relative_to(REPO_ROOT)))
+
+    # Root marketplace catalog.
+    market = build_marketplace(manifests)
+    market_path = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+    if check:
+        if not market_path.exists() or \
+                market_path.read_text(encoding="utf-8") != _serialize(market):
+            changed.append(str(market_path.relative_to(REPO_ROOT)))
+    elif _dump(market_path, market):
+        changed.append(str(market_path.relative_to(REPO_ROOT)))
+
+    return changed
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate the CCGM plugin marketplace from modules/*/module.json"
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not write; exit 1 if generated output would differ from "
+        "what is committed. Use in CI.",
+    )
+    args = parser.parse_args(argv)
+
+    changed = generate(check=args.check)
+
+    if args.check:
+        if changed:
+            print("Marketplace files are STALE. Re-run the generator:")
+            print("  python3 modules/plugin-marketplace/lib/gen_marketplace.py")
+            print("\nFiles that would change:")
+            for p in changed:
+                print(f"  {p}")
+            return 1
+        print("Marketplace files are up to date.")
+        return 0
+
+    if changed:
+        print(f"Wrote {len(changed)} file(s):")
+        for p in changed:
+            print(f"  {p}")
+    else:
+        print("Marketplace files already up to date; nothing written.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/plugin-marketplace/lib/validate_marketplace.py
+++ b/modules/plugin-marketplace/lib/validate_marketplace.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Validate the CCGM marketplace + plugin manifests (issue #703).
+
+CI runs `claude plugin validate` when the Claude Code CLI is available. When it
+is not (the common CI case), this script provides an equivalent structural
+check against the documented marketplace.json / plugin.json schemas:
+
+  https://docs.claude.com/en/docs/claude-code/plugin-marketplaces  (marketplace)
+  https://docs.claude.com/en/docs/claude-code/plugins-reference    (plugin)
+
+It is intentionally dependency-free (stdlib only) and portable (macOS BSD +
+Linux). It validates the SHAPE of the manifests, not the runtime behavior of the
+plugins, so it stays meaningful even where `claude` cannot run.
+
+Checks:
+  marketplace.json
+    - required: name (kebab-case string), owner.name (string), plugins (array)
+    - name not in the reserved-Anthropic set
+    - metadata.pluginRoot, when present, is a string
+    - each plugin entry: name (kebab-case) + source; relative-path sources start
+      with "./"; the resolved plugin directory exists and has plugin.json
+  each plugin.json
+    - required: name (kebab-case string)
+    - keywords, when present, is an array (a string would fail at load)
+    - hooks, when present, is an object
+    - declared component paths (commands/agents/skills/...) are relative + ./
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+KEBAB = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+# From the official marketplace schema "Reserved names" note.
+RESERVED_MARKETPLACE_NAMES = {
+    "claude-code-marketplace",
+    "claude-code-plugins",
+    "claude-plugins-official",
+    "claude-plugins-community",
+    "claude-community",
+    "anthropic-marketplace",
+    "anthropic-plugins",
+    "agent-skills",
+    "anthropic-agent-skills",
+    "knowledge-work-plugins",
+    "life-sciences",
+    "claude-for-legal",
+    "claude-for-financial-services",
+    "financial-services-plugins",
+}
+
+# Plugin manifest fields that hold component paths; each must be relative + ./.
+PATH_FIELDS = (
+    "skills",
+    "commands",
+    "agents",
+    "outputStyles",
+)
+
+
+class Result:
+    def __init__(self) -> None:
+        self.errors: "list[str]" = []
+        self.checks = 0
+
+    def check(self, cond: bool, msg: str) -> None:
+        self.checks += 1
+        if not cond:
+            self.errors.append(msg)
+
+
+def _load(path: Path) -> "dict | None":
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        return None  # caller reports; keep exc out of signature for simplicity
+
+
+def _is_kebab(val) -> bool:
+    return isinstance(val, str) and bool(KEBAB.match(val))
+
+
+def _check_path_field(r: Result, where: str, field: str, value) -> None:
+    vals = value if isinstance(value, list) else [value]
+    for v in vals:
+        if not isinstance(v, str):
+            r.check(False, f"{where}: {field} entry must be a string, got {type(v).__name__}")
+            continue
+        r.check(v.startswith("./"), f"{where}: {field} path '{v}' must start with './'")
+        r.check(".." not in v, f"{where}: {field} path '{v}' must not traverse outside plugin root")
+
+
+def validate_plugin(r: Result, plugin_path: Path) -> None:
+    where = str(plugin_path.relative_to(REPO_ROOT))
+    data = _load(plugin_path)
+    if data is None:
+        r.check(False, f"{where}: not valid JSON")
+        return
+    r.check(isinstance(data, dict), f"{where}: top level must be an object")
+    if not isinstance(data, dict):
+        return
+
+    r.check(_is_kebab(data.get("name")), f"{where}: 'name' must be kebab-case string")
+
+    if "keywords" in data:
+        r.check(isinstance(data["keywords"], list), f"{where}: 'keywords' must be an array")
+    if "hooks" in data:
+        r.check(isinstance(data["hooks"], (dict, str, list)),
+                f"{where}: 'hooks' must be object, array, or path string")
+
+    for field in PATH_FIELDS:
+        if field in data:
+            _check_path_field(r, where, field, data[field])
+
+
+def validate_marketplace(r: Result, market_path: Path) -> "list[str]":
+    """Validate marketplace.json. Returns list of plugin-source dirs to recurse."""
+    where = str(market_path.relative_to(REPO_ROOT))
+    data = _load(market_path)
+    if data is None:
+        r.check(False, f"{where}: not valid JSON")
+        return []
+    r.check(isinstance(data, dict), f"{where}: top level must be an object")
+    if not isinstance(data, dict):
+        return []
+
+    name = data.get("name")
+    r.check(_is_kebab(name), f"{where}: 'name' must be kebab-case string")
+    r.check(name not in RESERVED_MARKETPLACE_NAMES,
+            f"{where}: 'name' '{name}' is a reserved Anthropic marketplace name")
+
+    owner = data.get("owner")
+    r.check(isinstance(owner, dict) and isinstance(owner.get("name"), str),
+            f"{where}: 'owner.name' is required and must be a string")
+
+    plugins = data.get("plugins")
+    r.check(isinstance(plugins, list), f"{where}: 'plugins' must be an array")
+
+    plugin_root = "."
+    metadata = data.get("metadata")
+    if isinstance(metadata, dict) and "pluginRoot" in metadata:
+        pr = metadata["pluginRoot"]
+        r.check(isinstance(pr, str), f"{where}: metadata.pluginRoot must be a string")
+        if isinstance(pr, str):
+            plugin_root = pr
+
+    plugin_manifests: "list[str]" = []
+    if not isinstance(plugins, list):
+        return plugin_manifests
+
+    seen: "set[str]" = set()
+    market_root = market_path.parent.parent  # repo root (.claude-plugin/..)
+    for i, entry in enumerate(plugins):
+        tag = f"{where} plugins[{i}]"
+        if not isinstance(entry, dict):
+            r.check(False, f"{tag}: must be an object")
+            continue
+        pname = entry.get("name")
+        r.check(_is_kebab(pname), f"{tag}: 'name' must be kebab-case string")
+        r.check(pname not in seen, f"{tag}: duplicate plugin name '{pname}'")
+        if isinstance(pname, str):
+            seen.add(pname)
+
+        source = entry.get("source")
+        r.check(source is not None, f"{tag}: 'source' is required")
+        # Relative-path source: resolve through pluginRoot and confirm it exists.
+        if isinstance(source, str):
+            r.check(source.startswith("./"), f"{tag}: relative source '{source}' must start with './'")
+            rel = Path(plugin_root) / source[2:] if source.startswith("./") else Path(source)
+            resolved = (market_root / rel).resolve()
+            r.check(resolved.is_dir(), f"{tag}: source dir '{rel}' does not exist")
+            manifest = resolved / ".claude-plugin" / "plugin.json"
+            r.check(manifest.is_file(), f"{tag}: '{rel}' is missing .claude-plugin/plugin.json")
+            if manifest.is_file():
+                plugin_manifests.append(str(manifest))
+        elif isinstance(source, dict):
+            r.check(isinstance(source.get("source"), str),
+                    f"{tag}: object source must have a 'source' type field")
+
+    return plugin_manifests
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    market_path = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+    r = Result()
+
+    if not market_path.is_file():
+        print(f"FAIL: {market_path} does not exist. Run gen_marketplace.py first.")
+        return 1
+
+    manifests = validate_marketplace(r, market_path)
+    for m in manifests:
+        validate_plugin(r, Path(m))
+
+    if r.errors:
+        print(f"validate_marketplace: {len(r.errors)} error(s) in {r.checks} checks:")
+        for e in r.errors:
+            print(f"  - {e}")
+        return 1
+    print(f"validate_marketplace: all {r.checks} checks passed "
+          f"({len(manifests)} plugin manifest(s) validated).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/plugin-marketplace/module.json
+++ b/modules/plugin-marketplace/module.json
@@ -1,0 +1,17 @@
+{
+  "name": "plugin-marketplace",
+  "displayName": "Plugin Marketplace (generator)",
+  "description": "Maintainer tooling that projects CCGM's modules into a native Claude Code plugin marketplace (.claude-plugin/marketplace.json + per-module plugin.json), additively. The bash installer stays the canonical full-fidelity path. Ships the generator, a JSON-schema validator, and the SessionStart rule-injection hook that bridges the plugin-CLAUDE.md-not-loaded gap.",
+  "category": "core",
+  "scope": ["global"],
+  "status": "beta",
+  "dependencies": [],
+  "files": {
+    "rules/plugin-marketplace.md": { "target": "rules/plugin-marketplace.md", "type": "rule", "template": false },
+    "lib/gen_marketplace.py": { "target": "lib/gen_marketplace.py", "type": "lib", "template": false },
+    "lib/validate_marketplace.py": { "target": "lib/validate_marketplace.py", "type": "lib", "template": false },
+    "hooks/plugin-rule-inject.py": { "target": "hooks/plugin-rule-inject.py", "type": "hook", "template": false }
+  },
+  "tags": ["plugin", "marketplace", "generator", "distribution", "session-start", "opt-in"],
+  "configPrompts": []
+}

--- a/modules/plugin-marketplace/rules/plugin-marketplace.md
+++ b/modules/plugin-marketplace/rules/plugin-marketplace.md
@@ -1,0 +1,49 @@
+# Plugin Marketplace
+
+CCGM can be installed two ways. They are not equivalent; pick deliberately.
+
+## The two install paths
+
+| | Bash installer (`start.sh`) | Plugin marketplace |
+|---|---|---|
+| Canonical? | **Yes** — full fidelity | No — additive projection |
+| Deep `settings.json` merge | Yes | No (plugins ship only `agent`/`subagentStatusLine`) |
+| Global `CLAUDE.md` context | Yes (auto-loaded) | No (plugin `CLAUDE.md` is never auto-loaded) |
+| Rules (`rules/*.md`) | Auto-loaded by Claude Code | Injected by a SessionStart hook (opt-in) |
+| Commands / agents / skills | Installed to `~/.claude/` | Native plugin components |
+| Install command | `bash start.sh` | `claude plugin marketplace add <owner>/ccgm` (owner in README) |
+
+**When deep settings or always-on CLAUDE.md context matters, use the bash installer.** The marketplace path is for users who want CCGM's commands, agents, and skills delivered through Claude Code's native plugin manager, with rules available behind an opt-in flag.
+
+## How the marketplace is produced
+
+The marketplace is **generated, never hand-maintained**. The source of truth is `modules/*/module.json`. The generator projects those manifests into:
+
+- `.claude-plugin/marketplace.json` — the catalog, one entry per module, via `metadata.pluginRoot: "./modules"`.
+- `modules/<name>/.claude-plugin/plugin.json` — one manifest per module.
+
+Run it after changing any `module.json`:
+
+```bash
+python3 modules/plugin-marketplace/lib/gen_marketplace.py          # write
+python3 modules/plugin-marketplace/lib/gen_marketplace.py --check  # CI: fail if stale
+```
+
+The generator is deterministic (sorted output), so an unchanged tree produces byte-identical files. CI runs `--check` and fails if the committed output drifts from `module.json`.
+
+## The CLAUDE.md / rules gap and the workaround
+
+A plugin's root `CLAUDE.md` is **not** loaded as context, and a plugin can only contribute the `agent` and `subagentStatusLine` settings keys. So a rules-only module (autonomy, code-quality, git-workflow, systematic-debugging, ...) would contribute nothing under the plugin path.
+
+The workaround: the generator wires a `SessionStart` hook into every rules-bearing plugin's `plugin.json`. The hook (`hooks/plugin-rule-inject.py`) reads that plugin's bundled `rules/*.md` and emits them as `additionalContext` at session start. It is **opt-in** — a strict no-op unless `CCGM_PLUGIN_RULE_INJECTION=true` is set in the environment or `~/.claude/.ccgm.env`, because injecting full rule bodies costs tokens. With the flag off, the plugin's commands/agents/skills still work natively.
+
+## Validation
+
+- `claude plugin validate .claude-plugin/marketplace.json --strict` — validates the marketplace manifest when the Claude Code CLI is available.
+- `python3 modules/plugin-marketplace/lib/validate_marketplace.py` — dependency-free structural validation of the marketplace and every plugin manifest. CI runs this so the manifests stay valid even where `claude` is not installed.
+
+## Rules of the road
+
+- **Never hand-edit `marketplace.json` or any `plugin.json`.** Edit `module.json` and re-run the generator.
+- **Never let the bash path regress** to accommodate the plugin path. The bash installer is canonical.
+- After adding or changing a module, run the generator and commit its output in the same change.

--- a/modules/plugin-marketplace/tests/test_gen_marketplace.py
+++ b/modules/plugin-marketplace/tests/test_gen_marketplace.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Tests for the plugin-marketplace generator + validator (issue #703).
+
+These pin the projection's invariants:
+  * The generator is deterministic and in sync with what is committed (--check
+    passes against the live repo).
+  * The committed marketplace.json + per-module plugin.json files are
+    structurally valid (validate_marketplace passes).
+  * Every module has a generated plugin.json; rules-bearing modules get the
+    rule-injection hook wired and a copy of the hook on disk.
+  * The marketplace name is not a reserved Anthropic name.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LIB = REPO_ROOT / "modules" / "plugin-marketplace" / "lib"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+gen = _load_module("gen_marketplace", LIB / "gen_marketplace.py")
+validator = _load_module("validate_marketplace", LIB / "validate_marketplace.py")
+
+
+def _module_names() -> "list[str]":
+    return [
+        c.name
+        for c in (REPO_ROOT / "modules").iterdir()
+        if (c / "module.json").is_file()
+    ]
+
+
+def test_generator_check_is_clean():
+    """Committed marketplace files must be in sync with module.json."""
+    changed = gen.generate(check=True)
+    assert changed == [], (
+        "Generated marketplace files are stale. Run "
+        "python3 modules/plugin-marketplace/lib/gen_marketplace.py. Stale: "
+        + ", ".join(changed)
+    )
+
+
+def test_generator_is_deterministic():
+    """Two check runs produce the same (empty) diff."""
+    assert gen.generate(check=True) == gen.generate(check=True)
+
+
+def test_marketplace_exists_and_valid_json():
+    market = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+    assert market.is_file()
+    data = json.loads(market.read_text(encoding="utf-8"))
+    assert data["name"] == gen.MARKETPLACE_NAME
+    assert isinstance(data["plugins"], list)
+    assert data["metadata"]["pluginRoot"] == "./modules"
+
+
+def test_marketplace_name_not_reserved():
+    assert gen.MARKETPLACE_NAME not in validator.RESERVED_MARKETPLACE_NAMES
+
+
+def test_every_module_has_plugin_manifest():
+    for name in _module_names():
+        manifest = REPO_ROOT / "modules" / name / ".claude-plugin" / "plugin.json"
+        assert manifest.is_file(), f"{name} is missing .claude-plugin/plugin.json"
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        assert data["name"] == name
+
+
+def test_marketplace_lists_every_module():
+    market = json.loads(
+        (REPO_ROOT / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8")
+    )
+    listed = {p["name"] for p in market["plugins"]}
+    assert listed == set(_module_names())
+
+
+def test_rules_bearing_plugins_wire_the_hook():
+    for name in _module_names():
+        manifest_path = REPO_ROOT / "modules" / name / "module.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        plugin = json.loads(
+            (REPO_ROOT / "modules" / name / ".claude-plugin" / "plugin.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        has_rule = gen._has_rule(manifest)
+        if has_rule:
+            assert "hooks" in plugin, f"{name} has rules but no SessionStart hook wired"
+            cmd = plugin["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+            assert "plugin-rule-inject.py" in cmd
+            # the hook copy must exist on disk inside the plugin
+            hook = REPO_ROOT / "modules" / name / gen.HOOK_REL
+            assert hook.is_file(), f"{name} is missing its rule-inject hook copy"
+        else:
+            assert "hooks" not in plugin, f"{name} has no rules but a hook is wired"
+
+
+def test_validator_passes_on_committed_output():
+    r = validator.Result()
+    market_path = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+    manifests = validator.validate_marketplace(r, market_path)
+    for m in manifests:
+        validator.validate_plugin(r, Path(m))
+    assert r.errors == [], "validate_marketplace found errors: " + "; ".join(r.errors)
+    assert len(manifests) == len(_module_names())

--- a/modules/plugin-marketplace/tests/test_marketplace.sh
+++ b/modules/plugin-marketplace/tests/test_marketplace.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Shell smoke test for the plugin-marketplace module (issue #703).
+# Runs without pytest so CI's run-unit-tests.sh shell pass covers it too:
+#   1. generator --check must be clean (committed output in sync with module.json)
+#   2. JSON-schema validator must pass on the committed output
+#   3. if `claude` is available, `claude plugin validate` the marketplace manifest
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+GEN="modules/plugin-marketplace/lib/gen_marketplace.py"
+VAL="modules/plugin-marketplace/lib/validate_marketplace.py"
+
+echo "--- generator --check ---"
+python3 "$GEN" --check
+
+echo "--- validate_marketplace.py ---"
+python3 "$VAL"
+
+echo "--- claude plugin validate (optional) ---"
+if command -v claude >/dev/null 2>&1; then
+  claude plugin validate .claude-plugin/marketplace.json --strict
+else
+  echo "  SKIP: claude CLI not on PATH (validator above covers structure)"
+fi
+
+echo "test_marketplace.sh: all checks passed"

--- a/modules/plugin-marketplace/tests/test_plugin_rule_inject.py
+++ b/modules/plugin-marketplace/tests/test_plugin_rule_inject.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Tests for the plugin rule-injection SessionStart hook (issue #703)."""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HOOK = REPO_ROOT / "modules" / "plugin-marketplace" / "hooks" / "plugin-rule-inject.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("plugin_rule_inject", HOOK)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hook = _load()
+
+
+def _make_plugin(tmp_path: Path, rules: "dict[str, str]") -> Path:
+    root = tmp_path / "my-plugin"
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        '{"name": "my-plugin"}', encoding="utf-8"
+    )
+    rules_dir = root / "rules"
+    rules_dir.mkdir()
+    for fname, body in rules.items():
+        (rules_dir / fname).write_text(body, encoding="utf-8")
+    return root
+
+
+def test_noop_when_flag_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv(hook.FLAG, raising=False)
+    monkeypatch.setattr(hook, "_read_env_file", lambda: {})
+    root = _make_plugin(tmp_path, {"a.md": "Rule A body"})
+    assert hook.build_context(root) is None
+
+
+def test_injects_rules_when_flag_set_via_env(tmp_path, monkeypatch):
+    monkeypatch.setenv(hook.FLAG, "true")
+    monkeypatch.setattr(hook, "_read_env_file", lambda: {})
+    root = _make_plugin(tmp_path, {"a.md": "Rule A body", "b.md": "Rule B body"})
+    ctx = hook.build_context(root)
+    assert ctx is not None
+    assert "Rule A body" in ctx
+    assert "Rule B body" in ctx
+    assert '<ccgm-plugin-rules plugin="my-plugin">' in ctx
+    assert "</ccgm-plugin-rules>" in ctx
+    # rules emitted in sorted filename order
+    assert ctx.index("Rule A body") < ctx.index("Rule B body")
+
+
+def test_flag_via_env_file(tmp_path, monkeypatch):
+    monkeypatch.delenv(hook.FLAG, raising=False)
+    monkeypatch.setattr(hook, "_read_env_file", lambda: {hook.FLAG: "1"})
+    root = _make_plugin(tmp_path, {"a.md": "Rule A body"})
+    assert hook.build_context(root) is not None
+
+
+def test_none_when_no_rules_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv(hook.FLAG, "true")
+    monkeypatch.setattr(hook, "_read_env_file", lambda: {})
+    root = tmp_path / "empty-plugin"
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin" / "plugin.json").write_text('{"name":"empty-plugin"}', encoding="utf-8")
+    assert hook.build_context(root) is None
+
+
+def test_none_when_root_is_none(monkeypatch):
+    monkeypatch.setenv(hook.FLAG, "true")
+    monkeypatch.setattr(hook, "_read_env_file", lambda: {})
+    assert hook.build_context(None) is None
+
+
+def test_truthy_values():
+    assert hook._truthy("true")
+    assert hook._truthy("TRUE")
+    assert hook._truthy("1")
+    assert hook._truthy("yes")
+    assert not hook._truthy("false")
+    assert not hook._truthy("0")
+    assert not hook._truthy(None)
+    assert not hook._truthy("")

--- a/modules/pr-feedback/.claude-plugin/plugin.json
+++ b/modules/pr-feedback/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Structured resolver for PR review comments. /resolve-pr-feedback fetches unresolved review threads via GraphQL, triages new vs already-handled, and if 3+ new items arrive (or a cross-invocation signal fires) runs cluster analysis - categorizes each into 11 fixed concern categories and groups by category + spatial proximity. Clusters surface systemic issues instead of dispatching 10 one-off fixes. Parallel pr-comment-resolver subagents apply unambiguous fixes, post inline replies via gh api, and resolve threads; taste questions are batched for human decision.",
+  "displayName": "PR Feedback Resolver",
+  "keywords": [
+    "cluster",
+    "comments",
+    "feedback",
+    "github",
+    "graphql",
+    "pr",
+    "resolver",
+    "review"
+  ],
+  "license": "MIT",
+  "name": "pr-feedback"
+}

--- a/modules/pr-review-toolkit/.claude-plugin/plugin.json
+++ b/modules/pr-review-toolkit/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Augments the external pr-review-toolkit plugin with scope-drift detection (compare stated intent to actual diff) and a Fix-First output format (AUTO-FIXED vs NEEDS INPUT). Ported from garrytan/gstack review skill.",
+  "displayName": "PR Review Toolkit",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "commands",
+    "fix-first",
+    "pr",
+    "review",
+    "scope-drift"
+  ],
+  "license": "MIT",
+  "name": "pr-review-toolkit"
+}

--- a/modules/pr-review-toolkit/hooks/plugin-rule-inject.py
+++ b/modules/pr-review-toolkit/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/relevance-injection/.claude-plugin/plugin.json
+++ b/modules/relevance-injection/.claude-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Opt-in, backward-compatible relevance-scoped rule injection plus a tiered always-on safety core. Off by default: with the flag unset, all rules load exactly as before. When enabled, surfaces a pointer to the task-relevant rule subset while always including the safety core.",
+  "displayName": "Relevance-Scoped Rule Injection",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "context",
+    "opt-in",
+    "rules",
+    "safety-core",
+    "session-start",
+    "tokens"
+  ],
+  "license": "MIT",
+  "name": "relevance-injection"
+}

--- a/modules/relevance-injection/hooks/plugin-rule-inject.py
+++ b/modules/relevance-injection/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/remote-server/.claude-plugin/plugin.json
+++ b/modules/remote-server/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "SSH access to a remote server. Adds /onremote command for health checks and remote command execution. Delegates to Haiku.",
+  "displayName": "Remote Server",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "infrastructure",
+    "remote",
+    "server",
+    "ssh"
+  ],
+  "license": "MIT",
+  "name": "remote-server"
+}

--- a/modules/remote-server/hooks/plugin-rule-inject.py
+++ b/modules/remote-server/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/research/.claude-plugin/plugin.json
+++ b/modules/research/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/research - multi-channel research using parallel agents with WebSearch, WebFetch, GitHub, and Reddit. Zero external dependencies. For deeper research backed by Exa neural search, see the deepresearch module.",
+  "displayName": "Research",
+  "keywords": [
+    "commands",
+    "research",
+    "web-search"
+  ],
+  "license": "MIT",
+  "name": "research"
+}

--- a/modules/rule-authoring/.claude-plugin/plugin.json
+++ b/modules/rule-authoring/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Discipline for writing rules that hold up under pressure. Treats rule authoring as TDD: pressure-test a candidate rule with adversarial scenarios, capture the rationalizations agents use to bypass it, and rewrite until the rule closes those loopholes.",
+  "displayName": "Rule Authoring",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "authoring",
+    "discipline",
+    "pressure-testing",
+    "rules",
+    "tdd-for-rules"
+  ],
+  "license": "MIT",
+  "name": "rule-authoring"
+}

--- a/modules/rule-authoring/hooks/plugin-rule-inject.py
+++ b/modules/rule-authoring/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/self-improving/.claude-plugin/plugin.json
+++ b/modules/self-improving/.claude-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Meta-learning system with a structured JSONL learnings store (confidence decay, staleness, prompt-injection-filtered), automated reflection triggers, and hooks that fire at key moments (PR merge, context compaction, debugging failures). Replaces narrative MEMORY.md with a queryable, token-budgeted store while keeping MEMORY.md as a rendered index.",
+  "displayName": "Self-Improving Agent",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "confidence-decay",
+    "hooks",
+    "improvement",
+    "jsonl",
+    "learnings",
+    "memory",
+    "meta-learning",
+    "reflection"
+  ],
+  "license": "MIT",
+  "name": "self-improving"
+}

--- a/modules/self-improving/hooks/plugin-rule-inject.py
+++ b/modules/self-improving/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/session-history/.claude-plugin/plugin.json
+++ b/modules/session-history/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Cross-platform session historian agent. Searches prior Claude Code and Codex session transcripts for what was tried, what failed, and what was decided in earlier sessions on the same repo. Invoked by other skills (/compound, /xplan, /debug) to surface institutional knowledge a fresh session cannot see.",
+  "displayName": "Session History",
+  "keywords": [
+    "agent",
+    "claude-code",
+    "codex",
+    "cross-platform",
+    "history",
+    "recall",
+    "retrieval",
+    "session"
+  ],
+  "license": "MIT",
+  "name": "session-history"
+}

--- a/modules/session-lifecycle/.claude-plugin/plugin.json
+++ b/modules/session-lifecycle/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Structured session shutdown via /sds. Autonomous wrap-up sweep: commit dirty work, update referenced issues, run /reflect, write a handoff, broadcast to sibling clones. Complements /startup at the other end of the session.",
+  "displayName": "Session Lifecycle",
+  "keywords": [
+    "handoff",
+    "session",
+    "shutdown",
+    "workflow"
+  ],
+  "license": "MIT",
+  "name": "session-lifecycle"
+}

--- a/modules/settings/.claude-plugin/plugin.json
+++ b/modules/settings/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Base settings.json with comprehensive tool permissions (800+ allow entries), deny list for dangerous operations, and plugin configuration. Defaults to 'ask' mode for safety.",
+  "displayName": "Settings & Permissions",
+  "keywords": [
+    "permissions",
+    "security",
+    "settings"
+  ],
+  "license": "MIT",
+  "name": "settings"
+}

--- a/modules/shadcn/.claude-plugin/plugin.json
+++ b/modules/shadcn/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "shadcn/ui component patterns: composition over custom builds, semantic theming tokens, proper form architecture, accessibility, and CLI workflow.",
+  "displayName": "shadcn/ui Patterns",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "components",
+    "radix",
+    "react",
+    "shadcn",
+    "ui"
+  ],
+  "license": "MIT",
+  "name": "shadcn"
+}

--- a/modules/shadcn/hooks/plugin-rule-inject.py
+++ b/modules/shadcn/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/ship-readiness/.claude-plugin/plugin.json
+++ b/modules/ship-readiness/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/ship-ready command: at-a-glance dashboard of what gates a merge on the current branch (failing tests, open PR count, stale branches, outdated deps, merge velocity, review freshness, unresolved risks from docs/solutions/). Reads ce-review envelopes for commit-hash staleness detection.",
+  "displayName": "Ship Readiness Dashboard",
+  "keywords": [
+    "dashboard",
+    "gating",
+    "pre-merge",
+    "review",
+    "ship",
+    "staleness"
+  ],
+  "license": "MIT",
+  "name": "ship-readiness"
+}

--- a/modules/skill-authoring/.claude-plugin/plugin.json
+++ b/modules/skill-authoring/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Discipline for writing skills and slash commands that stay efficient, portable, and context-safe. Covers reference-file inclusion, conditional content extraction, tool selection, and writing style.",
+  "displayName": "Skill Authoring",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "authoring",
+    "commands",
+    "context-window",
+    "discipline",
+    "skills"
+  ],
+  "license": "MIT",
+  "name": "skill-authoring"
+}

--- a/modules/skill-authoring/hooks/plugin-rule-inject.py
+++ b/modules/skill-authoring/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/skillify/.claude-plugin/plugin.json
+++ b/modules/skillify/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Slash command that promotes an ad-hoc session capability into a durable skill: a command file with triggers and rules, optional deterministic helper script, a pinning test, and a learnings-store entry pointing at the new skill. Inspired by the 'skillify' pattern where every repeated failure becomes structurally unreachable by being turned into a tested skill.",
+  "displayName": "Skillify",
+  "keywords": [
+    "authoring",
+    "durability",
+    "meta-learning",
+    "skills"
+  ],
+  "license": "MIT",
+  "name": "skillify"
+}

--- a/modules/startup-dashboard/.claude-plugin/plugin.json
+++ b/modules/startup-dashboard/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Plain-text /startup dashboard for Claude Code sessions. Surfaces git state, live sessions, tracking.csv claims, and recent activity (via session-history /recall). No agent-log writes; session transcripts are captured by Claude Code natively.",
+  "displayName": "Startup Dashboard",
+  "keywords": [
+    "dashboard",
+    "session",
+    "startup"
+  ],
+  "license": "MIT",
+  "name": "startup-dashboard"
+}

--- a/modules/statusline/.claude-plugin/plugin.json
+++ b/modules/statusline/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Compact single-line Claude Code statusline: model + effort, multi-clone identity (.env.clone), dir + git branch, context-used % with a compaction warning, session cost, and 5h/7d rate-limit bars. Installs the script and wires the statusLine setting.",
+  "displayName": "Statusline",
+  "keywords": [
+    "context",
+    "cost",
+    "multi-clone",
+    "statusline",
+    "ui"
+  ],
+  "license": "MIT",
+  "name": "statusline"
+}

--- a/modules/subagent-patterns/.claude-plugin/plugin.json
+++ b/modules/subagent-patterns/.claude-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Subagent dispatch methodology: task decomposition, spec-driven delegation, pass-paths-not-contents, two-stage review (spec compliance then code quality), parallel coordination, and skill invocation modes.",
+  "displayName": "Subagent Patterns",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "agents",
+    "coordination",
+    "delegation",
+    "parallel",
+    "review",
+    "subagents"
+  ],
+  "license": "MIT",
+  "name": "subagent-patterns"
+}

--- a/modules/subagent-patterns/hooks/plugin-rule-inject.py
+++ b/modules/subagent-patterns/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/supabase/.claude-plugin/plugin.json
+++ b/modules/supabase/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Supabase-specific rules: API key terminology (publishable/secret), environment variable naming, migration validation, and database change workflow.",
+  "displayName": "Supabase Rules",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "auth",
+    "database",
+    "migrations",
+    "supabase"
+  ],
+  "license": "MIT",
+  "name": "supabase"
+}

--- a/modules/supabase/hooks/plugin-rule-inject.py
+++ b/modules/supabase/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/systematic-debugging/.claude-plugin/plugin.json
+++ b/modules/systematic-debugging/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "4-phase root cause investigation methodology: investigate, analyze patterns, test hypotheses, implement fix. Prevents random fix attempts.",
+  "displayName": "Systematic Debugging",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "debugging",
+    "methodology",
+    "root-cause",
+    "troubleshooting"
+  ],
+  "license": "MIT",
+  "name": "systematic-debugging"
+}

--- a/modules/systematic-debugging/hooks/plugin-rule-inject.py
+++ b/modules/systematic-debugging/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/tailwind/.claude-plugin/plugin.json
+++ b/modules/tailwind/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Tailwind CSS v4 design system patterns: CSS-first configuration, design token hierarchy, CVA component variants, dark mode, and responsive grid systems.",
+  "displayName": "Tailwind CSS Design System",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "css",
+    "design-system",
+    "tailwind",
+    "theming",
+    "tokens"
+  ],
+  "license": "MIT",
+  "name": "tailwind"
+}

--- a/modules/tailwind/hooks/plugin-rule-inject.py
+++ b/modules/tailwind/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/test-driven-development/.claude-plugin/plugin.json
+++ b/modules/test-driven-development/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Strict red-green-refactor TDD discipline. No production code without a failing test first. Enforces test-first methodology for all new features and bug fixes.",
+  "displayName": "Test-Driven Development",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "methodology",
+    "red-green-refactor",
+    "tdd",
+    "testing"
+  ],
+  "license": "MIT",
+  "name": "test-driven-development"
+}

--- a/modules/test-driven-development/hooks/plugin-rule-inject.py
+++ b/modules/test-driven-development/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/test-vision/.claude-plugin/plugin.json
+++ b/modules/test-vision/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Vision-driven e2e test suite generation. /test-vision for full repo analysis + parallel test suite creation. /e2e for single-feature spec generation. Composes /e2e as the atomic unit within /test-vision orchestration.",
+  "displayName": "Test Vision",
+  "keywords": [
+    "browser-automation",
+    "e2e",
+    "parallel",
+    "playwright",
+    "testing"
+  ],
+  "license": "MIT",
+  "name": "test-vision"
+}

--- a/modules/todos/.claude-plugin/plugin.json
+++ b/modules/todos/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "File-based review-finding tracker. Review findings, PR nitpicks, and tech debt that does not merit a full GitHub issue go to .claude/todos/NNN-{status}-{priority}-{description}.md with YAML frontmatter. Three skills compose - /todo-create (canonical writer), /todo-triage (interactive pending->ready), /todo-resolve (batch-resolve ready todos via parallel subagents). Fills the gap between review-found-it and cut-an-issue with a lightweight, in-repo third option.",
+  "displayName": "Todos",
+  "keywords": [
+    "pr-feedback",
+    "review",
+    "tech-debt",
+    "todos",
+    "tracker",
+    "triage"
+  ],
+  "license": "MIT",
+  "name": "todos"
+}

--- a/modules/verification/.claude-plugin/plugin.json
+++ b/modules/verification/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Evidence-before-claims methodology. Requires fresh execution of verification commands, reading full output, and confirming results before asserting completion.",
+  "displayName": "Verification Before Completion",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "completion",
+    "evidence",
+    "quality",
+    "verification"
+  ],
+  "license": "MIT",
+  "name": "verification"
+}

--- a/modules/verification/hooks/plugin-rule-inject.py
+++ b/modules/verification/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/xplan/.claude-plugin/plugin.json
+++ b/modules/xplan/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Deep research + planning + execution framework. Spawns parallel research/review agents, creates comprehensive plans, and executes via parallel agent waves.",
+  "displayName": "xplan Planning System",
+  "keywords": [
+    "execution",
+    "parallel",
+    "planning",
+    "research"
+  ],
+  "license": "MIT",
+  "name": "xplan"
+}

--- a/modules/youtube-transcripts/.claude-plugin/plugin.json
+++ b/modules/youtube-transcripts/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "/transcript <url> grabs a YouTube transcript via yt-dlp AND dispatches a subagent to produce an opinionated implications doc against your project memory. Saves both files with matching slug+date so the pair correlates by name. --no-analysis flag for extraction only.",
+  "displayName": "YouTube Transcripts",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "analysis",
+    "commands",
+    "subagent",
+    "transcripts",
+    "youtube"
+  ],
+  "license": "MIT",
+  "name": "youtube-transcripts"
+}

--- a/modules/youtube-transcripts/hooks/plugin-rule-inject.py
+++ b/modules/youtube-transcripts/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Makes CCGM installable as a native Claude Code plugin marketplace, **additively**. The bash installer (`start.sh`) remains the canonical full-fidelity path — only it does the deep `settings.json` merge and writes the always-on global `CLAUDE.md` context. The marketplace is a pure projection of the same `modules/*/module.json` source of truth.

Closes #703. Part of #659 (Wave 4).

## What the schema actually is (doc source)

Verified against the official docs (fetched live):
- Marketplace: `https://docs.claude.com/en/docs/claude-code/plugin-marketplaces` — catalog at `.claude-plugin/marketplace.json` with `name`, `owner`, `plugins[]`; `metadata.pluginRoot` lets each `source` be a bare relative dir.
- Plugin: `https://docs.claude.com/en/docs/claude-code/plugins-reference` — manifest at `<plugin-root>/.claude-plugin/plugin.json`; only `name` is required; components (`commands/`, `agents/`, `skills/`, `output-styles/`, `hooks/`) auto-discovered from default dirs.

Key constraint confirmed in the docs and load-bearing for the design: **a plugin's `CLAUDE.md` is NOT loaded as context**, and a plugin can only contribute the `agent`/`subagentStatusLine` settings keys. So CCGM's rules-only modules need a different bridge (below).

## How the generator works

`modules/plugin-marketplace/lib/gen_marketplace.py` projects every `module.json` into:
- one `modules/<name>/.claude-plugin/plugin.json` per module (plugin root = the module dir, since module layout already matches plugin layout), and
- the root `.claude-plugin/marketplace.json` cataloging all 71 modules via `metadata.pluginRoot: "./modules"`.

Output is fully sorted → deterministic → byte-identical on re-run. `--check` is the CI gate.

**The CLAUDE.md/rules gap workaround:** modules that ship `type:"rule"` files get a `SessionStart` hook wired into their generated `plugin.json` that injects the plugin's own bundled `rules/*.md` as `additionalContext`. The hook (`hooks/plugin-rule-inject.py`) reuses the relevance-injection (#702) posture — opt-in via `CCGM_PLUGIN_RULE_INJECTION`, startup-only, fail-safe no-op.

## Changes

- New `plugin-marketplace` module (status `beta`): generator, dependency-free JSON-schema validator, rule-injection hook, rule doc, tests, README.
- Generated output committed: 71 `plugin.json`, 34 rule-hook copies (rules-bearing modules), 1 `marketplace.json`.
- CI (`.github/workflows/test.yml`, both ubuntu + macOS jobs): `gen_marketplace.py --check` (in-sync gate) + `validate_marketplace.py`. `claude plugin validate` is run locally/optionally since `claude` is not on GitHub CI.
- README: documented the marketplace install path alongside the canonical bash path, explicit that bash stays canonical.
- Doc counts 70 → 71 (CLAUDE.md ×2, README, docs/modules.md, docs/getting-started.md).

## Test Plan

- `python3 gen_marketplace.py --check` → in sync; generator idempotent.
- `python3 validate_marketplace.py` → all 679 checks pass, 71 manifests validated.
- `claude plugin validate .claude-plugin/marketplace.json --strict` → ✔ passes (verified locally with claude 2.1.177).
- `bash tests/run-all.sh` → 12/12 groups pass (incl. 232 pytest, my 14 new tests).
- `bash tests/test-modules.sh` → 1438/0. `bash tests/test-doc-counts.sh` → pass (plugin-marketplace auto-excluded as beta). `bash tests/test-no-personal-data.sh` (+ self-test) → pass.

## Notes for reviewer

- Generated manifests deliberately omit the maintainer handle (author = `"CCGM"`, no repo URL) to satisfy the personal-data guard; the install command with the real owner lives in README (the allowed location).
- 3 pre-existing modules (`documentation`, `onboarding`, `test-vision`) have YAML-frontmatter parse warnings in their existing command files that `claude plugin validate <dir>` surfaces. These are out of scope (do-not-edit-existing-content) and are why CI validates the marketplace manifest + manifest structure rather than running full per-plugin command validation.
