### PR TITLE
#732: docupdate -- xplan Phase 5.7 + adversarial-review dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | **multi-agent** | workflow | Multi-clone parallel agent work with issue claiming, port allocation, /mawf workflow | startup-dashboard |
 | **atdd** | workflow | Agentic Test-Driven Development. /atdd reads Playwright vision specs, iteratively builds app code until all tests pass, then ships | - |
 | **test-vision** | workflow | Vision-driven e2e test suite generation. /test-vision for full repo analysis + parallel test suite creation. /e2e for single-feature spec generation | browser-automation, multi-agent |
-| **xplan** | workflow | Interactive planning framework: discovery interview, deep research, tech stack sign-off, peer review, parallel agent execution. Requires [/deepresearch](#companion-module-deepresearch) | multi-agent |
+| **xplan** | workflow | Interactive planning framework: discovery interview, deep research, tech stack sign-off, constructive peer review + a 3-pass sequential adversarial review, parallel agent execution. Requires [/deepresearch](#companion-module-deepresearch) | multi-agent, adversarial-review |
 | **remote-server** | workflow | SSH access to a configured remote server with /onremote command for health checks and remote task execution | - |
 | **agent-manager** | workflow | [DEPRECATED] Go-based terminal UI (/agents) for monitoring Claude Code agent processes via tmux. Unmaintained; not offered for new installs, kept in-repo for existing users | multi-agent |
 | **cloud-dispatch** | workflow | Delegate GitHub issues to autonomous Claude Code agents on Hetzner Cloud VMs. Includes /dispatch, /dispatch-status, /dispatch-stop, /vm-manage commands | - |

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -48,7 +48,7 @@ Choose a preset (minimal, standard, full, team) or select individual modules fro
 
 Automatically adds any modules required by your selection. Uses a depth-first topological sort with cycle detection. Reports any automatically added dependencies.
 
-For example, selecting `xplan` automatically adds `multi-agent` (its dependency), which adds `startup-dashboard` (multi-agent's dependency).
+For example, selecting `xplan` automatically adds its dependencies `multi-agent` and `adversarial-review`, which in turn add `startup-dashboard` (multi-agent's dependency) and `subagent-patterns` (adversarial-review's dependency).
 
 ### Step 7: Module config prompts
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -499,7 +499,7 @@ Commands installed:
 
 Deep research, planning, and execution framework for complex projects.
 
-**Installs**: 3 command files
+**Installs**: 5 command files + 2 lib files
 
 **What it does**: An interactive, human-in-the-loop planning framework:
 
@@ -510,8 +510,10 @@ Deep research, planning, and execution framework for complex projects.
 - **Phase 2** - Naming ideation (optional)
 - **Phase 2.5/2.6/2.7** - Tech stack sign-off, scope sign-off, multi-agent setup review
 - **Phase 3** - Plan creation with parallelized epics and dependency waves
-- **Phase 4** - Peer review by security, architecture, and business logic agents
-- **Phase 5-6** - Write plan.md, final confirmation gate
+- **Phase 4** - Constructive peer review by security, architecture, and business logic agents (review stage 1 of 2)
+- **Phase 5 (+5.6)** - Write plan.md, then a self-review loop for placeholders and identifier drift
+- **Phase 5.7** - Adversarial review sequence (stage 2 of 2): 3 sequential `adrev-reviewer` passes on Opus 4.8 (max effort), each attacking the plan after the prior pass's fixes are incorporated
+- **Phase 6** - Web review + final confirmation gate
 - **Phase 7** - Execute via parallel agents in separate clones
 - **Phase 8** - Verification, audit, and retrospective
 
@@ -522,10 +524,12 @@ Commands installed:
 | Command | Description |
 |---------|-------------|
 | `/xplan` | Launch the full planning and execution pipeline |
+| `/xplana` | Autonomous alias - `/xplan --autonomous` (full-depth, zero mid-flow prompts) |
 | `/xplan-status` | Check progress on a running or completed plan |
 | `/xplan-resume` | Resume an interrupted plan execution |
+| `/etp` | Execute a ready plan or GitHub issue(s) end-to-end with adversarial PR review |
 
-**Dependencies**: multi-agent (which depends on startup-dashboard)
+**Dependencies**: multi-agent (which depends on startup-dashboard), adversarial-review (which depends on subagent-patterns; provides the `adrev-reviewer` agent for Phase 5.7)
 
 ---
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -65,7 +65,7 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 When you select a module that depends on other modules, the installer automatically includes the dependencies. For example:
 
-- Selecting `xplan` automatically adds `multi-agent` and `startup-dashboard`
+- Selecting `xplan` automatically adds `multi-agent` and `adversarial-review`, plus their dependencies `startup-dashboard` and `subagent-patterns`
 - Selecting `hooks` automatically adds `settings`
 
 You don't need to manually track dependencies. The installer resolves them using topological sorting and reports any additions.


### PR DESCRIPTION
Closes #732

Post-merge `/docupdate` for #730 (xplan adversarial review sequence). Targeted doc-sync only.

## Changes
- **README.md**: xplan module row — dependency column `multi-agent` → `multi-agent, adversarial-review`; description now reflects 'constructive peer review + a 3-pass sequential adversarial review'.
- **docs/modules.md**: added **Phase 5.7** to the xplan phase list; updated Phase 4/5/6 wording for the two-stage review; Dependencies line now includes adversarial-review (→ subagent-patterns, provides `adrev-reviewer`). Fixed pre-existing drift in the same block: 'Installs: 3 command files' → '5 command files + 2 lib files', and added `/xplana` + `/etp` to the command table.
- **docs/presets.md** + **docs/installer.md**: dependency-resolution examples for `xplan` now list the new `adversarial-review` edge and its transitive `subagent-patterns`.

## Test plan
- `tests/test-modules.sh` — 1480 passed, 0 failed
- `tests/test-no-personal-data.sh` — PASS
- Grep confirms no remaining xplan dependency reference implies `multi-agent` as the sole dependency.