### PR TITLE
#777: adrev-404 auto-verify — sever last_verified refresh for unattended verifies

### DIFF
--- a/modules/dreaming/lib/apply_dream_proposal.py
+++ b/modules/dreaming/lib/apply_dream_proposal.py
@@ -12,7 +12,10 @@ triggered it.
 Dispatch table (plan.md Section 5 Epic 6):
     learning_add        -> `ccgm-learnings-log add` (project != _global)
                             -> `learnings_store.promote_to_global()` (project == _global)
-    learning_verify      -> `ccgm-learnings-log verify <target_id>`
+    learning_verify      -> `ccgm-learnings-log verify <target_id>` (human accept)
+                            -> `... verify <target_id> --auto` (auto-apply; adrev-404:
+                               bumps uses but does NOT refresh last_verified, so a
+                               nightly unattended verify cannot pin decay/staleness)
     learning_contradict  -> `ccgm-learnings-log contradict <target_id>`
     learning_supersede    -> `ccgm-learnings-log supersede <target_id> --expected-sha <sha>`
     learning_deprecate    -> `ccgm-learnings-log deprecate <target_id> --expected-sha <sha>`
@@ -392,7 +395,9 @@ def _first_evidence_session(row: dict[str, Any]) -> str | None:
     return None
 
 
-def _apply_learning_add(row: dict[str, Any], *, reviewed_by: str) -> dict[str, Any]:
+def _apply_learning_add(
+    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept"
+) -> dict[str, Any]:
     if row.get("project") == GLOBAL_SLUG:
         return _apply_global_add(row, reviewed_by=reviewed_by)
 
@@ -468,8 +473,13 @@ def _looks_like_uncaught_exception(stderr: str) -> bool:
     return "Traceback (most recent call last):" in stderr
 
 
-def _apply_counter_op(row: dict[str, Any], op: str) -> dict[str, Any]:
+def _apply_counter_op(row: dict[str, Any], op: str, *, auto: bool = False) -> dict[str, Any]:
     args = [op, row["target_id"], "--project", row["project"]]
+    if auto:
+        # adrev-404: an unattended auto-apply verify must NOT refresh
+        # last_verified. `--auto` is a verify-only flag on ccgm-learnings-log;
+        # only _apply_learning_verify ever passes auto=True here.
+        args.append("--auto")
     session = _first_evidence_session(row)
     if session:
         args += ["--session", session]
@@ -483,11 +493,19 @@ def _apply_counter_op(row: dict[str, Any], op: str) -> dict[str, Any]:
     return {"outcome": "unexpected_exit_code", "detail": f"exit={proc.returncode}: {proc.stderr.strip()}"}
 
 
-def _apply_learning_verify(row: dict[str, Any], *, reviewed_by: str) -> dict[str, Any]:
-    return _apply_counter_op(row, "verify")
+def _apply_learning_verify(
+    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept"
+) -> dict[str, Any]:
+    # adrev-404: an unattended auto-apply (method == "auto_apply") issues an
+    # AUTO verify (bump uses, do NOT refresh last_verified). A human accept
+    # (method == "human_accept", the /dream-apply accept path) issues a normal
+    # verify that refreshes last_verified exactly as before.
+    return _apply_counter_op(row, "verify", auto=(method == "auto_apply"))
 
 
-def _apply_learning_contradict(row: dict[str, Any], *, reviewed_by: str) -> dict[str, Any]:
+def _apply_learning_contradict(
+    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept"
+) -> dict[str, Any]:
     return _apply_counter_op(row, "contradict")
 
 
@@ -556,7 +574,9 @@ def _apply_cas_op(row: dict[str, Any], *, build_argv: Callable[[str], list[str]]
     return {"outcome": "failed_cas", "detail": "CAS mismatch persisted after one retry", "cas_retries": 1}
 
 
-def _apply_learning_deprecate(row: dict[str, Any], *, reviewed_by: str) -> dict[str, Any]:
+def _apply_learning_deprecate(
+    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept"
+) -> dict[str, Any]:
     def build_argv(sha: str) -> list[str]:
         args = ["deprecate", row["target_id"], "--project", row["project"], "--expected-sha", sha]
         session = _first_evidence_session(row)
@@ -567,7 +587,9 @@ def _apply_learning_deprecate(row: dict[str, Any], *, reviewed_by: str) -> dict[
     return _apply_cas_op(row, build_argv=build_argv)
 
 
-def _apply_learning_supersede(row: dict[str, Any], *, reviewed_by: str) -> dict[str, Any]:
+def _apply_learning_supersede(
+    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept"
+) -> dict[str, Any]:
     def build_argv(sha: str) -> list[str]:
         args = [
             "supersede", row["target_id"],
@@ -656,7 +678,7 @@ def apply_proposal(proposal_id: str, *, method: str = "human_accept", reviewed_b
             return record
 
         try:
-            result = handler(row, reviewed_by=reviewed_by)
+            result = handler(row, reviewed_by=reviewed_by, method=method)
         except Exception:  # noqa: BLE001 -- deliberate: a handler crash must become
             # an audited outcome, never an uncaught exception (adrev-012/adrev-302
             # "never silent"; also what keeps run_auto_apply's batch loop alive).

--- a/modules/dreaming/tests/test_apply_dream_proposal.py
+++ b/modules/dreaming/tests/test_apply_dream_proposal.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Tests for modules/dreaming/lib/apply_dream_proposal.py's adrev-404 wiring:
+an UNATTENDED auto-apply of a learning_verify must issue an AUTO verify
+(bump uses, do NOT refresh last_verified), while a human /dream-apply accept
+of the same kind issues a NORMAL verify (refreshes last_verified). End-to-
+end: these drive the real ccgm-learnings-log subprocess, so they prove the
+--auto flag is threaded all the way from the apply method down to the store.
+
+Runs in isolation: CCGM_LEARNINGS_DIR + CCGM_DREAMING_DIR are redirected to
+tempdirs BEFORE import (mirrors test_reconcile_automemory.py --
+learnings_store.LEARNINGS_ROOT is frozen at import time). learnings_store,
+dream_analyze, and apply_dream_proposal are popped from sys.modules first so
+this file never inherits a stale LEARNINGS_ROOT from whichever test module
+pytest collected first in the same process. Each test uses a slug + day +
+proposal id unique to that test, so they never interfere despite sharing one
+LEARNINGS_ROOT / dreaming dir for the whole file.
+
+Run with: python3 -m pytest modules/dreaming/tests/test_apply_dream_proposal.py -q
+      or: python3 modules/dreaming/tests/test_apply_dream_proposal.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / "lib"))
+
+# See module docstring: pop first, then point the store + dreaming dir at
+# fresh tempdirs, BEFORE importing apply_dream_proposal (which transitively
+# imports dream_analyze -> learnings_store, whose LEARNINGS_ROOT is frozen at
+# import time).
+sys.modules.pop("learnings_store", None)
+sys.modules.pop("dream_analyze", None)
+sys.modules.pop("apply_dream_proposal", None)
+
+_TMP_LEARNINGS = tempfile.mkdtemp(prefix="ccgm-dreaming-test-applyverify-learnings-")
+_TMP_DREAMING = tempfile.mkdtemp(prefix="ccgm-dreaming-test-applyverify-dreaming-")
+_TMP_HOME = tempfile.mkdtemp(prefix="ccgm-dreaming-test-applyverify-home-")
+_ORIG_LEARNINGS_DIR = os.environ.get("CCGM_LEARNINGS_DIR")
+_ORIG_DREAMING_DIR = os.environ.get("CCGM_DREAMING_DIR")
+_ORIG_HOME = os.environ.get("HOME")
+os.environ["CCGM_LEARNINGS_DIR"] = _TMP_LEARNINGS
+os.environ["CCGM_DREAMING_DIR"] = _TMP_DREAMING
+# Sandbox HOME so _resolve_sibling_bin() skips the installed
+# ~/.claude/bin/ccgm-learnings-log symlink (which points at the canonical
+# clone, not this workspace clone under test) and falls back to the
+# repo-relative bin -- exactly what test-dream-apply.sh does with HOME_DIR.
+os.environ["HOME"] = _TMP_HOME
+
+import apply_dream_proposal as adp  # noqa: E402
+import learnings_store as ls  # noqa: E402
+
+
+def tearDownModule() -> None:
+    """Undo the module-level env overrides so they cannot leak into whatever
+    test module pytest imports and runs next in the same process (#764)."""
+    for key, orig in (
+        ("CCGM_LEARNINGS_DIR", _ORIG_LEARNINGS_DIR),
+        ("CCGM_DREAMING_DIR", _ORIG_DREAMING_DIR),
+        ("HOME", _ORIG_HOME),
+    ):
+        if orig is not None:
+            os.environ[key] = orig
+        else:
+            os.environ.pop(key, None)
+
+
+def _proposal_row(*, pid: str, slug: str, target_id: str, confidence: int) -> dict:
+    return {
+        "id": pid,
+        "kind": "learning_verify",
+        "project": slug,
+        "target_id": target_id,
+        "content": None,
+        "type": None,
+        "confidence": confidence,
+        "prevalence": {"sessions": 1, "agents": 1},
+        "evidence": [{"session_id": "sess-fixture", "excerpt": "example excerpt"}],
+        "justification": "fixture justification",
+        "fingerprint": f"fp-{pid}",
+        "generated_at": "2026-01-01T00:00:00.000Z",
+        "status": "pending",
+    }
+
+
+class AutoApplyVerifyThreadsAutoFlag(unittest.TestCase):
+    def setUp(self):
+        # Re-assert this module's env at RUN time (not just import time):
+        # another test module collected in the same pytest run can have
+        # replaced these os.environ values with ITS tempdirs before we run.
+        # The ccgm-learnings-log subprocess (invoked deep inside the apply
+        # path) reads os.environ fresh, so it must agree with THIS module's
+        # in-process learnings_store, whose LEARNINGS_ROOT is frozen. Pinning
+        # to str(ls.LEARNINGS_ROOT) guarantees subprocess == in-process store.
+        self._pin_env("CCGM_LEARNINGS_DIR", str(ls.LEARNINGS_ROOT))
+        self._pin_env("CCGM_DREAMING_DIR", _TMP_DREAMING)
+        self._pin_env("HOME", _TMP_HOME)  # so _resolve_sibling_bin uses the repo-relative CLI
+        adp.proposals_dir().mkdir(parents=True, exist_ok=True)
+
+    def _pin_env(self, key: str, value: str) -> None:
+        had = key in os.environ
+        prior = os.environ.get(key)
+        os.environ[key] = value
+
+        def _restore() -> None:
+            if had:
+                os.environ[key] = prior
+            else:
+                os.environ.pop(key, None)
+
+        self.addCleanup(_restore)
+
+    def _seed_target(self, slug: str) -> str:
+        e = ls.build_entry(type_="pattern", content="apply-path verify target", confidence=9)
+        e["project"] = slug
+        ls.append_entry(e, slug=slug)
+        return e["id"]
+
+    def _head(self, slug: str, entry_id: str) -> dict:
+        # Force a full replay (no snapshot cache): the verify was written by a
+        # SEPARATE ccgm-learnings-log subprocess, so we must re-read the shards
+        # rather than trust any cache this process warmed before the write.
+        heads = ls.project_slug(slug, use_snapshot=False)["heads"]
+        head = next((h for h in heads if h["id"] == entry_id), None)
+        self.assertIsNotNone(head, f"target {entry_id} vanished from projection")
+        return head
+
+    def _verify_ops(self, slug: str) -> list[dict]:
+        """Every `verify` op-row across all agent shards for this slug --
+        robust to whatever agent_id the subprocess resolved."""
+        agents_dir = ls.project_dir(slug) / "agents"
+        ops: list[dict] = []
+        for shard in agents_dir.glob("*.jsonl"):
+            for ln in shard.read_text().splitlines():
+                ln = ln.strip()
+                if not ln:
+                    continue
+                row = json.loads(ln)
+                if row.get("op") == "verify":
+                    ops.append(row)
+        return ops
+
+    def _write_day(self, day: str, row: dict) -> None:
+        (adp.proposals_dir() / f"{day}.jsonl").write_text(
+            json.dumps(row, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    def test_auto_apply_issues_auto_verify_no_last_verified_refresh(self):
+        slug = f"autoapply-verify-{int(time.time()*1e6)}"
+        day = "2026-02-01"
+        target_id = self._seed_target(slug)
+        orig_lv = self._head(slug, target_id)["last_verified"]
+
+        self._write_day(day, _proposal_row(pid="autoverify01", slug=slug, target_id=target_id, confidence=9))
+
+        summary = adp.run_auto_apply(day)
+        self.assertEqual(summary["applied"], 1, summary)
+        self.assertEqual(summary["failed"], 0, summary)
+
+        head = self._head(slug, target_id)
+        self.assertEqual(head["uses"], 1)
+        # THE assertion: an unattended auto-apply verify left last_verified frozen.
+        self.assertEqual(head["last_verified"], orig_lv)
+
+        # and the op-row on disk carries `auto: true`
+        ops = self._verify_ops(slug)
+        self.assertEqual(len(ops), 1)
+        self.assertIs(ops[0].get("auto"), True)
+
+        # the proposal was marked auto_applied (positive terminal state)
+        _, row = adp.find_proposal("autoverify01")
+        self.assertEqual(row["status"], "auto_applied")
+
+    def test_human_accept_issues_normal_verify_refreshing_last_verified(self):
+        slug = f"humanaccept-verify-{int(time.time()*1e6)}"
+        day = "2026-02-02"
+        target_id = self._seed_target(slug)
+        orig_lv = self._head(slug, target_id)["last_verified"]
+
+        self._write_day(day, _proposal_row(pid="humanverify01", slug=slug, target_id=target_id, confidence=8))
+
+        result = adp.apply_proposal("humanverify01", method="human_accept", reviewed_by="tester")
+        self.assertEqual(result.get("outcome"), "applied", result)
+
+        head = self._head(slug, target_id)
+        self.assertEqual(head["uses"], 1)
+        # a human accept refreshes last_verified exactly as before adrev-404
+        self.assertGreater(ls._parse_iso(head["last_verified"]), ls._parse_iso(orig_lv))
+
+        # and the op-row on disk does NOT carry `auto` (absence == human)
+        ops = self._verify_ops(slug)
+        self.assertEqual(len(ops), 1)
+        self.assertNotIn("auto", ops[0])
+
+        _, row = adp.find_proposal("humanverify01")
+        self.assertEqual(row["status"], "accepted")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/self-improving/bin/ccgm-learnings-log
+++ b/modules/self-improving/bin/ccgm-learnings-log
@@ -7,6 +7,7 @@ Usage:
     ccgm-learnings-log --from-json '{...}'
     ccgm-learnings-log --stdin                     # read a JSON object
     ccgm-learnings-log verify <id>                 # bump uses + last_verified
+    ccgm-learnings-log verify <id> --auto          # bump uses ONLY (no last_verified refresh; adrev-404)
     ccgm-learnings-log contradict <id>             # bump contradictions counter
     ccgm-learnings-log deprecate <id> --expected-sha <hex>
     ccgm-learnings-log supersede <old_id> --content "..." --expected-sha <hex> [--reason "..."]
@@ -110,7 +111,10 @@ def _cmd_log(args: argparse.Namespace) -> int:
 
 def _cmd_verify(args: argparse.Namespace) -> int:
     try:
-        ok = ls.update_entry_by_id(args.id, slug=args.project, verify=True, source_session=args.session)
+        ok = ls.update_entry_by_id(
+            args.id, slug=args.project, verify=True, source_session=args.session,
+            auto=args.auto,
+        )
     except ls.GlobalPromotionError as e:
         print(f"error: {e}", file=sys.stderr)
         return 4
@@ -215,6 +219,11 @@ def build_parser() -> argparse.ArgumentParser:
     verify.add_argument("id")
     verify.add_argument("--project")
     verify.add_argument("--session")
+    verify.add_argument(
+        "--auto", action="store_true",
+        help="unattended verify (dreaming auto-apply): bump uses WITHOUT refreshing "
+             "last_verified, so decay/staleness are not reset (adrev-404). Default off = human semantics.",
+    )
     verify.set_defaults(func=_cmd_verify)
 
     contra = sub.add_parser("contradict", help="record a contradiction against a learning")

--- a/modules/self-improving/lib/learnings_store.py
+++ b/modules/self-improving/lib/learnings_store.py
@@ -762,9 +762,18 @@ def _build_op_row(
     expected_sha256: str | None = None,
     supersede_reason: str | None = None,
     event_id: str | None = None,
+    auto: bool = False,
 ) -> dict[str, Any]:
-    """Build a canonical v2 op-event row (§3.3 schema). Does not write."""
-    return {
+    """Build a canonical v2 op-event row (§3.3 schema). Does not write.
+
+    `auto` (adrev-404) marks an UNATTENDED verify (dreaming auto-apply). It
+    is set ONLY on a `verify` op-row and ONLY when True; every other op, and
+    every human verify, omits the key entirely -- so the on-disk shape is
+    byte-identical to every op-event already written (absence == human,
+    backward-compatible). The projection reads it to skip the `last_verified`
+    refresh for auto-verifies; see `_apply_op`.
+    """
+    row: dict[str, Any] = {
         "id": event_id or uuid.uuid4().hex[:12],
         "op": op,
         "target_id": target_id,
@@ -785,6 +794,9 @@ def _build_op_row(
         "last_verified": timestamp,
         "deprecated": True if op == "deprecate" else (False if op == "add" else None),
     }
+    if auto and op == "verify":
+        row["auto"] = True
+    return row
 
 
 def append_entry(entry: dict[str, Any], slug: str | None = None) -> Path:
@@ -962,7 +974,16 @@ def _apply_op(heads: dict[str, dict[str, Any]], op: dict[str, Any], target: dict
     kind = op.get("op")
     if kind == "verify":
         target["uses"] = int(target.get("uses", 0)) + 1
-        target["last_verified"] = op.get("timestamp") or target.get("last_verified")
+        # adrev-404: an UNATTENDED auto-verify (op carries `auto: true`) bumps
+        # `uses` (bounded confidence reinforcement, capped at +2.0) but must
+        # NOT refresh `last_verified` -- that field anchors BOTH decay's time
+        # term (`effective_confidence`) and `is_stale`, so refreshing it on
+        # every nightly auto-apply would immortalize a wrong-but-plausible row
+        # against the automatic-forgetting safety mechanisms. A human verify
+        # (no `auto` key -- absence == human, backward-compatible) refreshes
+        # `last_verified` exactly as before.
+        if not op.get("auto"):
+            target["last_verified"] = op.get("timestamp") or target.get("last_verified")
     elif kind == "contradict":
         target["contradictions"] = int(target.get("contradictions", 0)) + 1
     elif kind == "deprecate":
@@ -1762,6 +1783,7 @@ def update_entry_by_id(
     deprecate: bool = False,
     expected_sha256: str | None = None,
     source_session: str | None = None,
+    auto: bool = False,
 ) -> bool:
     """
     Mutate a chain head by appending verify/contradict/deprecate op-event(s)
@@ -1770,6 +1792,13 @@ def update_entry_by_id(
     Returns True if `entry_id` currently resolves to a live head; False if
     not found (nothing is written). `deprecate` honors CAS when
     `expected_sha256` is given (raises CASConflictError on mismatch).
+
+    `auto=True` (adrev-404) marks an UNATTENDED verify: it still bumps `uses`
+    but the projection will NOT refresh `last_verified` for it (severing the
+    decay/staleness reset so a nightly auto-apply cannot immortalize a row).
+    It is meaningful ONLY for `verify`; `_build_op_row` ignores it for
+    contradict/deprecate. Human verify (the default, `auto=False`) is
+    unchanged.
 
     Raises GlobalPromotionError if the target's OWN `project` is `_global`
     and CCGM_LEARNINGS_ADMIN=1 is not set -- verify/contradict/deprecate
@@ -1811,10 +1840,15 @@ def update_entry_by_id(
     shard = agent_shard_path(target_proj, writer)
     for kind in kinds:
         ts = _next_writer_timestamp(shard)
+        # `auto` is threaded to every op-row, but _build_op_row only stamps it
+        # on a `verify` (adrev-404: meaningless for contradict/deprecate). The
+        # single-source-of-truth guard lives in _build_op_row, so a future
+        # caller cannot accidentally auto-flag a non-verify op.
         row = _build_op_row(
             op=kind, target_id=entry_id, project=target_proj, writer=writer, timestamp=ts,
             source_session=source_session,
             expected_sha256=expected_sha256 if kind == "deprecate" else None,
+            auto=auto,
         )
         file_locked_append(str(shard), json.dumps(row, sort_keys=True))
     _maybe_autocommit()

--- a/modules/self-improving/tests/test_learnings_store.py
+++ b/modules/self-improving/tests/test_learnings_store.py
@@ -10,6 +10,7 @@ Run with: python3 modules/self-improving/tests/test_learnings_store.py
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import shutil
@@ -396,6 +397,170 @@ class UpdateTests(unittest.TestCase):
     def test_missing_id_returns_false(self):
         ok = ls.update_entry_by_id("nosuchid123")
         self.assertFalse(ok)
+
+
+def _load_sync_line_is_valid():
+    """Load `_line_is_valid` out of the ccgm-learnings-sync CLI (no .py
+    extension) -- the exact function the post-union-merge revalidation runs
+    on every newly-landed op-event line. Executing the module is side-effect
+    free (its CLI runs only under `if __name__ == '__main__'`); it reuses the
+    already-imported, tempdir-pointed `learnings_store`."""
+    from importlib.machinery import SourceFileLoader
+
+    sync_path = HERE.parent / "bin" / "ccgm-learnings-sync"
+    loader = SourceFileLoader("ccgm_learnings_sync_mod", str(sync_path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod._line_is_valid
+
+
+class AutoVerifyTests(unittest.TestCase):
+    """adrev-404: an unattended `auto` verify bumps `uses` but must NOT
+    refresh `last_verified` -- severing the decay/staleness reset so a
+    nightly auto-apply cannot immortalize a wrong-but-plausible row. Human
+    verify (auto=False) is unchanged."""
+
+    def setUp(self):
+        self.slug = f"autoverify-proj-{int(time.time()*1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+        e = ls.build_entry(type_="pattern", content="auto-verify target", confidence=5)
+        ls.append_entry(e)
+        self.id = e["id"]
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+
+    def _head(self) -> dict:
+        heads = ls.load_all(self.slug)
+        self.assertEqual(len(heads), 1)
+        return heads[0]
+
+    # (i) auto-verify bumps uses, leaves last_verified untouched -----------
+    def test_auto_verify_bumps_uses_but_not_last_verified(self):
+        before = self._head()
+        orig_lv = before["last_verified"]
+        self.assertEqual(before["uses"], 0)
+
+        self.assertTrue(ls.update_entry_by_id(self.id, verify=True, auto=True))
+
+        after = self._head()
+        self.assertEqual(after["uses"], 1)
+        self.assertEqual(after["last_verified"], orig_lv)
+
+    # (ii) a NORMAL verify still refreshes last_verified -------------------
+    def test_normal_verify_refreshes_last_verified(self):
+        before = self._head()
+        orig_lv = before["last_verified"]
+
+        self.assertTrue(ls.update_entry_by_id(self.id, verify=True))  # auto defaults False
+
+        after = self._head()
+        self.assertEqual(after["uses"], 1)
+        self.assertGreater(ls._parse_iso(after["last_verified"]), ls._parse_iso(orig_lv))
+
+    # (iii) THE core adrev-404 assertion: N consecutive auto-verifies do not
+    #       pin staleness at zero; decay's time term keeps decaying; uses climbs.
+    def test_n_auto_verifies_do_not_immortalize_the_row(self):
+        orig_lv = self._head()["last_verified"]
+        orig_epoch = ls._parse_iso(orig_lv)
+
+        n = 6
+        for i in range(n):
+            self.assertTrue(ls.update_entry_by_id(self.id, verify=True, auto=True))
+            # uses climbs on every single auto-verify
+            self.assertEqual(self._head()["uses"], i + 1)
+
+        head = self._head()
+        # last_verified never moved across all N auto-verifies
+        self.assertEqual(head["last_verified"], orig_lv)
+
+        # staleness STILL fires past the window (anchored on the frozen lv) --
+        # the whole point: a nightly auto-verify cannot keep pinning it at zero.
+        far = orig_epoch + (ls.DEFAULT_STALE_DAYS + 1) * 86400
+        self.assertTrue(ls.is_stale(head, now=far))
+        # and the window still MEANS something (not stale immediately after)
+        self.assertFalse(ls.is_stale(head, now=orig_epoch + 1))
+
+        # decay's time term keeps decaying as wall-clock advances from the
+        # frozen last_verified (further out => strictly lower effective conf).
+        eff_near = ls.effective_confidence(head, now=orig_epoch + 10 * 86400)
+        eff_far = ls.effective_confidence(head, now=orig_epoch + 200 * 86400)
+        self.assertGreater(eff_near, 0.0)
+        self.assertLess(eff_far, eff_near)
+
+    def test_normal_verify_would_have_moved_the_anchor(self):
+        # Contrast to (iii): the same repetition via HUMAN verify keeps
+        # advancing last_verified, which is exactly the immortalization the
+        # auto path severs. Proves the two paths genuinely diverge.
+        first = self._head()["last_verified"]
+        self.assertTrue(ls.update_entry_by_id(self.id, verify=True))
+        second = self._head()["last_verified"]
+        self.assertTrue(ls.update_entry_by_id(self.id, verify=True))
+        third = self._head()["last_verified"]
+        self.assertGreater(ls._parse_iso(second), ls._parse_iso(first))
+        self.assertGreater(ls._parse_iso(third), ls._parse_iso(second))
+
+    # (iv) the `auto` field survives projection + union-merge revalidation +
+    #      quarantine validation (never rejected as malformed) --------------
+    def test_auto_field_survives_projection_and_quarantine(self):
+        self.assertTrue(ls.update_entry_by_id(self.id, verify=True, auto=True))
+
+        # (a) the op-row on disk carries `auto: true`
+        shard = ls.agent_shard_path(self.slug, ls.agent_id())
+        rows = [json.loads(ln) for ln in shard.read_text().splitlines() if ln.strip()]
+        verify_rows = [r for r in rows if r.get("op") == "verify"]
+        self.assertEqual(len(verify_rows), 1)
+        self.assertIs(verify_rows[0].get("auto"), True)
+
+        # (b) projection (which runs quarantine suppression on EVERY call)
+        #     still returns the head with the verify folded in -- the auto op
+        #     is not rejected, and the head is not quarantined.
+        head = self._head()
+        self.assertEqual(head["id"], self.id)
+        self.assertEqual(head["uses"], 1)
+        self.assertNotIn(self.id, ls._read_quarantined_ids(self.slug))
+
+        # (c) the post-union-merge counter-op validator (ccgm-learnings-sync)
+        #     accepts the auto-verify op-row, extra `auto` field and all.
+        line_is_valid = _load_sync_line_is_valid()
+        self.assertTrue(line_is_valid(verify_rows[0]))
+        # sanity: the validator is not just returning True for everything
+        self.assertFalse(line_is_valid({"op": "verify", "id": "x", "target_id": None}))
+
+    def _cli_env(self) -> dict:
+        env = os.environ.copy()
+        # Pin the store dir to this module's frozen LEARNINGS_ROOT, immune to
+        # another test module's import-time CCGM_LEARNINGS_DIR override in the
+        # same pytest run (same rationale as CLIExitCodeTests._env()).
+        env["CCGM_LEARNINGS_DIR"] = str(ls.LEARNINGS_ROOT)
+        env["CCGM_LEARNINGS_PROJECT"] = self.slug
+        return env
+
+    # CLI wiring: `verify --auto` behaves like the store's auto path --------
+    def test_cli_auto_flag_skips_last_verified_refresh(self):
+        orig_lv = self._head()["last_verified"]
+        proc = subprocess.run(
+            [sys.executable, str(CLI_PATH), "verify", self.id, "--auto"],
+            env=self._cli_env(), capture_output=True, text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        after = self._head()
+        self.assertEqual(after["uses"], 1)
+        self.assertEqual(after["last_verified"], orig_lv)
+
+    def test_cli_bare_verify_refreshes_last_verified(self):
+        orig_lv = self._head()["last_verified"]
+        proc = subprocess.run(
+            [sys.executable, str(CLI_PATH), "verify", self.id],
+            env=self._cli_env(), capture_output=True, text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        after = self._head()
+        self.assertEqual(after["uses"], 1)
+        self.assertGreater(ls._parse_iso(after["last_verified"]), ls._parse_iso(orig_lv))
 
 
 class SupersedeTests(unittest.TestCase):
@@ -1622,6 +1787,13 @@ class CLIExitCodeTests(unittest.TestCase):
 
     def _env(self, **extra):
         env = os.environ.copy()
+        # Pin the store dir to THIS module's frozen LEARNINGS_ROOT rather than
+        # trusting os.environ, which another test module's import-time override
+        # (e.g. modules/dreaming's suites, collected in the same pytest run)
+        # can have replaced with ITS tempdir before this subprocess runs --
+        # otherwise the CLI reads a different store than the in-process
+        # assertions wrote to. Runs alone: this is a no-op (already equal).
+        env["CCGM_LEARNINGS_DIR"] = str(ls.LEARNINGS_ROOT)
         env["CCGM_LEARNINGS_PROJECT"] = self.slug
         env.pop("CCGM_LEARNINGS_ADMIN", None)
         env.update(extra)


### PR DESCRIPTION
## Summary

adrev-404: sever the `last_verified` refresh for **unattended** verifies so dreaming's nightly auto-apply cannot immortalize a wrong-but-plausible learning against the store's automatic-forgetting safety mechanisms. Unblocks flipping `auto_apply_counters` to true (pair-resolves with adrev-403).

**Problem:** a `verify` op previously bumped `uses` **and** set `last_verified = op.timestamp`. Both `effective_confidence` decay and `is_stale` anchor on `last_verified`, so the one op an unattended model may write (auto-apply applies `learning_verify` at confidence ≥9) reset *both* automatic-forgetting mechanisms every night. sec-5 bounded the confidence axis (`uses` boost caps at +2.0); the time axis was unbounded.

**Fix (plan option a):** an auto-verify bumps `uses` but does **not** refresh `last_verified`. Confidence reinforcement is preserved; only the automatic-forgetting reset is severed for unattended verifies. **Human verify is unchanged everywhere.**

## Changes

- **`modules/self-improving/lib/learnings_store.py`**
  - `_build_op_row`: new optional `auto` param. Stamps `"auto": true` on a `verify` op-row **only** when `auto` is True; every other op and every human verify omits the key entirely — byte-identical to every op-event already on disk (absence == human, backward-compatible).
  - `_apply_op` (projection): a `verify` always bumps `uses`; it refreshes `last_verified` **only** when the op does not carry `auto: true`.
  - `update_entry_by_id`: threads an `auto: bool = False` param (default = human semantics).
- **`ccgm-learnings-log`**: `verify --auto` flag (default off).
- **`modules/dreaming/lib/apply_dream_proposal.py`**: the verify handler passes `--auto` when `method == "auto_apply"` and **not** when `method == "human_accept"` (`/dream-apply` accept). `method` is threaded uniformly to every handler; only verify acts on it. contradict/deprecate untouched.

The `auto` field lives on op-rows only — it is never copied onto a projected head, so `validate_entry()` (which validates heads) never sees it, and the post-union-merge counter-op validator in `ccgm-learnings-sync` only checks `target_id`/`id`. `auto` therefore survives projection, union-merge, and quarantine validation without any schema change.

## Test Plan

Added tests:
- `test_learnings_store.py::AutoVerifyTests` — (i) auto-verify bumps `uses`, leaves `last_verified` unchanged; (ii) normal verify refreshes it; (iii) **the core assertion** — N consecutive auto-verifies: `is_stale` still fires after the window, decay's time term keeps decaying, `uses` climbs each time; (iv) the `auto` field survives projection + the post-union-merge counter-op validator + quarantine; plus CLI `--auto` wiring.
- `test_apply_dream_proposal.py` — end-to-end: auto-apply issues an auto-verify (no `last_verified` refresh); human accept issues a normal verify (refreshes).
- Pinned `CCGM_LEARNINGS_DIR` in the CLI-subprocess test env, fixing a **pre-existing** cross-module import-order failure (`test_v1_only_store_still_searchable_via_cli`) that made the combined pytest run red on `main`.

```
python3 -m pytest modules/self-improving/tests/ modules/dreaming/tests/ -q
  -> 371 passed, 4 subtests passed

bash modules/self-improving/tests/test-learnings-sync.sh
  -> 53 passed, 0 failed

bash tests/test-no-personal-data.sh
  -> PASS: No personal data or secret/PII shapes found
```

Verified green in isolation and in both directory orders.

Closes #777
