### PR TITLE
#779: judge — retry without temperature for models that deprecated the param

### DIFF
--- a/modules/dreaming/eval/memory_eval.py
+++ b/modules/dreaming/eval/memory_eval.py
@@ -552,29 +552,41 @@ def build_judge_payload(
     }
 
 
+# Judge models that returned HTTP 400 on `temperature` this run. Newer Claude
+# models (e.g. claude-opus-4-8) deprecated the parameter; once a model 400s on
+# it we stop sending it for the rest of the process (#779).
+_MODELS_WITHOUT_TEMPERATURE: set[str] = set()
+
+
 def _call_judge_api(
     *, model: str, system_prompt: str, user_obj: dict[str, Any], max_output_tokens: int, api_key: str, api_url: str,
 ) -> tuple[dict[str, Any] | None, dict[str, int]]:
-    """A judge-specific Messages API call with `temperature: 0`
-    (deterministic grading, as the spec requires for the judge
-    specifically). `da.get_model_response()` / `_call_curl_with_retry()`
+    """A judge-specific Messages API call with `temperature: 0` when the model
+    accepts it -- newer models (e.g. claude-opus-4-8) deprecated the parameter
+    and 400 on it, so such a model is recorded and retried without it (#779);
+    deterministic grading is preserved where the model still supports temp 0.
+    `da.get_model_response()` / `_call_curl_with_retry()`
     have no temperature dial and dream_analyze.py is never modified to add
     one (Epic 3's own map/reduce calls never needed it) -- this is a small,
     judge-specific sibling that mirrors da's retry/transport shape while
     reusing da's own (unmodified) response-parsing helpers, rather than an
     edit to that shared file. Never raises -- returns (None, zeroed usage)
     on any transport/parse failure."""
-    request_body = {
-        "model": model,
-        "max_tokens": max_output_tokens,
-        "temperature": 0,
-        "system": system_prompt,
-        "messages": [{"role": "user", "content": json.dumps(user_obj, ensure_ascii=False)}],
-    }
-    payload = json.dumps(request_body)
     zero_usage = {"input_tokens": 0, "output_tokens": 0}
 
     for attempt in range(da.MAX_429_RETRIES + 1):
+        # Rebuild each attempt so a model discovered mid-loop to reject
+        # `temperature` (newer models deprecated it) is retried without it,
+        # while models that accept it still get the spec's temperature:0 (#779).
+        request_body = {
+            "model": model,
+            "max_tokens": max_output_tokens,
+            "system": system_prompt,
+            "messages": [{"role": "user", "content": json.dumps(user_obj, ensure_ascii=False)}],
+        }
+        if model not in _MODELS_WITHOUT_TEMPERATURE:
+            request_body["temperature"] = 0
+        payload = json.dumps(request_body)
         try:
             proc = subprocess.run(
                 [
@@ -602,6 +614,19 @@ def _call_judge_api(
                 time.sleep(delay)
                 continue
             return None, zero_usage
+        if (
+            code == "400"
+            and model not in _MODELS_WITHOUT_TEMPERATURE
+            and "temperature" in body.lower()
+        ):
+            # Model rejects `temperature` (deprecated). Record + retry without
+            # it; this does not consume the transport failure budget (#779).
+            _MODELS_WITHOUT_TEMPERATURE.add(model)
+            print(
+                f"memory_eval: judge model {model} rejects temperature; retrying without it (#779)",
+                file=sys.stderr,
+            )
+            continue
         if code != "200":
             return None, zero_usage
 

--- a/modules/dreaming/tests/test_memory_eval.py
+++ b/modules/dreaming/tests/test_memory_eval.py
@@ -360,6 +360,59 @@ class CallJudgeApiTransportTests(unittest.TestCase):
             "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
         })
 
+    def tearDown(self):
+        # The module-global temperature-support cache must not leak between
+        # tests (#779).
+        me._MODELS_WITHOUT_TEMPERATURE.clear()  # noqa: SLF001
+
+    def test_temperature_deprecated_400_retries_without_it_and_caches(self):
+        calls = []
+
+        def fake_run(cmd, *, input, capture_output, text):  # noqa: A002
+            calls.append(json.loads(input))
+            if len(calls) == 1:
+                return self._fake_proc(
+                    body='{"type":"error","error":{"type":"invalid_request_error",'
+                         '"message":"`temperature` is deprecated for this model."}}',
+                    http_code="400",
+                )
+            return self._fake_proc(body=self._messages_api_body({"pass": True, "score": 9.0}))
+
+        model = "claude-temp-deprecated-fixture"
+        with mock.patch("memory_eval.subprocess.run", side_effect=fake_run):
+            parsed, usage = me._call_judge_api(  # noqa: SLF001
+                model=model, system_prompt="sys", user_obj={"a": 1},
+                max_output_tokens=100, api_key="sk-test-fixture",
+                api_url="https://api.anthropic.com/v1/messages",
+            )
+
+        # First attempt carries temperature; the 400 triggers a retry WITHOUT
+        # it; the model is remembered as temperature-unsupported.
+        self.assertEqual(len(calls), 2)
+        self.assertIn("temperature", calls[0])
+        self.assertNotIn("temperature", calls[1])
+        self.assertEqual(parsed, {"pass": True, "score": 9.0})
+        self.assertEqual(usage, {"input_tokens": 42, "output_tokens": 7})
+        self.assertIn(model, me._MODELS_WITHOUT_TEMPERATURE)  # noqa: SLF001
+
+    def test_known_temperature_unsupported_model_omits_it_from_the_first_call(self):
+        me._MODELS_WITHOUT_TEMPERATURE.add("claude-known-bad-fixture")  # noqa: SLF001
+        captured = {}
+
+        def fake_run(cmd, *, input, capture_output, text):  # noqa: A002
+            captured["body"] = json.loads(input)
+            return self._fake_proc(body=self._messages_api_body({"pass": True, "score": 7.0}))
+
+        with mock.patch("memory_eval.subprocess.run", side_effect=fake_run):
+            parsed, _ = me._call_judge_api(  # noqa: SLF001
+                model="claude-known-bad-fixture", system_prompt="sys", user_obj={"a": 1},
+                max_output_tokens=100, api_key="sk-test-fixture",
+                api_url="https://api.anthropic.com/v1/messages",
+            )
+
+        self.assertNotIn("temperature", captured["body"])
+        self.assertEqual(parsed, {"pass": True, "score": 7.0})
+
     def test_request_carries_temperature_zero_model_system_and_messages(self):
         captured = {}
 


### PR DESCRIPTION
## Summary
Fixes the live-eval blocker: the judge hardcoded `temperature: 0`, which `claude-opus-4-8` (the default judge model = `reduce_model`) rejects with `HTTP 400 "temperature is deprecated for this model"`, failing **100% of judge calls** — so no task can be scored and the adrev-305 gate can never open.

## Fix
`_call_judge_api` builds the request body per-attempt and includes `temperature: 0` only when the model isn't known to reject it. On a `400` whose body mentions `temperature`, the model is recorded in a process-global `_MODELS_WITHOUT_TEMPERATURE` set and the call retries without the parameter (cached for the rest of the run). Models that accept `temperature` still get the spec's deterministic `temp:0`. All existing transport behavior (429 backoff, non-200 → None, parse, never-raises, zeroed-usage-on-failure) preserved.

## Why unit tests missed it
The offline/mocked judge tests never hit the real Messages API; the deprecated-param rejection only surfaces on a **live** run.

## Tests
Added: a 400-temperature response triggers a retry that omits `temperature` + caches the model; a known-unsupported model omits it on the first call; `tearDown` resets the module-global cache. Verified live against `claude-opus-4-8`. `pytest modules/dreaming/ modules/self-improving/ -q` → 373 passed; `test-no-personal-data` → PASS.

Closes #779