### PR TITLE
#744: align audit multi-agent-config.md with the concurrency cap

### DIFF
--- a/modules/commands-extra/skills/audit/reference/multi-agent-config.md
+++ b/modules/commands-extra/skills/audit/reference/multi-agent-config.md
@@ -24,6 +24,8 @@ Architecture, Performance, Testing, Documentation.
 
 **Agent identity**: Derived from worktree directory name suffix. `agent-0` -> agent 0, `agent-3` -> agent 3.
 
+**Concurrency cap — avoid the 429 throttle.** The 4-agent default is deliberately at the safe ceiling for *heavy* workers: each `general-purpose` worker loads its pack's checks plus a spine slice (large context) and, under `FIX_MODE=true`, also commits and pushes. **Never launch more than 4 of these at once.** If you raise the worker count (more non-empty assignments, or a custom split), launch them in sequential waves of ≤4 rather than one burst; if a launch reports `Server is temporarily limiting requests · Rate limited`, that is the server throttle, not a usage cap — wait 30–60s and re-dispatch only the unfinished workers. This matches the M5 launch step in `SKILL.md`. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+
 ---
 
 ## CRITICAL: Worktree Isolation


### PR DESCRIPTION
## Summary

Follow-up to #743. The audit `SKILL.md` dispatch sites already carry the concurrency cap, but the internal worker-count reference (`reference/multi-agent-config.md`) was silent on it. Adds a matching note to the Agent Assignments section so the reference and `SKILL.md` agree: the 4-agent default is the safe ceiling for heavy `general-purpose`/FIX_MODE workers; raise it only in sequential waves of ≤4; 429 recovery; cross-ref to `concurrency-and-rate-limits.md`.

## Test Plan

- `tests/test-modules.sh` → 1481 passed, 0 failed.
- audit `test-detect-defaults.sh` → 20 passed, 0 failed.
- audit `test-reference-wiring.sh` → 41 passed, 0 failed.
- `test-no-personal-data.sh` → PASS; `gen_marketplace.py --check` → up to date.

Closes #744