### PR TITLE
#746: fix doc-count CI failures + run branch-guard tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           # assumption). Stage it before running.
           mkdir -p "$HOME/.claude/lib"
           cp modules/hooks/lib/*.py "$HOME/.claude/lib/"
-          for t in modules/hooks/tests/*.sh; do
+          for t in modules/hooks/tests/*.sh modules/branch-guard/tests/*.sh; do
             echo "=== Running $t ==="
             bash "$t"
           done
@@ -110,7 +110,7 @@ jobs:
           # assumption). Stage it before running.
           mkdir -p "$HOME/.claude/lib"
           cp modules/hooks/lib/*.py "$HOME/.claude/lib/"
-          for t in modules/hooks/tests/*.sh; do
+          for t in modules/hooks/tests/*.sh modules/branch-guard/tests/*.sh; do
             echo "=== Running $t ==="
             bash "$t"
           done

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Modular configuration system for [Claude Code](https://docs.anthropic.com/en/doc
 
 ## What is CCGM?
 
-CCGM is a curated collection of 71 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
+CCGM is a curated collection of 72 configuration modules for Claude Code. Instead of hand-crafting rules, hooks, commands, and permissions from scratch, you pick modules and install them with a single command.
 
 Each module is self-contained with its own README, so you can also [copy individual files manually](#manual-installation) without the installer.
 
@@ -131,9 +131,9 @@ For a quick install with a preset:
 | Preset | Modules | Best For |
 |--------|---------|----------|
 | **minimal** | global-claude-md, autonomy, git-workflow | Getting started |
-| **standard** | global-claude-md, autonomy, identity, git-workflow, hooks, settings, commands-core, commands-utility, output-formatting, statusline | Most users |
-| **full** | 68 modules | Power users |
-| **team** | global-claude-md, autonomy, git-workflow, hooks, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification, autoheal, output-formatting, ce-review, pr-feedback, document-review, compound-knowledge (+ deps) | Teams |
+| **standard** | global-claude-md, autonomy, identity, git-workflow, hooks, branch-guard, settings, commands-core, commands-utility, output-formatting, statusline | Most users |
+| **full** | 69 modules | Power users |
+| **team** | global-claude-md, autonomy, git-workflow, hooks, branch-guard, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification, autoheal, output-formatting, ce-review, pr-feedback, document-review, compound-knowledge (+ deps) | Teams |
 
 ### Other install options
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ The installer offers five presets, or you can select modules one by one:
 | **minimal** | Core autonomy + git workflow rules | Trying CCGM for the first time |
 | **standard** | Minimal + hooks, settings, core commands | Most individual developers |
 | **team** | Standard + github-protocols, code-quality, debugging, verification | Teams with shared repos |
-| **full** | 68 modules | Power users who want everything |
+| **full** | 69 modules | Power users who want everything |
 | **cloud-agent** | Full minus desktop-only modules, plus agent orchestration | Headless cloud VMs dispatching parallel agents |
 
 See [Presets](presets.md) for detailed breakdowns.

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -19,11 +19,13 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 **Best for**: Most individual developers. The recommended starting point.
 
-**Modules (9)**:
+**Modules (11)**:
 - Everything in **minimal**, plus:
 - `identity` - two foundational context files: soul.md and human-context.md
 - `settings` - base `settings.json` with 800+ pre-configured tool permissions
 - `hooks` - Python hooks for workflow enforcement (branch protection, commit format, auto-approval)
+- `branch-guard` - hard PreToolUse gate: no edits or git mutations while HEAD is on the default branch
+- `statusline` - custom status line for Claude Code sessions
 - `commands-core` - essential slash commands (`/commit`, `/pr`, `/cpm`, `/gs`, `/ghi`)
 - `commands-utility` - utility commands (`/cws-submit`, `/ccgm-sync`, `/user-test`)
 - `output-formatting` - copy-pasteable content goes in fenced code blocks, never blockquotes
@@ -34,8 +36,9 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 **Best for**: Teams with shared repositories who want consistent practices across contributors.
 
-**Modules (19)**:
+**Modules (20)**:
 - Everything in **standard** (minus `identity` and `commands-utility`), plus:
+- `branch-guard` - hard PreToolUse gate: no edits or git mutations while HEAD is on the default branch
 - `github-protocols` - issue-first workflow, PR conventions, label taxonomy, code review standards
 - `code-quality` - code standards, testing requirements, error handling, security, build verification
 - `systematic-debugging` - structured 4-phase debugging methodology
@@ -49,7 +52,7 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 **Best for**: Power users who want the complete CCGM experience, including multi-agent coordination, brand research, and tech-specific guides.
 
-**Modules (68)**: Every stable module — `full` is defined as the set of all modules whose `module.json` status is not `beta` or `deprecated`. This includes **autoheal** (continuous self-improvement; opt-in real-time alerts and auto-apply) and `cloud-dispatch`. The only modules omitted are the beta ones (`plugin-marketplace`, `relevance-injection`) and the deprecated `agent-manager`; install those individually via the module selector if you need them.
+**Modules (69)**: Every stable module — `full` is defined as the set of all modules whose `module.json` status is not `beta` or `deprecated`. This includes **autoheal** (continuous self-improvement; opt-in real-time alerts and auto-apply) and `cloud-dispatch`. The only modules omitted are the beta ones (`plugin-marketplace`, `relevance-injection`) and the deprecated `agent-manager`; install those individually via the module selector if you need them.
 
 **What you get**: The full suite. Includes multi-agent workflows, planning frameworks, tech-specific patterns (Cloudflare, Supabase, Tailwind, shadcn, MCP development), specialized commands, and the autoheal observability loop with three opt-in toggles (`/autoheal-toggle realtime|autoapply|webhook`).
 
@@ -57,7 +60,7 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 **Best for**: Running CCGM on headless cloud VMs that dispatch parallel agents to work on GitHub issues. Includes the `cloud-dispatch` orchestration module plus the review and authoring skills agents lean on most.
 
-**Modules (53)**: Curated for headless cloud agents — a headless-oriented selection drawn from the stable module set, including `cloud-dispatch` (Hetzner Cloud VM provisioning for parallel GitHub-issue work) and persona-relevant skills (`ce-review`, `pr-feedback`, `document-review`, `skill-authoring`, `rule-authoring`, `agent-native`, `git-worktrees`, `ship-readiness`, with their dependencies). The deprecated `agent-manager` (tmux-based dashboard) is not included; install it individually if you still need it.
+**Modules (54)**: Curated for headless cloud agents — a headless-oriented selection drawn from the stable module set, including `cloud-dispatch` (Hetzner Cloud VM provisioning for parallel GitHub-issue work) and persona-relevant skills (`ce-review`, `pr-feedback`, `document-review`, `skill-authoring`, `rule-authoring`, `agent-native`, `git-worktrees`, `ship-readiness`, with their dependencies). The deprecated `agent-manager` (tmux-based dashboard) is not included; install it individually if you still need it.
 
 **What you get**: The cloud-agent preset with cloud-dispatch commands (`/dispatch`, `/dispatch-status`, `/dispatch-stop`, `/vm-manage`). Intended for machines that provision cloud VMs and launch autonomous agents, not day-to-day laptop use.
 


### PR DESCRIPTION
## Summary

Main has been red since #747: CI's **Check doc counts + preset coverage** step (`tests/test-doc-counts.sh` — not in the CLAUDE.md pre-submit list, so it wasn't run locally) derives expected counts from the tree and flagged claims the branch-guard PRs missed.

## Changes

- `README.md`: intro 'collection of 71 configuration modules' → 72; presets table `**full** | 68 modules` → 69; standard/team rows now include `branch-guard`
- `docs/getting-started.md`: `**full** | 68 modules` → 69
- `docs/presets.md`: standard **Modules (9)** → **(11)** (adds `branch-guard` bullet and the previously-missing `statusline` bullet), team **(19)** → **(20)** with `branch-guard` bullet, full **(68)** → **(69)**, cloud-agent **(53)** → **(54)**
- `.github/workflows/test.yml`: hooks-suite loop in both jobs now also runs `modules/branch-guard/tests/*.sh` (36 assertions) on every push

## Test Plan

Full CI parity run locally this time — every step in test.yml:
- `test-doc-counts.sh` → all checks passed (was 5 failures)
- `test-modules.sh` 1500 passed · `test-frontmatter-yaml.sh` all valid · `gen_marketplace.py --check` in sync · `validate_marketplace.py` passed · `test-no-personal-data.sh` (+ `--self-test`) PASS · `test-templates.sh` 22 passed · `test-installer.sh` 54 passed · `test-link-mode.sh` 11 passed · `run-audit-suite.sh` 33 passed
- Hooks suites: auto-commit-prefix 9, cross-clone-file-lock 6, deny-segments 24, dispatcher 20, hook-utils 25, platform 11, sync-ccgm-canonical — all passed
- `modules/branch-guard/tests/test-branch-guard.sh` → 36 passed