### PR TITLE
#739: regenerate stale plugin marketplace manifests (fixes red main)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -405,7 +405,7 @@
     },
     {
       "category": "commands",
-      "description": "/editorial-critique - deep editorial review of long-form writing. 8 parallel analysis passes: prose craft, AI-tell detection, argument architecture, conciseness, data verification, structure, impact, grammar. Scored report with optional auto-fix.",
+      "description": "/editorial-critique - deep editorial review of long-form writing. 8 parallel analysis passes: prose craft, AI-tell detection, argument architecture, conciseness, data verification, structure, impact, grammar. Judges prose against a lean, Hemingway-style house standard over ornate maximalism. Scored report with optional auto-fix.",
       "name": "editorial-critique",
       "source": "./editorial-critique",
       "tags": [

--- a/modules/editorial-critique/.claude-plugin/plugin.json
+++ b/modules/editorial-critique/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "author": {
     "name": "CCGM"
   },
-  "description": "/editorial-critique - deep editorial review of long-form writing. 8 parallel analysis passes: prose craft, AI-tell detection, argument architecture, conciseness, data verification, structure, impact, grammar. Scored report with optional auto-fix.",
+  "description": "/editorial-critique - deep editorial review of long-form writing. 8 parallel analysis passes: prose craft, AI-tell detection, argument architecture, conciseness, data verification, structure, impact, grammar. Judges prose against a lean, Hemingway-style house standard over ornate maximalism. Scored report with optional auto-fix.",
   "displayName": "Editorial Critique",
   "keywords": [
     "commands",


### PR DESCRIPTION
## Summary

`main` has been red since #737 (editorial-critique). That PR updated `modules/editorial-critique/module.json`'s description but the squash-merge did not include the regenerated marketplace manifests, so the CI gate `gen_marketplace.py --check` fails on every push to main — blocking all PRs.

## Changes

Mechanical regeneration only (`python3 modules/plugin-marketplace/lib/gen_marketplace.py`):
- `modules/editorial-critique/.claude-plugin/plugin.json` — description synced to module.json (the Hemingway sentence)
- `.claude-plugin/marketplace.json` — same entry synced

No hand edits; generated artifacts only.

## Test Plan

- `gen_marketplace.py --check` → 'Marketplace files are up to date.'
- `validate_marketplace.py` → all 679 checks passed (71 manifests).
- `tests/test-modules.sh` → 1481 passed, 0 failed.

Closes #739