### PR TITLE
#712: gitignore project-scope backups to prevent accidental commits

### DIFF
--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -16,6 +16,37 @@ backup_base_for() {
   echo "${target_dir%/}/backups"
 }
 
+# --- Ensure a project-scope backups dir is gitignored ---
+# Project-scope backups live inside a project's .claude/backups, which may sit
+# in a git repo. Without this, `git add .` would stage backup snapshots. We drop
+# a self-contained `.gitignore` (containing `*`) inside the backups dir so the
+# whole dir is ignored, scoped exactly to backups and touching nothing else.
+# Global-scope backups (~/.claude/backups) are irrelevant here and skipped.
+# Idempotent: only writes when the marker is absent.
+# Usage: ensure_backups_gitignored "/target/dir"
+ensure_backups_gitignored() {
+  local target_dir="$1"
+
+  # No target means global scope (~/.claude/backups) -> nothing to do.
+  if [ -z "$target_dir" ]; then
+    return 0
+  fi
+
+  local backup_base
+  backup_base=$(backup_base_for "$target_dir")
+
+  # Global scope: backup base equals the home ~/.claude/backups -> skip.
+  if [ "$backup_base" = "${HOME}/.claude/backups" ]; then
+    return 0
+  fi
+
+  local ignore_file="${backup_base}/.gitignore"
+  if [ ! -f "$ignore_file" ]; then
+    mkdir -p "$backup_base"
+    printf '*\n' > "$ignore_file"
+  fi
+}
+
 # --- Create timestamped backup ---
 # Usage: create_backup "/target/dir"
 # Backs up existing config files to <target>/backups/ccgm-YYYYMMDD-HHMMSS/
@@ -58,6 +89,11 @@ create_backup() {
 
   # Create backup directory
   mkdir -p "$backup_dir"
+
+  # For project-scope installs, the backups dir may live inside a git repo.
+  # Drop a .gitignore so snapshots never get accidentally committed (no-op for
+  # global scope). Idempotent across repeated backups.
+  ensure_backups_gitignored "$target_dir"
 
   # Copy existing files
   for p in "${check_paths[@]}"; do

--- a/tests/test-backup.sh
+++ b/tests/test-backup.sh
@@ -319,6 +319,65 @@ else
 fi
 echo ""
 
+# --- Test 9: project-scope backups dir is gitignored ---
+echo "--- Test 9: project-scope backups gitignored ---"
+
+GI_PROJECT="$TMPDIR/gi-project"
+GI_TARGET="$GI_PROJECT/.claude"
+mkdir -p "$GI_TARGET"
+echo '{"scope": "gi-project"}' > "$GI_TARGET/settings.json"
+
+gi_backup=$(create_backup "$GI_TARGET")
+GI_BASE="$GI_TARGET/backups"
+
+# A .gitignore must exist inside the backups dir and ignore everything.
+if [ -f "$GI_BASE/.gitignore" ]; then
+  pass "Project-scope backups dir has a .gitignore"
+else
+  fail "Project-scope backups dir is missing a .gitignore"
+fi
+
+if [ -f "$GI_BASE/.gitignore" ] && [ "$(cat "$GI_BASE/.gitignore")" = '*' ]; then
+  pass "backups/.gitignore contains '*' (ignores all backup content)"
+else
+  fail "backups/.gitignore does not contain the expected '*' entry"
+fi
+
+# Idempotent: a second backup must not duplicate or alter the entry.
+gi_lines_before=$(wc -l < "$GI_BASE/.gitignore" | tr -d ' ')
+sleep 1  # ensure a distinct ccgm-YYYYMMDD-HHMMSS timestamp for the 2nd backup
+gi_backup2=$(create_backup "$GI_TARGET")
+gi_lines_after=$(wc -l < "$GI_BASE/.gitignore" | tr -d ' ')
+
+if [ "$gi_lines_before" = "$gi_lines_after" ] && [ "$(cat "$GI_BASE/.gitignore")" = '*' ]; then
+  pass "Repeated backup does not duplicate the .gitignore entry"
+else
+  fail "Repeated backup changed .gitignore (before=$gi_lines_before after=$gi_lines_after)"
+fi
+
+# Two distinct backups should have been created (sanity that we exercised it twice).
+if [ -n "$gi_backup" ] && [ -n "$gi_backup2" ] && [ "$gi_backup" != "$gi_backup2" ]; then
+  pass "Two distinct project-scope backups created"
+else
+  fail "Expected two distinct project-scope backups (got '$gi_backup' and '$gi_backup2')"
+fi
+echo ""
+
+# --- Test 10: global-scope backups are NOT gitignored ---
+echo "--- Test 10: global-scope backups unaffected ---"
+
+# Clean any prior global backups, then create a fresh global-scope backup.
+rm -rf "$HOME/.claude/backups"/ccgm-*
+echo '{"scope": "global-gi"}' > "$HOME/.claude/settings.json"
+global_gi_backup=$(create_backup "$HOME/.claude")
+
+if [ ! -f "$HOME/.claude/backups/.gitignore" ]; then
+  pass "Global-scope backups dir has no .gitignore (irrelevant for ~/.claude)"
+else
+  fail "Global-scope backups dir unexpectedly got a .gitignore"
+fi
+echo ""
+
 # --- Summary ---
 echo "==================================="
 echo "  Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Follow-up to #668, which scoped project-scope backups to `<project>/.claude/backups`. That directory can live inside a git repo, so `git add .` could accidentally stage CCGM backup snapshots.

This change drops a self-contained `.gitignore` (containing `*`) inside the backups dir whenever a **project-scope** backup is created, so the entire dir is ignored. Scoped exactly to the backups dir — touches no shared `.gitignore` the user may manage. Global-scope backups (`~/.claude/backups`) are intentionally skipped.

## Changes

- `lib/backup.sh`: new `ensure_backups_gitignored()` helper, invoked from `create_backup`. Idempotent (only writes when the marker is absent); no-op for global scope.
- `tests/test-backup.sh`: Test 9 (project-scope backups gitignored + repeated backups don't duplicate the entry) and Test 10 (global-scope unaffected).

## Test Plan

- `bash tests/test-backup.sh` — 28 passed, 0 failed
- `bash tests/test-installer.sh` — 54 passed, 0 failed
- `bash tests/test-no-personal-data.sh` — pass

Closes #712
Part of #659