### PR TITLE
#714: clarify/resolve manifest field semantics (functional vs advisory)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,14 +159,26 @@ The runner discovers these automatically, so no registration is needed.
 
 Each entry in the `files` object maps a source path (relative to the module directory) to a descriptor:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `target` | string | yes | Destination path relative to the install root (`~/.claude/` or `.claude/`). |
-| `type` | string | yes | File type: `rule`, `command`, `agent`, `skill`, `skill-reference`, `hook`, `lib`, `script`, `config`, `doc`, or `content`. |
-| `template` | boolean | yes | Whether the file contains `__PLACEHOLDER__` template variables to expand. |
-| `merge` | boolean | no | For `config` type only. If `true`, the file is merged into the target rather than replacing it. Used for settings partials. |
+| Field | Type | Required | Behavior-bearing | Description |
+|-------|------|----------|:----------------:|-------------|
+| `target` | string | yes | yes | Destination path relative to the install root (`~/.claude/` or `.claude/`). This alone determines where the file lands. |
+| `template` | boolean | yes | yes | Whether the file contains `__PLACEHOLDER__` template variables to expand at install time. |
+| `merge` | boolean | no | yes | If `true`, the file is merged into the target rather than replacing it (used for settings partials). The installer derives copy/link/merge from this flag plus `--link` mode — **not** from `type`. |
+| `type` | string | yes | no (advisory) | A label describing the kind of file (`rule`, `command`, `agent`, `skill`, `skill-reference`, `hook`, `lib`, `script`, `config`, `doc`, or `content`). Documentation only — see "Functional vs advisory fields" below. |
+
+### Functional vs advisory fields
+
+Not every manifest field changes what the installer does. Knowing which is which prevents you from assuming behavior that does not exist:
+
+- **Behavior-bearing fields** drive installation: `name`, `scope`, `dependencies`, `configPrompts`, and each file's `target`, `template`, and `merge`. `status` gates whether a module is offered (`deprecated` and `beta` are recognized). `displayName` and `description` are shown to the user.
+- **Advisory fields** are catalog/documentation metadata only and do **not** change install behavior:
+  - **`category`** — used for grouping in the human-readable module listing. It is required and validated against the enum below, but the installer never branches on it.
+  - **`files[].type`** — a descriptive label for the kind of file. The install location is set by `target` and copy/link/merge is set by `merge` plus link mode; `type` is not consumed by the installer and is not validated against an enum. Set it accurately for readers, but do not expect it to control where or how a file installs.
+  - **`postInstall`** — present in one legacy (deprecated) manifest but **not executed by the installer**. There is no post-install hook mechanism in `start.sh` or `lib/`. Do not add `postInstall` to a manifest expecting it to run; if a module needs a binary fetched or a build step, document a manual step in its README instead.
 
 ### File Types
+
+The `type` values below are descriptive labels (advisory — see above). The "installed to" notes describe the **convention** authors follow via each file's `target`; `type` itself does not set the destination.
 
 | Type | Extension | Description |
 |------|-----------|-------------|

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -669,7 +669,7 @@ Methodology for decomposing tasks and delegating to subagents.
 
 [DEPRECATED] Go-based terminal UI for managing Claude Code agent processes. Unmaintained; no longer offered for new installs (not shown in the installer list, not in any preset), kept in-repo for existing users.
 
-**Installs**: `commands/agents.md`, Go binary (`~/.ccgm/bin/ccgm-agents`) via postInstall.sh
+**Installs**: `commands/agents.md`. The Go binary (`~/.ccgm/bin/ccgm-agents`) is **not** installed by CCGM — run `modules/agent-manager/postInstall.sh` manually to fetch it.
 
 **What it does**: Provides a terminal dashboard for monitoring and controlling Claude Code agents across multi-clone repos:
 
@@ -678,7 +678,7 @@ Methodology for decomposing tasks and delegating to subagents.
 - **Controls**: Launch, stop, restart, and force-kill agents from the TUI
 - **Filtering**: Filter agent list by name, status, or repo
 
-The `/agents` command launches the TUI. The binary is built and installed by the `postInstall.sh` script during CCGM installation.
+The `/agents` command launches the TUI. The CCGM installer has no post-install hook, so the binary is not installed automatically — fetch it by running `modules/agent-manager/postInstall.sh` manually (it downloads and checksum-verifies the release binary into `~/.ccgm/bin/`).
 
 | Command | Description |
 |---------|-------------|

--- a/lib/modules.sh
+++ b/lib/modules.sh
@@ -186,6 +186,8 @@ get_module_scope() {
 # --- Get module files ---
 # Returns JSON object of files (requires jq)
 # Each line: source_path|target|type|template|merge
+# NOTE: `type` is advisory metadata only — callers discard it. Install location
+# is driven by `target`, and copy/link/merge by `template`/`merge` + link mode.
 get_module_files() {
   local name="$1"
   local manifest="${CCGM_ROOT}/modules/${name}/module.json"

--- a/modules/agent-manager/README.md
+++ b/modules/agent-manager/README.md
@@ -26,13 +26,15 @@ The agent manager gives you a live view of all running Claude Code agents: their
 
 ## Installation
 
-### Via CCGM Installer (Recommended)
+> This module is deprecated and is not offered in the installer's module list, so there is no installer-driven setup path. The CCGM installer also has **no post-install hook mechanism** — the `postInstall.sh` script in this directory is never run automatically. Install the binary manually using either the script or the steps below.
+
+### Binary install via script
+
+Run the bundled script directly. It downloads the correct platform binary, verifies its checksum, and installs it to `~/.ccgm/bin/`:
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/lucasmccomb/ccgm/main/start.sh)
+bash modules/agent-manager/postInstall.sh
 ```
-
-Select "Agent Manager TUI" from the module list. The installer runs `postInstall.sh` automatically, which downloads the correct binary for your platform.
 
 ### Manual Installation
 

--- a/modules/agent-manager/commands/agents.md
+++ b/modules/agent-manager/commands/agents.md
@@ -21,7 +21,7 @@ Run the agent manager binary:
 ~/.ccgm/bin/ccgm-agents
 ```
 
-If the binary is not found at `~/.ccgm/bin/ccgm-agents`, inform the user that the agent-manager module may not be installed or the postInstall script may not have run. They can install it by re-running the CCGM installer or running `postInstall.sh` from `modules/agent-manager/` manually.
+If the binary is not found at `~/.ccgm/bin/ccgm-agents`, inform the user that the binary has not been installed. The CCGM installer does not install it automatically — they need to run `postInstall.sh` from `modules/agent-manager/` manually (or follow the manual steps in the module's README).
 
 ## Keybindings Reference
 

--- a/modules/agent-manager/postInstall.sh
+++ b/modules/agent-manager/postInstall.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# postInstall.sh - Download and install the ccgm-agents binary after module install.
+# postInstall.sh - Download and install the ccgm-agents binary.
+#
+# NOTE: The CCGM installer has no post-install hook mechanism; the `postInstall`
+# key in module.json is advisory metadata and is NOT executed automatically.
+# Run this script manually to install the binary.
 #
 # Downloads the correct platform binary from GitHub Releases, verifies the
 # SHA-256 checksum, and installs it to ~/.ccgm/bin/ccgm-agents.


### PR DESCRIPTION
## Summary

Resolves the "dead manifest schema" concern (#678) conservatively and honestly. Investigation confirmed that three `module.json` fields are parsed/declared but never acted on by the installer. Rather than mass-rewrite all module manifests or add speculative behavior, this PR documents which manifest fields are functional (behavior-bearing) vs advisory, and corrects docs/comments that imply behavior the code does not implement.

## Findings (evidence from `start.sh` / `lib/`)

- **`files[].type`** (12 values: agent, command, config, content, doc, hook, lib, rule, script, settings, skill, skill-reference) — **inert**. `get_module_files` emits it (`lib/modules.sh`), but both install loops read it into a discarded field (`IFS='|' read -r src target _ template merge`). Install action (copy/link/merge) is derived purely from the `merge` flag + `--link` mode; the destination is `target`. Nothing branches on `type`, and it is not enum-validated.
- **`category`** (5 values) — **advisory/display-only**. Printed in `get_module_info` and required + enum-validated by `tests/test-modules.sh`, but the installer never branches on it. Left as-is (it is a valid catalog field), documented as advisory.
- **`postInstall`** — **dead and misleading**. Declared only by `agent-manager/module.json` (which is `status: deprecated`), and the README/command/docs claimed "the installer runs postInstall.sh automatically." It is **never invoked** anywhere in `start.sh` or `lib/`. There is no post-install hook mechanism. Since the sole declaring module is deprecated and excluded from installs/presets, wiring up a generic post-install hook would be speculative; the honest fix is to stop claiming it runs.

## Changes (no behavior change, no module.json rewrites)

- `CONTRIBUTING.md`: added a "Functional vs advisory fields" subsection; marked the file-descriptor table behavior-bearing vs advisory; corrected the `merge` description that wrongly tied it to `type`; noted the File Types table is descriptive.
- `lib/modules.sh`: comment on `get_module_files` noting `type` is advisory and discarded by callers.
- `modules/agent-manager/{README.md,commands/agents.md,postInstall.sh}` and `docs/modules.md`: corrected the "installer runs postInstall.sh automatically" claims to "run it manually; the installer has no post-install hook."

## Test Plan

- `bash tests/test-modules.sh` → 1442 passed, 0 failed
- `bash tests/run-all.sh` → All tests passed (exit 0)
- `bash tests/test-no-personal-data.sh` → PASS

Closes #714
Part of #659
resolves #678
