### PR TITLE
#754: Read path -- verification-on-read wrappers + opt-in SessionStart learnings injection

### DIFF
--- a/modules/self-improving/bin/ccgm-learnings-search
+++ b/modules/self-improving/bin/ccgm-learnings-search
@@ -27,9 +27,15 @@ Every preamble/markdown entry is wrapped with a verification reminder --
 asserting]` -- since a learning is a claim recorded at write time, not a
 live guarantee about the codebase now (epic 4: verification-on-read). When a
 listed files[] anchor no longer exists under the current working directory,
-the wrapper additionally appends `[anchor-missing]`. `--format jsonl` output
-gains a matching `age_days` integer field; nothing else about its shape
-changes.
+the wrapper additionally appends `[anchor-missing]`. When the entry has two
+live competing supersedes (adrev-011), the wrapper additionally appends
+`[conflict: competing heads -- not settled]` -- conflicted rows are shown
+here, not suppressed; only the SessionStart injection path
+(hooks/learnings-inject.py) hides them outright, since that path has no
+human in the loop to notice the flag. `--format jsonl` output gains a
+matching `age_days` integer field; nothing else about its shape changes
+(the `conflict` field, when present on an entry, was already passed through
+unmodified).
 """
 
 from __future__ import annotations
@@ -92,13 +98,21 @@ def _age_days(entry: dict, *, now: float | None = None) -> int:
 def _verify_wrapper(entry: dict, *, repo_root: Path | None = None, now: float | None = None) -> str:
     """`[age: Nd · last_verified: DATE · verify files[] anchors before
     asserting]`, plus a trailing `[anchor-missing]` when a listed files[]
-    path does not exist under `repo_root`."""
+    path does not exist under `repo_root`, and `[conflict: competing heads
+    — not settled]` when the entry has two live competing supersedes
+    (adrev-011). Unlike the SessionStart injection path
+    (hooks/learnings-inject.py), which suppresses conflicted rows outright
+    since no human is in the loop to notice a flag, a human running this
+    CLI directly should SEE the conflict -- so it is tagged here, never
+    hidden."""
     age = _age_days(entry, now=now)
     last_verified = entry.get("last_verified") or entry.get("timestamp") or ""
     date_str = last_verified[:10] if len(last_verified) >= 10 else "unknown"
     wrapper = f"[age: {age}d · last_verified: {date_str} · verify files[] anchors before asserting]"
     if ls.has_stale_file_refs(entry, repo_root):
         wrapper += " [anchor-missing]"
+    if entry.get("conflict"):
+        wrapper += " [conflict: competing heads — not settled]"
     return wrapper
 
 

--- a/modules/self-improving/bin/ccgm-learnings-search
+++ b/modules/self-improving/bin/ccgm-learnings-search
@@ -21,6 +21,15 @@ Examples:
 The search path applies time-based confidence decay, dedupes by (key, type),
 drops deprecated or stale-below-threshold entries, and caps output by the
 configured token budget (chars/4 approximation).
+
+Every preamble/markdown entry is wrapped with a verification reminder --
+`[age: {N}d · last_verified: {date} · verify files[] anchors before
+asserting]` -- since a learning is a claim recorded at write time, not a
+live guarantee about the codebase now (epic 4: verification-on-read). When a
+listed files[] anchor no longer exists under the current working directory,
+the wrapper additionally appends `[anchor-missing]`. `--format jsonl` output
+gains a matching `age_days` integer field; nothing else about its shape
+changes.
 """
 
 from __future__ import annotations
@@ -29,6 +38,8 @@ import argparse
 import json
 import os
 import sys
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 _HERE = Path(__file__).resolve().parent
@@ -37,7 +48,61 @@ sys.path.insert(0, str(_HERE.parent / "lib"))
 import learnings_store as ls  # noqa: E402
 
 
-def _render_markdown(entries: list[dict]) -> str:
+# ---------------------------------------------------------------------------
+# Age / verification wrapper (epic 4: verification-on-read)
+# ---------------------------------------------------------------------------
+#
+# learnings_store.py owns confidence decay and staleness math, but has no
+# public helper that returns a plain "days since last_verified" integer --
+# effective_confidence() folds age into a decayed score, and is_stale() only
+# returns a bool. Rather than modify the store (out of scope for this
+# change; see rules/learnings-store.md ownership), a small local ISO parser
+# mirrors the store's own tolerant format handling (with/without
+# milliseconds). The identical helper is duplicated in
+# hooks/learnings-inject.py, which renders the same wrapper for the
+# SessionStart injection block -- these are two independent entry points
+# that must not import each other.
+
+_ISO_FORMATS = ("%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso_epoch(value: str) -> float:
+    """Parse an ISO-8601 UTC timestamp (ms-precision or not) to epoch
+    seconds. Returns 0.0 for empty/unparseable input."""
+    if not value:
+        return 0.0
+    for fmt in _ISO_FORMATS:
+        try:
+            return datetime.strptime(value, fmt).replace(tzinfo=timezone.utc).timestamp()
+        except ValueError:
+            continue
+    return 0.0
+
+
+def _age_days(entry: dict, *, now: float | None = None) -> int:
+    """Whole days since `last_verified` (falling back to `timestamp`).
+    Deterministic arithmetic on data already in hand -- never estimated."""
+    ts = _parse_iso_epoch(entry.get("last_verified") or entry.get("timestamp", ""))
+    if ts <= 0:
+        return 0
+    now_ts = now if now is not None else time.time()
+    return max(0, int((now_ts - ts) // 86400))
+
+
+def _verify_wrapper(entry: dict, *, repo_root: Path | None = None, now: float | None = None) -> str:
+    """`[age: Nd · last_verified: DATE · verify files[] anchors before
+    asserting]`, plus a trailing `[anchor-missing]` when a listed files[]
+    path does not exist under `repo_root`."""
+    age = _age_days(entry, now=now)
+    last_verified = entry.get("last_verified") or entry.get("timestamp") or ""
+    date_str = last_verified[:10] if len(last_verified) >= 10 else "unknown"
+    wrapper = f"[age: {age}d · last_verified: {date_str} · verify files[] anchors before asserting]"
+    if ls.has_stale_file_refs(entry, repo_root):
+        wrapper += " [anchor-missing]"
+    return wrapper
+
+
+def _render_markdown(entries: list[dict], *, repo_root: Path | None = None, now: float | None = None) -> str:
     if not entries:
         return "_No learnings matched._\n"
     lines = ["# Learnings (ranked)", ""]
@@ -49,6 +114,8 @@ def _render_markdown(entries: list[dict]) -> str:
             lines.append(tag_str)
         lines.append("")
         lines.append(e.get("content", ""))
+        lines.append("")
+        lines.append(_verify_wrapper(e, repo_root=repo_root, now=now))
         if e.get("files"):
             lines.append("")
             lines.append("**Anchors:** " + ", ".join(f"`{f}`" for f in e["files"]))
@@ -56,7 +123,7 @@ def _render_markdown(entries: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _render_preamble(entries: list[dict]) -> str:
+def _render_preamble(entries: list[dict], *, repo_root: Path | None = None, now: float | None = None) -> str:
     """Compact preamble block suitable for injection at command start."""
     if not entries:
         return ""
@@ -68,12 +135,18 @@ def _render_preamble(entries: list[dict]) -> str:
             f"  - [{e.get('type')}] ({eff:.1f}) {e.get('content')}"
             + (f"  [tags: {tags}]" if tags else "")
         )
+        lines.append(f"    {_verify_wrapper(e, repo_root=repo_root, now=now)}")
     lines.append("</learnings>")
     return "\n".join(lines) + "\n"
 
 
-def _render_jsonl(entries: list[dict]) -> str:
-    return "\n".join(json.dumps(e, sort_keys=True) for e in entries) + ("\n" if entries else "")
+def _render_jsonl(entries: list[dict], *, now: float | None = None) -> str:
+    rows = []
+    for e in entries:
+        row = dict(e)
+        row["age_days"] = _age_days(e, now=now)
+        rows.append(json.dumps(row, sort_keys=True))
+    return "\n".join(rows) + ("\n" if rows else "")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -113,9 +186,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.format == "jsonl":
         sys.stdout.write(_render_jsonl(entries))
     elif args.format == "markdown":
-        sys.stdout.write(_render_markdown(entries))
+        sys.stdout.write(_render_markdown(entries, repo_root=Path.cwd()))
     else:
-        sys.stdout.write(_render_preamble(entries))
+        sys.stdout.write(_render_preamble(entries, repo_root=Path.cwd()))
     return 0
 
 

--- a/modules/self-improving/hooks/learnings-inject.py
+++ b/modules/self-improving/hooks/learnings-inject.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""SessionStart hook: opt-in, prefix-cache-safe learnings injection (issue #754).
+
+PURPOSE
+-------
+The learnings store (modules/self-improving/lib/learnings_store.py) accumulates
+durable, cross-session patterns/pitfalls/preferences per project. Today the
+only way to see them is to explicitly run `ccgm-learnings-search`. This hook
+offers an OPT-IN alternative: at fresh session start, surface the top-ranked
+learnings for the current project directly into context, so an agent starts a
+session already aware of what it (or a sibling agent) has learned before.
+
+CRITICAL SAFETY PROPERTY
+-------------------------
+This hook is a strict NO-OP unless BOTH of the following hold:
+
+    1. The SessionStart event fires with source == "startup" (never on
+       resume/compact -- re-injecting on every resume would re-rank and
+       re-render the block each time, which is exactly the per-turn
+       re-injection pattern the durable-memory plan's prefix-cache-safety
+       requirement forbids -- see decisions.md Key Insight 6).
+    2. The environment variable CCGM_LEARNINGS_INJECT is truthy.
+
+With the flag unset (the default for every existing and new install), the
+hook reads stdin, finds the flag absent, and exits having printed nothing.
+Nothing about existing sessions changes. This mirrors the relevance-injection
+module's opt-in posture (modules/relevance-injection/hooks/relevance-inject.py)
+and its own settings.partial.json registration shape.
+
+PROJECT SLUG RESOLUTION (arch-1, CRITICAL)
+-------------------------------------------
+The slug is resolved via `learnings_store.detect_project_slug(cwd)` -- the
+SAME canonical function every read/write in the store already uses. This
+hook MUST NEVER resolve the slug via session-history's repo_detect.py:
+that module answers a DIFFERENT question (which Claude Code project
+directories, under ~/.claude/projects/, belong to clones of a repo) and
+returns a DIFFERENT, incompatible string -- a bare repo name (e.g. "myrepo")
+rather than detect_project_slug()'s {owner}_{repo} slug (e.g.
+"myorg-myrepo"). Reusing repo_detect.py here would make this hook silently
+read an empty or wrong project directory for essentially every real repo.
+
+CONFLICT SUPPRESSION (adrev-011)
+---------------------------------
+learnings_store.search() does not filter out rows flagged `conflict: true`
+(two competing supersede events racing the same target) -- Epic 1's job was
+only to make sure the flag reaches those rows, not to hide them, since
+`/consolidate` and the dream digest are supposed to show them to a human.
+This hook is different: it hands its output to an agent as ambient context,
+with no human in the loop to notice a flag. A conflicted row is NOT settled
+truth, so it is suppressed here before rendering -- never injected as if it
+were an ordinary, resolved learning.
+
+BUDGET / RANKING
+-----------------
+Selection reuses learnings_store.search()'s own ranking (effective
+confidence, decay, staleness) and the store's configured token budget --
+this hook does not re-implement ranking. It over-fetches a superset of
+candidates so that removing conflicted rows can still backfill up to the
+real cap/budget from the next-ranked alternative (see
+_select_for_injection()).
+
+OUTPUT
+------
+Exactly one stdout block, `<ccgm-learnings-injection>...</ccgm-learnings-injection>`,
+each entry rendered with the same age/verification wrapper
+ccgm-learnings-search's preamble output uses (epic 4: verification-on-read --
+a learning is a claim recorded at write time, not a live guarantee). Content
+is a pure function of hook input + store state + env, so two invocations
+against the same store produce byte-identical output within a session
+(prefix-cache safety).
+
+SAFETY
+------
+Never raises: any failure path (missing flag, unresolvable store, empty
+result set, malformed stdin) returns without emitting, so this can never
+crash or block a session.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+FLAG = "CCGM_LEARNINGS_INJECT"
+
+# learnings_store.py is installed at ~/.claude/lib/learnings_store.py by CCGM
+# and lives at ../lib/learnings_store.py relative to this file's own repo
+# location. Insert both so the hook resolves it whether it is running from
+# an installed symlink (resolves back into the repo) or a plain copy.
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(Path.home() / ".claude" / "lib"))
+sys.path.insert(0, str(_HERE.parent / "lib"))
+
+try:
+    import learnings_store  # type: ignore
+except Exception:  # pragma: no cover - import guard; hook must never crash a session
+    learnings_store = None
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def resolve_slug(cwd: str) -> str:
+    """The ONE call site this hook uses to resolve a project slug.
+
+    MUST delegate to learnings_store.detect_project_slug() -- never
+    session-history's repo_detect.py (arch-1; see module docstring)."""
+    return learnings_store.detect_project_slug(cwd)
+
+
+# ---------------------------------------------------------------------------
+# Age / verification wrapper -- mirrors bin/ccgm-learnings-search's own
+# _verify_wrapper()/_age_days() exactly (epic 4: verification-on-read). The
+# two copies are deliberately independent: a bin/ CLI and a hooks/ script are
+# separate entry points that must not import one another, and
+# learnings_store.py itself is out of scope for this change (owned
+# elsewhere; it exposes no plain "days since" helper -- effective_confidence
+# folds age into a decayed score, is_stale only returns a bool).
+# ---------------------------------------------------------------------------
+
+_ISO_FORMATS = ("%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso_epoch(value: str) -> float:
+    """Parse an ISO-8601 UTC timestamp (ms-precision or not) to epoch
+    seconds. Returns 0.0 for empty/unparseable input."""
+    if not value:
+        return 0.0
+    for fmt in _ISO_FORMATS:
+        try:
+            return datetime.strptime(value, fmt).replace(tzinfo=timezone.utc).timestamp()
+        except ValueError:
+            continue
+    return 0.0
+
+
+def _age_days(entry: dict, *, now: "float | None" = None) -> int:
+    """Whole days since `last_verified` (falling back to `timestamp`).
+    Deterministic arithmetic on data already in hand -- never estimated."""
+    ts = _parse_iso_epoch(entry.get("last_verified") or entry.get("timestamp", ""))
+    if ts <= 0:
+        return 0
+    now_ts = now if now is not None else time.time()
+    return max(0, int((now_ts - ts) // 86400))
+
+
+def _verify_wrapper(entry: dict, *, repo_root: "Path | None" = None, now: "float | None" = None) -> str:
+    """`[age: Nd · last_verified: DATE · verify files[] anchors before
+    asserting]`, plus a trailing `[anchor-missing]` when a listed files[]
+    path does not exist under `repo_root`."""
+    age = _age_days(entry, now=now)
+    last_verified = entry.get("last_verified") or entry.get("timestamp") or ""
+    date_str = last_verified[:10] if len(last_verified) >= 10 else "unknown"
+    wrapper = f"[age: {age}d · last_verified: {date_str} · verify files[] anchors before asserting]"
+    if learnings_store.has_stale_file_refs(entry, repo_root):
+        wrapper += " [anchor-missing]"
+    return wrapper
+
+
+def _select_for_injection(slug: str, *, max_results: int, token_budget: int) -> "list[dict]":
+    """Fetch a superset of ranked candidates via learnings_store.search()
+    (ranking/relevance/decay stay entirely owned by the store), drop
+    conflicted rows (adrev-011), then re-apply the real cap/budget over the
+    filtered, already-ranked set -- mirroring search()'s own trailing budget
+    loop so backfill works after conflict suppression.
+
+    Over-fetches 4x cap/budget: conflicts should be rare, and this margin is
+    enough for a non-conflicted alternative to backfill in the common case
+    without walking the entire store.
+    """
+    over_fetched = learnings_store.search(
+        slug=slug,
+        max_results=max_results * 4,
+        token_budget=token_budget * 4,
+    )
+    non_conflicted = [e for e in over_fetched if not e.get("conflict")]
+
+    char_budget = token_budget * 4
+    used = 0
+    out: "list[dict]" = []
+    for e in non_conflicted:
+        snippet_len = len(e.get("content", "")) + 80
+        if used + snippet_len > char_budget:
+            break
+        out.append(e)
+        used += snippet_len
+        if len(out) >= max_results:
+            break
+    return out
+
+
+def build_context(hook_input: dict, env: "dict[str, str] | None" = None) -> "str | None":
+    """Build the injected block, or None if there is nothing to emit.
+
+    Depends only on hook_input + env + store state -- no caller-visible
+    side effects. Every "None" branch means the caller emits nothing and
+    session behavior is exactly what it was before this hook existed.
+    """
+    env = env if env is not None else os.environ
+    if not _truthy(env.get(FLAG)):
+        return None
+    if learnings_store is None:
+        return None
+
+    cwd = hook_input.get("cwd") or os.getcwd()
+    slug = resolve_slug(cwd)
+
+    cfg = learnings_store.load_config()
+    max_results = int(cfg.get("max_results", learnings_store.DEFAULT_MAX_RESULTS))
+    token_budget = int(cfg.get("token_budget", learnings_store.DEFAULT_TOKEN_BUDGET))
+
+    selected = _select_for_injection(slug, max_results=max_results, token_budget=token_budget)
+    if not selected:
+        return None
+
+    repo_root = Path(cwd)
+    lines = [
+        "<ccgm-learnings-injection>",
+        f"Durable learnings for this project ({len(selected)} of top-ranked, budget-capped).",
+        "Each is a claim recorded at write time, not a live guarantee -- verify before",
+        "treating as settled fact, especially any files[] anchor.",
+        "",
+    ]
+    for e in selected:
+        eff = learnings_store.effective_confidence(e)
+        tags = ",".join(e.get("tags", []))
+        lines.append(
+            f"  - [{e.get('type')}] ({eff:.1f}) {e.get('content')}"
+            + (f"  [tags: {tags}]" if tags else "")
+        )
+        lines.append(f"    {_verify_wrapper(e, repo_root=repo_root)}")
+    lines += [
+        "",
+        "Run `ccgm-learnings-search --query <topic>` for more, or `--cross-project` to widen scope.",
+        "</ccgm-learnings-injection>",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions -- never resume/compact (prefix-cache
+    # safety: re-injecting per-turn is the exact anti-pattern this hook
+    # exists to avoid).
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(hook_input)
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/self-improving/hooks/learnings-inject.py
+++ b/modules/self-improving/hooks/learnings-inject.py
@@ -86,6 +86,13 @@ from pathlib import Path
 
 FLAG = "CCGM_LEARNINGS_INJECT"
 
+# Rough chars-per-token approximation; matches learnings_store.py's own
+# "4 chars ~ 1 token" convention (search()'s char_budget = budget * 4).
+# Distinct from the *candidate over-fetch* multiplier used below (also 4,
+# but an unrelated "fetch this many times the cap" concept -- Stage-2
+# review nit).
+CHARS_PER_TOKEN = 4
+
 # learnings_store.py is installed at ~/.claude/lib/learnings_store.py by CCGM
 # and lives at ../lib/learnings_store.py relative to this file's own repo
 # location. Insert both so the hook resolves it whether it is running from
@@ -156,22 +163,107 @@ def _verify_wrapper(entry: dict, *, repo_root: "Path | None" = None, now: "float
     last_verified = entry.get("last_verified") or entry.get("timestamp") or ""
     date_str = last_verified[:10] if len(last_verified) >= 10 else "unknown"
     wrapper = f"[age: {age}d · last_verified: {date_str} · verify files[] anchors before asserting]"
-    if learnings_store.has_stale_file_refs(entry, repo_root):
+    # files[] elements are supposed to be strings, but learnings_store's own
+    # validate_entry() only checks list-ness, not element type -- a caller
+    # of build_entry(..., files=[123]) writes successfully through the
+    # store's public API and only crashes here, at read time, inside
+    # has_stale_file_refs(). Filter defensively (skip, don't crash) rather
+    # than trust the shape (Stage-2 review: "hook must never raise").
+    safe_files = [f for f in (entry.get("files") or []) if isinstance(f, str)]
+    if learnings_store.has_stale_file_refs({**entry, "files": safe_files}, repo_root):
         wrapper += " [anchor-missing]"
     return wrapper
 
 
-def _select_for_injection(slug: str, *, max_results: int, token_budget: int) -> "list[dict]":
+def _render_entry_lines(entry: dict, *, repo_root: "Path | None" = None) -> "list[str]":
+    """The exact two lines build_context() emits for one entry: the bullet
+    (type/confidence/content/tags) and the verification wrapper. Shared by
+    _select_for_injection()'s budget accounting and build_context()'s real
+    render so the two can never drift apart -- the root cause of the
+    Stage-2 budget-overflow finding was an estimate (`len(content) + 80`)
+    that did not know this second, wrapper line existed at all.
+    """
+    eff = learnings_store.effective_confidence(entry)
+    tags = ",".join(entry.get("tags", []))
+    bullet = (
+        f"  - [{entry.get('type')}] ({eff:.1f}) {entry.get('content')}"
+        + (f"  [tags: {tags}]" if tags else "")
+    )
+    wrapper = f"    {_verify_wrapper(entry, repo_root=repo_root)}"
+    return [bullet, wrapper]
+
+
+def _envelope_lines(count: int) -> "tuple[list[str], list[str]]":
+    """The exact header/footer line lists build_context() wraps entries in,
+    parameterized by the "N of top-ranked" count so the real render and the
+    budget pre-check below always use identical text."""
+    header = [
+        "<ccgm-learnings-injection>",
+        f"Durable learnings for this project ({count} of top-ranked, budget-capped).",
+        "Each is a claim recorded at write time, not a live guarantee -- verify before",
+        "treating as settled fact, especially any files[] anchor.",
+        "",
+    ]
+    footer = [
+        "",
+        "Run `ccgm-learnings-search --query <topic>` for more, or `--cross-project` to widen scope.",
+        "</ccgm-learnings-injection>",
+    ]
+    return header, footer
+
+
+def _envelope_char_cost(max_results: int) -> int:
+    """Reserved char cost of the header+footer envelope around the entries,
+    computed with max_results as an upper bound on the eventual "N of
+    top-ranked" digit count -- the real len(selected) can never exceed
+    max_results, so this can never *underestimate* the true reservation
+    (only ever reserve a few extra, harmless chars when the digit count of
+    the eventual real count is shorter than max_results's).
+
+    Mirrors exactly what "\\n".join(header + entries + footer) + "\\n" costs
+    when zero entries are spliced in: sum(line lengths) + (n-1) internal
+    separators + 1 trailing newline == sum(line lengths) + n. The per-entry
+    loop in _select_for_injection() adds its own "+2" per entry for the two
+    newline separators each entry's two lines introduce once spliced
+    between header and footer -- see that loop for the entry-side half of
+    this same accounting.
+    """
+    header, footer = _envelope_lines(max(max_results, 0))
+    all_lines = header + footer
+    return sum(len(line) for line in all_lines) + len(all_lines)
+
+
+def _select_for_injection(
+    slug: str, *, max_results: int, token_budget: int, repo_root: "Path | None" = None
+) -> "list[dict]":
     """Fetch a superset of ranked candidates via learnings_store.search()
     (ranking/relevance/decay stay entirely owned by the store), drop
     conflicted rows (adrev-011), then re-apply the real cap/budget over the
     filtered, already-ranked set -- mirroring search()'s own trailing budget
     loop so backfill works after conflict suppression.
 
+    Budget accounting uses the ACTUAL rendered text (_render_entry_lines(),
+    the same helper build_context() renders with) rather than an estimate,
+    and reserves the header/footer envelope's fixed cost
+    (_envelope_char_cost()) before the per-entry loop runs -- so the
+    invariant `len(build_context(...)) <= token_budget * CHARS_PER_TOKEN`
+    holds by construction, not by chance (Stage-2 review: the prior
+    `len(content) + 80` heuristic knew about neither the wrapper line nor
+    the envelope, and drifted 129-136% over budget under realistic,
+    non-default configs).
+
+    max_results <= 0 means "inject nothing": returns [] immediately, rather
+    than the previous pre-cap-check loop shape that appended before
+    checking the cap and so returned exactly 1 entry for max_results=0
+    (Stage-2 review, Recommend).
+
     Over-fetches 4x cap/budget: conflicts should be rare, and this margin is
     enough for a non-conflicted alternative to backfill in the common case
     without walking the entire store.
     """
+    if max_results <= 0:
+        return []
+
     over_fetched = learnings_store.search(
         slug=slug,
         max_results=max_results * 4,
@@ -179,15 +271,21 @@ def _select_for_injection(slug: str, *, max_results: int, token_budget: int) -> 
     )
     non_conflicted = [e for e in over_fetched if not e.get("conflict")]
 
-    char_budget = token_budget * 4
+    char_budget = token_budget * CHARS_PER_TOKEN
+    available = char_budget - _envelope_char_cost(max_results)
+
     used = 0
     out: "list[dict]" = []
     for e in non_conflicted:
-        snippet_len = len(e.get("content", "")) + 80
-        if used + snippet_len > char_budget:
+        bullet, wrapper = _render_entry_lines(e, repo_root=repo_root)
+        # +2: the two newline separators this entry's two lines add once
+        # spliced between the surrounding lines (see _envelope_char_cost()'s
+        # docstring for the matching header/footer half of this accounting).
+        entry_cost = len(bullet) + len(wrapper) + 2
+        if used + entry_cost > available:
             break
         out.append(e)
-        used += snippet_len
+        used += entry_cost
         if len(out) >= max_results:
             break
     return out
@@ -199,6 +297,14 @@ def build_context(hook_input: dict, env: "dict[str, str] | None" = None) -> "str
     Depends only on hook_input + env + store state -- no caller-visible
     side effects. Every "None" branch means the caller emits nothing and
     session behavior is exactly what it was before this hook existed.
+
+    NOTE: `env` only gates the CCGM_LEARNINGS_INJECT flag checked just
+    below -- project-slug resolution (resolve_slug() ->
+    learnings_store.detect_project_slug()) always reads the REAL process
+    os.environ, regardless of what is passed here. Harmless in production
+    (where `env` defaults to `os.environ` anyway); tests that need to
+    isolate slug resolution do so via CCGM_LEARNINGS_PROJECT/DIR, not via
+    this parameter.
     """
     env = env if env is not None else os.environ
     if not _truthy(env.get(FLAG)):
@@ -208,36 +314,33 @@ def build_context(hook_input: dict, env: "dict[str, str] | None" = None) -> "str
 
     cwd = hook_input.get("cwd") or os.getcwd()
     slug = resolve_slug(cwd)
+    repo_root = Path(cwd)
 
     cfg = learnings_store.load_config()
-    max_results = int(cfg.get("max_results", learnings_store.DEFAULT_MAX_RESULTS))
-    token_budget = int(cfg.get("token_budget", learnings_store.DEFAULT_TOKEN_BUDGET))
+    # cfg values come from a user-editable config.json: syntactically valid
+    # JSON with the wrong type (a string, or null) must fall back to the
+    # store's own defaults, never crash a SessionStart hook (Stage-2
+    # review, matches this file's own established local-guard idiom).
+    try:
+        max_results = int(cfg.get("max_results", learnings_store.DEFAULT_MAX_RESULTS))
+    except (TypeError, ValueError):
+        max_results = learnings_store.DEFAULT_MAX_RESULTS
+    try:
+        token_budget = int(cfg.get("token_budget", learnings_store.DEFAULT_TOKEN_BUDGET))
+    except (TypeError, ValueError):
+        token_budget = learnings_store.DEFAULT_TOKEN_BUDGET
 
-    selected = _select_for_injection(slug, max_results=max_results, token_budget=token_budget)
+    selected = _select_for_injection(
+        slug, max_results=max_results, token_budget=token_budget, repo_root=repo_root
+    )
     if not selected:
         return None
 
-    repo_root = Path(cwd)
-    lines = [
-        "<ccgm-learnings-injection>",
-        f"Durable learnings for this project ({len(selected)} of top-ranked, budget-capped).",
-        "Each is a claim recorded at write time, not a live guarantee -- verify before",
-        "treating as settled fact, especially any files[] anchor.",
-        "",
-    ]
+    header, footer = _envelope_lines(len(selected))
+    lines = list(header)
     for e in selected:
-        eff = learnings_store.effective_confidence(e)
-        tags = ",".join(e.get("tags", []))
-        lines.append(
-            f"  - [{e.get('type')}] ({eff:.1f}) {e.get('content')}"
-            + (f"  [tags: {tags}]" if tags else "")
-        )
-        lines.append(f"    {_verify_wrapper(e, repo_root=repo_root)}")
-    lines += [
-        "",
-        "Run `ccgm-learnings-search --query <topic>` for more, or `--cross-project` to widen scope.",
-        "</ccgm-learnings-injection>",
-    ]
+        lines.extend(_render_entry_lines(e, repo_root=repo_root))
+    lines.extend(footer)
     return "\n".join(lines) + "\n"
 
 
@@ -253,7 +356,15 @@ def main() -> None:
     if hook_input.get("source", "") != "startup":
         return
 
-    context = build_context(hook_input)
+    # Defense-in-depth (Stage-2 review): build_context() should never raise,
+    # but a SessionStart hook must NEVER surface a traceback regardless of
+    # what upstream guard might have a gap -- any unexpected failure here is
+    # a silent no-op, same as every other "nothing to inject" branch above.
+    try:
+        context = build_context(hook_input)
+    except Exception:
+        return
+
     if context:
         sys.stdout.write(context)
 

--- a/modules/self-improving/module.json
+++ b/modules/self-improving/module.json
@@ -13,6 +13,7 @@
     "commands/retro.md": { "target": "commands/retro.md", "type": "command", "template": false },
     "hooks/reflection-trigger.py": { "target": "hooks/reflection-trigger.py", "type": "hook", "template": false },
     "hooks/precompact-reflection.py": { "target": "hooks/precompact-reflection.py", "type": "hook", "template": false },
+    "hooks/learnings-inject.py": { "target": "hooks/learnings-inject.py", "type": "hook", "template": false },
     "bin/ccgm-learnings-log": { "target": "bin/ccgm-learnings-log", "type": "script", "template": false },
     "bin/ccgm-learnings-search": { "target": "bin/ccgm-learnings-search", "type": "script", "template": false },
     "lib/learnings_store.py": { "target": "lib/learnings_store.py", "type": "lib", "template": false },

--- a/modules/self-improving/settings.partial.json
+++ b/modules/self-improving/settings.partial.json
@@ -22,6 +22,18 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/learnings-inject.py",
+            "timeout": 5000
+          }
+        ]
+      }
     ]
   }
 }

--- a/modules/self-improving/tests/test_learnings_inject.py
+++ b/modules/self-improving/tests/test_learnings_inject.py
@@ -79,8 +79,13 @@ search_cli = _load_module("ccgm_learnings_search_cli", SEARCH_CLI_PATH)
 
 
 class HermeticEnvTestCase(unittest.TestCase):
-    """Base class: saves + restores CCGM_LEARNINGS_PROJECT and
-    CCGM_LEARNINGS_DIR around every test (issue #764 defense-in-depth).
+    """Base class: saves + restores CCGM_LEARNINGS_PROJECT, CCGM_LEARNINGS_DIR,
+    and config.json around every test (issue #764 defense-in-depth). The
+    config.json guard exists for the Stage-2-review regression tests below
+    (budget/config-cast/conflict-render) that call `ls.save_config(...)` --
+    CONFIG_PATH lives inside the SAME shared CCGM_LEARNINGS_DIR tempdir
+    every test in this file runs against, so a config left behind by one
+    test would otherwise leak into every test that runs after it.
 
     Subclasses that override setUp() must call super().setUp() FIRST (before
     mutating either var) so the pre-test value is captured accurately.
@@ -94,6 +99,12 @@ class HermeticEnvTestCase(unittest.TestCase):
                 self.addCleanup(os.environ.pop, key, None)
             else:
                 self.addCleanup(os.environ.__setitem__, key, saved)
+
+        if ls.CONFIG_PATH.is_file():
+            saved_config = ls.CONFIG_PATH.read_bytes()
+            self.addCleanup(ls.CONFIG_PATH.write_bytes, saved_config)
+        else:
+            self.addCleanup(lambda: ls.CONFIG_PATH.unlink(missing_ok=True))
 
 
 # ---------------------------------------------------------------------------
@@ -234,6 +245,79 @@ class SearchCliSubprocessTests(HermeticEnvTestCase):
         self.assertIn("age_days", rows[0])
 
 
+class SearchCliConflictRenderingTests(HermeticEnvTestCase):
+    """adrev-011 half (b): unlike the SessionStart injection path (which
+    suppresses conflicted rows outright, hooks/learnings-inject.py), the
+    search CLI must render a visible marker on a conflicted row -- a human
+    running this CLI directly should see the conflict, not have it silently
+    hidden as if it were settled truth. Same fixture technique as
+    ConflictSuppressionTests below (two independent supersedes on the same
+    target -> conflict: true on both live heads)."""
+
+    def setUp(self):
+        super().setUp()
+        self.slug = f"search-conflict-{uuid.uuid4().hex[:10]}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        os.environ.pop("CCGM_AGENT_ID", None)
+
+        contested = ls.build_entry(type_="pattern", content="contested cli-render learning", confidence=9)
+        ls.append_entry(contested)
+        self.old_id = contested["id"]
+        ls.supersede_entry(self.old_id, content="conflicted cli branch A", slug=self.slug)
+        ls.supersede_entry(self.old_id, content="conflicted cli branch B", slug=self.slug)
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+        os.environ.pop("CCGM_AGENT_ID", None)
+        super().tearDown()
+
+    def _conflicted_rows(self) -> list[dict]:
+        rows = [r for r in ls.search(slug=self.slug) if r.get("conflict")]
+        self.assertEqual(len(rows), 2, "fixture setup should yield exactly 2 live conflicting heads")
+        return rows
+
+    def test_verify_wrapper_tags_conflicted_row(self):
+        wrapper = search_cli._verify_wrapper(self._conflicted_rows()[0])
+        self.assertIn("[conflict: competing heads", wrapper)
+        self.assertIn("not settled", wrapper)
+
+    def test_verify_wrapper_does_not_tag_clean_row(self):
+        clean = ls.build_entry(type_="pattern", content="clean cli-render learning", confidence=9)
+        wrapper = search_cli._verify_wrapper(clean)
+        self.assertNotIn("[conflict:", wrapper)
+
+    def test_preamble_shows_conflict_tag(self):
+        out = search_cli._render_preamble(self._conflicted_rows())
+        self.assertIn("[conflict: competing heads", out)
+
+    def test_markdown_shows_conflict_tag(self):
+        out = search_cli._render_markdown(self._conflicted_rows())
+        self.assertIn("[conflict: competing heads", out)
+
+    def test_cli_subprocess_shows_conflict_tag_and_does_not_suppress(self):
+        env = os.environ.copy()
+        env["CCGM_LEARNINGS_DIR"] = str(ls.LEARNINGS_ROOT)
+        result = subprocess.run(
+            [sys.executable, str(SEARCH_CLI_PATH), "--project", self.slug, "--max", "10"],
+            env=env, capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("[conflict: competing heads", result.stdout)
+        # Do NOT suppress: unlike the SessionStart injection path, a human
+        # running the CLI directly should still see both competing heads.
+        self.assertIn("conflicted cli branch A", result.stdout)
+        self.assertIn("conflicted cli branch B", result.stdout)
+
+    def test_jsonl_still_carries_conflict_field(self):
+        rows = self._conflicted_rows()
+        out = search_cli._render_jsonl(rows)
+        parsed = [json.loads(line) for line in out.strip().splitlines()]
+        self.assertEqual(len(parsed), 2)
+        for row in parsed:
+            self.assertTrue(row.get("conflict"))
+
+
 # ---------------------------------------------------------------------------
 # learnings-inject.py: opt-in gate, budget, ordering, conflict suppression
 # ---------------------------------------------------------------------------
@@ -366,16 +450,20 @@ class SelectForInjectionBudgetTests(HermeticEnvTestCase):
         shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
         super().tearDown()
 
-    def test_respects_small_token_budget(self):
-        # ~90-char content -> ~170-char snippet (content + 80 overhead) each.
-        # A 90-token (360-char) budget fits exactly 2 of the 6 entries
-        # (2*170=340 <= 360 < 510=3*170), so this pins a genuine partial cap
-        # rather than an all-or-nothing budget.
-        selected = hook._select_for_injection(self.slug, max_results=6, token_budget=90)
+    def test_partial_selection_under_tight_budget(self):
+        # A 200-token (800-char) budget with 6 sizeable entries should
+        # select some but not all -- a genuine partial cap, not an
+        # all-or-nothing budget. (The envelope alone costs ~352 real chars
+        # for this fixture, and each real entry ~195 -- a budget much
+        # smaller than 800 would be consumed entirely by the envelope
+        # reservation and legitimately select zero; see
+        # BuildContextTokenBudgetTests below for the actual
+        # budget-compliance regression assertion, which checks the real
+        # observable len(build_context(...)) rather than recomputing the
+        # code's own internal estimate here.)
+        selected = hook._select_for_injection(self.slug, max_results=6, token_budget=200)
         self.assertGreater(len(selected), 0)
         self.assertLess(len(selected), 6)
-        total_chars = sum(len(e.get("content", "")) + 80 for e in selected)
-        self.assertLessEqual(total_chars, 90 * 4)
 
     def test_respects_max_results_cap(self):
         selected = hook._select_for_injection(self.slug, max_results=2, token_budget=2000)
@@ -384,6 +472,161 @@ class SelectForInjectionBudgetTests(HermeticEnvTestCase):
     def test_generous_budget_returns_all(self):
         selected = hook._select_for_injection(self.slug, max_results=8, token_budget=2000)
         self.assertEqual(len(selected), 6)
+
+    def test_max_results_zero_returns_empty(self):
+        # Stage-2 review, Recommend: the old loop appended before checking
+        # the cap, so max_results=0 returned exactly 1 entry instead of 0.
+        selected = hook._select_for_injection(self.slug, max_results=0, token_budget=2000)
+        self.assertEqual(selected, [])
+
+    def test_max_results_negative_returns_empty(self):
+        selected = hook._select_for_injection(self.slug, max_results=-1, token_budget=2000)
+        self.assertEqual(selected, [])
+
+
+class BuildContextTokenBudgetTests(HermeticEnvTestCase):
+    """Regression guard for the Stage-2 budget-overflow finding: the OLD
+    per-entry estimate (`len(content) + 80`) did not know about the second
+    (verify-wrapper) rendered line per entry, nor about the header/footer
+    envelope, and drifted 129-136% over the configured budget under
+    realistic (non-default) configs -- while the one test meant to catch it
+    recomputed that same broken estimate and could never fail. The only
+    assertion that actually proves the invariant is on build_context()'s
+    real, observable output length -- never an internal estimate.
+
+    60 entries (bigger than SelectForInjectionBudgetTests' 6-entry fixture)
+    so that at max_results=100/token_budget=2000 the token budget -- not
+    entry-count scarcity or the cap -- is genuinely the binding constraint,
+    same as it would be for a real, well-populated store.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.slug = f"inject-real-budget-{uuid.uuid4().hex[:10]}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        for i in range(60):
+            e = ls.build_entry(
+                type_="pattern",
+                content=f"real budget regression fixture entry number {i} " + ("x" * 60),
+                confidence=9,
+            )
+            ls.append_entry(e)
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+        super().tearDown()
+
+    def test_build_context_never_exceeds_configured_budget(self):
+        # The exact two (max_results, token_budget) configs the Stage-2
+        # review reproduced overflow with (129% and 136% of budget
+        # respectively, against an independently-sized store).
+        for max_results, token_budget in ((100, 2000), (8, 300)):
+            with self.subTest(max_results=max_results, token_budget=token_budget):
+                ls.save_config({"max_results": max_results, "token_budget": token_budget})
+                block = hook.build_context(
+                    {"source": "startup", "cwd": os.getcwd()},
+                    env={"CCGM_LEARNINGS_INJECT": "true"},
+                )
+                self.assertIsNotNone(block, "expected at least one entry to fit the budget")
+                self.assertLessEqual(len(block), token_budget * 4)
+
+
+class ConfigCastGuardTests(HermeticEnvTestCase):
+    """Stage-2 review Blocking #2: a syntactically-valid but
+    semantically-wrong-typed config.json (max_results/token_budget as a
+    string, or null) crashed the hook with an unhandled ValueError/TypeError
+    from the raw int() casts -- directly contradicting this file's own
+    "never raises" safety claim. Uses an EMPTY store so the assertion
+    isolates the crash-safety property (exit 0, no stderr, no stdout) from
+    selection correctness -- with nothing in the store to select, "prints
+    nothing" is the expected output regardless of which fallback default
+    the guard resolves to.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.slug = f"inject-badconfig-{uuid.uuid4().hex[:10]}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+        super().tearDown()
+
+    def _run(self) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        env["CCGM_LEARNINGS_PROJECT"] = self.slug
+        env["CCGM_LEARNINGS_DIR"] = str(ls.LEARNINGS_ROOT)
+        env["CCGM_LEARNINGS_INJECT"] = "true"
+        return subprocess.run(
+            [sys.executable, str(INJECT_HOOK_PATH)],
+            input=json.dumps({"source": "startup", "cwd": os.getcwd()}),
+            env=env, capture_output=True, text=True,
+        )
+
+    def test_max_results_wrong_type_never_crashes(self):
+        ls.save_config({"max_results": "not-a-number", "token_budget": 2000})
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(result.stdout, "")
+
+    def test_max_results_null_never_crashes(self):
+        ls.save_config({"max_results": None, "token_budget": 2000})
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(result.stdout, "")
+
+    def test_token_budget_wrong_type_never_crashes(self):
+        ls.save_config({"max_results": 8, "token_budget": "not-a-number"})
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(result.stdout, "")
+
+
+class FilesFieldCrashGuardTests(HermeticEnvTestCase):
+    """Stage-2 review Blocking #2 (second reachable path): files[] elements
+    are supposed to be strings, but learnings_store.validate_entry() only
+    checks list-ness, not element type, so
+    learnings_store.build_entry(..., files=[123]) writes successfully
+    through the store's own public API and only crashes later, at read
+    time, inside has_stale_file_refs(). The hook must tolerate this (skip
+    the bad element, don't crash) and must not let one bad entry suppress
+    its well-formed siblings from the same injected block.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.slug = f"inject-badfiles-{uuid.uuid4().hex[:10]}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        bad = ls.build_entry(
+            type_="pattern", content="entry with non-string files element", confidence=9, files=[123],
+        )
+        ls.append_entry(bad)
+        ls.append_entry(ls.build_entry(type_="pattern", content="clean sibling entry", confidence=9))
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+        super().tearDown()
+
+    def test_non_string_files_element_never_crashes_and_still_injects_siblings(self):
+        env = os.environ.copy()
+        env["CCGM_LEARNINGS_PROJECT"] = self.slug
+        env["CCGM_LEARNINGS_DIR"] = str(ls.LEARNINGS_ROOT)
+        env["CCGM_LEARNINGS_INJECT"] = "true"
+        result = subprocess.run(
+            [sys.executable, str(INJECT_HOOK_PATH)],
+            input=json.dumps({"source": "startup", "cwd": os.getcwd()}),
+            env=env, capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+        self.assertIn("entry with non-string files element", result.stdout)
+        self.assertIn("clean sibling entry", result.stdout)
 
 
 class OrderingStabilityTests(HermeticEnvTestCase):

--- a/modules/self-improving/tests/test_learnings_inject.py
+++ b/modules/self-improving/tests/test_learnings_inject.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""
+Tests for the learnings-store READ path (epic 4, issue #754):
+
+  - modules/self-improving/bin/ccgm-learnings-search's new age/verify
+    wrapper, `--format jsonl` `age_days` field, and `[anchor-missing]`
+    tagging.
+  - modules/self-improving/hooks/learnings-inject.py, the new opt-in,
+    prefix-cache-safe SessionStart injection hook.
+
+Runs against an isolated CCGM_LEARNINGS_DIR tempdir, never the real
+~/.claude/learnings/ store.
+
+Hermetic by design (issue #764 defense-in-depth): #764 documents a leak
+where a self-improving test setUp sets CCGM_LEARNINGS_PROJECT /
+CCGM_LEARNINGS_DIR without a matching tearDown restore, poisoning slug
+resolution in tests that run later in the same pytest process. Fixing that
+leak in test_learnings_store.py is tracked separately (#764) and is out of
+scope here (that file is not touched by this change). This file protects
+itself either way: every test that touches either env var goes through
+HermeticEnvTestCase, which saves the pre-test value in setUp and restores
+(not merely deletes) it via addCleanup, so this file can never leak into --
+or be silently misled by -- a sibling test file/process.
+
+Run with: python3 -m pytest modules/self-improving/tests/test_learnings_inject.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import uuid
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[2]
+
+sys.path.insert(0, str(HERE.parent / "lib"))
+
+# Isolate the store BEFORE importing learnings_store -- LEARNINGS_ROOT and
+# LEARNINGS_CACHE_ROOT are module-level constants computed once at import
+# time from this env var (mirrors test_learnings_store.py's own setup).
+_TMP = tempfile.mkdtemp(prefix="ccgm-learnings-inject-test-")
+os.environ["CCGM_LEARNINGS_DIR"] = _TMP
+
+import learnings_store as ls  # noqa: E402
+
+SEARCH_CLI_PATH = HERE.parent / "bin" / "ccgm-learnings-search"
+INJECT_HOOK_PATH = HERE.parent / "hooks" / "learnings-inject.py"
+REPO_DETECT_PATH = REPO_ROOT / "modules" / "session-history" / "scripts" / "repo_detect.py"
+
+
+def _load_module(name: str, path: Path):
+    # spec_from_file_location() infers the loader from the file extension,
+    # which fails for extension-less scripts like ccgm-learnings-search and
+    # learnings-inject.py's installed-symlink name. Building the loader
+    # explicitly works regardless of the file's name/extension.
+    loader = SourceFileLoader(name, str(path))
+    spec = importlib.util.spec_from_loader(name, loader)
+    assert spec
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+# The hook and the ccgm-learnings-search CLI are extension-less scripts; load
+# them once as modules so most tests can call their functions directly
+# instead of paying subprocess overhead. A handful of tests below still
+# shell out via subprocess to pin the real stdin/argv/stdout contract.
+hook = _load_module("learnings_inject_hook", INJECT_HOOK_PATH)
+search_cli = _load_module("ccgm_learnings_search_cli", SEARCH_CLI_PATH)
+
+
+class HermeticEnvTestCase(unittest.TestCase):
+    """Base class: saves + restores CCGM_LEARNINGS_PROJECT and
+    CCGM_LEARNINGS_DIR around every test (issue #764 defense-in-depth).
+
+    Subclasses that override setUp() must call super().setUp() FIRST (before
+    mutating either var) so the pre-test value is captured accurately.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        for key in ("CCGM_LEARNINGS_PROJECT", "CCGM_LEARNINGS_DIR"):
+            saved = os.environ.get(key)
+            if saved is None:
+                self.addCleanup(os.environ.pop, key, None)
+            else:
+                self.addCleanup(os.environ.__setitem__, key, saved)
+
+
+# ---------------------------------------------------------------------------
+# ccgm-learnings-search: age/verify wrapper, age_days, anchor-missing
+# ---------------------------------------------------------------------------
+
+class SearchWrapperRenderingTests(unittest.TestCase):
+    """Pure rendering-function tests -- no store I/O, no env dependence."""
+
+    def _entry(self, **overrides) -> dict:
+        base = ls.build_entry(type_="pattern", content="wrapper rendering fixture", confidence=8)
+        base.update(overrides)
+        return base
+
+    def test_preamble_includes_age_wrapper(self):
+        out = search_cli._render_preamble([self._entry()])
+        self.assertIn("[age:", out)
+        self.assertIn("verify files[] anchors before asserting", out)
+
+    def test_markdown_includes_age_wrapper(self):
+        out = search_cli._render_markdown([self._entry()])
+        self.assertIn("[age:", out)
+        self.assertIn("verify files[] anchors before asserting", out)
+
+    def test_age_days_reflects_elapsed_time(self):
+        e = self._entry()
+        e["last_verified"] = "2020-01-01T00:00:00.000Z"
+        now = ls._parse_iso("2020-01-11T00:00:00.000Z")  # exactly 10 days later
+        self.assertEqual(search_cli._age_days(e, now=now), 10)
+
+    def test_age_days_zero_for_unparseable_timestamp(self):
+        e = self._entry()
+        e["last_verified"] = ""
+        e["timestamp"] = ""
+        self.assertEqual(search_cli._age_days(e), 0)
+
+    def test_jsonl_gains_age_days_and_nothing_else_changes(self):
+        e = self._entry()
+        out = search_cli._render_jsonl([e])
+        parsed = json.loads(out.strip())
+        self.assertIn("age_days", parsed)
+        self.assertIsInstance(parsed["age_days"], int)
+
+        original_keys = set(e.keys())
+        parsed_keys = set(parsed.keys())
+        self.assertEqual(parsed_keys - original_keys, {"age_days"},
+                          "jsonl format must add exactly age_days, nothing else")
+        self.assertEqual(original_keys - parsed_keys, set(),
+                          "jsonl format must not drop any existing field")
+        for k in original_keys:
+            self.assertEqual(parsed[k], e[k], f"field {k!r} changed value/shape")
+
+    def test_jsonl_empty_input_still_empty_output(self):
+        self.assertEqual(search_cli._render_jsonl([]), "")
+
+    def test_anchor_missing_tagged_when_file_gone(self):
+        e = self._entry(files=["definitely/does/not/exist.py"])
+        with tempfile.TemporaryDirectory() as td:
+            wrapper = search_cli._verify_wrapper(e, repo_root=Path(td))
+        self.assertIn("[anchor-missing]", wrapper)
+
+    def test_anchor_present_not_tagged(self):
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / "exists.py").write_text("# fixture\n", encoding="utf-8")
+            e = self._entry(files=["exists.py"])
+            wrapper = search_cli._verify_wrapper(e, repo_root=Path(td))
+        self.assertNotIn("[anchor-missing]", wrapper)
+
+    def test_no_files_never_tagged(self):
+        e = self._entry(files=[])
+        with tempfile.TemporaryDirectory() as td:
+            wrapper = search_cli._verify_wrapper(e, repo_root=Path(td))
+        self.assertNotIn("[anchor-missing]", wrapper)
+
+    def test_no_repo_root_never_tagged(self):
+        # has_stale_file_refs fails safe (False) when repo_root is None,
+        # regardless of whether files[] is populated.
+        e = self._entry(files=["some/file.py"])
+        wrapper = search_cli._verify_wrapper(e, repo_root=None)
+        self.assertNotIn("[anchor-missing]", wrapper)
+
+
+class SearchCliSubprocessTests(HermeticEnvTestCase):
+    """End-to-end: invoke the real ccgm-learnings-search script, pinning the
+    literal contract the acceptance criteria exercise
+    (`ccgm-learnings-search --query git --max 2`)."""
+
+    def setUp(self):
+        super().setUp()
+        self.slug = f"inject-cli-{uuid.uuid4().hex[:10]}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        e = ls.build_entry(
+            type_="pattern", content="git branch workflow fixture learning",
+            tags=["git"], confidence=8,
+        )
+        ls.append_entry(e)
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+        super().tearDown()
+
+    def _env(self):
+        env = os.environ.copy()
+        env["CCGM_LEARNINGS_PROJECT"] = self.slug
+        # Pin to the store dir THIS process actually bound at import time
+        # (ls.LEARNINGS_ROOT), never the raw os.environ value: if a sibling
+        # test file (e.g. test_learnings_store.py) is collected in the same
+        # pytest run and reassigns CCGM_LEARNINGS_DIR at ITS OWN module
+        # level, os.environ ends up holding whichever file's assignment ran
+        # last while ls.LEARNINGS_ROOT stays bound to whichever file
+        # imported learnings_store FIRST (import caching) -- the two can
+        # diverge. Spawning a subprocess with the stale env value would
+        # silently query an empty, unrelated directory (issue #764's class
+        # of bug, manifesting through CCGM_LEARNINGS_DIR instead of
+        # CCGM_LEARNINGS_PROJECT). Pinning to ls.LEARNINGS_ROOT directly
+        # makes this test immune to collection order.
+        env["CCGM_LEARNINGS_DIR"] = str(ls.LEARNINGS_ROOT)
+        return env
+
+    def test_cli_preamble_output_shows_age_wrapper(self):
+        result = subprocess.run(
+            [sys.executable, str(SEARCH_CLI_PATH), "--query", "git", "--max", "2"],
+            env=self._env(), capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("[age:", result.stdout)
+        self.assertIn("verify files[] anchors before asserting", result.stdout)
+
+    def test_cli_jsonl_output_shape(self):
+        result = subprocess.run(
+            [sys.executable, str(SEARCH_CLI_PATH), "--query", "git", "--format", "jsonl"],
+            env=self._env(), capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        rows = [json.loads(line) for line in result.stdout.strip().splitlines()]
+        self.assertTrue(rows)
+        self.assertIn("age_days", rows[0])
+
+
+# ---------------------------------------------------------------------------
+# learnings-inject.py: opt-in gate, budget, ordering, conflict suppression
+# ---------------------------------------------------------------------------
+
+class TruthyTests(unittest.TestCase):
+    def test_truthy_values(self):
+        self.assertTrue(hook._truthy("true"))
+        self.assertTrue(hook._truthy("TRUE"))
+        self.assertTrue(hook._truthy("1"))
+        self.assertTrue(hook._truthy("yes"))
+
+    def test_falsy_values(self):
+        self.assertFalse(hook._truthy("false"))
+        self.assertFalse(hook._truthy("0"))
+        self.assertFalse(hook._truthy(None))
+        self.assertFalse(hook._truthy(""))
+
+
+class BuildContextGateTests(HermeticEnvTestCase):
+    def setUp(self):
+        super().setUp()
+        self.slug = f"inject-gate-{uuid.uuid4().hex[:10]}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        ls.append_entry(ls.build_entry(type_="pattern", content="gate fixture learning", confidence=9))
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+        super().tearDown()
+
+    def test_silent_when_flag_unset(self):
+        self.assertIsNone(hook.build_context({"source": "startup", "cwd": os.getcwd()}, env={}))
+
+    def test_silent_when_flag_false(self):
+        self.assertIsNone(
+            hook.build_context({"source": "startup", "cwd": os.getcwd()}, env={"CCGM_LEARNINGS_INJECT": "false"})
+        )
+
+    def test_emits_block_when_flag_true(self):
+        block = hook.build_context(
+            {"source": "startup", "cwd": os.getcwd()}, env={"CCGM_LEARNINGS_INJECT": "true"}
+        )
+        self.assertIsNotNone(block)
+        self.assertIn("<ccgm-learnings-injection>", block)
+        self.assertIn("</ccgm-learnings-injection>", block)
+        self.assertIn("gate fixture learning", block)
+
+
+class HookSubprocessTests(HermeticEnvTestCase):
+    """End-to-end: the literal stdin/env contract from the acceptance
+    criteria (`echo '{"source":"startup"}' | CCGM_LEARNINGS_INJECT=true
+    python3 .../learnings-inject.py`)."""
+
+    def setUp(self):
+        super().setUp()
+        self.slug = f"inject-subproc-{uuid.uuid4().hex[:10]}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        ls.append_entry(ls.build_entry(type_="pattern", content="subprocess visible learning", confidence=8))
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+        super().tearDown()
+
+    def _env(self, **extra):
+        env = os.environ.copy()
+        env["CCGM_LEARNINGS_PROJECT"] = self.slug
+        # See SearchCliSubprocessTests._env() for why this is pinned to the
+        # actually-bound ls.LEARNINGS_ROOT rather than trusted from
+        # os.environ (issue #764-class collection-order hazard).
+        env["CCGM_LEARNINGS_DIR"] = str(ls.LEARNINGS_ROOT)
+        env.pop("CCGM_LEARNINGS_INJECT", None)
+        env.update(extra)
+        return env
+
+    def _run(self, source: str, **extra_env) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(INJECT_HOOK_PATH)],
+            input=json.dumps({"source": source, "cwd": os.getcwd()}),
+            env=self._env(**extra_env),
+            capture_output=True, text=True,
+        )
+
+    def test_prints_block_when_flag_set(self):
+        result = self._run("startup", CCGM_LEARNINGS_INJECT="true")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("ccgm-learnings-injection", result.stdout)
+        self.assertIn("subprocess visible learning", result.stdout)
+
+    def test_silent_without_flag(self):
+        result = self._run("startup")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_silent_on_non_startup_sources_even_with_flag(self):
+        for source in ("resume", "compact"):
+            with self.subTest(source=source):
+                result = self._run(source, CCGM_LEARNINGS_INJECT="true")
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, "", f"expected no-op for source={source!r}")
+
+    def test_malformed_stdin_never_crashes(self):
+        result = subprocess.run(
+            [sys.executable, str(INJECT_HOOK_PATH)],
+            input="not json{{{",
+            env=self._env(CCGM_LEARNINGS_INJECT="true"),
+            capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        # No "source" survives a parse failure -> falls through the
+        # startup-only gate -> silent, same as any other non-startup call.
+        self.assertEqual(result.stdout, "")
+
+
+class SelectForInjectionBudgetTests(HermeticEnvTestCase):
+    def setUp(self):
+        super().setUp()
+        self.slug = f"inject-budget-{uuid.uuid4().hex[:10]}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        for i in range(6):
+            e = ls.build_entry(
+                type_="pattern",
+                content=f"budget test learning number {i} " + ("x" * 60),
+                confidence=9,
+            )
+            ls.append_entry(e)
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+        super().tearDown()
+
+    def test_respects_small_token_budget(self):
+        # ~90-char content -> ~170-char snippet (content + 80 overhead) each.
+        # A 90-token (360-char) budget fits exactly 2 of the 6 entries
+        # (2*170=340 <= 360 < 510=3*170), so this pins a genuine partial cap
+        # rather than an all-or-nothing budget.
+        selected = hook._select_for_injection(self.slug, max_results=6, token_budget=90)
+        self.assertGreater(len(selected), 0)
+        self.assertLess(len(selected), 6)
+        total_chars = sum(len(e.get("content", "")) + 80 for e in selected)
+        self.assertLessEqual(total_chars, 90 * 4)
+
+    def test_respects_max_results_cap(self):
+        selected = hook._select_for_injection(self.slug, max_results=2, token_budget=2000)
+        self.assertLessEqual(len(selected), 2)
+
+    def test_generous_budget_returns_all(self):
+        selected = hook._select_for_injection(self.slug, max_results=8, token_budget=2000)
+        self.assertEqual(len(selected), 6)
+
+
+class OrderingStabilityTests(HermeticEnvTestCase):
+    def setUp(self):
+        super().setUp()
+        self.slug = f"inject-order-{uuid.uuid4().hex[:10]}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        for conf in (9, 7, 5):
+            e = ls.build_entry(type_="pattern", content=f"ordering fixture confidence {conf}", confidence=conf)
+            ls.append_entry(e)
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+        super().tearDown()
+
+    def test_two_invocations_produce_byte_identical_output(self):
+        hook_input = {"source": "startup", "cwd": os.getcwd()}
+        env = {"CCGM_LEARNINGS_INJECT": "true"}
+        first = hook.build_context(hook_input, env)
+        second = hook.build_context(hook_input, env)
+        self.assertIsNotNone(first)
+        self.assertEqual(first, second)
+
+
+class ConflictSuppressionTests(HermeticEnvTestCase):
+    """adrev-011: a row with two live competing supersedes must never reach
+    the injected block as if it were settled truth."""
+
+    def setUp(self):
+        super().setUp()
+        self.slug = f"inject-conflict-{uuid.uuid4().hex[:10]}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        os.environ.pop("CCGM_AGENT_ID", None)
+
+        clean = ls.build_entry(type_="pattern", content="clean unconflicted learning", confidence=9)
+        ls.append_entry(clean)
+
+        contested = ls.build_entry(type_="pattern", content="contested original learning", confidence=9)
+        ls.append_entry(contested)
+        self.old_id = contested["id"]
+        # Two independent supersedes on the same target -> conflict (mirrors
+        # test_learnings_store.py's ConflictTests technique exactly).
+        ls.supersede_entry(self.old_id, content="conflicted branch A content", slug=self.slug)
+        ls.supersede_entry(self.old_id, content="conflicted branch B content", slug=self.slug)
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+        os.environ.pop("CCGM_AGENT_ID", None)
+        super().tearDown()
+
+    def test_conflicted_rows_excluded_from_injected_block(self):
+        # Sanity: default search() (which _select_for_injection fetches
+        # from) already hides the old, now-superseded head via the
+        # pre-existing superseded_by filter, but still carries the conflict
+        # flag on BOTH live competing heads it returns (Epic 1's contract
+        # this test depends on -- mirrors test_learnings_store.py's own
+        # test_conflict_flag_survives_into_default_search_results).
+        conflicted = [r for r in ls.search(slug=self.slug) if r.get("conflict")]
+        self.assertEqual(len(conflicted), 2)
+
+        block = hook.build_context(
+            {"source": "startup", "cwd": os.getcwd()}, env={"CCGM_LEARNINGS_INJECT": "true"}
+        )
+        self.assertIsNotNone(block)
+        self.assertIn("clean unconflicted learning", block)
+        self.assertNotIn("conflicted branch A content", block)
+        self.assertNotIn("conflicted branch B content", block)
+
+    def test_select_for_injection_excludes_conflicts_directly(self):
+        selected = hook._select_for_injection(self.slug, max_results=8, token_budget=2000)
+        contents = [e.get("content", "") for e in selected]
+        self.assertIn("clean unconflicted learning", contents)
+        self.assertNotIn("conflicted branch A content", contents)
+        self.assertNotIn("conflicted branch B content", contents)
+
+
+class SlugAgreementTests(HermeticEnvTestCase):
+    """arch-1 regression guard: the hook must resolve project slugs via
+    learnings_store.detect_project_slug() -- never session-history's
+    repo_detect.py, whose bare-repo-name output is a different, incompatible
+    slug space."""
+
+    def test_hook_slug_matches_detect_project_slug_for_real_repo(self):
+        # Exercise the real git-remote-derived path, not the env override.
+        os.environ.pop("CCGM_LEARNINGS_PROJECT", None)
+
+        # A synthetic, well-known example identity (GitHub's own placeholder
+        # mascot account) -- never the maintainer's real username/repo,
+        # which tests/test-no-personal-data.sh unconditionally rejects.
+        fixture_repo = tempfile.mkdtemp(prefix="ccgm-fixture-repo-")
+        self.addCleanup(shutil.rmtree, fixture_repo, ignore_errors=True)
+        subprocess.run(["git", "init", "-q"], cwd=fixture_repo, check=True)
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/octocat/hello-world.git"],
+            cwd=fixture_repo, check=True,
+        )
+
+        expected = ls.detect_project_slug(fixture_repo)
+        # Pin the concrete value (not just "not None") so this assertion is
+        # not vacuous if detect_project_slug's algorithm drifts.
+        self.assertEqual(expected, "octocat-hello-world")
+
+        hook_slug = hook.resolve_slug(fixture_repo)
+        self.assertEqual(hook_slug, expected)
+
+        # Strengthen the guard: repo_detect.py answers a DIFFERENT question
+        # and returns a DIFFERENT string for this exact fixture -- if a
+        # future change swapped the hook onto repo_detect.py by mistake,
+        # hook_slug would become "hello-world" and the assertion above
+        # would already fail. Confirm the two really do disagree here so
+        # this test is not silently vacuous.
+        repo_detect = _load_module("repo_detect_fixture", REPO_DETECT_PATH)
+        self.assertEqual(repo_detect.detect_repo(fixture_repo), "hello-world")
+        self.assertNotEqual(repo_detect.detect_repo(fixture_repo), hook_slug)
+
+
+def _cleanup():
+    shutil.rmtree(_TMP, ignore_errors=True)
+    shutil.rmtree(ls.LEARNINGS_CACHE_ROOT, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    try:
+        unittest.main(verbosity=2, exit=False)
+    finally:
+        _cleanup()


### PR DESCRIPTION
## Summary

Epic 4 of the CCGM durable memory system: surfaces the learnings store safely on the read side. `ccgm-learnings-search` gains an age/verification wrapper on every preamble/markdown entry (plus `[anchor-missing]` tagging and an `age_days` field on `--format jsonl`), and a new opt-in, prefix-cache-safe `learnings-inject.py` SessionStart hook surfaces top-ranked learnings for the current project directly into a fresh session. No store-write changes.

Closes #754

## Changes

- **`modules/self-improving/bin/ccgm-learnings-search`**
  - Every preamble/markdown entry gains a `[age: {N}d · last_verified: {date} · verify files[] anchors before asserting]` wrapper line, plus a trailing `[anchor-missing]` when a `files[]` path no longer exists under the cwd (via the store's existing public `has_stale_file_refs()`)
  - `--format jsonl` gains an `age_days` integer field; every other field is untouched (verified by an exact key-set/value diff test)
  - A small local ISO-timestamp parser computes age -- `learnings_store.py` is out of scope for this change (Epic 5 owns it) and exposes no plain "days since" helper (`effective_confidence()` folds age into a decayed score; `is_stale()` only returns a bool)
- **`modules/self-improving/hooks/learnings-inject.py`** (new) -- opt-in SessionStart hook:
  - No-op unless `source == "startup"` AND env `CCGM_LEARNINGS_INJECT` is truthy (mirrors `relevance-inject.py`'s posture/registration shape)
  - Resolves the project slug via `learnings_store.detect_project_slug(cwd)` -- **never** `session-history/repo_detect.py`, whose bare-repo-name output is a different, incompatible slug space (arch-1)
  - Reuses `learnings_store.search()`'s own ranking/decay/budget; over-fetches a superset, drops rows flagged `conflict: true` (adrev-011 -- a row with two live competing supersedes is not settled truth and must never reach an agent as ambient context), then re-applies the real cap/budget so a dropped conflict can still backfill from the next-ranked alternative
  - Emits one `<ccgm-learnings-injection>` block with the same age/verify wrapper as the CLI, plus a pointer to `ccgm-learnings-search`; pure function of hook input + env + store state, so two invocations against the same store are byte-identical (prefix-cache safety)
- **`modules/self-improving/module.json`** / **`settings.partial.json`** -- register the new hook file + its `SessionStart` (`matcher: startup`) entry, alongside the existing `PostToolUse`/`PreCompact` hooks
- **`modules/self-improving/tests/test_learnings_inject.py`** (new) -- 28 test cases covering the wrapper/age_days/anchor-missing behavior, the hook's opt-in gate (env + source), budget/cap trimming, byte-stable ordering across two invocations, conflict suppression, and an arch-1 slug-agreement regression guard (asserts the hook's resolved slug equals `detect_project_slug()`'s for a fixture repo, and that both diverge from `repo_detect.py`'s answer for the same fixture)

Did not touch `modules/self-improving/lib/learnings_store.py` or `rules/learnings-store.md` (Epic 5's file-overlap boundary, plan.md §7.1).

## Test plan

- [x] `python3 -m pytest modules/self-improving/tests/test_learnings_inject.py -q` -- 28 passed
- [x] `echo '{"source":"startup"}' | CCGM_LEARNINGS_INJECT=true python3 modules/self-improving/hooks/learnings-inject.py` -- prints a block against a seeded scratch store; prints nothing without the env var, and prints nothing for `source: resume`/`compact`
- [x] `ccgm-learnings-search --query git --max 2` -- output shows the `[age: ...]` wrapper (verified against a scratch store; installed-symlink bring-up is a separate post-merge step per the plan's runbook)
- [x] `bash tests/test-no-personal-data.sh` -- PASS
- [x] `bash tests/test-modules.sh` -- 1517 passed, 0 failed
- [x] `bash tests/test-doc-counts.sh` -- all checks passed
- [x] `python3 modules/plugin-marketplace/lib/gen_marketplace.py --check` -- up to date (no diff; self-improving already ships `hook`+`rule` file types)
- [x] `python3 modules/plugin-marketplace/lib/validate_marketplace.py` -- all 698 checks passed
- [x] `bash tests/test-frontmatter-yaml.sh` -- all frontmatter valid

## Concerns

- Running `python3 -m pytest modules/self-improving/tests/` (both test files together) surfaces a **pre-existing, already-tracked** issue: #764 documents a `CCGM_LEARNINGS_PROJECT`/`CCGM_LEARNINGS_DIR` leak between test files collected in the same pytest session. This new file is hardened against it (28/28 pass standalone, and still 28/28 in combination, in either collection order) -- but `test_learnings_store.py`'s own `CLIExitCodeTests._env()` helper does not pin `CCGM_LEARNINGS_DIR` and surfaces one failure (`test_v1_only_store_still_searchable_via_cli`) once a second file participates in the same collection-order race. This is exactly the mechanism #764 already describes and attributes to that file; fixing it there is out of scope here (not in this epic's file list, and `test_learnings_store.py` is actively owned elsewhere). Today's CI does not run pytest at all (`.github/workflows/test.yml` has no `pytest` step), so this does not affect the current pipeline -- it will matter once a future epic wires pytest into CI per plan.md §8.4, which is exactly when #764 anticipates it becoming visible.