### PR TITLE
#764: fix pytest env-var state leak between self-improving and dreaming test suites

### DIFF
--- a/modules/dreaming/tests/test_transcript_miner.py
+++ b/modules/dreaming/tests/test_transcript_miner.py
@@ -488,6 +488,29 @@ class WatermarkTests(unittest.TestCase):
 
 
 class DiscoverTests(unittest.TestCase):
+    def setUp(self):
+        # Hermetic against upstream env leaks (#764): a test module that ran
+        # earlier in the same pytest process (e.g. self-improving's
+        # test_learnings_store.py) may have set CCGM_LEARNINGS_PROJECT (or
+        # CCGM_LEARNINGS_DIR) without restoring it. detect_project_slug()
+        # treats CCGM_LEARNINGS_PROJECT as a priority-1 override, so a leaked
+        # value would make every call below return the SAME slug regardless
+        # of cwd/git-remote, silently breaking the assertions in this class.
+        # Neutralize both here and restore whatever this process actually
+        # had on the way out.
+        self._prev_learnings_project = os.environ.pop("CCGM_LEARNINGS_PROJECT", None)
+        self._prev_learnings_dir = os.environ.pop("CCGM_LEARNINGS_DIR", None)
+
+    def tearDown(self):
+        if self._prev_learnings_project is not None:
+            os.environ["CCGM_LEARNINGS_PROJECT"] = self._prev_learnings_project
+        else:
+            os.environ.pop("CCGM_LEARNINGS_PROJECT", None)
+        if self._prev_learnings_dir is not None:
+            os.environ["CCGM_LEARNINGS_DIR"] = self._prev_learnings_dir
+        else:
+            os.environ.pop("CCGM_LEARNINGS_DIR", None)
+
     def _write_transcript(self, root: Path, project_dir: str, filename: str, cwd: str, ts_epoch: float | None = None):
         d = root / project_dir
         d.mkdir(parents=True, exist_ok=True)
@@ -576,6 +599,25 @@ class SlugAgreementTests(unittest.TestCase):
     basename-fallback-only test would trivially "pass" without proving
     arch-1's fix is wired correctly.
     """
+
+    def setUp(self):
+        # Hermetic against upstream env leaks (#764): see DiscoverTests.setUp
+        # for the full rationale -- a leaked CCGM_LEARNINGS_PROJECT would
+        # make detect_project_slug() ignore this test's real git remote
+        # entirely and return the leaked value instead, breaking the
+        # equality assertions below silently.
+        self._prev_learnings_project = os.environ.pop("CCGM_LEARNINGS_PROJECT", None)
+        self._prev_learnings_dir = os.environ.pop("CCGM_LEARNINGS_DIR", None)
+
+    def tearDown(self):
+        if self._prev_learnings_project is not None:
+            os.environ["CCGM_LEARNINGS_PROJECT"] = self._prev_learnings_project
+        else:
+            os.environ.pop("CCGM_LEARNINGS_PROJECT", None)
+        if self._prev_learnings_dir is not None:
+            os.environ["CCGM_LEARNINGS_DIR"] = self._prev_learnings_dir
+        else:
+            os.environ.pop("CCGM_LEARNINGS_DIR", None)
 
     def test_miner_slug_matches_detect_project_slug_for_real_repo(self):
         with tempfile.TemporaryDirectory() as td:

--- a/modules/self-improving/tests/test_learnings_store.py
+++ b/modules/self-improving/tests/test_learnings_store.py
@@ -24,14 +24,75 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE.parent / "lib"))
 
+# Drop any pre-existing `learnings_store` entry from a prior import under
+# the same bare module name (#764). modules/dreaming's transcript_miner.py
+# also imports `learnings_store` (to reach detect_project_slug), via either
+# the ~/.claude/lib installed symlink or this same repo-relative path. If
+# pytest collects that test file first (e.g. `pytest modules/dreaming/tests
+# modules/self-improving/tests`), `learnings_store` is already cached in
+# sys.modules -- with LEARNINGS_ROOT computed from whatever
+# CCGM_LEARNINGS_DIR was (or was not) set to at THAT import, before this
+# file ever gets a chance to override it below. Reusing that cached module
+# would silently point this whole test file's reads/writes at the real
+# ~/.claude/learnings/ (or a stale checkout via the installed symlink)
+# instead of the tempdir, and cause exactly one symptom: any test that
+# shells out to the CLI (a fresh subprocess, which always re-imports
+# learnings_store from the CURRENT environment) disagrees with this
+# process's stale copy about where the store lives. Popping first
+# guarantees the `import learnings_store` below always re-executes fresh,
+# picking up CCGM_LEARNINGS_DIR (set immediately after) and this file's own
+# sys.path entry (inserted immediately above), regardless of what any
+# other test module already imported earlier in the same pytest process.
+sys.modules.pop("learnings_store", None)
+
 # Point the store at a tempdir BEFORE importing the lib
 _TMP = tempfile.mkdtemp(prefix="ccgm-learnings-test-")
+_ORIG_CCGM_LEARNINGS_DIR = os.environ.get("CCGM_LEARNINGS_DIR")
 os.environ["CCGM_LEARNINGS_DIR"] = _TMP
 
 import learnings_store as ls  # noqa: E402
 
 CLI_PATH = HERE.parent / "bin" / "ccgm-learnings-log"
 SEARCH_CLI_PATH = HERE.parent / "bin" / "ccgm-learnings-search"
+
+
+def tearDownModule() -> None:
+    """Undo the module-level CCGM_LEARNINGS_DIR override set above (before
+    `import learnings_store`, so this file's tests never touch the real
+    ~/.claude/learnings/ store) so it cannot leak into whatever test
+    module pytest imports and runs next in the same process (#764: a
+    leaked CCGM_LEARNINGS_PROJECT from this file previously broke
+    modules/dreaming's transcript_miner tests when both suites ran in one
+    pytest invocation). pytest calls tearDownModule() once, after every
+    test in this module has finished, per its unittest-module support."""
+    if _ORIG_CCGM_LEARNINGS_DIR is not None:
+        os.environ["CCGM_LEARNINGS_DIR"] = _ORIG_CCGM_LEARNINGS_DIR
+    else:
+        os.environ.pop("CCGM_LEARNINGS_DIR", None)
+
+
+def _isolate_env(testcase: unittest.TestCase, key: str) -> None:
+    """Snapshot os.environ[key]'s current value (or absence) and register
+    an addCleanup that restores it -- so a test's setUp() that sets or
+    pops `key` can never leak it past that single test, into a later test
+    in this file or (worse) into a different test module running later in
+    the same pytest process (#764).
+
+    Call this immediately BEFORE mutating `key`. addCleanup callbacks fire
+    even if a later line in the same setUp() raises, which a manual
+    tearDown() override would not guard against -- unittest never calls
+    tearDown() if setUp() itself raised partway through.
+    """
+    had_prior = key in os.environ
+    prior = os.environ.get(key)
+
+    def _restore() -> None:
+        if had_prior:
+            os.environ[key] = prior
+        else:
+            os.environ.pop(key, None)
+
+    testcase.addCleanup(_restore)
 
 
 # ---------------------------------------------------------------------------
@@ -165,6 +226,7 @@ class WriteReadTests(unittest.TestCase):
     def setUp(self):
         # Fresh slug per test via env override
         self.slug = f"test-proj-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
 
     def tearDown(self):
@@ -253,6 +315,7 @@ class DecayTests(unittest.TestCase):
 class SearchTests(unittest.TestCase):
     def setUp(self):
         self.slug = f"search-proj-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
         # Seed entries
         self.entries = []
@@ -303,6 +366,7 @@ class SearchTests(unittest.TestCase):
 class UpdateTests(unittest.TestCase):
     def setUp(self):
         self.slug = f"upd-proj-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
         e = ls.build_entry(type_="pattern", content="testme", confidence=5)
         ls.append_entry(e)
@@ -337,6 +401,7 @@ class UpdateTests(unittest.TestCase):
 class SupersedeTests(unittest.TestCase):
     def setUp(self):
         self.slug = f"sup-proj-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
         e = ls.build_entry(
             type_="pattern",
@@ -449,7 +514,9 @@ class CompactGuardTests(unittest.TestCase):
 class V2ShardTests(unittest.TestCase):
     def setUp(self):
         self.slug = f"v2-shard-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        _isolate_env(self, "CCGM_AGENT_ID")
         os.environ.pop("CCGM_AGENT_ID", None)
 
     def tearDown(self):
@@ -497,6 +564,7 @@ class BackwardCompatProjectionTests(unittest.TestCase):
 
     def setUp(self):
         self.slug = f"v1-compat-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
 
     def tearDown(self):
@@ -641,7 +709,9 @@ class ContradictionBeforeDedupTests(unittest.TestCase):
 class ConflictTests(unittest.TestCase):
     def setUp(self):
         self.slug = f"conflict-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        _isolate_env(self, "CCGM_AGENT_ID")
         os.environ.pop("CCGM_AGENT_ID", None)
         e = ls.build_entry(type_="pattern", content="contested entry")
         ls.append_entry(e)
@@ -706,6 +776,7 @@ class ConflictTests(unittest.TestCase):
 class CASTests(unittest.TestCase):
     def setUp(self):
         self.slug = f"cas-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
         e = ls.build_entry(type_="pattern", content="cas target content")
         ls.append_entry(e)
@@ -748,6 +819,7 @@ class CASTests(unittest.TestCase):
 class OriginBindingTests(unittest.TestCase):
     def setUp(self):
         self.slug = f"origin-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
         self._orig_projects_root = ls.CLAUDE_PROJECTS_ROOT
         self._tmp_projects = Path(tempfile.mkdtemp(prefix="ccgm-transcripts-test-"))
@@ -968,6 +1040,7 @@ class GlobalPromotionGuardTests(unittest.TestCase):
 class TrustedWriterOriginBindingTests(unittest.TestCase):
     def setUp(self):
         self.slug = f"trusted-writer-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
         os.environ.pop("CCGM_LEARNINGS_ADMIN", None)
         self._orig_agent_id = os.environ.get("CCGM_AGENT_ID")
@@ -1075,6 +1148,7 @@ class TrustedWriterOriginBindingTests(unittest.TestCase):
 class SupersedeReasonSanitizationTests(unittest.TestCase):
     def setUp(self):
         self.slug = f"reason-sani-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
         e = ls.build_entry(type_="pattern", content="entry to supersede")
         ls.append_entry(e)
@@ -1107,6 +1181,7 @@ class SupersedeReasonSanitizationTests(unittest.TestCase):
 class SnapshotCacheTests(unittest.TestCase):
     def setUp(self):
         self.slug = f"snapshot-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
 
     def tearDown(self):
@@ -1248,6 +1323,7 @@ class AgentIdTests(unittest.TestCase):
 class PerformanceTests(unittest.TestCase):
     def setUp(self):
         self.slug = f"perf-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
         os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
 
     def tearDown(self):


### PR DESCRIPTION
## Summary

Closes #764.

`test_learnings_store.py`'s `setUp()` methods set/pop `CCGM_LEARNINGS_PROJECT` (and `CCGM_AGENT_ID`) without restoring them in `tearDown()`, so the last leaked value — a `perf-<timestamp>` slug from `PerformanceTests` — survived past this file's own test run. When `modules/dreaming/tests/test_transcript_miner.py` ran later in the same pytest process, its `DiscoverTests` and `SlugAgreementTests` inherited that override: `learnings_store.detect_project_slug()` treats `CCGM_LEARNINGS_PROJECT` as a priority-1 override, so it ignored `cwd`/git-remote entirely and returned the leaked slug for every call, breaking both tests' equality assertions.

Both files pass in isolation; the leak only reproduces when both suites run in one pytest process (`pytest modules/self-improving/tests/ modules/dreaming/tests/`), which is exactly what `tests/run-unit-tests.sh` does via `pytest modules/ -q`.

## Changes

Test-only — no product/lib/bin code touched.

**`modules/self-improving/tests/test_learnings_store.py`**
- Added an `addCleanup`-based `_isolate_env()` helper and used it in every `setUp()` that mutates `CCGM_LEARNINGS_PROJECT`/`CCGM_AGENT_ID` (13 classes), so each test restores its prior env state regardless of outcome — including if a later line in the same `setUp()` raises, which a manual `tearDown()` override would not guard against.
- Restored the module-level `CCGM_LEARNINGS_DIR` override via a new `tearDownModule()`.
- Dropped any stale `sys.modules["learnings_store"]` entry before importing. `transcript_miner.py` imports the same bare module name (via the `~/.claude/lib` installed symlink or the repo-relative fallback); if pytest collects that file first, the cached module's `LEARNINGS_ROOT` was computed before `CCGM_LEARNINGS_DIR` was ever set here. This surfaced as a second, subtler bug: `CLIExitCodeTests::test_v1_only_store_still_searchable_via_cli` failed only when `modules/dreaming/tests/` was collected before `modules/self-improving/tests/`, because the parent process's stale `ls` module and the CLI subprocess's freshly-imported copy disagreed about where the store lives.

**`modules/dreaming/tests/test_transcript_miner.py`**
- Added `setUp`/`tearDown` to `DiscoverTests` and `SlugAgreementTests` that neutralize (pop) and restore `CCGM_LEARNINGS_PROJECT` and `CCGM_LEARNINGS_DIR`, so these tests are hermetic against any upstream leak regardless of which other test module ran before them.

## Test plan

- [x] Reproduced the original failure first: `python3 -m pytest modules/self-improving/tests/ modules/dreaming/tests/ -q` → 2 failed, 130 passed (before fix)
- [x] Same command after fix → 132 passed
- [x] Reverse order `python3 -m pytest modules/dreaming/tests/ modules/self-improving/tests/ -q` → 132 passed (also caught and fixed the `sys.modules` collision described above, verified against unmodified origin/main to confirm it was pre-existing, not a regression from this fix)
- [x] Both orderings re-run 3x each — no flakiness
- [x] `modules/self-improving/tests/test_learnings_store.py` alone → 95 passed
- [x] `modules/dreaming/tests/test_transcript_miner.py` alone → 37 passed
- [x] `bash tests/test-modules.sh` → 1516 passed, 0 failed
- [x] `bash tests/test-no-personal-data.sh` → PASS
- [x] `bash tests/run-unit-tests.sh` (full `modules/` sweep, the real-world scenario this bug affects) → 336 passed, exit 0