### PR TITLE
#726: audit spine — exclude vendored *.min.js + gitignored files (gitleaks .env.local)

### DIFF
--- a/modules/commands-extra/README.md
+++ b/modules/commands-extra/README.md
@@ -126,7 +126,8 @@ cp commands/checkpoint.md .claude/commands/checkpoint.md
 | `skills/audit/scripts/spine/run.sh` | Deterministic tool spine: runs 18 wrapped tools, reports per-tool progress to stderr, applies the junk-path post-filter, emits finding JSONL |
 | `skills/audit/scripts/spine/wrap-*.sh` | Per-tool wrappers (gitleaks, semgrep, knip, eslint, trivy, …) |
 | `skills/audit/scripts/spine/exclude-dirs.txt` | Canonical excluded-dir list (node_modules, worktrees, build output) — single source of truth |
-| `skills/audit/scripts/spine/exclude.sh` / `exclude.py` | Build per-tool exclusion flags (sh) and the gitleaks config + always-on junk-path post-filter (py) from `exclude-dirs.txt` |
+| `skills/audit/scripts/spine/exclude-file-globs.txt` | Canonical excluded file-glob list (`*.min.js`, `*.bundle.js`, `*.map`) — catches vendored/minified files by name regardless of directory |
+| `skills/audit/scripts/spine/exclude.sh` / `exclude.py` | Build per-tool exclusion flags (sh) and the gitleaks config + always-on post-filter (py) from the dir + file-glob lists. The post-filter also drops findings on `.gitignore`d paths and a looks-minified backstop drops lint/SAST findings on minified vendored files (e.g. `js-dos.js`); the gitleaks config allowlists gitignored files so a never-committed `.env.local` is not reported as a leaked credential |
 | `skills/audit/schemas/finding.schema.json` | JSON schema for normalized finding records |
 | `skills/audit/schemas/severity-rubric.json` | Per-check severity + confidence overrides |
 | `skills/audit/reference/*.md` | Runtime reference docs: security patterns, fix-patterns, architecture guides, output templates |

--- a/modules/commands-extra/module.json
+++ b/modules/commands-extra/module.json
@@ -229,6 +229,11 @@
       "type": "doc",
       "template": false
     },
+    "skills/audit/scripts/spine/exclude-file-globs.txt": {
+      "target": "skills/audit/scripts/spine/exclude-file-globs.txt",
+      "type": "doc",
+      "template": false
+    },
     "skills/audit/scripts/spine/exclude.sh": {
       "target": "skills/audit/scripts/spine/exclude.sh",
       "type": "script",

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -454,9 +454,14 @@ python3 -c "import json,sys;p=sys.argv[1];d=json.load(open(p));d['base_sha']=sys
 
 **Step 2 — Run the deterministic spine** (coordinator responsibility, once per audit run).
 Runs against the **clean main checkout** — no audit worktrees exist yet (see M3 step 5).
-The spine excludes vendored/generated dirs and stale worktrees per-tool AND applies a
-junk-path post-filter (`scripts/spine/exclude.py`); it also reports per-tool timing +
-finding counts to stderr so a slow tool is visible immediately, not mistaken for a hang:
+The spine excludes vendored/generated dirs (`exclude-dirs.txt`) and vendored/minified
+files by name (`exclude-file-globs.txt`: `*.min.js`, `*.bundle.js`, `*.map`) per-tool, AND
+applies a post-filter (`scripts/spine/exclude.py`) that additionally drops findings on
+`.gitignore`d paths and a looks-minified backstop that drops lint/SAST findings on minified
+vendored files not caught by name (e.g. `js-dos.js`). gitleaks runs with a generated config
+that allowlists gitignored files, so a never-committed `.env.local` is never reported as a
+leaked credential. The spine also reports per-tool timing + finding counts to stderr so a
+slow tool is visible immediately, not mistaken for a hang:
 ```bash
 # Compute union of tools[] across all selected packs
 SPINE_TOOLS=$(python3 - "$AUDIT_DIR/current/selected-packs.json" << 'PYEOF'

--- a/modules/commands-extra/skills/audit/scripts/spine/exclude-file-globs.txt
+++ b/modules/commands-extra/skills/audit/scripts/spine/exclude-file-globs.txt
@@ -1,0 +1,21 @@
+# CCGM audit spine -- canonical excluded FILE-GLOB list (single source of truth).
+#
+# Companion to exclude-dirs.txt. These globs match vendored or generated files
+# by NAME, regardless of which directory they live in -- the directory denylist
+# cannot catch a committed `client/public/js-dos/foo.min.js` because none of its
+# path segments is an excluded dir name. Minified / bundled assets are machine-
+# generated; linting them produces thousands of junk findings (the lem-work run
+# reported 4,828 eqeqeq from minified vendor JS).
+#
+# Consumed by:
+#   - exclude.sh   (sourced by the bash wrappers; builds per-tool exclude flags)
+#   - exclude.py   (path_is_excluded basename match + the run.sh post-filter)
+#
+# Format: one glob per line, matched against the file BASENAME (fnmatch). Blank
+# lines and #-comment lines are ignored.
+*.min.js
+*.min.css
+*.min.mjs
+*.bundle.js
+*.bundle.css
+*.map

--- a/modules/commands-extra/skills/audit/scripts/spine/exclude.py
+++ b/modules/commands-extra/skills/audit/scripts/spine/exclude.py
@@ -2,55 +2,84 @@
 """
 CCGM audit spine -- shared path-exclusion helpers (STDLIB ONLY).
 
-Single source of truth for excluded directory NAMES is `exclude-dirs.txt`
-(same directory).  This module reads that file and provides:
+Single source of truth:
+  - excluded directory NAMES   -> `exclude-dirs.txt`      (same directory)
+  - excluded file-name GLOBS   -> `exclude-file-globs.txt` (same directory)
+
+This module reads those files and provides:
 
   Library:
-    load_excluded_dirs()      -> list[str]   canonical excluded dir names
-    path_is_excluded(path)    -> bool        True if any path SEGMENT is excluded
+    load_excluded_dirs()       -> list[str]   canonical excluded dir names
+    load_excluded_file_globs() -> list[str]   canonical excluded file globs
+    path_is_excluded(path)     -> bool        True if any path SEGMENT is an
+                                              excluded dir OR the basename
+                                              matches an excluded file glob
 
   CLI:
-    exclude.py --gitleaks-config <out>
+    exclude.py --gitleaks-config <out> [<repo>]
         Write a gitleaks v8 config that keeps the default ruleset
-        ([extend] useDefault = true) but allowlists every excluded dir by
-        path regex.  Dropped gitleaks from 22 min -> 34 s in the field report.
+        ([extend] useDefault = true) but allowlists, by path regex:
+          - every excluded dir + file glob (vendored/generated/worktree), and
+          - when <repo> is a git repo, every GITIGNORED path. A "leaked
+            credential" describes committed/tracked content; a gitignored,
+            never-committed file like .env.local must not be reported as one.
 
-    exclude.py --filter <in.jsonl> <out.jsonl>
+    exclude.py --filter <in.jsonl> <out.jsonl> [<repo>]
         Coordinator-side junk-path post-filter (defense-in-depth, #1).
         Drops FINDING records whose location.path contains an excluded
-        segment; passes through every record with a "type" field
-        (provenance, coverage_gap, skipped) untouched.  Prints a one-line
+        segment, matches an excluded file glob, or -- when <repo> is given --
+        is gitignored. Passes through every record with a "type" field
+        (provenance, coverage_gap, skipped) untouched. Prints a one-line
         summary to stderr: "filter-excluded: dropped N junk-path finding(s)".
 
 The wrappers that walk the filesystem also apply per-tool exclusion flags
-(built from the same list by exclude.sh) so the tools never SCAN the junk
-dirs in the first place -- that is the performance fix.  This filter is the
+(built from the same lists by exclude.sh) so the tools never SCAN the junk
+paths in the first place -- that is the performance fix. This filter is the
 correctness backstop that catches anything a tool's own ignore logic misses.
 """
 
+import fnmatch
 import json
 import os
 import re
+import subprocess
 import sys
 
 _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 _EXCLUDE_LIST = os.path.join(_SCRIPT_DIR, "exclude-dirs.txt")
+_EXCLUDE_GLOBS = os.path.join(_SCRIPT_DIR, "exclude-file-globs.txt")
+
+
+def _read_list(path):
+    """Read a list file (one entry per line; # comments and blanks ignored)."""
+    out = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for raw in fh:
+                line = raw.split("#", 1)[0].strip()
+                if line:
+                    out.append(line)
+    except OSError:
+        return None
+    return out
 
 
 def load_excluded_dirs():
     """Return the canonical excluded directory names from exclude-dirs.txt."""
-    dirs = []
-    try:
-        with open(_EXCLUDE_LIST, encoding="utf-8") as fh:
-            for raw in fh:
-                line = raw.split("#", 1)[0].strip()
-                if line:
-                    dirs.append(line)
-    except OSError:
+    dirs = _read_list(_EXCLUDE_LIST)
+    if dirs is None:
         # Fall back to a hard-coded minimal set so the filter never silently
         # becomes a no-op if the list file is missing.
         dirs = ["node_modules", ".git", ".claude", ".audit", "dist", "build"]
     return dirs
+
+
+def load_excluded_file_globs():
+    """Return the canonical excluded file globs from exclude-file-globs.txt."""
+    globs = _read_list(_EXCLUDE_GLOBS)
+    if globs is None:
+        globs = ["*.min.js", "*.min.css", "*.bundle.js"]
+    return globs
 
 
 def _build_segment_matcher(dirs):
@@ -61,37 +90,169 @@ def _build_segment_matcher(dirs):
 
 
 _EXCLUDED_DIRS = load_excluded_dirs()
+_EXCLUDED_FILE_GLOBS = load_excluded_file_globs()
 _SEGMENT_RE = _build_segment_matcher(_EXCLUDED_DIRS)
 
 
 def path_is_excluded(path):
-    """True if any segment of `path` is an excluded directory name."""
+    """True if any segment of `path` is an excluded directory name, or the
+    basename matches an excluded file glob."""
     if not path:
         return False
     normalized = str(path).replace("\\", "/")
-    return bool(_SEGMENT_RE.search(normalized))
+    if _SEGMENT_RE.search(normalized):
+        return True
+    base = normalized.rsplit("/", 1)[-1]
+    for glob in _EXCLUDED_FILE_GLOBS:
+        if fnmatch.fnmatch(base, glob):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Gitignore awareness
+# ---------------------------------------------------------------------------
+
+def gitignored_entries(repo):
+    """Return repo-relative gitignored paths, or [] when `repo` is not a git
+    repo / git is unavailable.
+
+    Uses `--directory` so a fully-ignored directory collapses to a single
+    entry (e.g. "node_modules/") instead of every file underneath it -- keeps
+    the list small on real repos. Directory entries keep their trailing slash.
+    """
+    if not repo or not os.path.isdir(repo):
+        return []
+    try:
+        proc = subprocess.run(
+            [
+                "git", "-C", repo, "ls-files", "-z",
+                "--others", "--ignored", "--exclude-standard", "--directory",
+                "--", ".",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except (OSError, ValueError):
+        return []
+    if proc.returncode != 0 or not proc.stdout:
+        return []
+    raw = proc.stdout.decode("utf-8", "replace")
+    return [e for e in raw.split("\0") if e]
+
+
+# ---------------------------------------------------------------------------
+# Looks-minified heuristic
+# ---------------------------------------------------------------------------
+
+# A line longer than this in the file's leading bytes marks it as machine-
+# generated/minified. Real hand-written source rarely exceeds a few hundred
+# chars; vendored bundles like js-dos run to 100k+ char lines.
+_MINIFIED_MAX_LINE = 1000
+_MINIFIED_READ_BYTES = 262144  # inspect only the first 256 KB
+
+
+def looks_minified(abs_path, cache):
+    """True if the file at abs_path looks machine-minified (a very long line in
+    its leading bytes). Memoized via the caller-supplied `cache` dict so a file
+    with hundreds of findings is read once."""
+    if abs_path in cache:
+        return cache[abs_path]
+    result = False
+    try:
+        with open(abs_path, encoding="utf-8", errors="replace") as fh:
+            chunk = fh.read(_MINIFIED_READ_BYTES)
+        for line in chunk.split("\n"):
+            if len(line) >= _MINIFIED_MAX_LINE:
+                result = True
+                break
+    except OSError:
+        result = False
+    cache[abs_path] = result
+    return result
+
+
+def _path_is_gitignored(path, entries):
+    """True if `path` equals or sits under any gitignored entry."""
+    if not path:
+        return False
+    p = str(path).replace("\\", "/").lstrip("./")
+    for e in entries:
+        clean = e.rstrip("/")
+        if not clean:
+            continue
+        if e.endswith("/"):
+            if p == clean or p.startswith(clean + "/"):
+                return True
+        elif p == clean:
+            return True
+    return False
 
 
 # ---------------------------------------------------------------------------
 # CLI: gitleaks config
 # ---------------------------------------------------------------------------
 
-def _write_gitleaks_config(out_path):
-    dirs = load_excluded_dirs()
+def _regex_escape_path(path):
+    """Escape a repo-relative path into a literal RE2 sub-pattern (slashes kept)."""
+    return re.sub(r"([.^$*+?()\[\]{}|\\])", r"\\\1", path)
+
+
+def _glob_to_basename_regex(glob):
+    """Convert a simple basename glob (e.g. *.min.js) into an RE2 sub-pattern.
+    `*` -> any run of non-slash chars, `?` -> one non-slash char, all else
+    literal. Avoids fnmatch.translate, whose (?s:...)\\Z wrapper is not a
+    valid embeddable RE2 fragment."""
+    out = []
+    for ch in glob:
+        if ch == "*":
+            out.append("[^/]*")
+        elif ch == "?":
+            out.append("[^/]")
+        else:
+            out.append(re.escape(ch))
+    return "".join(out)
+
+
+def _gitleaks_allowlist_paths(repo):
+    """Build the list of allowlist path regexes for the gitleaks config."""
+    paths = []
+    # Excluded directories: match the dir anywhere in the path.
+    for d in load_excluded_dirs():
+        paths.append("(^|/){0}(/|$)".format(_regex_escape_path(d)))
+    # Excluded file globs: match the basename at the end of the path.
+    for glob in load_excluded_file_globs():
+        paths.append("(^|/){0}$".format(_glob_to_basename_regex(glob)))
+    # Gitignored paths: a leaked credential must be committed/tracked, never a
+    # gitignored local file (e.g. .env.local). Skip ones already covered above.
+    for e in gitignored_entries(repo):
+        clean = e.rstrip("/")
+        if not clean or path_is_excluded(clean):
+            continue
+        esc = _regex_escape_path(clean)
+        if e.endswith("/"):
+            paths.append("(^|/){0}(/|$)".format(esc))
+        else:
+            paths.append("(^|/){0}$".format(esc))
+    return paths
+
+
+def _write_gitleaks_config(out_path, repo=None):
     lines = [
-        "# Auto-generated by exclude.py from exclude-dirs.txt. Do not edit by hand.",
-        "# Keeps gitleaks' default ruleset; allowlists vendored/generated/worktree dirs.",
+        "# Auto-generated by exclude.py from exclude-dirs.txt + exclude-file-globs.txt.",
+        "# Do not edit by hand. Keeps gitleaks' default ruleset; allowlists",
+        "# vendored/generated/worktree paths and gitignored (never-committed) files.",
         "[extend]",
         "useDefault = true",
         "",
         "[allowlist]",
-        'description = "skip vendored/generated/worktree dirs (CCGM audit spine)"',
+        'description = "skip vendored/generated/worktree/gitignored paths (CCGM audit spine)"',
         "paths = [",
     ]
-    for d in dirs:
-        esc = d.replace(".", r"\.")
+    for pat in _gitleaks_allowlist_paths(repo):
         # Triple-quoted TOML string so backslashes are literal (no escaping).
-        lines.append("    '''(^|/){0}(/|$)''',".format(esc))
+        lines.append("    '''{0}''',".format(pat))
     lines.append("]")
     with open(out_path, "w", encoding="utf-8") as fh:
         fh.write("\n".join(lines) + "\n")
@@ -101,9 +262,11 @@ def _write_gitleaks_config(out_path):
 # CLI: JSONL junk-path filter
 # ---------------------------------------------------------------------------
 
-def _filter_jsonl(in_path, out_path):
+def _filter_jsonl(in_path, out_path, repo=None):
     dropped = 0
     kept = 0
+    entries = gitignored_entries(repo) if repo else []
+    minified_cache = {}
     with open(in_path, encoding="utf-8") as fin, \
             open(out_path, "w", encoding="utf-8") as fout:
         for raw in fin:
@@ -120,7 +283,20 @@ def _filter_jsonl(in_path, out_path):
             # always pass through; they have no location to judge.
             if isinstance(rec, dict) and "type" not in rec:
                 path = (rec.get("location") or {}).get("path", "")
-                if path_is_excluded(path):
+                drop = path_is_excluded(path) or _path_is_gitignored(path, entries)
+                # Looks-minified backstop: drop findings on vendored/minified files
+                # that no name/dir rule caught (e.g. client/public/js-dos/js-dos.js
+                # -- minified but not *.min.js, not in an excluded dir). Minified
+                # bundles are generated/vendored, not authored source, so lint and
+                # code-pattern (SAST) findings there are noise. SECRETS are kept: a
+                # committed credential is actionable regardless of minification.
+                # Needs repo to resolve the relative path to file content.
+                if not drop and repo and path \
+                        and not str(rec.get("check_id", "")).startswith("secrets/"):
+                    abs_path = os.path.join(repo, path)
+                    if looks_minified(abs_path, minified_cache):
+                        drop = True
+                if drop:
                     dropped += 1
                     continue
                 kept += 1
@@ -136,15 +312,17 @@ def _filter_jsonl(in_path, out_path):
 
 def main(argv):
     if len(argv) >= 3 and argv[1] == "--gitleaks-config":
-        _write_gitleaks_config(argv[2])
+        repo = argv[3] if len(argv) >= 4 else None
+        _write_gitleaks_config(argv[2], repo)
         return 0
     if len(argv) >= 4 and argv[1] == "--filter":
-        _filter_jsonl(argv[2], argv[3])
+        repo = argv[4] if len(argv) >= 5 else None
+        _filter_jsonl(argv[2], argv[3], repo)
         return 0
     sys.stderr.write(
         "Usage:\n"
-        "  exclude.py --gitleaks-config <out.toml>\n"
-        "  exclude.py --filter <in.jsonl> <out.jsonl>\n"
+        "  exclude.py --gitleaks-config <out.toml> [<repo>]\n"
+        "  exclude.py --filter <in.jsonl> <out.jsonl> [<repo>]\n"
     )
     return 2
 

--- a/modules/commands-extra/skills/audit/scripts/spine/exclude.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/exclude.sh
@@ -21,30 +21,65 @@
 # Resolve our own directory even when sourced.
 _CCGM_EXCLUDE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _CCGM_EXCLUDE_LIST="$_CCGM_EXCLUDE_DIR/exclude-dirs.txt"
+_CCGM_EXCLUDE_GLOBS="$_CCGM_EXCLUDE_DIR/exclude-file-globs.txt"
+
+# Read a one-entry-per-line list file into the array named by $1 (comments and
+# blank lines stripped). Bash-3.2-portable (no namerefs): appends via eval-free
+# `read -r` loop targeting a temporary, then assigns the caller's array.
+_ccgm_read_list() {
+  local _file="$1"
+  CCGM_LIST_RESULT=()
+  [[ -f "$_file" ]] || return 0
+  local _line
+  while read -r _line || [[ -n "$_line" ]]; do
+    _line="${_line%%#*}"                          # strip comments
+    _line="${_line#"${_line%%[![:space:]]*}"}"    # ltrim
+    _line="${_line%"${_line##*[![:space:]]}"}"    # rtrim
+    [[ -z "$_line" ]] && continue
+    CCGM_LIST_RESULT+=("$_line")
+  done < "$_file"
+}
 
 # Canonical excluded directory NAMES.
+# The length guard keeps the empty-array assignment nounset-safe on bash 3.2,
+# where "${arr[@]}" on an empty array errors under `set -u`.
 CCGM_EXCLUDE_DIRS=()
-if [[ -f "$_CCGM_EXCLUDE_LIST" ]]; then
-  while read -r _ccgm_line || [[ -n "$_ccgm_line" ]]; do
-    _ccgm_line="${_ccgm_line%%#*}"                              # strip comments
-    _ccgm_line="${_ccgm_line#"${_ccgm_line%%[![:space:]]*}"}"   # ltrim
-    _ccgm_line="${_ccgm_line%"${_ccgm_line##*[![:space:]]}"}"   # rtrim
-    [[ -z "$_ccgm_line" ]] && continue
-    CCGM_EXCLUDE_DIRS+=("$_ccgm_line")
-  done < "$_CCGM_EXCLUDE_LIST"
+_ccgm_read_list "$_CCGM_EXCLUDE_LIST"
+if [[ ${#CCGM_LIST_RESULT[@]} -gt 0 ]]; then
+  CCGM_EXCLUDE_DIRS=("${CCGM_LIST_RESULT[@]}")
+else
+  # Fallback (mirrors exclude.py): never leave the dir list empty, so the
+  # unguarded `for d in "${CCGM_EXCLUDE_DIRS[@]}"` loops below stay nounset-safe
+  # on bash 3.2 and exclusion degrades gracefully if the list file is missing.
+  CCGM_EXCLUDE_DIRS=(node_modules .git .claude .audit dist build)
+fi
+
+# Canonical excluded file-name GLOBS (e.g. *.min.js) -- caught by basename
+# regardless of directory, so a committed client/public/js-dos/foo.min.js is
+# excluded even though none of its path segments is an excluded dir name.
+CCGM_EXCLUDE_FILE_GLOBS=()
+_ccgm_read_list "$_CCGM_EXCLUDE_GLOBS"
+if [[ ${#CCGM_LIST_RESULT[@]} -gt 0 ]]; then
+  CCGM_EXCLUDE_FILE_GLOBS=("${CCGM_LIST_RESULT[@]}")
 fi
 
 # Each function below sets the global array CCGM_FLAGS to the tool-specific
 # exclusion flags.  Callers read CCGM_FLAGS immediately after calling.
 
 # eslint: --ignore-pattern globs (work with --no-config-lookup).  Match both
-# top-level (<dir>/**) and nested (**/<dir>/**) occurrences.
+# top-level (<dir>/**) and nested (**/<dir>/**) occurrences, plus file globs
+# (**/*.min.js) so vendored minified files outside an excluded dir are skipped.
 ccgm_eslint_ignore_args() {
   CCGM_FLAGS=()
-  local d
+  local d g
   for d in "${CCGM_EXCLUDE_DIRS[@]}"; do
     CCGM_FLAGS+=(--ignore-pattern "$d/**" --ignore-pattern "**/$d/**")
   done
+  if [[ ${#CCGM_EXCLUDE_FILE_GLOBS[@]} -gt 0 ]]; then
+    for g in "${CCGM_EXCLUDE_FILE_GLOBS[@]}"; do
+      CCGM_FLAGS+=(--ignore-pattern "**/$g")
+    done
+  fi
 }
 
 # bandit: -x / --exclude takes one comma-separated list of path globs.
@@ -61,13 +96,19 @@ ccgm_bandit_exclude_csv() {
   done
 }
 
-# trivy: --skip-dirs takes a doublestar glob, repeatable.
+# trivy: --skip-dirs takes a doublestar glob, repeatable; --skip-files for the
+# vendored minified file globs.
 ccgm_trivy_skip_args() {
   CCGM_FLAGS=()
-  local d
+  local d g
   for d in "${CCGM_EXCLUDE_DIRS[@]}"; do
     CCGM_FLAGS+=(--skip-dirs "**/$d/**" --skip-dirs "$d/**")
   done
+  if [[ ${#CCGM_EXCLUDE_FILE_GLOBS[@]} -gt 0 ]]; then
+    for g in "${CCGM_EXCLUDE_FILE_GLOBS[@]}"; do
+      CCGM_FLAGS+=(--skip-files "**/$g")
+    done
+  fi
 }
 
 # checkov: --skip-path takes a regex, repeatable.
@@ -80,13 +121,18 @@ ccgm_checkov_skip_args() {
   done
 }
 
-# semgrep: --exclude takes a path/basename glob, repeatable.
+# semgrep: --exclude takes a path/basename glob, repeatable (dirs + file globs).
 ccgm_semgrep_exclude_args() {
   CCGM_FLAGS=()
-  local d
+  local d g
   for d in "${CCGM_EXCLUDE_DIRS[@]}"; do
     CCGM_FLAGS+=(--exclude "$d")
   done
+  if [[ ${#CCGM_EXCLUDE_FILE_GLOBS[@]} -gt 0 ]]; then
+    for g in "${CCGM_EXCLUDE_FILE_GLOBS[@]}"; do
+      CCGM_FLAGS+=(--exclude "$g")
+    done
+  fi
 }
 
 # find(1): prune predicate elements for find-based wrappers.  Emits

--- a/modules/commands-extra/skills/audit/scripts/spine/run.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/run.sh
@@ -203,13 +203,15 @@ done
 # ---------------------------------------------------------------------------
 # Coordinator-side junk-path post-filter (#1, defense-in-depth).
 # Drops any FINDING whose location.path contains an excluded segment
-# (node_modules, stale .claude/worktrees, .audit, dist, ...).  Provenance and
-# coverage_gap notes pass through untouched.  This is the correctness backstop
-# for anything a tool's own ignore logic missed; the per-wrapper exclusion
-# flags are the performance half (the tools never scan those paths).
+# (node_modules, stale .claude/worktrees, .audit, dist, ...), matches an
+# excluded file glob (*.min.js), or -- via REPO_ROOT -- is gitignored.
+# Provenance and coverage_gap notes pass through untouched.  This is the
+# correctness backstop for anything a tool's own ignore logic missed; the
+# per-wrapper exclusion flags are the performance half (the tools never scan
+# those paths).
 # ---------------------------------------------------------------------------
 # The filter prints its drop/keep summary to stderr (observability, #6).
-if python3 "$SCRIPT_DIR/exclude.py" --filter "$AGTMPFILE" "$FILTEREDFILE"; then
+if python3 "$SCRIPT_DIR/exclude.py" --filter "$AGTMPFILE" "$FILTEREDFILE" "$REPO_ROOT"; then
   EMIT_FILE="$FILTEREDFILE"
 else
   # Filter unavailable -- emit unfiltered rather than lose data.

--- a/modules/commands-extra/skills/audit/scripts/spine/wrap-gitleaks.sh
+++ b/modules/commands-extra/skills/audit/scripts/spine/wrap-gitleaks.sh
@@ -57,7 +57,12 @@ trap 'rm -f "$TMPFILE" "$CONFIGFILE"' EXIT
 # without a config.  We generate a config that keeps the default ruleset
 # ([extend] useDefault = true) and allowlists every canonical excluded dir;
 # this dropped gitleaks from 22 min -> 34 s.
-python3 "$SCRIPT_DIR/exclude.py" --gitleaks-config "$CONFIGFILE" 2>/dev/null || true
+#
+# Passing REPO_ROOT also allowlists GITIGNORED paths: a working-tree scan would
+# otherwise report a gitignored, never-committed .env.local as a CRITICAL
+# leaked-credential. A leaked credential describes committed/tracked content,
+# so gitignored local files must not be flagged (field report #726).
+python3 "$SCRIPT_DIR/exclude.py" --gitleaks-config "$CONFIGFILE" "$REPO_ROOT" 2>/dev/null || true
 
 # Determine scan mode: history or working-tree
 HISTORY_MODE="${CCGM_GITLEAKS_HISTORY:-0}"

--- a/modules/commands-extra/skills/audit/tests/test-spine-excludes.sh
+++ b/modules/commands-extra/skills/audit/tests/test-spine-excludes.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# CCGM audit spine -- exclude/scope regression test (issue #726)
+#
+# Builds a tiny fixture repo containing:
+#   - a real source file with one genuine eqeqeq violation (tracked)
+#   - a .audit/worktrees/x.js copy (untracked, NOT gitignored)
+#   - a dist/app.min.js minified file (gitignored)
+#   - a committed public/vendor/lib.min.js vendored file (tracked)
+#   - a gitignored .env.local with a fake API key
+#
+# Runs scripts/spine/run.sh --tools eslint,semgrep,gitleaks and asserts:
+#   - exactly the ONE real source finding is reported
+#     (no findings under .audit/, dist/, public/vendor, or *.min.js)
+#   - gitleaks does NOT emit a leaked-credential finding for .env.local
+#
+# Exit code: 0 = all tests passed, 1 = failure
+#
+# This test FAILS on main (eslint lints the generated/vendored copies and
+# gitleaks flags the gitignored .env.local) and PASSES after the spine-scope fix.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPINE_DIR="$SCRIPT_DIR/../scripts/spine"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+  printf '  [PASS] %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  ERRORS+=("$1")
+  FAIL=$((FAIL + 1))
+}
+
+# ---------------------------------------------------------------------------
+# eslint is required to surface the real finding. Without it the "exactly one
+# finding" assertion is meaningless -- skip the whole test gracefully.
+# ---------------------------------------------------------------------------
+if ! command -v eslint > /dev/null 2>&1; then
+  printf 'eslint not installed -- spine-scope regression test skipped.\n'
+  exit 0
+fi
+if ! command -v git > /dev/null 2>&1; then
+  printf 'git not installed -- spine-scope regression test skipped.\n'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Build the fixture repo
+# ---------------------------------------------------------------------------
+# Resolve symlinks (macOS /tmp -> /private/tmp) so the path eslint reports
+# matches the repo_root the parser strips -- otherwise location.path stays
+# absolute and the path assertions test the symlink quirk, not the scoping.
+TESTRUN_TMPDIR="$(cd "$(mktemp -d /tmp/ccgm-excludes-XXXXXX)" && pwd -P)"
+trap 'rm -rf "$TESTRUN_TMPDIR"' EXIT
+
+FIX="$TESTRUN_TMPDIR/repo"
+mkdir -p "$FIX/src" "$FIX/dist" "$FIX/client/public/jsdos" "$FIX/.audit/worktrees"
+
+# Real, tracked source with a genuine eqeqeq violation.
+cat > "$FIX/src/real.js" <<'EOF'
+function check(a, b) {
+  if (a == b) {
+    return true;
+  }
+  return false;
+}
+EOF
+
+# Audit-internal coordination copy (untracked, NOT gitignored). eqeqeq present.
+cat > "$FIX/.audit/worktrees/x.js" <<'EOF'
+function check(a, b) {
+  if (a == b) {
+    return true;
+  }
+  return false;
+}
+EOF
+
+# Generated, gitignored, minified file under an excluded dir (single long line with ==).
+printf 'var a=1,b=2,c=3,d=4,e=5,f=6,g=7,h=8,i=9,j=10;function z(){if(a==b){return c==d}return e==f}var k=z();console.log(k==g);\n' > "$FIX/dist/app.min.js"
+
+# Vendored-but-committed minified file NOT under any excluded directory name
+# (mirrors the lem-work client/public/js-dos/*.min.js case). Only the *.min.js
+# file-glob exclude can drop this -- the directory denylist cannot.
+printf 'var p=1,q=2,r=3,s=4,t=5,u=6,v=7,w=8,x=9,y=10;function m(){if(p==q){return r==s}return t==u}var n=m();console.log(n==v);\n' > "$FIX/client/public/jsdos/engine.min.js"
+
+# Vendored minified file NOT named *.min.js (mirrors js-dos/js-dos.js exactly).
+# Neither the directory denylist nor the *.min.js glob catches it -- only the
+# looks-minified heuristic (a single >1000-char line) drops its lint findings.
+python3 - "$FIX/client/public/jsdos/jsdos.js" <<'PYEOF'
+import sys
+# One ~3000-char minified line containing many == (each an eqeqeq violation).
+line = "var z=0;" + "".join("if(a%d==b%d){z++}" % (i, i) for i in range(200)) + "\n"
+with open(sys.argv[1], "w") as fh:
+    fh.write(line)
+PYEOF
+
+# Gitignored local env file with a fake GitHub PAT (36 chars after ghp_).
+printf 'GITHUB_TOKEN=ghp_FakeTokenForTesting1234567890abcdefX\n' > "$FIX/.env.local"
+
+cat > "$FIX/.gitignore" <<'EOF'
+dist/
+.env.local
+EOF
+
+# Commit tracked content. dist/ and .env.local are gitignored (never committed);
+# .audit/ is left untracked. The vendored engine.min.js is committed (tracked).
+(
+  cd "$FIX"
+  git init -q
+  git config user.email "test@example.com"
+  git config user.name "test"
+  git add src/real.js client/public/jsdos/engine.min.js client/public/jsdos/jsdos.js .gitignore
+  git commit -q -m "fixture" --no-verify
+) > /dev/null 2>&1
+
+# ---------------------------------------------------------------------------
+# Run the spine
+# ---------------------------------------------------------------------------
+printf '\nSpine-scope regression (issue #726): eslint,semgrep,gitleaks on fixture\n'
+
+OUT="$TESTRUN_TMPDIR/out.jsonl"
+set +e
+bash "$SPINE_DIR/run.sh" \
+  --repo "$FIX" \
+  --tools "eslint,semgrep,gitleaks" \
+  --output "$OUT" \
+  2>/dev/null
+RUN_EXIT=$?
+set -e
+
+if [[ $RUN_EXIT -eq 0 ]]; then
+  pass "run.sh exits 0"
+else
+  fail "run.sh exits $RUN_EXIT (expected 0)"
+fi
+
+# ---------------------------------------------------------------------------
+# Analyze findings with python (deterministic JSON parsing)
+# ---------------------------------------------------------------------------
+ANALYSIS="$(python3 - "$OUT" <<'PYEOF'
+import json, sys
+
+findings = []
+with open(sys.argv[1]) as fh:
+    for raw in fh:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "type" not in obj:
+            findings.append(obj)
+
+def path_of(f):
+    return (f.get("location") or {}).get("path", "")
+
+def is_excluded(p):
+    if p.startswith(".audit/") or "/.audit/" in p:
+        return True
+    if p.startswith("dist/") or "/dist/" in p:
+        return True
+    if p.endswith(".min.js") or p.endswith(".min.css") or p.endswith(".bundle.js"):
+        return True
+    return False
+
+excluded = [f for f in findings if is_excluded(path_of(f))]
+leaked = [f for f in findings if f.get("check_id") == "secrets/leaked-credential"]
+eqeqeq = [f for f in findings if f.get("check_id") == "lint/eqeqeq"]
+
+nonreal = [f for f in findings if path_of(f) != "src/real.js"]
+
+print("TOTAL=%d" % len(findings))
+print("EXCLUDED=%d" % len(excluded))
+print("LEAKED=%d" % len(leaked))
+print("EQEQEQ=%d" % len(eqeqeq))
+print("NONREAL=%d" % len(nonreal))
+# real finding path
+real_ok = any(path_of(f) == "src/real.js" for f in eqeqeq)
+print("REAL_OK=%d" % (1 if real_ok else 0))
+# Dump non-real / excluded / leaked paths for debugging
+for f in nonreal:
+    print("NONREAL_PATH=%s|%s" % (f.get("check_id", "?"), path_of(f)))
+for f in leaked:
+    print("LEAKED_PATH=%s" % path_of(f))
+PYEOF
+)"
+
+get() { printf '%s\n' "$ANALYSIS" | grep "^$1=" | head -1 | cut -d= -f2; }
+
+TOTAL="$(get TOTAL)"
+EXCLUDED="$(get EXCLUDED)"
+LEAKED="$(get LEAKED)"
+REAL_OK="$(get REAL_OK)"
+
+# Debug context on failure
+print_debug() {
+  printf '  --- analysis ---\n'
+  printf '%s\n' "$ANALYSIS" | sed 's/^/    /'
+}
+
+# Assertion 1: no findings in generated/vendored/.audit paths
+if [[ "$EXCLUDED" == "0" ]]; then
+  pass "no findings under .audit/, dist/, public/vendor, or *.min.js"
+else
+  fail "found $EXCLUDED finding(s) in excluded paths (expected 0)"
+  print_debug
+fi
+
+# Assertion 2: the real source finding is present
+if [[ "$REAL_OK" == "1" ]]; then
+  pass "real eqeqeq finding in src/real.js is reported"
+else
+  fail "real eqeqeq finding in src/real.js is missing"
+  print_debug
+fi
+
+# Assertion 3: gitleaks does not report the gitignored .env.local as a leak
+if [[ "$LEAKED" == "0" ]]; then
+  pass "no gitleaks leaked-credential finding (gitignored .env.local not flagged)"
+else
+  fail "found $LEAKED leaked-credential finding(s) (expected 0; .env.local is gitignored)"
+  print_debug
+fi
+
+# Assertion 4: exactly one finding total (the real source eqeqeq)
+if [[ "$TOTAL" == "1" ]]; then
+  pass "exactly one finding total"
+else
+  fail "found $TOTAL finding(s) total (expected exactly 1)"
+  print_debug
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n-------------------------------------------------\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  printf '\nFailed tests:\n'
+  for err in "${ERRORS[@]}"; do
+    printf '  - %s\n' "$err"
+  done
+  exit 1
+fi
+
+printf 'All tests passed.\n'
+exit 0


### PR DESCRIPTION
## Summary

Closes #726. Builds on the merged #724 path-exclusion subsystem to close two remaining noise sources a real `/audit` run against lem-work still hit. #724 added a directory-name denylist + per-tool flags + post-filter; it did **not** handle (C) vendored/minified files outside an excluded dir, or (D) gitleaks reporting gitignored files.

## Root causes (post-#724)

1. **`*.min.js` outside an excluded dir.** The dir denylist (`exclude-dirs.txt`) cannot exclude a committed `client/public/js-dos/*.min.js` — no path segment is an excluded dir name. lem-work's js-dos library (190k-char minified lines) produced **685 eslint findings**.
2. **gitleaks flags gitignored files.** `gitleaks detect --no-git` scans the working tree including gitignored files; the #724 config only allowlisted excluded *dirs*. A never-committed, gitignored `.env.local` was reported as a CRITICAL `secrets/leaked-credential`. A leaked credential describes committed/tracked content.

## Changes

- **`exclude-file-globs.txt`** (new single-source-of-truth): `*.min.js`, `*.bundle.js`, `*.map`, … — matched by basename regardless of directory.
- **`exclude.sh`**: eslint/semgrep/trivy flag builders now also emit file-glob excludes. Bash-3.2 nounset-safe (length-guarded array assignment + hardcoded dir fallback if the list file is missing).
- **`exclude.py`**:
  - `path_is_excluded()` also matches the file globs (basename).
  - **Looks-minified backstop** in `--filter`: drops findings on minified files (a >1000-char line) that no name/dir rule caught — e.g. js-dos. Scoped to drop everything **except** `secrets/*`, so a committed credential inside a minified bundle is still surfaced.
  - `--filter` and `--gitleaks-config` take an optional `<repo>`: the filter drops findings on **gitignored** paths; the gitleaks config allowlists every gitignored path so `.env.local` is never reported as a leak.
- **`run.sh`** / **`wrap-gitleaks.sh`**: pass `REPO_ROOT` into the filter and config generator.

Config-isolation guarantees are unchanged: `--no-config-lookup`, explicit `--config` (never `--config auto`), paths passed as argv, no `eval`. All wrappers shellcheck-clean.

## Tooling-coverage note

Verified each tree-walking wrapper. eslint/semgrep/trivy get file-glob flags at the tool level; the run.sh post-filter (`.audit` + dir + file-glob + gitignored + looks-minified) is the always-on correctness backstop for **all** tools, so bandit/checkov/hadolint/knip etc. are covered even where a tool-level flag isn't wired. Directory-scoped tools (sqlfluff, squawk, zizmor, pinact, actionlint) and manifest-scoped tools (dep-audit, pip/cargo/bundler-audit, govulncheck) never recurse into `.audit/` and are additionally guarded by the backstop.

## Test plan

TDD — failing regression test first, then fix:

- **New** `tests/test-spine-excludes.sh`: fixture repo with a real `eqeqeq`, a `.audit/worktrees/` copy, a gitignored `dist/*.min.js`, a vendored `*.min.js`, a vendored js-dos-style minified `.js` (no `.min`), and a gitignored `.env.local` with a fake PAT → asserts exactly the one real finding survives and no `.env.local` gitleaks hit. Fails on the pre-fix tree; passes after. Runs under bash 5 and bash 3.2.
- Existing suites green: `test-exclusion.sh` (12), `test-spine.sh` (36, incl. shellcheck on every wrapper), `test-merge.sh` (51), `test-modules.sh` (1479), `test-audit-manifest-complete.sh` (3), `test-no-personal-data.sh`.
- **lem-work acceptance re-run** (`--tools eslint,semgrep,gitleaks,dep-audit,zizmor,pinact,actionlint`): eslint 685 vendored findings → **0 in output**; 9 vendored js-dos semgrep findings dropped; gitleaks `.env.local` hit **gone**; real findings intact (dep-audit ×24, zizmor ×18, pinact ×4, actionlint ×1, the **2 worker/src semgrep format-string hits**). 0 surviving junk-path findings.