### PR TITLE
#709: quote command frontmatter for strict YAML; add frontmatter CI guard; fix+guard module count

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Check doc counts + preset coverage
         run: bash tests/test-doc-counts.sh
 
+      - name: Validate command/skill/agent frontmatter YAML
+        run: bash tests/test-frontmatter-yaml.sh
+
       - name: Plugin marketplace in sync (generator --check)
         run: python3 modules/plugin-marketplace/lib/gen_marketplace.py --check
 
@@ -58,6 +61,9 @@ jobs:
 
       - name: Check doc counts + preset coverage
         run: bash tests/test-doc-counts.sh
+
+      - name: Validate command/skill/agent frontmatter YAML
+        run: bash tests/test-frontmatter-yaml.sh
 
       - name: Plugin marketplace in sync (generator --check)
         run: python3 modules/plugin-marketplace/lib/gen_marketplace.py --check

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Modular configuration system for [Claude Code](https://docs.anthropic.com/en/doc
 
 ## What is CCGM?
 
-CCGM is a curated collection of 64 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
+CCGM is a curated collection of 71 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
 
 Each module is self-contained with its own README, so you can also [copy individual files manually](#manual-installation) without the installer.
 

--- a/modules/capability-router/commands/capabilities.md
+++ b/modules/capability-router/commands/capabilities.md
@@ -1,7 +1,7 @@
 ---
 description: Print the CCGM capability map - which command/skill to use among overlapping clusters (research, review, planning/execution, debugging, knowledge).
 allowed-tools: Read, Glob, Grep
-argument-hint: [cluster: research | review | plan | debug | knowledge]
+argument-hint: "[cluster: research | review | plan | debug | knowledge]"
 ---
 
 # /capabilities - Which Command Do I Use?

--- a/modules/documentation/commands/docupdate.md
+++ b/modules/documentation/commands/docupdate.md
@@ -1,7 +1,7 @@
 ---
 description: Comprehensive documentation audit and update - checks README, docs, TOC, onboarding, packages, and modules against actual codebase state
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch, AskUserQuestion
-argument-hint: [--scope readme|docs|toc|onboarding|all] [--dry-run]
+argument-hint: "[--scope readme|docs|toc|onboarding|all] [--dry-run]"
 ---
 
 # /docupdate - Comprehensive Documentation Update

--- a/modules/onboarding/commands/onboarding.md
+++ b/modules/onboarding/commands/onboarding.md
@@ -1,7 +1,7 @@
 ---
 description: Generate a structured ONBOARDING.md for the current repo from a code inventory. Architecture, dev setup, key commands, test workflow, glossary. Always regenerates from scratch.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
-argument-hint: [path] [--dry-run]
+argument-hint: "[path] [--dry-run]"
 ---
 
 # /onboarding - Structured ONBOARDING.md Generator

--- a/modules/test-vision/commands/test-vision.md
+++ b/modules/test-vision/commands/test-vision.md
@@ -1,7 +1,7 @@
 ---
 description: Comprehensive e2e test suite generation. Discovers all features, interviews user, generates infrastructure, dispatches parallel /e2e agents.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion
-argument-hint: [--skip-chrome] [--skip-interview]
+argument-hint: "[--skip-chrome] [--skip-interview]"
 ---
 
 # /test-vision - Vision-Driven E2E Test Suite Generation

--- a/modules/xplan/commands/xplan-status.md
+++ b/modules/xplan/commands/xplan-status.md
@@ -1,7 +1,7 @@
 ---
 description: Check progress on a running or completed xplan
 allowed-tools: Agent
-argument-hint: [plan-name]
+argument-hint: "[plan-name]"
 ---
 
 # xplan-status - Plan Progress Dashboard

--- a/tests/test-doc-counts.sh
+++ b/tests/test-doc-counts.sh
@@ -70,8 +70,49 @@ $current"
 check_count_claim "CLAUDE.md"               "It contains __N__ modules"          "$MODULE_COUNT"
 check_count_claim "CLAUDE.md"               "# __N__ self-contained modules"     "$MODULE_COUNT"
 check_count_claim "README.md"               "all __N__ modules"                  "$MODULE_COUNT"
+check_count_claim "README.md"               "collection of __N__ configuration modules" "$MODULE_COUNT"
 check_count_claim "docs/modules.md"         "CCGM contains __N__ modules"        "$MODULE_COUNT"
 check_count_claim "docs/getting-started.md" "all __N__ modules"                  "$MODULE_COUNT"
+
+# --- (a2) generic stale-count phrasings anywhere in tracked docs -------------
+# Catch the "N configuration modules" and "collection of N ... modules" classes
+# regardless of which doc they appear in, so a wrong number cannot slip in via a
+# phrasing the explicit list above does not cover. Any match whose number is NOT
+# the derived MODULE_COUNT fails.
+check_no_wrong_count_phrasing() {
+  local label="$1"
+  shift
+  local regex="$1"
+  local found_wrong=0
+  local matches
+  # -R over the docs we ship; -n for line numbers; -E for extended regex.
+  # Limit to Markdown docs at the repo root and under docs/ to avoid scanning
+  # module bodies that legitimately discuss arbitrary counts.
+  matches=$(grep -REn "$regex" README.md CLAUDE.md docs 2>/dev/null || true)
+  if [ -z "$matches" ]; then
+    ok "no '$label' phrasing present (nothing to drift)"
+    return
+  fi
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    # Extract the first integer that the phrasing wraps.
+    n=$(printf '%s' "$line" | grep -oE "$regex" | grep -oE '[0-9]+' | head -1)
+    if [ -n "$n" ] && [ "$n" != "$MODULE_COUNT" ]; then
+      fail "stale '$label' count ($n, expected $MODULE_COUNT): $line"
+      found_wrong=1
+    fi
+  done <<EOF
+$matches
+EOF
+  if [ "$found_wrong" -eq 0 ]; then
+    ok "all '$label' phrasings use $MODULE_COUNT"
+  fi
+}
+
+check_no_wrong_count_phrasing "N configuration modules" \
+  '[0-9]+ configuration modules'
+check_no_wrong_count_phrasing "collection of N ... modules" \
+  'collection of [0-9]+ [a-zA-Z]+ modules'
 
 # --- (b) full preset count claim in docs -----------------------------------
 check_count_claim "README.md"               "**full** | __N__ modules"           "$FULL_PRESET_COUNT"

--- a/tests/test-frontmatter-yaml.sh
+++ b/tests/test-frontmatter-yaml.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CCGM Command/Skill/Agent Frontmatter YAML Guard (issue #709)
+#
+# Claude Code parses command/skill/agent frontmatter with a STRICT YAML parser.
+# A value like `argument-hint: [a] [b]` is read as a flow sequence and fails to
+# parse, at which point ALL frontmatter fields are silently dropped at load time.
+#
+# This guard scans every:
+#   modules/**/commands/*.md
+#   modules/**/skills/**/SKILL.md
+#   modules/**/agents/*.md
+#
+# extracts the leading `---`...`---` frontmatter, and FAILS if:
+#   - the frontmatter block is malformed (opens with `---` but never closes), or
+#   - any top-level value is an UNQUOTED flow collection (starts with `[` or `{`).
+#
+# It does NOT implement full YAML. It deterministically detects the specific
+# breakage class above, which is the one that bites Claude Code command loading.
+#
+# Dependency-free: python3 stdlib only (no pyyaml). Portable: macOS BSD + Linux.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "FAIL: python3 is required for tests/test-frontmatter-yaml.sh" >&2
+  exit 1
+fi
+
+# Write the dependency-free checker to a temp file so single/double quotes in the
+# Python source never collide with the surrounding shell quoting.
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/ccgm-fm.XXXXXX")"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+CHECKER="$WORKDIR/check_frontmatter.py"
+cat >"$CHECKER" <<'PYEOF'
+import sys, re
+
+# The breakage class: a top-level value that begins with an unquoted flow
+# collection indicator. Quoted scalars are always safe.
+FLOW_OPENERS = ("[", "{")
+
+
+def frontmatter(text):
+    # Must start at byte 0 with a --- line.
+    if not text.startswith("---"):
+        return None, None  # no frontmatter -> nothing to check
+    m = re.match(r"^---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(\r?\n|$)", text, re.S)
+    if not m:
+        return None, "frontmatter opens with --- but is never closed by a --- line"
+    return m.group(1), None
+
+
+def value_is_unquoted_flow(val):
+    v = val.strip()
+    if not v:
+        return False
+    c = v[0]
+    if c == '"' or c == "'":
+        return False  # quoted scalar, safe
+    return c in FLOW_OPENERS
+
+
+def main():
+    violations = 0
+    for raw in sys.stdin.read().splitlines():
+        path = raw.strip()
+        if not path:
+            continue
+        try:
+            with open(path, encoding="utf-8") as fh:
+                text = fh.read()
+        except OSError as exc:
+            print("%s: cannot read (%s)" % (path, exc))
+            violations += 1
+            continue
+
+        fm, err = frontmatter(text)
+        if err:
+            print("%s: %s" % (path, err))
+            violations += 1
+            continue
+        if fm is None:
+            # No frontmatter block; not the breakage class this guard targets.
+            continue
+
+        for line in fm.split("\n"):
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            if line[:1] == " " or line[:1] == "\t":
+                continue  # nested mapping/sequence content; not a top-level scalar
+            if line.lstrip().startswith("-"):
+                continue
+            if ":" not in line:
+                print("%s: malformed frontmatter line (no key): %r" % (path, line))
+                violations += 1
+                continue
+            key, _, val = line.partition(":")
+            if value_is_unquoted_flow(val):
+                print("%s: key %r has an unquoted flow value (quote it): %r"
+                      % (path, key.strip(), val.strip()))
+                violations += 1
+
+    if violations:
+        print("\n%d frontmatter violation(s) found." % violations)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+PYEOF
+
+collect_targets() {
+  # Print every target md path, one per line. CCGM paths contain no newlines.
+  find modules -type f \
+    \( -path 'modules/*/commands/*.md' \
+       -o -path 'modules/*/skills/*/SKILL.md' \
+       -o -path 'modules/*/skills/SKILL.md' \
+       -o -path 'modules/*/agents/*.md' \) \
+    | sort
+}
+
+# --- Self-check: a planted bad fixture must FAIL, a clean one must PASS --------
+BAD_FIXTURE="$WORKDIR/bad.md"
+GOOD_FIXTURE="$WORKDIR/good.md"
+
+cat >"$BAD_FIXTURE" <<'EOF'
+---
+description: planted bad fixture
+argument-hint: [--flag] [arg]
+---
+body
+EOF
+
+cat >"$GOOD_FIXTURE" <<'EOF'
+---
+description: planted good fixture
+argument-hint: "[--flag] [arg]"
+---
+body
+EOF
+
+echo "self-test: bad fixture must FAIL..."
+if printf '%s\n' "$BAD_FIXTURE" | python3 "$CHECKER" >/dev/null 2>&1; then
+  echo "FAIL: planted bad fixture was accepted; the guard is not catching the breakage class" >&2
+  exit 1
+fi
+echo "ok: bad fixture rejected"
+
+echo "self-test: good fixture must PASS..."
+if ! printf '%s\n' "$GOOD_FIXTURE" | python3 "$CHECKER" >/dev/null 2>&1; then
+  echo "FAIL: planted good fixture was rejected; the guard has a false positive" >&2
+  exit 1
+fi
+echo "ok: good fixture accepted"
+
+# --- Real scan --------------------------------------------------------------
+COUNT=$(collect_targets | grep -c . || true)
+echo "Scanning $COUNT command/skill/agent frontmatter file(s)..."
+
+if collect_targets | python3 "$CHECKER"; then
+  echo "test-frontmatter-yaml.sh: all frontmatter valid"
+else
+  echo "" >&2
+  echo "test-frontmatter-yaml.sh: frontmatter validation failed." >&2
+  echo "Quote any value that starts with [ or { as a double-quoted string." >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #709
Part of #659

## Summary

Three fixes around command/skill/agent frontmatter and module-count drift.

### 1. Quote broken frontmatter (strict-YAML breakage)

Five command files had `argument-hint` values that start with `[`, which strict YAML reads as a flow sequence. The two with `[...] [...]` groups failed to parse outright; the single-`[...]` ones parsed as a list (semantically wrong). When parsing fails, Claude Code silently drops **all** frontmatter fields at load time. Each value is now a double-quoted string. Human-readable content is unchanged.

Files quoted:
- `modules/capability-router/commands/capabilities.md`
- `modules/documentation/commands/docupdate.md`
- `modules/onboarding/commands/onboarding.md`
- `modules/test-vision/commands/test-vision.md`
- `modules/xplan/commands/xplan-status.md`

Verified with `claude plugin validate`: all 71 module plugins + the marketplace manifest validate clean.

### 2. CI guard: `tests/test-frontmatter-yaml.sh`

Dependency-free (python3 stdlib, no pyyaml). Scans every `modules/**/commands/*.md`, `modules/**/skills/**/SKILL.md`, and `modules/**/agents/*.md`, extracts the leading `---`...`---` frontmatter, and fails if the block is malformed (never closed) or any top-level value is an unquoted flow collection (starts with `[` or `{`). Includes a self-check: a planted bad fixture must fail and a clean one must pass (both temp, cleaned up). Wired into `tests/run-all.sh` (auto-discovered) and added as a step to **both** jobs of `.github/workflows/test.yml`.

### 3. Fix + guard module count

README said "collection of 64 configuration modules" — the real count is 71. Fixed, and extended `tests/test-doc-counts.sh` with two generic checks that fail on any wrong number in the "N configuration modules" and "collection of N ... modules" phrasings across README/CLAUDE.md/docs, so this stale-count class can't recur.

## Test plan

- `bash tests/test-frontmatter-yaml.sh` — pass (110 files scanned; self-test green)
- `bash tests/test-doc-counts.sh` — pass (derived count 71)
- `bash tests/test-modules.sh` — 1442 passed, 0 failed
- `bash tests/run-all.sh` — 13 passed, 0 failed (incl. new guard + 31 audit suites)
- `bash tests/test-no-personal-data.sh` — pass
- `claude plugin validate` on all 71 module plugins + marketplace — clean
- `gen_marketplace.py --check` + `validate_marketplace.py` — clean (679 checks)