### PR TITLE
#742: propagate concurrency/rate-limit guidance into all fan-out skills

### DIFF
--- a/modules/agent-native/skills/agent-native-audit/SKILL.md
+++ b/modules/agent-native/skills/agent-native-audit/SKILL.md
@@ -84,6 +84,8 @@ for design guidance.
 
 Dispatch **eight agents in parallel** - two per principle. One agent per pair measures (counts, inventory); the other critiques (examples, violations, fixes). Use `subagent_type: "Explore"` and launch all eight in a single message so they run concurrently.
 
+> **Concurrency — avoid the 429 throttle.** Eight light `Explore` agents is at the safe ceiling for a single parallel wave — acceptable because they are cheap and scoped. Do NOT raise the count, and if you ever switch them to a heavier model / higher reasoning effort, split into two sequential waves of 4 (measure pass, then critique pass). Bursting more than ~5 heavy agents — or many more light ones — trips a server-side rate limit (`Server is temporarily limiting requests · Rate limited`) that fails the whole dispatch; if you hit it, launch as 4+4. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 Pass paths, not file contents (see `modules/subagent-patterns/rules/subagent-patterns.md`). Each agent gets the triage summary, the principle text verbatim from `modules/agent-native/rules/agent-native.md`, and the scoped paths to analyze.
 
 Every agent prompt must end with:

--- a/modules/brand-naming/commands/brand-check.md
+++ b/modules/brand-naming/commands/brand-check.md
@@ -59,7 +59,9 @@ Interpret HTTP codes from SOCIAL section:
 
 ## Phase 2: Web Search Checks (parallel tool calls)
 
-Run ALL of the following WebSearch/WebFetch calls **in parallel tool calls** (batch them into a single response, do not run sequentially):
+Run the following WebSearch/WebFetch calls **in parallel tool calls** (batch them into a single response, do not run sequentially):
+
+> **Concurrency — avoid the 429 throttle.** Batch at most ~4 parallel WebSearch/WebFetch calls per message; if a call returns HTTP 429, wait ~30s and re-issue only the failed queries. (These are tool calls, not agents, but the same burst discipline applies.) See `~/.claude/rules/concurrency-and-rate-limits.md`.
 
 1. **USPTO trademark**: `WebSearch: "{name}" trademark USPTO`
 2. **WIPO trademark**: `WebSearch: "{name}" site:branddb.wipo.int OR "{name}" WIPO trademark`

--- a/modules/brand-naming/commands/brand.md
+++ b/modules/brand-naming/commands/brand.md
@@ -70,6 +70,8 @@ mkdir -p "$WORK_DIR"
 
 Launch 4 parallel agents to explore the word space. Each agent writes results to `$WORK_DIR/`.
 
+> **Concurrency:** four `haiku` agents in one wave is well within the safe band — keep the model light and the count at 4. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 ### Agent 1: Datamuse Semantic Explorer
 
 Query the Datamuse API for each key concept word in the user's description. Use these endpoints (no auth needed):

--- a/modules/ce-review/skills/ce-review/SKILL.md
+++ b/modules/ce-review/skills/ce-review/SKILL.md
@@ -171,6 +171,8 @@ Do NOT pass the implementer's conversation, completion report, or commit-message
 
 Reviewers are independent. Do not share their drafts between each other in this phase. Each reviewer writes its findings to its artifact path and replies with only that path plus `Findings written.`; the orchestrator reads the files (Results Stay in Files, above), not the replies.
 
+> **Concurrency — avoid the 429 throttle.** Dispatch reviewers at `model: "sonnet"` with medium reasoning effort (they read a bounded diff, not the whole repo). With all five conditional reviewers firing this fan-out reaches 9 agents — past the safe burst. Launch the 4 always-on reviewers in the first wave, wait for them to return, then launch the conditional subset in a second wave; never more than ~5 at once. Bursting too many heavy agents trips a server-side rate limit (`Server is temporarily limiting requests · Rate limited`) that fails the whole dispatch. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 ## Phase 4: Adversarial / Red-Team Lens
 
 After Phase 3 completes, dispatch the `adversarial-reviewer` agent with:

--- a/modules/cloud-dispatch/commands/dispatch.md
+++ b/modules/cloud-dispatch/commands/dispatch.md
@@ -90,6 +90,8 @@ bash ~/.claude/lib/cloud-dispatch/workspace-setup-all.sh "https://github.com/$RE
 bash ~/.claude/lib/cloud-dispatch/agent-launch-all.sh --max-turns $MAX_TURNS --jitter 75
 ```
 
+> **Concurrency — avoid the 429 throttle.** The org-level rate limit applies across *all* VMs at once, not per machine — every remote agent's requests bill against the same ceiling. Keep `VM_COUNT` modest and the launch `--jitter` on (it staggers VM starts so they don't burst together). If a run reports `Server is temporarily limiting requests · Rate limited`, that is the server throttle, not a usage cap — reduce `VM_COUNT` and re-dispatch the affected issues rather than relaunching the whole fleet. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 ### Step 7: Report
 
 Print a summary of what was dispatched:

--- a/modules/commands-extra/skills/audit/SKILL.md
+++ b/modules/commands-extra/skills/audit/SKILL.md
@@ -733,6 +733,8 @@ PYEOF
 
 **CRITICAL**: Determine which workers have non-empty pack assignments, then launch only those workers — in a SINGLE message with parallel Agent tool calls (`subagent_type: "general-purpose"`, `run_in_background: true`).
 
+> **Concurrency — avoid the 429 throttle.** `general-purpose` workers each load a pack's checks plus a spine slice (large context) and, under `FIX_MODE=true`, also commit and push — these are heavy agents. Launch **at most 4 workers at once**. If more than 4 have non-empty assignments, launch the first 4 in this message, wait for them to return (`run_in_background` plus the M6 collect step gives you the join point), then launch the next wave of 4. Bursting more than ~5 heavy workers together trips a server-side rate limit (`Server is temporarily limiting requests · Rate limited`) that fails the whole batch; if you see it mid-run, stop, wait 30–60s, and re-dispatch only the failed workers in waves of ≤4. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 ```bash
 # Determine active worker ids
 ACTIVE_WORKERS=$(python3 -c "
@@ -1821,6 +1823,8 @@ Then produce per-pack spine slices using the same slicing logic as Phase M4.
 
 Launch **one Agent per SELECTED pack** (not a fixed 9) in a SINGLE message with parallel
 Agent tool calls (`subagent_type: "Explore"`, `run_in_background: true`).
+
+> **Concurrency — avoid the 429 throttle.** These are light `Explore` agents, but a full audit can select well over 8 packs — and launching 15–20+ at once trips a server-side rate limit (`Server is temporarily limiting requests · Rate limited`) that fails the whole batch. Launch in **waves of ≤8** (`run_in_background` lets a wave drain while you start the next): dispatch the first 8 packs, then the rest. If you see the throttle mid-run, wait 30–60s and re-dispatch only the failed packs. See `~/.claude/rules/concurrency-and-rate-limits.md`.
 
 For each pack, the subagent receives:
 - The absolute path to the pack's `checks.md` (`$SKILL_ROOT/packs/<pack-dir>/checks.md`)

--- a/modules/compound-knowledge/skills/compound/SKILL.md
+++ b/modules/compound-knowledge/skills/compound/SKILL.md
@@ -46,6 +46,8 @@ If the user runs `/compound` with no arguments and the session is short or still
 
 Dispatch four subagents in parallel with the pass-paths-not-contents pattern (see `modules/subagent-patterns/rules/subagent-patterns.md`). Each returns a short structured report; the orchestrator merges them.
 
+> **Concurrency — avoid the 429 throttle.** Dispatch these four at `model: "sonnet"` with medium reasoning effort — they are bounded researchers returning a short report, not deep synthesizers. Four light agents in one wave is within the safe band; do not widen this fan-out or escalate to a heavier model without capping simultaneous heavy agents at 4 and waving the rest. Bursting >5 heavy agents trips a server-side rate limit (`Server is temporarily limiting requests · Rate limited`) that fails the whole dispatch. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 ### Context Analyzer
 
 Objective: Restate the problem in one paragraph and identify what would make this learning retrievable.

--- a/modules/copycat/commands/copycat.md
+++ b/modules/copycat/commands/copycat.md
@@ -121,6 +121,8 @@ Build a mental model of:
 
 Launch analysis agents in parallel using the Agent tool. Set model to **sonnet** for all agents.
 
+> **Concurrency:** four `sonnet` agents in one wave is within the safe band — keep the model on `sonnet` and the count at 4. If you widen this fan-out, cap simultaneous heavy agents at 4 and wave the rest. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 Each agent receives:
 1. The target repo path
 2. A specific analysis focus

--- a/modules/design-review/skills/design-review/SKILL.md
+++ b/modules/design-review/skills/design-review/SKILL.md
@@ -106,6 +106,8 @@ JSON.stringify(results, null, 2)
 
 Launch **6 agents in parallel** (single message, all `subagent_type: "Explore"`, `run_in_background: true`). Each agent receives the CSS source, computed styles JSON, and DOM structure extract. They analyze from one design lens.
 
+> **Concurrency:** six light `Explore` agents with `run_in_background: true` is within the safe band — keep it that way. If you ever widen the lens set past ~8 or switch these to a heavier model / higher effort, cap simultaneous heavy agents at 4 and run the rest in a second wave. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 Include the collected data directly in each agent's prompt (not file paths).
 
 Every agent prompt must end with:

--- a/modules/document-review/skills/document-review/SKILL.md
+++ b/modules/document-review/skills/document-review/SKILL.md
@@ -69,6 +69,8 @@ In headless mode, suppress commentary and return only the structured output bloc
 
 Dispatch the selected lens agents in parallel. Use the pass-paths-not-contents pattern (see `modules/subagent-patterns/rules/subagent-patterns.md`) - pass `doc_path` and the review context, let each agent Read the doc itself.
 
+> **Concurrency — avoid the 429 throttle.** Dispatch the lens agents at `model: "sonnet"` with medium reasoning effort — they are bounded analyzers reading one doc, not deep synthesizers. At Sonnet, all 7 lenses in one parallel wave is within the safe band. If you ever escalate the lenses to a heavier model or higher effort, launch at most 4 at once and run the rest in a second wave — bursting >5 heavy agents trips a server-side rate limit (`Server is temporarily limiting requests · Rate limited`) that fails the whole dispatch. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 Each agent is installed under `~/.claude/agents/{lens}-reviewer.md`. Each agent returns JSON matching:
 
 ```json

--- a/modules/editorial-critique/skills/editorial-critique/SKILL.md
+++ b/modules/editorial-critique/skills/editorial-critique/SKILL.md
@@ -29,6 +29,8 @@ Read the full file content. Strip frontmatter (everything between the opening an
 
 Launch **8 agents in parallel** (single message, all `subagent_type: "Explore"`). Do **NOT** use `run_in_background: true` - the agents must run in the foreground so the system waits for all 8 to complete before returning results. Launching all 8 in a single message ensures they execute concurrently while still blocking until all finish.
 
+> **Concurrency — avoid the 429 throttle.** Eight light `Explore` agents is at the safe ceiling for one parallel wave — acceptable here because they are cheap and each reads only the source text. Do NOT add lenses beyond 8 in a single burst, and never escalate these to a heavier model / higher reasoning effort while keeping all 8 in one message — if you need heavier passes, split into two waves of 4. Bursting too many heavy agents trips a server-side rate limit (`Server is temporarily limiting requests · Rate limited`) that fails the whole dispatch; if you hit it, run the 8 as 4+4. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 Each agent receives the full text and analyzes it from one lens.
 
 Include the full text in each agent's prompt (not a file path - the agent needs to analyze text, not explore code).

--- a/modules/multi-agent/commands/mawf.md
+++ b/modules/multi-agent/commands/mawf.md
@@ -202,6 +202,8 @@ For each wave:
 
 Use the Agent tool to launch one agent per assigned issue, each in its own clone directory:
 
+> **Concurrency — avoid the 429 throttle.** Wave size is naturally bounded by the number of clones, and execution agents run on `sonnet` — both keep this fan-out safe. If a workspace ever has more than ~8 clones, cap each wave at 8 light agents (or 4 if you escalate them to a heavier model). If a wave reports `Server is temporarily limiting requests · Rate limited`, wait 30–60s and re-launch only the failed issues. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 Each agent should:
 1. Navigate to its assigned clone directory
 2. Run `/startup` to initialize the session

--- a/modules/pr-feedback/skills/resolve-pr-feedback/SKILL.md
+++ b/modules/pr-feedback/skills/resolve-pr-feedback/SKILL.md
@@ -154,6 +154,8 @@ In `mode:headless`: proceed with `safe_auto` only. Return `manual`, `gated_auto`
 
 Dispatch one `pr-comment-resolver` per cluster (or per thread, when clustering was skipped), in parallel. Pass paths, not contents - see `modules/subagent-patterns/rules/subagent-patterns.md`.
 
+> **Concurrency — avoid the 429 throttle.** Dispatch resolvers at `model: "sonnet"` with medium reasoning effort. Clustering already keeps the count low, but a busy PR can yield more clusters than is safe to burst — launch **at most 4 at once**, and if there are more, run them in sequential waves of 4 rather than one message. Bursting too many heavy agents trips a server-side rate limit (`Server is temporarily limiting requests · Rate limited`) that fails the whole batch; if you hit it, wait 30–60s and re-dispatch only the unfinished clusters in waves of ≤4. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 Per-subagent spec:
 
 **Objective** - Implement the `fix_hypothesis` for this cluster; post an inline reply on each covered thread; resolve each thread if the reply is a fix (not an acknowledgment).

--- a/modules/research/commands/research.md
+++ b/modules/research/commands/research.md
@@ -138,6 +138,8 @@ Pass these targeted sub-questions to each agent instead of (or alongside) the br
 ## Phase 2: Spawn Research Agents
 
 Launch the selected research agents in **parallel** using the Agent tool. Each agent gets:
+
+> **Concurrency — avoid the 429 throttle.** These agents already run on `model: sonnet` (see the Sub-Agent Model Optimization section), so launching all 7 in one parallel wave is within the safe band. If you ever raise the count past ~8 or escalate the agents to a heavier model, cap simultaneous heavy agents at 4 and run the rest in a second wave. See `~/.claude/rules/concurrency-and-rate-limits.md`.
 1. The topic/concept to research
 2. Its targeted sub-questions from Phase 1.5
 3. The Internet Research Tools reference (below)

--- a/modules/rule-authoring/commands/pressure-test.md
+++ b/modules/rule-authoring/commands/pressure-test.md
@@ -73,6 +73,8 @@ Options: "proceed", "edit N", "regenerate".
 
 For each approved scenario, dispatch a subagent using the Agent tool. Model: **sonnet**. Dispatch in parallel where possible.
 
+> **Concurrency — avoid the 429 throttle.** "In parallel where possible" means **at most 4 at once**. With 5–7 scenarios, dispatch a wave of 4, read their results, then dispatch the rest — do not launch all 7 in one message. The GREEN and hardening phases are already throttled by the blocking read between phases. Bursting too many agents trips a server-side rate limit (`Server is temporarily limiting requests · Rate limited`) that fails the whole batch. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 The subagent prompt should:
 
 1. Present the scenario setup, pressures, and request

--- a/modules/test-vision/commands/test-vision.md
+++ b/modules/test-vision/commands/test-vision.md
@@ -351,6 +351,8 @@ No two agents may touch the same file.
 
 For repos with >12 feature domains, split into two dispatch waves of 6-8 agents each. This keeps orchestrator context manageable. Files don't conflict between waves, so this is purely for orchestrator management.
 
+> **Concurrency — avoid the 429 throttle.** The wave cap above is also what keeps the fan-out under the server-side rate limit. The `/e2e` agents are light (`model: sonnet`), so 6–8 per wave is fine; never launch all domains for a large repo in one burst, and if you escalate the agents to a heavier model, drop the wave size to ≤4. If a wave returns `Server is temporarily limiting requests · Rate limited`, wait 30–60s and re-dispatch the failed domains. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 ### 4.3 Dispatch Agents
 
 For each feature domain, spawn an agent (model: sonnet) with the following prompt:

--- a/modules/todos/skills/todo-resolve/SKILL.md
+++ b/modules/todos/skills/todo-resolve/SKILL.md
@@ -68,6 +68,8 @@ Parse `$ARGUMENTS` for optional filters (compose with the mode token):
 
 Dispatch one subagent per non-blocked todo, in parallel. Each subagent spec:
 
+> **Concurrency — avoid the 429 throttle.** Dispatch resolver subagents at `model: "sonnet"` with medium reasoning effort, and **launch at most 4 at once**. If more than 4 todos are ready, run them in sequential waves of 4 (dispatch 4, wait for them to return, dispatch the next 4) rather than one burst — a batch of 10 ready todos must NOT become 10 simultaneous agents. Bursting too many heavy agents trips a server-side rate limit (`Server is temporarily limiting requests · Rate limited`) that fails the whole batch; if you hit it, wait 30–60s and re-dispatch only the unfinished todos in waves of ≤4. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 **Objective** - Implement the Proposed Change section of the todo file.
 
 **Context** (pass paths, not contents - see `modules/subagent-patterns/rules/subagent-patterns.md`):

--- a/modules/xplan/commands/etp.md
+++ b/modules/xplan/commands/etp.md
@@ -204,6 +204,8 @@ For each wave, in order (a single issue is a wave of one). This is the core loop
 ### 4.1 Implement (parallel within a wave)
 
 Spawn one `implementer` agent per unit (model sonnet), each in its own clone or worktree. Each agent:
+
+> **Concurrency — avoid the 429 throttle.** `implementer` agents run on `sonnet` (light), so a wave of up to ~8 is safe. But the default `--max-agents` (widest wave, clamped to isolation slots) can exceed that in a workspace with many clones — **cap the live wave at 8 light agents, or 4 if you raise `implementer` to a heavier model / higher effort**. If a wave has more units than the cap, split it into sub-waves. Bursting too many heavy agents trips a server-side rate limit (`Server is temporarily limiting requests · Rate limited`) that fails the whole wave; if you hit it, wait 30–60s and re-spawn only the unfinished units in smaller sub-waves. See `~/.claude/rules/concurrency-and-rate-limits.md`.
 - Branches from `origin/main` (`git checkout -b {issue#}-{desc} origin/main` for an issue unit, `{slug}-{desc}` for a plan unit).
 - Implements the unit with tests, following the existing project patterns.
 - **Verifies the work actually functions** - unit tests passing is the floor, not the finish line. Run the real path where feasible.

--- a/modules/xplan/commands/xplan.md
+++ b/modules/xplan/commands/xplan.md
@@ -1338,6 +1338,8 @@ This phase scopes to the **main planning flow (Phases 5 → 6)**. Deepen Mode re
 
 Compute the date once for the run: `date +%F`. Then run **exactly three `adrev-reviewer` passes, one at a time** (installed at `~/.claude/agents/adrev-reviewer.md`). Do NOT launch them together — pass `k` does not start until pass `k-1` has returned, its changes are incorporated, and the self-review (5.7.3) is clean:
 
+> **Concurrency — avoid the 429 throttle.** Running these one at a time is also what keeps them under the rate limit: each pass is an Opus-4.8, max-effort agent — the heaviest dispatch in CCGM — and three of them firing together would almost certainly trip the server-side throttle (`Server is temporarily limiting requests · Rate limited`). Do not parallelize the passes to "save time." If a single pass returns the throttle, wait 30–60s and retry that one pass. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 ```
 Pass 1  →  incorporate  →  5.6 self-review clean
    ↓


### PR DESCRIPTION
## Summary

Follow-up to #735 (concurrency-and-rate-limits.md rule). The rule is guidance in the orchestrator's context; it does NOT auto-cap skills that hard-code their own fan-out width. This PR audits **every** skill + command in modules/ (84 files) for hard-coded parallel agent fan-out and incorporates the guidance into the 19 that spin up a team of agents, so the server-side 429 throttle is avoided across all of CCGM's surface area.

## Method

Classified all 84 skills/commands via a bounded wave of 4 read-only Explore agents (dogfooding the rule). Single source of truth: each affected skill gets a short cross-reference to `~/.claude/rules/concurrency-and-rate-limits.md` plus a skill-specific cap/wave/model instruction — the full rule is NOT duplicated.

## Changes (19 files)

**High risk — added model/effort default + explicit wave/cap + 429 recovery:**
- `document-review` (7 lenses, unspecified → sonnet/medium), `ce-review` (up to 9 reviewers → sonnet + 4-then-conditional waves), `audit` (both dispatch sites: general-purpose workers → waves of ≤4 under FIX_MODE; single-session Explore packs → waves of ≤8), `compound` (4 unspecified → sonnet/medium), `etp` (cap live wave at 8 light / 4 heavy), `todo-resolve` (unbounded one-per-todo → sonnet + waves of 4), `agent-native-audit` (8 Explore → 4+4 if escalated), `cloud-dispatch/dispatch` (org limit spans all VMs).

**Medium — cap/wave note + cross-ref:**
- `editorial-critique` (8 light, at ceiling), `pr-feedback` (cluster fan-out → sonnet + waves of 4), `xplan` Phase 5.7 (never parallelize the 3 sequential Opus passes), `brand-check` (≤4 parallel web calls), `pressure-test` (5–7 scenarios → waves of 4).

**Already compliant — concise cross-ref for durability:**
- `design-review`, `test-vision`, `mawf`, `research`, `copycat`, `brand`.

**Audited and left unchanged (single-agent / sequential / not agent fan-out):** `adrev`, `argus`, `ship-ready`, `sds`, `startup`, `gs`, `dispatch-status`, `dispatch-stop`, `capabilities`, `transcript`, `compound-refresh`, `deepresearch` (MCP tool calls, not agents).

## Test Plan

- `tests/test-modules.sh` → 1481 passed, 0 failed.
- `tests/test-no-personal-data.sh` → PASS.
- `gen_marketplace.py --check` → up to date (body-only edits, no frontmatter touched).

Closes #742