### PR TITLE
#781: injection telemetry for the learnings SessionStart hook

### DIFF
--- a/modules/self-improving/hooks/learnings-inject.py
+++ b/modules/self-improving/hooks/learnings-inject.py
@@ -74,6 +74,19 @@ SAFETY
 Never raises: any failure path (missing flag, unresolvable store, empty
 result set, malformed stdin) returns without emitting, so this can never
 crash or block a session.
+
+TELEMETRY (issue #781)
+----------------------
+After the injected block is written to stdout, the hook appends ONE
+best-effort telemetry record per surfacing so a future weekly scorecard can
+measure how often / which memories are actually surfaced. The record carries
+memory IDs + counts + a token estimate ONLY -- never any memory CONTENT (the
+content already lives in the store; copying it here would create a second PII
+surface). It lands in a per-machine JSONL under the dreaming module's
+CCGM_DREAMING_DIR root (~/.claude/dreaming/injection-log/<date>.jsonl),
+deliberately OUTSIDE the synced ~/.claude/learnings/ store. The whole write is
+wrapped so any failure is swallowed: it can never alter the injected bytes,
+block the injection, or raise. Nothing is written when injection did not run.
 """
 from __future__ import annotations
 
@@ -105,6 +118,17 @@ try:
     import learnings_store  # type: ignore
 except Exception:  # pragma: no cover - import guard; hook must never crash a session
     learnings_store = None
+
+# hook_utils (modules/hooks/lib/hook_utils.py, installed at
+# ~/.claude/lib/hook_utils.py) provides file_locked_append for the #781
+# injection-telemetry side-channel. The ~/.claude/lib path was already
+# inserted above; add the repo path too so it resolves from a plain checkout.
+# Guarded: its absence must never crash a session (telemetry is best-effort).
+sys.path.insert(0, str(_HERE.parent.parent / "hooks" / "lib"))
+try:
+    import hook_utils  # type: ignore
+except Exception:  # pragma: no cover - import guard; telemetry is best-effort
+    hook_utils = None
 
 
 def _truthy(val: "str | None") -> bool:
@@ -291,26 +315,31 @@ def _select_for_injection(
     return out
 
 
-def build_context(hook_input: dict, env: "dict[str, str] | None" = None) -> "str | None":
-    """Build the injected block, or None if there is nothing to emit.
+def _build_injection(
+    hook_input: dict, env: "dict[str, str] | None" = None
+) -> "tuple[str | None, list[dict], str]":
+    """Core selection+render shared by build_context() and main().
 
-    Depends only on hook_input + env + store state -- no caller-visible
-    side effects. Every "None" branch means the caller emits nothing and
-    session behavior is exactly what it was before this hook existed.
+    Returns (context, selected, slug):
 
-    NOTE: `env` only gates the CCGM_LEARNINGS_INJECT flag checked just
-    below -- project-slug resolution (resolve_slug() ->
-    learnings_store.detect_project_slug()) always reads the REAL process
-    os.environ, regardless of what is passed here. Harmless in production
-    (where `env` defaults to `os.environ` anyway); tests that need to
-    isolate slug resolution do so via CCGM_LEARNINGS_PROJECT/DIR, not via
-    this parameter.
+      - context: the rendered `<ccgm-learnings-injection>` block, or None when
+        nothing should be emitted -- byte-identical to what build_context()
+        has always returned (build_context() is now a thin wrapper over this,
+        so no existing caller ever sees a different string).
+      - selected: the EXACT list of store entries rendered into `context`
+        (empty when context is None). main() reuses this for the #781
+        telemetry side-channel -- the memory list is never re-queried.
+      - slug: the resolved project slug ("" when the flag gate short-circuits
+        before slug resolution).
+
+    See build_context()'s docstring for the `env` nuance (it gates only the
+    CCGM_LEARNINGS_INJECT flag; slug resolution always reads os.environ).
     """
     env = env if env is not None else os.environ
     if not _truthy(env.get(FLAG)):
-        return None
+        return None, [], ""
     if learnings_store is None:
-        return None
+        return None, [], ""
 
     cwd = hook_input.get("cwd") or os.getcwd()
     slug = resolve_slug(cwd)
@@ -334,14 +363,108 @@ def build_context(hook_input: dict, env: "dict[str, str] | None" = None) -> "str
         slug, max_results=max_results, token_budget=token_budget, repo_root=repo_root
     )
     if not selected:
-        return None
+        return None, [], slug
 
     header, footer = _envelope_lines(len(selected))
     lines = list(header)
     for e in selected:
         lines.extend(_render_entry_lines(e, repo_root=repo_root))
     lines.extend(footer)
-    return "\n".join(lines) + "\n"
+    return "\n".join(lines) + "\n", selected, slug
+
+
+def build_context(hook_input: dict, env: "dict[str, str] | None" = None) -> "str | None":
+    """Build the injected block, or None if there is nothing to emit.
+
+    Depends only on hook_input + env + store state -- no caller-visible
+    side effects. Every "None" branch means the caller emits nothing and
+    session behavior is exactly what it was before this hook existed.
+
+    NOTE: `env` only gates the CCGM_LEARNINGS_INJECT flag checked just
+    below -- project-slug resolution (resolve_slug() ->
+    learnings_store.detect_project_slug()) always reads the REAL process
+    os.environ, regardless of what is passed here. Harmless in production
+    (where `env` defaults to `os.environ` anyway); tests that need to
+    isolate slug resolution do so via CCGM_LEARNINGS_PROJECT/DIR, not via
+    this parameter.
+    """
+    context, _selected, _slug = _build_injection(hook_input, env)
+    return context
+
+
+# ---------------------------------------------------------------------------
+# Injection telemetry (issue #781) -- a per-machine, best-effort side-channel.
+#
+# After the injected block is written to stdout, main() appends ONE record per
+# surfacing so a future weekly scorecard can measure memory utilization. The
+# record carries memory IDs + counts + a token estimate ONLY -- never any
+# memory CONTENT: the content already lives in the store, and copying it here
+# would create a second PII surface (issue #781). The log lives OUTSIDE the
+# synced ~/.claude/learnings/ store (telemetry is per-machine, never
+# committed), under the dreaming module's own CCGM_DREAMING_DIR root so the
+# scorecard reads a consistent path.
+# ---------------------------------------------------------------------------
+
+def _utc_now_iso(now: "datetime | None" = None) -> str:
+    """ISO-8601 UTC, millisecond precision -- matches learnings_store's own
+    timestamp format. Inlined rather than imported from the store to keep this
+    side-channel self-contained (same independence rationale as
+    _verify_wrapper vs. the search CLI's copy)."""
+    dt = now if now is not None else datetime.now(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S") + f".{dt.microsecond // 1000:03d}Z"
+
+
+def _injection_log_path(now: "datetime | None" = None) -> Path:
+    """Per-machine telemetry path:
+    <CCGM_DREAMING_DIR>/injection-log/<date>.jsonl (default root
+    ~/.claude/dreaming). Deliberately NOT under ~/.claude/learnings/ -- that
+    directory is a synced git repo and telemetry must never be committed to
+    it (issue #781)."""
+    root = Path(os.environ.get("CCGM_DREAMING_DIR", os.path.expanduser("~/.claude/dreaming")))
+    day = (now if now is not None else datetime.now(timezone.utc)).date().isoformat()
+    return root / "injection-log" / f"{day}.jsonl"
+
+
+def _telemetry_record(
+    hook_input: dict,
+    slug: str,
+    selected: "list[dict]",
+    context: str,
+    *,
+    now: "datetime | None" = None,
+) -> dict:
+    """One telemetry record for a single injection. IDs + counts + a token
+    estimate ONLY -- no memory content (issue #781). session_id/source come
+    from the hook's stdin input; approx_tokens is the injected block's own
+    size (len(context) // CHARS_PER_TOKEN), reusing the already-rendered
+    string rather than recomputing anything."""
+    return {
+        "timestamp": _utc_now_iso(now),
+        "session_id": str(hook_input.get("session_id", "")),
+        "source": str(hook_input.get("source", "")),
+        "project_slug": slug,
+        "injected_count": len(selected),
+        "injected_ids": [e.get("id") for e in selected],
+        "approx_tokens": len(context) // CHARS_PER_TOKEN,
+    }
+
+
+def _log_injection(hook_input: dict, slug: str, selected: "list[dict]", context: str) -> None:
+    """Best-effort append of one telemetry record. Wrapped so ANY failure
+    (hook_utils unavailable, unwritable dir, malformed input, the append
+    helper raising) is swallowed: telemetry must NEVER block the injected
+    context from reaching stdout or raise from the hook (issue #781). The
+    caller MUST have already written `context` to stdout before calling this.
+    """
+    try:
+        if hook_utils is None:
+            return
+        record = _telemetry_record(hook_input, slug, selected, context)
+        hook_utils.file_locked_append(
+            str(_injection_log_path()), json.dumps(record, ensure_ascii=False)
+        )
+    except Exception:
+        return
 
 
 def main() -> None:
@@ -356,17 +479,27 @@ def main() -> None:
     if hook_input.get("source", "") != "startup":
         return
 
-    # Defense-in-depth (Stage-2 review): build_context() should never raise,
-    # but a SessionStart hook must NEVER surface a traceback regardless of
-    # what upstream guard might have a gap -- any unexpected failure here is
+    # Defense-in-depth (Stage-2 review): _build_injection() should never
+    # raise, but a SessionStart hook must NEVER surface a traceback regardless
+    # of what upstream guard might have a gap -- any unexpected failure here is
     # a silent no-op, same as every other "nothing to inject" branch above.
     try:
-        context = build_context(hook_input)
+        context, selected, slug = _build_injection(hook_input)
     except Exception:
         return
 
-    if context:
-        sys.stdout.write(context)
+    if not context:
+        # Inert (flag off or zero memories selected): emit nothing and write
+        # NO telemetry record (issue #781).
+        return
+
+    # Byte-stability + fail-safe ordering (issue #781): write the injected
+    # context to stdout FIRST -- it is the load-bearing output and must be
+    # byte-identical to the pre-telemetry behavior -- THEN attempt the
+    # best-effort telemetry side-channel. _log_injection swallows every
+    # failure, so it can neither alter nor block what was just written.
+    sys.stdout.write(context)
+    _log_injection(hook_input, slug, selected, context)
 
 
 if __name__ == "__main__":

--- a/modules/self-improving/tests/test_learnings_inject.py
+++ b/modules/self-improving/tests/test_learnings_inject.py
@@ -27,7 +27,9 @@ Run with: python3 -m pytest modules/self-improving/tests/test_learnings_inject.p
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import shutil
@@ -38,6 +40,7 @@ import unittest
 import uuid
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
+from unittest import mock
 
 HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parents[2]
@@ -743,6 +746,216 @@ class SlugAgreementTests(HermeticEnvTestCase):
         repo_detect = _load_module("repo_detect_fixture", REPO_DETECT_PATH)
         self.assertEqual(repo_detect.detect_repo(fixture_repo), "hello-world")
         self.assertNotEqual(repo_detect.detect_repo(fixture_repo), hook_slug)
+
+
+class InjectionTelemetryTests(HermeticEnvTestCase):
+    """#781: after emitting the injected block, the hook appends ONE
+    best-effort telemetry record (memory IDs + counts + a token estimate
+    ONLY, never memory content) to a per-machine JSONL under
+    CCGM_DREAMING_DIR. The write is a pure side-channel: it must never alter
+    the injected stdout bytes, never block injection, and never raise -- and
+    must write nothing when injection did not run.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.slug = f"inject-telem-{uuid.uuid4().hex[:10]}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+
+        # Isolate the telemetry log dir into a tempdir (restored after) so a
+        # test can never touch the real ~/.claude/dreaming/injection-log/.
+        self._dreaming_dir = tempfile.mkdtemp(prefix="ccgm-injection-log-test-")
+        saved_dreaming = os.environ.get("CCGM_DREAMING_DIR")
+        os.environ["CCGM_DREAMING_DIR"] = self._dreaming_dir
+        if saved_dreaming is None:
+            self.addCleanup(os.environ.pop, "CCGM_DREAMING_DIR", None)
+        else:
+            self.addCleanup(os.environ.__setitem__, "CCGM_DREAMING_DIR", saved_dreaming)
+        self.addCleanup(shutil.rmtree, self._dreaming_dir, ignore_errors=True)
+
+        # main()'s in-process path reads the flag from os.environ;
+        # HermeticEnvTestCase only saves PROJECT/DIR, so manage INJECT here.
+        saved_flag = os.environ.get("CCGM_LEARNINGS_INJECT")
+        if saved_flag is None:
+            self.addCleanup(os.environ.pop, "CCGM_LEARNINGS_INJECT", None)
+        else:
+            self.addCleanup(os.environ.__setitem__, "CCGM_LEARNINGS_INJECT", saved_flag)
+
+        self.n = 4
+        # DISTINCT confidences -> a TOTAL ranking order, so search()/selection
+        # is stable across the two separate builds a byte-stability/record test
+        # compares. Tied confidences expose a pre-existing store
+        # snapshot-cache read-order artifact (two builds straddling cache
+        # materialization can reorder tied heads) that has nothing to do with
+        # telemetry -- OrderingStabilityTests uses distinct confidences for
+        # exactly this reason.
+        for i in range(self.n):
+            ls.append_entry(ls.build_entry(
+                type_="pattern",
+                content=f"telemetry fixture learning number {i}",
+                confidence=9 - i,
+            ))
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+        super().tearDown()
+
+    def _payload(self, **extra) -> dict:
+        p = {"source": "startup", "cwd": os.getcwd(), "session_id": "sess-telem-1"}
+        p.update(extra)
+        return p
+
+    def _run_main(self, payload: dict) -> str:
+        """Drive the real main() in-process: feed `payload` on stdin, capture
+        and return stdout. Used both for the happy path and (with the append
+        helper patched to raise) for the fail-safe path -- the only way to
+        force file_locked_append to raise is in-process."""
+        buf = io.StringIO()
+        saved_stdin = sys.stdin
+        sys.stdin = io.StringIO(json.dumps(payload))
+        try:
+            with contextlib.redirect_stdout(buf):
+                hook.main()
+        finally:
+            sys.stdin = saved_stdin
+        return buf.getvalue()
+
+    def _read_records(self) -> "list[dict]":
+        log_dir = Path(self._dreaming_dir) / "injection-log"
+        if not log_dir.is_dir():
+            return []
+        records: "list[dict]" = []
+        for f in sorted(log_dir.glob("*.jsonl")):  # glob avoids a midnight-UTC date assumption
+            for line in f.read_text(encoding="utf-8").splitlines():
+                if line.strip():
+                    records.append(json.loads(line))
+        return records
+
+    # -- record shape / counts / ids / tokens ------------------------------
+
+    def test_injection_writes_exactly_one_record_with_correct_fields(self):
+        os.environ["CCGM_LEARNINGS_INJECT"] = "true"
+        payload = self._payload()
+
+        # The control build also tells us the exact selected set + token
+        # estimate the record must match (reused, never re-queried).
+        context, selected, slug = hook._build_injection(payload, env=os.environ)
+        self.assertIsNotNone(context)
+        self.assertEqual(len(selected), self.n)
+
+        self._run_main(payload)
+        records = self._read_records()
+        self.assertEqual(len(records), 1, "exactly one record per injection")
+
+        rec = records[0]
+        self.assertEqual(
+            set(rec.keys()),
+            {"timestamp", "session_id", "source", "project_slug",
+             "injected_count", "injected_ids", "approx_tokens"},
+        )
+        self.assertEqual(rec["session_id"], "sess-telem-1")
+        self.assertEqual(rec["source"], "startup")
+        self.assertEqual(rec["project_slug"], slug)
+        self.assertEqual(rec["injected_count"], self.n)
+        self.assertEqual(rec["injected_ids"], [e["id"] for e in selected])
+        self.assertEqual(len(rec["injected_ids"]), rec["injected_count"])
+        self.assertEqual(rec["approx_tokens"], len(context) // hook.CHARS_PER_TOKEN)
+
+    def test_record_never_contains_memory_content(self):
+        os.environ["CCGM_LEARNINGS_INJECT"] = "true"
+        payload = self._payload()
+        _context, selected, _slug = hook._build_injection(payload, env=os.environ)
+
+        self._run_main(payload)
+        log_dir = Path(self._dreaming_dir) / "injection-log"
+        raw = "\n".join(f.read_text(encoding="utf-8") for f in log_dir.glob("*.jsonl"))
+        self.assertTrue(raw.strip())
+        for e in selected:
+            self.assertNotIn(
+                e["content"], raw,
+                "memory content must NEVER be copied into the telemetry log (issue #781)",
+            )
+
+    def test_log_path_is_outside_the_synced_learnings_store(self):
+        path = str(hook._injection_log_path())
+        self.assertIn("injection-log", path)
+        # The synced store root must never contain the telemetry log.
+        self.assertNotIn(str(ls.LEARNINGS_ROOT), path)
+
+    def test_subprocess_end_to_end_writes_record(self):
+        env = os.environ.copy()
+        env["CCGM_LEARNINGS_PROJECT"] = self.slug
+        # See SearchCliSubprocessTests._env() for why DIR is pinned to the
+        # actually-bound ls.LEARNINGS_ROOT (issue #764 collection-order hazard).
+        env["CCGM_LEARNINGS_DIR"] = str(ls.LEARNINGS_ROOT)
+        env["CCGM_DREAMING_DIR"] = self._dreaming_dir
+        env["CCGM_LEARNINGS_INJECT"] = "true"
+        result = subprocess.run(
+            [sys.executable, str(INJECT_HOOK_PATH)],
+            input=json.dumps(self._payload()),
+            env=env, capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("ccgm-learnings-injection", result.stdout)
+        records = self._read_records()
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["injected_count"], self.n)
+        self.assertEqual(records[0]["session_id"], "sess-telem-1")
+
+    # -- fail-safe ---------------------------------------------------------
+
+    def test_forced_telemetry_failure_still_emits_and_never_raises(self):
+        os.environ["CCGM_LEARNINGS_INJECT"] = "true"
+        payload = self._payload()
+        control = hook.build_context(payload, env=os.environ)
+        self.assertIsNotNone(control)
+
+        with mock.patch.object(
+            hook.hook_utils, "file_locked_append",
+            side_effect=RuntimeError("disk on fire"),
+        ):
+            # Must NOT raise, and stdout must be byte-identical to the control.
+            out = self._run_main(payload)
+        self.assertEqual(out, control)
+        # And nothing was written (the append was forced to fail).
+        self.assertEqual(self._read_records(), [])
+
+    # -- inert -------------------------------------------------------------
+
+    def test_no_record_when_flag_unset(self):
+        os.environ.pop("CCGM_LEARNINGS_INJECT", None)
+        out = self._run_main(self._payload())
+        self.assertEqual(out, "")
+        self.assertEqual(self._read_records(), [])
+
+    def test_no_record_when_zero_memories_selected(self):
+        os.environ["CCGM_LEARNINGS_INJECT"] = "true"
+        # Point at an empty slug so selection yields nothing (inert path).
+        empty_slug = f"inject-telem-empty-{uuid.uuid4().hex[:10]}"
+        os.environ["CCGM_LEARNINGS_PROJECT"] = empty_slug
+        self.addCleanup(shutil.rmtree, ls.project_dir(empty_slug), ignore_errors=True)
+        self.addCleanup(shutil.rmtree, ls._cache_dir(empty_slug), ignore_errors=True)
+
+        out = self._run_main(self._payload())
+        self.assertEqual(out, "")
+        self.assertEqual(self._read_records(), [])
+
+    # -- byte-stability ----------------------------------------------------
+
+    def test_injected_stdout_bytes_identical_with_telemetry_vs_control(self):
+        os.environ["CCGM_LEARNINGS_INJECT"] = "true"
+        payload = self._payload()
+        # Control: the pure injected block (build_context never logs telemetry).
+        control = hook.build_context(payload, env=os.environ)
+        self.assertIsNotNone(control)
+        # Full main() path DOES write telemetry -- its stdout must still be
+        # byte-identical to the control.
+        out = self._run_main(payload)
+        self.assertEqual(out, control)
+        # Sanity: telemetry really did fire (otherwise this would vacuously
+        # compare two telemetry-free runs).
+        self.assertEqual(len(self._read_records()), 1)
 
 
 def _cleanup():


### PR DESCRIPTION
## Summary

Closes #781.

The `learnings-inject.py` SessionStart hook surfaces top-K memories into a session's context but recorded nothing, so there was no signal for how often / which memories are actually surfaced. This adds a per-machine, best-effort telemetry record per injection — the foundation for a "is memory being utilized" metric / weekly scorecard.

## Changes

- **Refactor** `build_context()` → `_build_injection()` which returns `(context, selected, slug)`. `build_context()` is now a thin wrapper preserving its exact `str | None` contract, so every existing caller/test sees byte-identical output. `main()` uses `_build_injection()` to get the already-selected memory list (no re-query).
- **`main()` order**: write the injected context to stdout **first**, then append one telemetry record. Telemetry is a pure side-channel.
- **Record shape**: `{timestamp, session_id, source, project_slug, injected_count, injected_ids, approx_tokens}` — memory **IDs + counts + a token estimate only**, never any memory content (avoids a second PII surface). `session_id`/`source` come from the hook's stdin JSON.
- **Location**: `<CCGM_DREAMING_DIR>/injection-log/<date>.jsonl` (default `~/.claude/dreaming/injection-log/`), written via the existing `file_locked_append` helper. Deliberately **outside** the synced `~/.claude/learnings/` git repo — no gitignore entry needed since it is not inside either repo.

## Hard constraints (all covered by tests)

- **Fail-safe**: the entire telemetry write is wrapped in `try/except`; any failure (unwritable dir, bad input, helper raising, `hook_utils` unavailable) is swallowed and cannot prevent the injected context from reaching stdout or raise from the hook.
- **Byte-stability**: stdout is written before telemetry and telemetry touches only a file — the injected bytes are byte-identical to pre-change behavior.
- **Inert when off**: flag unset or zero memories selected → no record written.
- **No extra store read**: reuses the already-selected memory list.

## Tests (added to `modules/self-improving/tests/test_learnings_inject.py`)

New `InjectionTelemetryTests` class:
- Injection of N memories → exactly one record with correct `injected_count` / `injected_ids` / `approx_tokens`.
- Record never contains memory content.
- Telemetry append forced to raise → injection still emits its context, no exception propagates, stdout byte-identical, no record written.
- Inert hook (flag unset; zero memories) → no record.
- Byte-stability: `main()` stdout (telemetry on) identical to the `build_context()` control.
- Subprocess end-to-end: real hook binary writes a record to the isolated log dir.
- Log path asserted to live outside the synced learnings store root.

## Test Plan

```
python3 -m pytest modules/self-improving/tests/ modules/dreaming/tests/ -q
# 381 passed, 4 subtests passed

bash tests/test-no-personal-data.sh
# PASS: No personal data or secret/PII shapes found
```
