### PR TITLE
#713: EINTR-resilient test-modules output; gate hooks dispatcher tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Hooks test suites (dispatcher equivalence + precedence)
         run: |
           set -e
+          # enforce-git-workflow.py imports hook_utils from ~/.claude/lib, so the
+          # suites need the hooks lib on that path (an installed-environment
+          # assumption). Stage it before running.
+          mkdir -p "$HOME/.claude/lib"
+          cp modules/hooks/lib/*.py "$HOME/.claude/lib/"
           for t in modules/hooks/tests/*.sh; do
             echo "=== Running $t ==="
             bash "$t"
@@ -100,6 +105,11 @@ jobs:
       - name: Hooks test suites (dispatcher equivalence + precedence)
         run: |
           set -e
+          # enforce-git-workflow.py imports hook_utils from ~/.claude/lib, so the
+          # suites need the hooks lib on that path (an installed-environment
+          # assumption). Stage it before running.
+          mkdir -p "$HOME/.claude/lib"
+          cp modules/hooks/lib/*.py "$HOME/.claude/lib/"
           for t in modules/hooks/tests/*.sh; do
             echo "=== Running $t ==="
             bash "$t"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,14 @@ jobs:
       - name: Audit skill test suite
         run: bash tests/run-audit-suite.sh
 
+      - name: Hooks test suites (dispatcher equivalence + precedence)
+        run: |
+          set -e
+          for t in modules/hooks/tests/*.sh; do
+            echo "=== Running $t ==="
+            bash "$t"
+          done
+
   test-macos:
     runs-on: macos-latest
     steps:
@@ -88,3 +96,11 @@ jobs:
 
       - name: Audit skill test suite
         run: bash tests/run-audit-suite.sh
+
+      - name: Hooks test suites (dispatcher equivalence + precedence)
+        run: |
+          set -e
+          for t in modules/hooks/tests/*.sh; do
+            echo "=== Running $t ==="
+            bash "$t"
+          done

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -11,10 +11,19 @@ PASS=0
 FAIL=0
 ERRORS=()
 
+# Per-assertion PASS lines run into the thousands and, under heavy stdout on
+# the macOS CI runner, a signal can interrupt a write mid-flush and surface as
+# "echo: write error: Interrupted system call" (EINTR), failing the run
+# spuriously. By default we stay quiet on success and only print failures plus
+# the final summary, which keeps total writes small. Set VERBOSE=1 for the old
+# per-assertion PASS output (used for local debugging).
+VERBOSE="${VERBOSE:-0}"
+
 # --- Helpers ---
 pass() {
   PASS=$((PASS + 1))
-  echo "  PASS: $1"
+  [ "$VERBOSE" = "1" ] && echo "  PASS: $1"
+  return 0
 }
 
 fail() {


### PR DESCRIPTION
## Summary

Two test-infra fixes (Wave 0.8).

### 1. EINTR flake in `tests/test-modules.sh`
The `pass()` helper printed one `  PASS:` line per assertion — ~1442 lines per run. Under heavy stdout on the macOS CI runner a signal could interrupt a write mid-flush, surfacing as `echo: write error: Interrupted system call` (EINTR) and failing the run spuriously.

**Fix:** Default to quiet — `pass()` no longer prints per-assertion; only failures and the final summary are emitted, cutting total writes from ~1442 to a handful. `VERBOSE=1` restores the old per-assertion output for local debugging. The pass/fail contract and counts are unchanged (still 1442 passed, 0 failed). Stays portable for bash 3.2 / macOS (`return 0` keeps the helper `set -e`-safe).

### 2. Gate the hooks test suites in CI
`modules/hooks/tests/*.sh` — including the 80/80 dispatcher equivalence proof from #707 — were not run by `.github/workflows/test.yml` (it runs a fixed list, never `run-all.sh`, and `run-unit-tests.sh` only globs `test_*.sh` with an underscore, missing the hyphenated hooks tests). Added a `Hooks test suites` step to **both** the `test` (ubuntu) and `test-macos` jobs that runs every `modules/hooks/tests/*.sh` so the equivalence/precedence guarantees gate PRs.

## Test Plan

All run locally from a clean branch, exit 0:

- `bash tests/test-modules.sh` → `1442 passed, 0 failed` (quiet); `VERBOSE=1` prints all 1442 PASS lines, same counts
- `bash modules/hooks/tests/test-dispatcher.sh` → `20 passed, 0 failed`, `equivalence: 80/80 command×mode pairs match`
- All 6 `modules/hooks/tests/*.sh` pass individually
- `bash tests/run-all.sh` → `13 passed, 0 failed` + `/audit suite 31 passed` → `All tests passed!`
- `bash tests/test-no-personal-data.sh` → `No personal data or secret/PII shapes found`

Closes #713
Part of #659