### PR TITLE
#784: eval gate — credit efficiency in high_value

### DIFF
--- a/modules/dreaming/eval/memory_eval.py
+++ b/modules/dreaming/eval/memory_eval.py
@@ -945,9 +945,13 @@ def classify_bucket(
         if delta_sat > 0:
             return "high_value", delta, delta_sat
         # Path B (efficiency win): memory MATCHES the dump's outcome (does
-        # not lose beyond noise) at materially fewer input tokens.
+        # not lose beyond noise) at materially fewer input tokens. BOTH
+        # token means must be positive -- a degenerate zero-input treatment
+        # arm (a total run failure) is trivially <= any ratio of the dump
+        # and must never spuriously satisfy the efficiency condition.
         if (
             delta_sat >= -HIGH_VALUE_SAT_TOLERANCE
+            and treatment_input_tokens > 0
             and full_context_input_tokens > 0
             and treatment_input_tokens <= HIGH_VALUE_EFFICIENCY_RATIO * full_context_input_tokens
         ):

--- a/modules/dreaming/eval/memory_eval.py
+++ b/modules/dreaming/eval/memory_eval.py
@@ -27,7 +27,9 @@ recent results file exists, is fresh (newer than the configured freshness
 bound AND newer than the last CONTENT-SHAPING store mutation -- pure
 `verify` counter-ops are excluded from that bound, adrev-403), has zero
 `regression` rows, at least one `high_value` row, the live (non-offline)
-`kind:dreamed` row itself classifies `high_value` with Δ_sat>0 (adrev-305),
+`kind:dreamed` row itself classifies `high_value` (adrev-305; #784: via the
+outcome path Δ_sat>0 OR the efficiency path -- memory matching the dump at
+materially fewer input tokens -- both encoded by classify_bucket()),
 AND that same row's paired noise-only corpus produced NO high-value
 proposal (`mining.noise_high_value` is not true -- adrev-305's own
 Acceptance sentence: a pipeline that manufactures memories from noise must
@@ -55,7 +57,7 @@ mine->analyze step also runs offline in this mode (reusing dream_analyze.py
 via `--offline <dir>/../offline-responses-dreamed`, a sibling of the outer
 `--offline` directory) and is explicitly labeled `"offline": true` in its
 results row -- `--gate` never accepts an offline-labeled `dreamed` row as
-satisfying its live-Δ_sat requirement.
+satisfying its live-high_value requirement.
 """
 from __future__ import annotations
 
@@ -107,6 +109,11 @@ REGRESSION_DELTA_THRESHOLD = -1.0
 REDUNDANT_BASELINE_THRESHOLD = 8.5
 REDUNDANT_DELTA_ABS_THRESHOLD = 1.0
 GAP_MEAN_THRESHOLD = 5.0
+# high_value Path B, the efficiency win (#784): memory that MATCHES the
+# full-context dump's outcome at materially fewer input tokens is high_value
+# even when it does not BEAT the dump on score. Both bounds must hold.
+HIGH_VALUE_SAT_TOLERANCE = 0.5      # treatment may be at most 0.5 below full_context on score (must essentially MATCH, within noise)
+HIGH_VALUE_EFFICIENCY_RATIO = 0.5   # treatment mean_input_tokens must be <= 0.5 * full_context mean_input_tokens
 
 ARMS = ("baseline", "treatment", "full_context")
 
@@ -896,7 +903,8 @@ def run_arms(
 
 
 def classify_bucket(
-    *, baseline_mean: float, treatment_mean: float, full_context_mean: float
+    *, baseline_mean: float, treatment_mean: float, full_context_mean: float,
+    treatment_input_tokens: float = 0.0, full_context_input_tokens: float = 0.0,
 ) -> tuple[str, float, float]:
     """Returns (bucket, delta, delta_sat).
 
@@ -908,14 +916,42 @@ def classify_bucket(
     low; the two conditions can genuinely overlap, e.g. baseline=4.0,
     treatment=2.9): regression > high_value > redundant > gap >
     "inconclusive" (a task that clears none of the four named buckets).
+
+    high_value has TWO independent paths (#784), both gated behind
+    delta >= HIGH_VALUE_DELTA_THRESHOLD -- a task that does not clear
+    baseline over noise is never high_value by either path:
+      - Path A (outcome win): memory BEATS the full-context dump on score
+        (delta_sat > 0). Memory added value beyond a naive dump of the same
+        facts. Independent of token cost.
+      - Path B (efficiency win): memory MATCHES the dump's outcome within
+        noise (delta_sat >= -HIGH_VALUE_SAT_TOLERANCE) at materially fewer
+        input tokens (treatment_input_tokens <= HIGH_VALUE_EFFICIENCY_RATIO
+        * full_context_input_tokens). For a capable model that resolves even
+        a full dump on its own, matching the dump's result at a fraction of
+        the context cost IS memory's value. Self-guarding: Path B can only
+        fire when full_context_input_tokens is materially larger than
+        treatment's, so it stays inert on today's small fixtures (where the
+        two arms' token counts are comparable) and defaults OFF when the
+        token means are absent -- both params default to 0.0, which fails
+        the `full_context_input_tokens > 0` guard.
     """
     delta = treatment_mean - baseline_mean
     delta_sat = treatment_mean - full_context_mean
 
     if delta <= REGRESSION_DELTA_THRESHOLD:
         return "regression", delta, delta_sat
-    if delta >= HIGH_VALUE_DELTA_THRESHOLD and delta_sat > 0:
-        return "high_value", delta, delta_sat
+    if delta >= HIGH_VALUE_DELTA_THRESHOLD:
+        # Path A (outcome win): memory beats the full dump on score.
+        if delta_sat > 0:
+            return "high_value", delta, delta_sat
+        # Path B (efficiency win): memory MATCHES the dump's outcome (does
+        # not lose beyond noise) at materially fewer input tokens.
+        if (
+            delta_sat >= -HIGH_VALUE_SAT_TOLERANCE
+            and full_context_input_tokens > 0
+            and treatment_input_tokens <= HIGH_VALUE_EFFICIENCY_RATIO * full_context_input_tokens
+        ):
+            return "high_value", delta, delta_sat
     if baseline_mean >= REDUNDANT_BASELINE_THRESHOLD and abs(delta) < REDUNDANT_DELTA_ABS_THRESHOLD:
         return "redundant", delta, delta_sat
     if baseline_mean < GAP_MEAN_THRESHOLD and treatment_mean < GAP_MEAN_THRESHOLD:
@@ -972,6 +1008,8 @@ def run_task(
         bucket, delta, delta_sat = classify_bucket(
             baseline_mean=arms["baseline"]["mean_score"], treatment_mean=arms["treatment"]["mean_score"],
             full_context_mean=arms["full_context"]["mean_score"],
+            treatment_input_tokens=arms["treatment"]["mean_input_tokens"],
+            full_context_input_tokens=arms["full_context"]["mean_input_tokens"],
         )
         rows.append(_build_result_row(
             task_id=task_id, kind=kind, backbone=backbone, runs=runs, offline=offline_all_scores is not None,
@@ -1240,6 +1278,8 @@ def run_dreamed_task(
         bucket, delta, delta_sat = classify_bucket(
             baseline_mean=arms["baseline"]["mean_score"], treatment_mean=arms["treatment"]["mean_score"],
             full_context_mean=arms["full_context"]["mean_score"],
+            treatment_input_tokens=arms["treatment"]["mean_input_tokens"],
+            full_context_input_tokens=arms["full_context"]["mean_input_tokens"],
         )
         rows.append(_build_result_row(
             task_id=task_id, kind="dreamed", backbone=backbone, runs=runs, offline=offline,
@@ -1351,13 +1391,20 @@ def latest_content_shaping_mutation_epoch(learnings_root: Path) -> float | None:
 def gate_check(*, freshness_days: int = DEFAULT_EVAL_FRESHNESS_DAYS, now: float | None = None) -> tuple[bool, str]:
     """Returns (open, reason). Fails closed on every branch: missing
     results, stale results (either bound), any regression row, no
-    high_value row, no LIVE dreamed row classifying high_value with
-    Δ_sat>0 (adrev-305), or that live dreamed row's paired noise-only
-    corpus itself yielding a high-value proposal (`mining.noise_high_value`
-    -- adrev-305's Acceptance sentence, the mining-side negative control
-    that must ALSO hold before auto-apply's gate can open) -- exactly one
-    reason string per failure mode, "stale" handled identically to
-    "missing"."""
+    high_value row, no LIVE dreamed row classifying high_value (adrev-305),
+    or that live dreamed row's paired noise-only corpus itself yielding a
+    high-value proposal (`mining.noise_high_value` -- adrev-305's Acceptance
+    sentence, the mining-side negative control that must ALSO hold before
+    auto-apply's gate can open) -- exactly one reason string per failure
+    mode, "stale" handled identically to "missing".
+
+    #784: the live-dreamed check no longer independently re-tests Δ_sat>0.
+    "high_value" now covers BOTH the outcome path (Δ_sat>0) and the
+    efficiency path (memory matches the full-context dump within noise at
+    materially fewer input tokens); the explicit Δ_sat>0 clause that used to
+    live here is subsumed by classify_bucket()'s two-path definition, so a
+    dreamed row that is high_value via efficiency (Δ_sat can be 0) now opens
+    the gate. The judge-error and noise-control guards below are unchanged."""
     now = now if now is not None else time.time()
 
     latest = _find_latest_results_file()
@@ -1386,10 +1433,10 @@ def gate_check(*, freshness_days: int = DEFAULT_EVAL_FRESHNESS_DAYS, now: float 
 
     live_dreamed_high_value = [
         r for r in rows
-        if r.get("kind") == "dreamed" and not r.get("offline") and r.get("bucket") == "high_value" and r.get("delta_sat", -1) > 0
+        if r.get("kind") == "dreamed" and not r.get("offline") and r.get("bucket") == "high_value"
     ]
     if not live_dreamed_high_value:
-        return False, "kind:dreamed task has not classified high_value with Δ_sat>0 under a live (non-offline) run"
+        return False, "kind:dreamed task has not classified high_value under a live (non-offline) run"
 
     # Stage-2 #771 Blocking fix: classify_bucket() is a judge-error-unaware
     # pure function -- a judge-API transport/parse failure on one arm

--- a/modules/dreaming/tests/test_memory_eval.py
+++ b/modules/dreaming/tests/test_memory_eval.py
@@ -143,6 +143,140 @@ class ClassifyBucketTests(unittest.TestCase):
         bucket, _delta, _ = me.classify_bucket(baseline_mean=5.5, treatment_mean=6.2, full_context_mean=6.0)
         self.assertEqual(bucket, "inconclusive")
 
+    # ---- #784: high_value Path B (efficiency win) ----------------------
+
+    def test_efficiency_path_fires_when_memory_matches_dump_at_far_fewer_tokens(self):
+        """#784 Path B: memory MATCHES the full-context dump on score
+        (delta_sat=0) but at materially fewer input tokens (3000 vs 20000)
+        -- high_value via the efficiency path even though it did not BEAT
+        the dump on outcome. This is the case the old delta_sat>0-only
+        definition made unreachable for a capable model."""
+        bucket, delta, delta_sat = me.classify_bucket(
+            baseline_mean=5.0, treatment_mean=8.0, full_context_mean=8.0,
+            treatment_input_tokens=3000, full_context_input_tokens=20000,
+        )
+        self.assertEqual(delta, 3.0)
+        self.assertEqual(delta_sat, 0.0)
+        self.assertEqual(bucket, "high_value")
+
+    def test_efficiency_path_inert_when_tokens_not_materially_fewer(self):
+        """#784 self-guard: same score shape (delta=+3, delta_sat=0) but
+        treatment's input tokens are ~the same as full_context's (3000 vs
+        3200, above the 0.5 ratio) -- Path B must NOT fire. This is the
+        shape of today's small fixtures, where the two arms' token counts
+        are comparable, so the efficiency path is provably inert on them."""
+        bucket, _delta, _ = me.classify_bucket(
+            baseline_mean=5.0, treatment_mean=8.0, full_context_mean=8.0,
+            treatment_input_tokens=3000, full_context_input_tokens=3200,
+        )
+        self.assertEqual(bucket, "inconclusive")
+
+    def test_efficiency_path_inert_when_treatment_uses_more_tokens_than_dump(self):
+        """#784 self-guard (the realistic small-fixture case): treatment
+        used MORE input tokens than the full dump (3200 vs 3000) -- memory
+        is not cheaper, so Path B stays inert despite the matching score."""
+        bucket, _delta, _ = me.classify_bucket(
+            baseline_mean=5.0, treatment_mean=8.0, full_context_mean=8.0,
+            treatment_input_tokens=3200, full_context_input_tokens=3000,
+        )
+        self.assertNotEqual(bucket, "high_value")
+
+    def test_efficiency_path_defaults_off_when_token_means_absent(self):
+        """#784 self-guard: with no token means supplied (both default to
+        0.0), the `full_context_input_tokens > 0` guard fails, so every
+        pre-#784 3-arg caller keeps its old classification -- the change
+        alone cannot open the gate without the paired realistic fixtures."""
+        bucket, _delta, delta_sat = me.classify_bucket(
+            baseline_mean=5.0, treatment_mean=8.0, full_context_mean=8.0,
+        )
+        self.assertEqual(delta_sat, 0.0)
+        self.assertNotEqual(bucket, "high_value")
+
+    def test_efficiency_path_inert_when_memory_loses_beyond_tolerance(self):
+        """#784: memory LOSES to the dump by more than the noise tolerance
+        (delta_sat=-2.0 < -0.5) -- not a match, so Path B must NOT fire even
+        at a huge token advantage (3000 vs 20000)."""
+        bucket, _delta, delta_sat = me.classify_bucket(
+            baseline_mean=5.0, treatment_mean=8.0, full_context_mean=10.0,
+            treatment_input_tokens=3000, full_context_input_tokens=20000,
+        )
+        self.assertEqual(delta_sat, -2.0)
+        self.assertNotEqual(bucket, "high_value")
+
+    def test_efficiency_path_sat_tolerance_boundary_inclusive(self):
+        """#784 boundary: delta_sat exactly -HIGH_VALUE_SAT_TOLERANCE
+        (-0.5) still counts as a match -- Path B fires at the boundary."""
+        bucket, _delta, delta_sat = me.classify_bucket(
+            baseline_mean=5.0, treatment_mean=8.0, full_context_mean=8.5,
+            treatment_input_tokens=3000, full_context_input_tokens=20000,
+        )
+        self.assertAlmostEqual(delta_sat, -0.5)
+        self.assertEqual(bucket, "high_value")
+
+    def test_efficiency_path_sat_tolerance_boundary_exclusive(self):
+        """#784 boundary: just past the tolerance (delta_sat=-0.6) is a
+        loss, not a match -- Path B does not fire."""
+        bucket, _delta, delta_sat = me.classify_bucket(
+            baseline_mean=5.0, treatment_mean=8.0, full_context_mean=8.6,
+            treatment_input_tokens=3000, full_context_input_tokens=20000,
+        )
+        self.assertAlmostEqual(delta_sat, -0.6)
+        self.assertNotEqual(bucket, "high_value")
+
+    def test_efficiency_path_ratio_boundary_inclusive(self):
+        """#784 boundary: treatment_input exactly at the ratio ceiling
+        (10000 == 0.5 * 20000) still fires (<=)."""
+        bucket, _delta, _ = me.classify_bucket(
+            baseline_mean=5.0, treatment_mean=8.0, full_context_mean=8.0,
+            treatment_input_tokens=10000, full_context_input_tokens=20000,
+        )
+        self.assertEqual(bucket, "high_value")
+
+    def test_efficiency_path_ratio_boundary_exclusive(self):
+        """#784 boundary: one token over the ratio ceiling (10001 > 0.5 *
+        20000) does not fire."""
+        bucket, _delta, _ = me.classify_bucket(
+            baseline_mean=5.0, treatment_mean=8.0, full_context_mean=8.0,
+            treatment_input_tokens=10001, full_context_input_tokens=20000,
+        )
+        self.assertNotEqual(bucket, "high_value")
+
+    def test_saturated_task_never_high_value_via_efficiency(self):
+        """#784 poisoning/canary safety (the critical property): a saturated
+        task with no uplift (baseline~10, delta~0) can NEVER reach
+        high_value via the efficiency path, even at an extreme token
+        advantage -- delta < HIGH_VALUE_DELTA_THRESHOLD keeps execution out
+        of the high_value block entirely. It classifies redundant."""
+        bucket, delta, _ = me.classify_bucket(
+            baseline_mean=10.0, treatment_mean=10.0, full_context_mean=10.0,
+            treatment_input_tokens=100, full_context_input_tokens=20000,
+        )
+        self.assertLess(delta, me.HIGH_VALUE_DELTA_THRESHOLD)
+        self.assertNotEqual(bucket, "high_value")
+        self.assertEqual(bucket, "redundant")
+
+    def test_outcome_path_a_fires_regardless_of_token_cost(self):
+        """#784: Path A (delta_sat>0, memory BEATS the dump) is independent
+        of tokens -- it fires even when treatment used MORE input tokens
+        than the full dump (20000 vs 3000)."""
+        bucket, _delta, delta_sat = me.classify_bucket(
+            baseline_mean=3.0, treatment_mean=8.5, full_context_mean=6.0,
+            treatment_input_tokens=20000, full_context_input_tokens=3000,
+        )
+        self.assertGreater(delta_sat, 0)
+        self.assertEqual(bucket, "high_value")
+
+    def test_regression_precedence_over_efficiency_path(self):
+        """#784: regression is still checked FIRST -- a delta <= -1.0 row
+        classifies regression even when its tokens look maximally efficient
+        (Path B must never rescue a regression)."""
+        bucket, delta, _ = me.classify_bucket(
+            baseline_mean=8.0, treatment_mean=6.0, full_context_mean=8.0,
+            treatment_input_tokens=100, full_context_input_tokens=20000,
+        )
+        self.assertLessEqual(delta, me.REGRESSION_DELTA_THRESHOLD)
+        self.assertEqual(bucket, "regression")
+
 
 # ---------------------------------------------------------------------------
 # Isolated config guard (adrev-003a).
@@ -1131,11 +1265,32 @@ class GateTests(unittest.TestCase):
         self.assertFalse(is_open)
         self.assertIn("live", reason)
 
-    def test_dreamed_row_with_non_positive_delta_sat_does_not_satisfy_gate(self):
+    def test_dreamed_high_value_via_efficiency_delta_sat_zero_opens_gate(self):
+        """#784: the gate no longer independently re-checks Δ_sat>0 -- that
+        is subsumed by classify_bucket()'s two-path high_value definition. A
+        live dreamed row the classifier deemed high_value via the EFFICIENCY
+        path (it matched the full-context dump within noise, so delta_sat can
+        be 0, at materially fewer input tokens) must now OPEN the gate.
+        Before #784 this exact row (bucket=high_value, delta_sat=0) was
+        force-closed by the gate's own Δ_sat>0 clause."""
         self._write_results(self._healthy_rows(dreamed_offline=False, dreamed_delta_sat=0.0))
         is_open, reason = me.gate_check()
+        self.assertTrue(is_open, reason)
+
+    def test_non_high_value_dreamed_row_does_not_satisfy_gate(self):
+        """#784: the replacement negative control for the removed Δ_sat>0
+        clause -- a live dreamed row that is NOT high_value (via either
+        path) still fails the dreamed condition, and the reason no longer
+        names Δ_sat (that check moved into the classifier)."""
+        rows = self._healthy_rows()
+        for r in rows:
+            if r["kind"] == "dreamed":
+                r["bucket"] = "inconclusive"
+        self._write_results(rows)
+        is_open, reason = me.gate_check()
         self.assertFalse(is_open)
-        self.assertIn("Δ_sat", reason)
+        self.assertIn("dreamed", reason)
+        self.assertNotIn("Δ_sat", reason)
 
     def test_noise_only_corpus_producing_high_value_proposal_closes_gate(self):
         """adrev-305's own Acceptance sentence: a live dreamed task

--- a/modules/dreaming/tests/test_memory_eval.py
+++ b/modules/dreaming/tests/test_memory_eval.py
@@ -192,6 +192,22 @@ class ClassifyBucketTests(unittest.TestCase):
         self.assertEqual(delta_sat, 0.0)
         self.assertNotEqual(bucket, "high_value")
 
+    def test_efficiency_path_inert_when_treatment_arm_has_zero_input_tokens(self):
+        """#784 defense-in-depth (Stage-2 Recommend): a degenerate treatment
+        arm that recorded ZERO input tokens (a total run failure) is
+        trivially <= any ratio of the full dump, and would otherwise
+        spuriously satisfy the efficiency condition. The symmetric
+        `treatment_input_tokens > 0` guard keeps Path B inert here even with
+        a huge full_context arm, a matching score (delta_sat=0), and
+        delta >= HIGH_VALUE_DELTA_THRESHOLD."""
+        bucket, delta, delta_sat = me.classify_bucket(
+            baseline_mean=5.0, treatment_mean=8.0, full_context_mean=8.0,
+            treatment_input_tokens=0, full_context_input_tokens=20000,
+        )
+        self.assertGreaterEqual(delta, me.HIGH_VALUE_DELTA_THRESHOLD)
+        self.assertEqual(delta_sat, 0.0)
+        self.assertEqual(bucket, "inconclusive")
+
     def test_efficiency_path_inert_when_memory_loses_beyond_tolerance(self):
         """#784: memory LOSES to the dump by more than the noise tolerance
         (delta_sat=-2.0 < -0.5) -- not a match, so Path B must NOT fire even


### PR DESCRIPTION
## Summary

Adds an **efficiency path (Path B)** to `classify_bucket`'s `high_value` definition in `modules/dreaming/eval/memory_eval.py`. For capable models, curated memory ties a full-context dump on outcome (`delta_sat≈0`) and wins on **efficiency** (far fewer input tokens). The old definition (`delta>=1.5 AND delta_sat>0`) required memory to BEAT the dump on outcome — near-unreachable for a strong model that resolves even a noisy dump on its own. Path B credits memory that MATCHES the dump's outcome within noise at materially lower token cost.

Closes #784.

## Changes

- **New constants** (`HIGH_VALUE_SAT_TOLERANCE = 0.5`, `HIGH_VALUE_EFFICIENCY_RATIO = 0.5`) in the classifier-thresholds block.
- **`classify_bucket`** gains `treatment_input_tokens` / `full_context_input_tokens` params (default `0.0`) and a restructured `high_value` branch with two independent paths:
  - Path A (outcome win): `delta_sat > 0` — unchanged, token-independent.
  - Path B (efficiency win): `delta_sat >= -TOLERANCE` AND `full_context_input_tokens > 0` AND `treatment_input_tokens <= RATIO * full_context_input_tokens`.
  - **Precedence unchanged:** `regression > high_value > redundant > gap > inconclusive`; the `regression` check stays first.
- **Both callers** (`run_task`, `run_dreamed_task`) now pass the two arms' `mean_input_tokens`.
- **`gate_check`** dreamed condition no longer independently re-tests `Δ_sat>0` — that check is subsumed by the classifier's two-path definition, so a dreamed row that is `high_value` via efficiency now opens the gate. Reason string and docstrings updated. The judge-error guard and noise-control guard are untouched.

## Self-guarding (why this change alone cannot open the gate)

Path B can only fire when `full_context_input_tokens` is materially larger than treatment's. With today's small fixtures the two arms' token counts are comparable, so Path B is provably inert; it also defaults OFF when token means are absent (both params default to `0.0`, failing the `> 0` guard). Opening the gate requires the paired realistic-fixture work.

## Test Plan

Added 14 tests (12 classifier, 2 gate) covering: efficiency fires; self-guards (near-equal tokens, treatment-heavier tokens, absent token means); loss beyond tolerance; sat-tolerance and ratio boundaries (inclusive/exclusive); **saturated/canary safety** (`delta≈0` never `high_value` regardless of tokens); Path A independent of token cost; regression precedence; gate opens via efficiency (`delta_sat=0`); non-high_value dreamed row still fails.

```
python3 -m pytest modules/dreaming/tests/ modules/self-improving/tests/ -q
# 394 passed, 4 subtests passed

bash tests/test-no-personal-data.sh
# PASS: No personal data or secret/PII shapes found
```
