### PR TITLE
#746: docupdate — hooks reference entry for branch-guard + stale hook counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ The `docs/` directory contains comprehensive documentation:
 | [Install via Agent](docs/install-via-agent.md) | Per-preset paste-blocks and how to dry-run them safely |
 | [Module Catalog](docs/modules.md) | Detailed reference for all 72 modules |
 | [Commands Reference](docs/commands.md) | All 74 slash commands with usage examples |
-| [Hooks Reference](docs/hooks.md) | All 13 hooks explained - what they do and when they fire |
+| [Hooks Reference](docs/hooks.md) | All 18 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |
 | [Configuration](docs/configuration.md) | Customization, template variables, settings overrides |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -18,7 +18,7 @@ Hooks are registered in `settings.json` under the `hooks` key. Each hook specifi
 
 ## Installed hooks
 
-The **hooks** module installs 13 hooks, 2 Python libraries, and a settings partial. The **self-improving** module installs 2 additional hooks. Total: 15 hooks across 2 modules.
+The **hooks** module installs 15 hooks, 6 Python libraries, and a settings partial. The **self-improving** module installs 2 additional hooks and the **branch-guard** module 1. Total: 18 hooks across 3 modules (the **autoheal** module's observational hooks are documented in their own section below).
 
 ---
 
@@ -269,6 +269,18 @@ Pauses destructive Bash commands for confirmation. Catches `rm -rf`, SQL `DROP`/
 Scope-locks file edits to a frozen directory. When `~/.claude/freeze-dir.txt` contains a directory path, any Edit or Write outside that directory is denied. Paths are normalised (symlinks resolved, `..` collapsed) before the containment check.
 
 **Activation**: `/freeze <dir>` to set, `/unfreeze` to clear.
+
+---
+
+### branch-guard.py
+
+**Type**: PreToolUse:Edit/MultiEdit/Write/NotebookEdit/filesystem-MCP writes + PreToolUse:Bash
+**Module**: branch-guard
+**Can block**: Yes (exit 2 — survives bypass mode)
+
+Hard gate against work on a repo's default branch (main/master, per `origin/HEAD` with fallbacks). Blocks file edits whose target file lives in a repo checked out on its default branch (symlinks resolved; the file's repo is checked, not the session cwd), and mutating git commands — `git commit`/`add`/`stage`/`apply` — in any `&&`/`;`/`|` segment, honoring `git -C <path>`. Fires before the first edit so uncommitted work can never be stranded on main and destroyed by a later origin sync. The denial teaches the fix: `git fetch origin && git checkout -b <type>/<short-desc> origin/<default>` (type: feature/fix/chore/docs).
+
+**Exemptions**: `ALLOW_MAIN_COMMIT=1` (env or inline), in-progress rebase/merge/cherry-pick/revert/bisect, unborn HEAD, repos with no origin remote, and `~/.claude/git-flow-direct-to-main-repos.json` entries.
 
 ---
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -111,7 +111,7 @@ Base `settings.json` with 800+ pre-configured tool permission entries.
 
 Python hooks that automate and enforce development workflows.
 
-**Installs**: 9 hook scripts, 2 Python libraries, settings.json fragment
+**Installs**: 15 hook scripts, 6 Python libraries, settings.json fragment
 
 This module installs the most hooks of any module. See [Hooks Reference](hooks.md) for detailed documentation of each hook.
 
@@ -128,6 +128,12 @@ This module installs the most hooks of any module. See [Hooks Reference](hooks.m
 | `agent-tracking-pre.py` | PreToolUse:Bash | Warns when claiming already-claimed issues |
 | `agent-tracking-post.py` | PostToolUse:Bash | Records issue claims, status transitions in tracking CSV |
 | `check-migration-timestamps.py` | PreToolUse | Validates Supabase migration file timestamps for duplicates before commit |
+| `pretooluse-bash-dispatch.py` | PreToolUse:Bash | Consolidated dispatcher running the Bash check chain (git-workflow, destructive, patterns, port, tracking, careful) in one process |
+| `check-careful.py` | PreToolUse:Bash | Force-push-to-main hard block + careful-mode destructive-command prompts |
+| `check-freeze.py` | PreToolUse | Scope-locks Edit/Write to the `/freeze` directory |
+| `orphan-process-check.py` | SessionStart | Warns about orphaned test worker processes (vitest/jest) |
+| `session-start-enforce.py` | SessionStart | Opt-in rule-enforcement meta-instruction injection |
+| `sync-ccgm-canonical.py` | PostToolUse:Bash | Auto-pulls the canonical CCGM clone after PR merges |
 
 **Config prompts**: Protected branches (custom list), auto update check (yes/no)
 


### PR DESCRIPTION
## Summary

Post-merge `/docupdate` pass for #747/#748.

## Changes

- `docs/hooks.md`: new `branch-guard.py` reference entry (type, block semantics, exemptions); header counts corrected — the hooks module ships 15 hooks + 6 libraries per its manifest (doc said 13 + 2); total now 18 hooks across 3 modules
- `docs/modules.md`: hooks-module **Installs** line corrected (9/2 → 15/6) and six missing rows added to the hooks table (pretooluse-bash-dispatch, check-careful, check-freeze, orphan-process-check, session-start-enforce, sync-ccgm-canonical)

## Test Plan

- `grep` sweep: no stale hook/module counts remain in README.md or docs/
- `bash tests/test-no-personal-data.sh` → PASS