### PR TITLE
#728: sync-ccgm-canonical fires on cd-prefixed/chained `gh pr merge`

### DIFF
--- a/modules/hooks/hooks/sync-ccgm-canonical.py
+++ b/modules/hooks/hooks/sync-ccgm-canonical.py
@@ -7,7 +7,8 @@ in workspace clones, that canonical checkout drifts unless something pulls it.
 This hook removes the manual sync step.
 
 Triggers when:
-- The Bash command was `gh pr merge ...`
+- The Bash command invokes `gh pr merge ...` in any segment (it is usually
+  `cd <repo>` first, or chained with && / piped to tail -- not the first token)
 - The cwd's git remote points at a repo named "ccgm" (any owner)
 - The canonical clone exists at $CCGM_CANONICAL_DIR (default ~/code/ccgm)
 
@@ -43,6 +44,22 @@ def get_origin_url(cwd: str) -> str | None:
     except (subprocess.SubprocessError, OSError):
         pass
     return None
+
+
+def command_triggers_merge(command: str) -> bool:
+    """True if any segment of `command` invokes `gh pr merge`.
+
+    `gh pr merge` is almost never the first token of the command string -- it is
+    typically `cd <repo>` first (often on its own line) or chained with && / piped
+    to tail. A start-anchored match therefore misses real merges and leaves the
+    canonical clone stale (#728). Split on shell separators (newline ; | &) and
+    check each segment. A false positive only costs one harmless, idempotent
+    ff-only pull, so erring toward matching is safe.
+    """
+    for segment in re.split(r"[\n;|&]+", command):
+        if re.match(r"\s*gh\s+pr\s+merge(\s|$)", segment):
+            return True
+    return False
 
 
 def is_ccgm_repo(cwd: str) -> bool:
@@ -91,7 +108,7 @@ def main() -> None:
         sys.exit(0)
 
     command = (payload.get("tool_input") or {}).get("command", "")
-    if not re.match(r"\s*gh\s+pr\s+merge(\s|$)", command):
+    if not command_triggers_merge(command):
         sys.exit(0)
 
     cwd = payload.get("cwd") or os.getcwd()

--- a/modules/hooks/tests/test-sync-ccgm-canonical.sh
+++ b/modules/hooks/tests/test-sync-ccgm-canonical.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# CI wrapper for the sync-ccgm-canonical hook's python unit tests.
+#
+# CI runs only modules/hooks/tests/*.sh (see .github/workflows/test.yml), so the
+# python test file beside this one (test_sync_ccgm_canonical.py) was never
+# executed on the runner -- which is how the start-anchored matcher bug (#728)
+# shipped undetected. This wrapper runs those tests and propagates their exit
+# code so the hook is actually gated.
+#
+# Run: bash modules/hooks/tests/test-sync-ccgm-canonical.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+python3 "${SCRIPT_DIR}/test_sync_ccgm_canonical.py" -v
+STATUS=$?
+
+if [ "${STATUS}" -eq 0 ]; then
+  echo "test-sync-ccgm-canonical.sh: passed"
+else
+  echo "test-sync-ccgm-canonical.sh: FAILED (exit ${STATUS})"
+fi
+exit "${STATUS}"

--- a/modules/hooks/tests/test_sync_ccgm_canonical.py
+++ b/modules/hooks/tests/test_sync_ccgm_canonical.py
@@ -35,6 +35,42 @@ class TestRepoDetection(unittest.TestCase):
             self.assertFalse(sync.is_ccgm_repo('/any/path'))
 
 
+class TestMergeMatcher(unittest.TestCase):
+    """The trigger must fire when `gh pr merge` is any command segment, not only
+    when the whole command starts with it. Real merges are cd-prefixed or chained
+    (#728)."""
+
+    def test_matches_bare_merge(self):
+        self.assertTrue(sync.command_triggers_merge("gh pr merge 5 --squash"))
+
+    def test_matches_cd_prefixed_multiline(self):
+        # The common shape: cd into the repo, then merge on the next line.
+        self.assertTrue(
+            sync.command_triggers_merge(
+                "cd /repo/clone\ngh pr merge 727 --squash --delete-branch 2>&1 | tail -5"
+            )
+        )
+
+    def test_matches_and_chained(self):
+        self.assertTrue(sync.command_triggers_merge("cd /repo && gh pr merge 5 --squash"))
+
+    def test_matches_piped(self):
+        self.assertTrue(sync.command_triggers_merge("gh pr merge 5 --squash | tail -5"))
+
+    def test_matches_semicolon_chained(self):
+        self.assertTrue(sync.command_triggers_merge("cd /repo ; gh pr merge 5"))
+
+    def test_no_match_other_command(self):
+        self.assertFalse(sync.command_triggers_merge("ls -la"))
+
+    def test_no_match_gh_pr_view(self):
+        self.assertFalse(sync.command_triggers_merge("gh pr view 5"))
+
+    def test_no_match_substring_in_word(self):
+        # "merged" / "mergeable" must not trip the (\s|$) boundary.
+        self.assertFalse(sync.command_triggers_merge("echo gh pr merged"))
+
+
 class TestSyncCanonical(unittest.TestCase):
     def test_skips_when_dir_missing_git(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -79,6 +115,32 @@ class TestHookRouting(unittest.TestCase):
                     {
                         "tool_name": "Bash",
                         "tool_input": {"command": "gh pr merge 1 --squash"},
+                        "cwd": cwd,
+                    },
+                    env={"CCGM_CANONICAL_DIR": missing},
+                )
+                self.assertEqual(result.returncode, 0)
+                self.assertIn("does not exist", result.stderr)
+
+    def test_cd_prefixed_merge_reaches_sync(self):
+        # Regression for #728: a cd-prefixed multiline merge command (the real
+        # shape) must get PAST the matcher. With a missing canonical dir it
+        # reaches the "does not exist" branch -- proof the matcher fired.
+        with tempfile.TemporaryDirectory() as cwd:
+            subprocess.run(["git", "init", "-q", cwd], check=True)
+            subprocess.run(
+                ["git", "-C", cwd, "remote", "add", "origin",
+                 "git@github.com:testuser/ccgm.git"],
+                check=True,
+            )
+            with tempfile.TemporaryDirectory() as fake_home:
+                missing = os.path.join(fake_home, "no-such-dir")
+                result = self._run(
+                    {
+                        "tool_name": "Bash",
+                        "tool_input": {
+                            "command": f"cd {cwd}\ngh pr merge 1 --squash --delete-branch 2>&1 | tail -5"
+                        },
                         "cwd": cwd,
                     },
                     env={"CCGM_CANONICAL_DIR": missing},


### PR DESCRIPTION
## Summary

Closes #728. The `PostToolUse:Bash` hook that fast-forwards the canonical clone (`~/code/ccgm` — the symlink source for `~/.claude/`) after a CCGM PR merges had a start-anchored matcher and so almost never fired. The canonical clone was found **29 commits behind `origin/main`**, meaning the installed config silently lagged ~29 merged PRs.

## Root cause (verified empirically)

```python
if not re.match(r"\s*gh\s+pr\s+merge(\s|$)", command):
    sys.exit(0)
```

`re.match` is start-anchored — it only matches when the command **string starts with** `gh pr merge`. Real merges don't:

| command | old matcher |
|---|---|
| `gh pr merge 5 --squash` | ✅ match (rare) |
| `cd /repo && gh pr merge 5` | ❌ no match |
| `cd /repo`⏎`gh pr merge 5 … \| tail` (the common shape) | ❌ no match |

Confirmed by feeding the hook both payloads: bare merge → syncs ("Already up to date"); real `cd …`⏎`gh pr merge …` → silent no-op. Registration, repo detection, and the sync itself are all correct — only the matcher was wrong.

## Fix

`command_triggers_merge()` splits the command on shell separators (`\n ; | &`) and matches `gh pr merge` as **any** segment. A false positive only costs one harmless, idempotent `ff-only` pull, so it errs toward matching.

## Also: wire the hook's tests into CI

`test_sync_ccgm_canonical.py` existed but **CI only runs `modules/hooks/tests/*.sh`**, so it never executed on the runner — which is how this bug shipped. Added `test-sync-ccgm-canonical.sh` (runs the python tests, propagates exit code) plus regression cases for the `cd`-prefixed, `&&`-chained, piped, and `;`-chained shapes, an `echo gh pr merged` negative, and an end-to-end routing test. All fail on the old matcher, pass on the new.

## Test plan

- `bash modules/hooks/tests/test-sync-ccgm-canonical.sh` → 18 tests pass (failed on old matcher).
- Full hooks suite (`modules/hooks/tests/*.sh`), `test-modules.sh` (1479), `test-no-personal-data.sh` — all green. New wrapper shellcheck-clean.

## Note

This explains the canonical-clone drift flagged during #726/#727. After this merges, the canonical clone needs one manual `git -C ~/code/ccgm merge --ff-only origin/main` to pick up this fix; subsequent merges will auto-sync.