### PR TITLE
#789: count cached input tokens in efficiency ratio

### DIFF
--- a/modules/dreaming/eval/memory_eval.py
+++ b/modules/dreaming/eval/memory_eval.py
@@ -113,7 +113,7 @@ GAP_MEAN_THRESHOLD = 5.0
 # full-context dump's outcome at materially fewer input tokens is high_value
 # even when it does not BEAT the dump on score. Both bounds must hold.
 HIGH_VALUE_SAT_TOLERANCE = 0.5      # treatment may be at most 0.5 below full_context on score (must essentially MATCH, within noise)
-HIGH_VALUE_EFFICIENCY_RATIO = 0.5   # treatment mean_input_tokens must be <= 0.5 * full_context mean_input_tokens
+HIGH_VALUE_EFFICIENCY_RATIO = 0.5   # treatment mean_total_input_tokens must be <= 0.5 * full_context mean_total_input_tokens (#789: total incl. cached prompt tokens, not just marginal input_tokens)
 
 ARMS = ("baseline", "treatment", "full_context")
 

--- a/modules/dreaming/eval/memory_eval.py
+++ b/modules/dreaming/eval/memory_eval.py
@@ -795,10 +795,23 @@ def _run_one(
     )
 
     usage = result.get("usage") or {}
+    # #789: Claude Code caches the static prompt prefix (system prompt,
+    # tools, and the large static facts block), so usage["input_tokens"]
+    # reports only the marginal UNCACHED remainder -- the cache_read/
+    # cache_creation counts carry the rest of the true prompt size. The
+    # efficiency ratio (classify_bucket Path B) must compare TOTAL input or
+    # the full-context arm's facts block is invisible to the metric. Keep
+    # input_tokens unchanged (its meaning for cost/reporting is the billable
+    # marginal count); the offline branch above has no cache fields, so
+    # total_input_tokens == input_tokens there.
+    input_tokens = int(usage.get("input_tokens", 0) or 0)
+    cache_read_input_tokens = int(usage.get("cache_read_input_tokens", 0) or 0)
+    cache_creation_input_tokens = int(usage.get("cache_creation_input_tokens", 0) or 0)
     row = {
         "score": judged["score"],
         "pass": judged["pass"],
-        "input_tokens": int(usage.get("input_tokens", 0) or 0),
+        "input_tokens": input_tokens,
+        "total_input_tokens": input_tokens + cache_read_input_tokens + cache_creation_input_tokens,
         "output_tokens": int(usage.get("output_tokens", 0) or 0),
         "turns": int(result.get("num_turns", 0) or 0),
         "run_cost_usd": float(result.get("total_cost_usd", 0.0) or 0.0),
@@ -818,7 +831,8 @@ def _run_one(
 def _aggregate_arm_runs(runs: list[dict[str, Any]]) -> dict[str, Any]:
     if not runs:
         return {
-            "mean_score": 0.0, "pass_rate": 0.0, "mean_input_tokens": 0.0, "mean_output_tokens": 0.0,
+            "mean_score": 0.0, "pass_rate": 0.0, "mean_input_tokens": 0.0, "mean_total_input_tokens": 0.0,
+            "mean_output_tokens": 0.0,
             "mean_turns": 0.0, "mean_cost_usd": 0.0, "format_error_rate": 0.0, "judge_error_rate": 0.0, "runs": 0,
         }
     # Stage-2 #771 Blocking fix: a run whose judge call itself failed
@@ -837,6 +851,7 @@ def _aggregate_arm_runs(runs: list[dict[str, Any]]) -> dict[str, Any]:
         "mean_score": statistics.fmean(r["score"] for r in scored_runs) if scored_runs else 0.0,
         "pass_rate": (sum(1 for r in scored_runs if r["pass"]) / len(scored_runs)) if scored_runs else 0.0,
         "mean_input_tokens": statistics.fmean(r["input_tokens"] for r in runs),
+        "mean_total_input_tokens": statistics.fmean(r["total_input_tokens"] for r in runs),
         "mean_output_tokens": statistics.fmean(r["output_tokens"] for r in runs),
         "mean_turns": statistics.fmean(r["turns"] for r in runs),
         "mean_cost_usd": statistics.fmean(r["run_cost_usd"] for r in runs),
@@ -1012,8 +1027,8 @@ def run_task(
         bucket, delta, delta_sat = classify_bucket(
             baseline_mean=arms["baseline"]["mean_score"], treatment_mean=arms["treatment"]["mean_score"],
             full_context_mean=arms["full_context"]["mean_score"],
-            treatment_input_tokens=arms["treatment"]["mean_input_tokens"],
-            full_context_input_tokens=arms["full_context"]["mean_input_tokens"],
+            treatment_input_tokens=arms["treatment"]["mean_total_input_tokens"],
+            full_context_input_tokens=arms["full_context"]["mean_total_input_tokens"],
         )
         rows.append(_build_result_row(
             task_id=task_id, kind=kind, backbone=backbone, runs=runs, offline=offline_all_scores is not None,
@@ -1282,8 +1297,8 @@ def run_dreamed_task(
         bucket, delta, delta_sat = classify_bucket(
             baseline_mean=arms["baseline"]["mean_score"], treatment_mean=arms["treatment"]["mean_score"],
             full_context_mean=arms["full_context"]["mean_score"],
-            treatment_input_tokens=arms["treatment"]["mean_input_tokens"],
-            full_context_input_tokens=arms["full_context"]["mean_input_tokens"],
+            treatment_input_tokens=arms["treatment"]["mean_total_input_tokens"],
+            full_context_input_tokens=arms["full_context"]["mean_total_input_tokens"],
         )
         rows.append(_build_result_row(
             task_id=task_id, kind="dreamed", backbone=backbone, runs=runs, offline=offline,

--- a/modules/dreaming/tests/test_memory_eval.py
+++ b/modules/dreaming/tests/test_memory_eval.py
@@ -1622,6 +1622,81 @@ class DreamedTaskOfflineNoiseFixtureTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# #789: pin the CALLER wiring. run_task() and run_dreamed_task() must feed
+# classify_bucket()'s efficiency args from mean_total_input_tokens, NOT
+# mean_input_tokens. With run_arms() mocked to return arms whose two token
+# means DIFFER (TOTAL 3000 vs 11000 across treatment/full_context, but
+# MARGINAL 3000 vs 3000 everywhere), the efficiency ratio only clears 0.5 on
+# the total counts -> bucket high_value. If either caller reverts to
+# mean_input_tokens the ratio is 1.0 and the bucket collapses to
+# inconclusive, failing these -- the mutation Stage-1 review found unpinned.
+# ---------------------------------------------------------------------------
+
+class CallerWiringToTotalInputTokensTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _isolate_env(self)
+
+    @staticmethod
+    def _arm(*, mean_score, mean_total_input_tokens, mean_input_tokens=3000.0):
+        """Mirror _aggregate_arm_runs()'s output shape (every key
+        _build_result_row and classify_bucket read). mean_input_tokens is
+        pinned at 3000 across ALL arms so the OLD (buggy) metric sees a 1.0
+        ratio; only mean_total_input_tokens carries the real spread."""
+        return {
+            "mean_score": mean_score, "pass_rate": 1.0 if mean_score >= 6.0 else 0.0,
+            "mean_input_tokens": mean_input_tokens, "mean_total_input_tokens": mean_total_input_tokens,
+            "mean_output_tokens": 10.0, "mean_turns": 1.0, "mean_cost_usd": 0.0,
+            "format_error_rate": 0.0, "judge_error_rate": 0.0, "runs": 1,
+        }
+
+    def _efficiency_arms(self):
+        # treatment MATCHES full_context on score (delta_sat 0) at far fewer
+        # TOTAL input tokens (3000 vs 11000, ratio 0.27 <= 0.5) -> Path B.
+        return {
+            "baseline": self._arm(mean_score=0.0, mean_total_input_tokens=3000.0),
+            "treatment": self._arm(mean_score=10.0, mean_total_input_tokens=3000.0),
+            "full_context": self._arm(mean_score=10.0, mean_total_input_tokens=11000.0),
+        }
+
+    def test_run_task_feeds_total_input_tokens_to_classify_bucket(self):
+        sandbox = self.tmp / "sandbox"
+        sandbox.mkdir()
+        task = {"id": "wiring-task", "kind": "uplift", "prompt": "Do X.",
+                "seed_learnings": [], "criteria": ["done"]}
+        with mock.patch("memory_eval.run_arms", return_value=self._efficiency_arms()):
+            rows = me.run_task(
+                task, backbones=["fixture-model"], runs=1, api_key="", claude_bin="claude",
+                max_budget_usd=0.1, timeout_s=5, judge_model="fixture-judge",
+                judge_system_prompt="unused", api_url="http://unused.invalid",
+                offline_all_scores=None, sandbox_root=sandbox,
+            )
+        self.assertEqual(len(rows), 1)
+        # high_value ONLY if the caller passed mean_total_input_tokens;
+        # mean_input_tokens (3000 vs 3000, ratio 1.0) classifies inconclusive.
+        self.assertEqual(rows[0]["bucket"], "high_value")
+
+    def test_run_dreamed_task_feeds_total_input_tokens_to_classify_bucket(self):
+        task = me.load_task(TASKS_DIR / "09-dreamed-pipeline-end-to-end.json")
+        offline_scores = me.load_offline_scores(OFFLINE_FIXTURES)
+        sandbox = self.tmp / "sandbox"
+        sandbox.mkdir()
+        # The real offline mine->analyze->apply machinery runs as in
+        # DreamedTaskOfflineNoiseFixtureTests; only run_arms is replaced, so
+        # the crafted differing-token arms reach classify_bucket unchanged.
+        with contextlib.redirect_stderr(io.StringIO()), \
+                mock.patch("memory_eval.run_arms", return_value=self._efficiency_arms()):
+            rows = me.run_dreamed_task(
+                task, backbones=["fixture-model"], runs=1, api_key="", claude_bin="claude",
+                max_budget_usd=0.1, timeout_s=5, judge_model="fixture-judge",
+                judge_system_prompt="unused", api_url="http://unused.invalid",
+                offline=True, offline_dir=OFFLINE_FIXTURES, offline_all_scores=offline_scores,
+                sandbox_root=sandbox,
+            )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["bucket"], "high_value")
+
+
+# ---------------------------------------------------------------------------
 # --runs validation (Stage-2 #771 Recommend): --runs 0 (or negative) used
 # to be silently accepted and produce a meaningless, plausible-looking
 # results file.

--- a/modules/dreaming/tests/test_memory_eval.py
+++ b/modules/dreaming/tests/test_memory_eval.py
@@ -293,6 +293,28 @@ class ClassifyBucketTests(unittest.TestCase):
         self.assertLessEqual(delta, me.REGRESSION_DELTA_THRESHOLD)
         self.assertEqual(bucket, "regression")
 
+    def test_789_efficiency_ratio_fires_on_total_tokens_not_marginal(self):
+        """#789 regression: the efficiency path must be fed the TRUE prompt
+        size (marginal + cached prefix) so the full-context arm's larger
+        context is visible to the ratio. On the total counts (treatment
+        3000 vs full-context 11000, ratio 0.27 <= 0.5) the efficiency path
+        fires; on the marginal-only counts the arms report an identical
+        ~3000 each -- ratio 1.0 -- and the path can never fire, which is
+        exactly the #788 root cause this change fixes."""
+        high_value, _delta, delta_sat = me.classify_bucket(
+            baseline_mean=0, treatment_mean=10, full_context_mean=10,
+            treatment_input_tokens=3000, full_context_input_tokens=11000,
+        )
+        self.assertEqual(delta_sat, 0.0)
+        self.assertEqual(high_value, "high_value")
+        # Same scores, but the marginal-only counts both arms saw (~3000
+        # each) leave the efficiency ratio at 1.0 -> no bucket matches.
+        inconclusive, _d, _s = me.classify_bucket(
+            baseline_mean=0, treatment_mean=10, full_context_mean=10,
+            treatment_input_tokens=3000, full_context_input_tokens=3000,
+        )
+        self.assertEqual(inconclusive, "inconclusive")
+
 
 # ---------------------------------------------------------------------------
 # Isolated config guard (adrev-003a).
@@ -723,7 +745,7 @@ class JudgeErrorPropagationTests(unittest.TestCase):
 class AggregateArmRunsJudgeErrorTests(unittest.TestCase):
     def _run(self, *, score=7.0, is_error=False, judge_error=None):
         return {
-            "score": score, "pass": score >= 6.0, "input_tokens": 100, "output_tokens": 20,
+            "score": score, "pass": score >= 6.0, "input_tokens": 100, "total_input_tokens": 100, "output_tokens": 20,
             "turns": 2, "run_cost_usd": 0.01, "judge_input_tokens": 10, "judge_output_tokens": 5,
             "is_error": is_error, "judge_error": judge_error,
         }
@@ -765,7 +787,7 @@ class AggregateArmRunsJudgeErrorTests(unittest.TestCase):
         judge_error key at all, e.g. an older row shape) must not be
         treated as judge-errored."""
         run_no_key = {
-            "score": 8.0, "pass": True, "input_tokens": 100, "output_tokens": 20,
+            "score": 8.0, "pass": True, "input_tokens": 100, "total_input_tokens": 100, "output_tokens": 20,
             "turns": 2, "run_cost_usd": 0.01, "judge_input_tokens": 10, "judge_output_tokens": 5,
             "is_error": False,
         }
@@ -906,7 +928,7 @@ class OfflineScoresTests(unittest.TestCase):
 class AggregateArmRunsTests(unittest.TestCase):
     def _run(self, *, score=7.0, is_error=False):
         return {
-            "score": score, "pass": score >= 6.0, "input_tokens": 100, "output_tokens": 20,
+            "score": score, "pass": score >= 6.0, "input_tokens": 100, "total_input_tokens": 100, "output_tokens": 20,
             "turns": 2, "run_cost_usd": 0.01, "judge_input_tokens": 10, "judge_output_tokens": 5,
             "is_error": is_error,
         }
@@ -925,6 +947,59 @@ class AggregateArmRunsTests(unittest.TestCase):
         self.assertEqual(agg["runs"], 0)
         self.assertEqual(agg["format_error_rate"], 0.0)
         self.assertEqual(agg["mean_score"], 0.0)
+
+
+# ---------------------------------------------------------------------------
+# #789: _run_one() must fold the CACHED prompt prefix (cache_read +
+# cache_creation input tokens) into a new total_input_tokens row field, so
+# the efficiency ratio sees the TRUE prompt size, not just the marginal
+# uncached remainder. input_tokens keeps its billable-marginal meaning, and
+# _aggregate_arm_runs() surfaces mean_total_input_tokens alongside it.
+# ---------------------------------------------------------------------------
+
+class TotalInputTokensCaptureTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _isolate_env(self)
+
+    def _run_one_row(self, usage):
+        """Drive the real _run_one() row-construction with run_claude_p and
+        judge_output mocked, so only the usage->row token capture is under
+        test (not the curl/agent subprocess plumbing)."""
+        sandbox = self.tmp / "sandbox"
+        sandbox.mkdir(exist_ok=True)
+        agent_result = {
+            "is_error": False, "result": "ok", "num_turns": 1,
+            "total_cost_usd": 0.0, "usage": usage,
+        }
+        judged = {"pass": True, "score": 8.0, "usage": {"input_tokens": 1, "output_tokens": 1}}
+        with mock.patch("memory_eval.run_claude_p", return_value=agent_result), \
+                mock.patch("memory_eval.judge_output", return_value=judged):
+            return me._run_one(  # noqa: SLF001
+                task_id="t", project_slug="proj", arm="treatment", run_index=0,
+                prompt="Do X.", fixture_files={}, learnings_dir=self.tmp / "learnings",
+                backbone="fixture-model", inject=True, api_key="sk-fixture",
+                claude_bin="claude", max_budget_usd=0.5, timeout_s=5,
+                judge_model="fixture-judge", judge_system_prompt="sys", criteria=["done"],
+                api_url="https://api.anthropic.com/v1/messages", offline_score=None,
+                sandbox_root=sandbox,
+            )
+
+    def test_cache_tokens_folded_into_total_input_tokens(self):
+        row = self._run_one_row(
+            {"input_tokens": 3000, "cache_read_input_tokens": 8000, "cache_creation_input_tokens": 0}
+        )
+        # total = 3000 marginal + 8000 cached-read + 0 cached-creation.
+        self.assertEqual(row["total_input_tokens"], 11000)
+        # input_tokens preserves its billable-marginal meaning, unchanged.
+        self.assertEqual(row["input_tokens"], 3000)
+
+    def test_aggregate_surfaces_mean_total_input_tokens(self):
+        row = self._run_one_row(
+            {"input_tokens": 3000, "cache_read_input_tokens": 8000, "cache_creation_input_tokens": 0}
+        )
+        agg = me._aggregate_arm_runs([row])  # noqa: SLF001
+        self.assertEqual(agg["mean_total_input_tokens"], 11000)
+        self.assertEqual(agg["mean_input_tokens"], 3000)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Root cause 1 of #788. The #784 efficiency `high_value` path compares `treatment_input_tokens` vs `full_context_input_tokens`, but the eval harness recorded **only** `usage["input_tokens"]` and dropped `cache_read_input_tokens` + `cache_creation_input_tokens`. Claude Code caches the static prompt prefix (system prompt, tools, and the large static facts block), so `input_tokens` reports only the marginal uncached remainder (~3K on every arm). The full-context arm's 8.4K facts block was invisible to the metric → the ratio was always ~1.1, never ≤0.5, and the efficiency path could never fire.

## Changes (`modules/dreaming/eval/memory_eval.py`)

- **`_run_one`**: capture `cache_read_input_tokens` + `cache_creation_input_tokens` from `result["usage"]` and add a new row field `total_input_tokens = input_tokens + cache_read + cache_creation` (each `int(... or 0)`). `input_tokens` is left unchanged (preserves its billable-marginal meaning for cost/reporting). The offline branch has no cache fields, so `total_input_tokens == input_tokens` there.
- **`_aggregate_arm_runs`**: add `mean_total_input_tokens` alongside `mean_input_tokens` (both the empty-runs default and the main aggregation).
- **`run_task` + `run_dreamed_task`**: pass `arms[...]["mean_total_input_tokens"]` (not `mean_input_tokens`) as the `treatment_input_tokens` / `full_context_input_tokens` args to `classify_bucket`, so the efficiency ratio is computed on the TRUE prompt size.
- `classify_bucket`, the `-0.5` sat tolerance, and the judge-error / noise-control gate guards are unchanged. The cost/reporting `token_delta` still uses `mean_input_tokens`.

## Test Plan

- New `TotalInputTokensCaptureTests`: drives real `_run_one` row-construction (with `run_claude_p`/`judge_output` mocked) where usage is `{input_tokens: 3000, cache_read_input_tokens: 8000, cache_creation_input_tokens: 0}` → row `total_input_tokens == 11000`, `input_tokens == 3000` (unchanged), and `_aggregate_arm_runs` yields `mean_total_input_tokens == 11000`.
- New `ClassifyBucketTests::test_789_...`: `classify_bucket(baseline=0, treatment=10, full_context=10, treatment_input_tokens=3000, full_context_input_tokens=11000)` → `high_value` (efficiency path fires); the same call with both token counts at 3000 → `inconclusive` (documents the bug this fixes).
- Updated three pre-existing synthetic `_aggregate_arm_runs` fixtures to carry the new `total_input_tokens` row field.
- `python3 -m pytest modules/dreaming/tests/ modules/self-improving/tests/ -q` → 398 passed, 4 subtests passed.
- `bash tests/test-no-personal-data.sh` → PASS.

Closes #789