### PR TITLE
#790: weekly observability scorecard (captured / injected / reused / applied)

### DIFF
--- a/modules/dreaming/bin/dream-scorecard.sh
+++ b/modules/dreaming/bin/dream-scorecard.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# CCGM dreaming — weekly observability scorecard renderer.
+#
+# Renders a deterministic weekly scorecard over the read-path signals that are
+# ALREADY recorded on disk (captured / injected / reused / applied / store
+# health) to ~/.claude/dreaming/scorecards/{week-ending}.md, then prints that
+# path on stdout.
+#
+# This wrapper is deliberately thin: it resolves the window + generated-at wall
+# clock (the ONLY place a wall-clock read is allowed -- lib/scorecard.py never
+# calls Date.now) and hands them to scorecard.render(), which does all the
+# read-only aggregation. Mirrors dream-digest.sh's lib/bin split and its
+# tm._import_sibling_module() path for reaching the self-improving module's
+# learnings_store.
+#
+# Usage:
+#   dream-scorecard.sh [YYYY-MM-DD]   # week-ending date; defaults to today (UTC)
+#
+# The window is the 7 calendar days ending on (and including) the week-ending
+# date: [week_ending-6d 00:00Z, week_ending+1d 00:00Z).
+#
+# Exit codes:
+#   0  scorecard rendered (path printed on stdout)
+#   2  invariant violation (python3 missing, bad date argument, renderer error)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+DATE_ARG="${1:-}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "dream-scorecard: python3 not found on PATH" >&2
+    exit 2
+fi
+
+if [ -n "${DATE_ARG}" ]; then
+    if ! python3 -c "import datetime as dt, sys; dt.date.fromisoformat(sys.argv[1])" "${DATE_ARG}" 2>/dev/null; then
+        echo "dream-scorecard: '${DATE_ARG}' is not a valid YYYY-MM-DD date" >&2
+        exit 2
+    fi
+    WEEK_ENDING="${DATE_ARG}"
+else
+    WEEK_ENDING="${CCGM_DREAMING_TODAY:-$(python3 -c 'import datetime; print(datetime.datetime.now(datetime.timezone.utc).date().isoformat())')}"
+fi
+
+DREAMING_DIR="${CCGM_DREAMING_DIR:-${HOME}/.claude/dreaming}"
+LEARNINGS_DIR="${CCGM_LEARNINGS_DIR:-${HOME}/.claude/learnings}"
+INJECTION_LOG_DIR="${DREAMING_DIR}/injection-log"
+PROPOSALS_DIR="${DREAMING_DIR}/proposals"
+APPLY_AUDIT_FILE="${DREAMING_DIR}/state/apply-audit.jsonl"
+SCORECARDS_DIR="${DREAMING_DIR}/scorecards"
+
+mkdir -p "${SCORECARDS_DIR}"
+
+OUTPUT="$(
+    CCGM_SC_WEEK_ENDING="${WEEK_ENDING}" \
+    CCGM_SC_LEARNINGS_DIR="${LEARNINGS_DIR}" \
+    CCGM_SC_INJECTION_LOG_DIR="${INJECTION_LOG_DIR}" \
+    CCGM_SC_PROPOSALS_DIR="${PROPOSALS_DIR}" \
+    CCGM_SC_APPLY_AUDIT_FILE="${APPLY_AUDIT_FILE}" \
+    CCGM_SC_MODULE_ROOT="${MODULE_ROOT}" \
+    python3 - <<'PYEOF'
+import os
+import sys
+from datetime import datetime, time, timedelta, timezone
+
+module_root = os.environ["CCGM_SC_MODULE_ROOT"]
+sys.path.insert(0, os.path.join(module_root, "lib"))
+
+import scorecard  # noqa: E402  (dreaming lib, just inserted on sys.path)
+# learnings_store lives in a DIFFERENT module's lib/ dir (self-improving);
+# reuse transcript_miner's established installed-or-sibling import helper
+# rather than re-deriving the path (same pattern as dream-digest.sh).
+import transcript_miner as tm  # noqa: E402
+learnings_store = tm._import_sibling_module(  # noqa: SLF001
+    "self-improving", "learnings_store",
+    "projection (_project_lines) + effective_confidence for store-health scoring",
+)
+
+week_ending = datetime.strptime(os.environ["CCGM_SC_WEEK_ENDING"], "%Y-%m-%d").date()
+# Half-open 7-day window ending on (and including) week_ending.
+window_end = datetime.combine(week_ending + timedelta(days=1), time.min, tzinfo=timezone.utc)
+window_start = window_end - timedelta(days=7)
+# Wall-clock reads live HERE (the wrapper), never in the library.
+generated_at = datetime.now(timezone.utc)
+
+md = scorecard.render(
+    window_start,
+    window_end,
+    learnings_dir=os.environ["CCGM_SC_LEARNINGS_DIR"],
+    injection_log_dir=os.environ["CCGM_SC_INJECTION_LOG_DIR"],
+    proposals_dir=os.environ["CCGM_SC_PROPOSALS_DIR"],
+    apply_audit_path=os.environ["CCGM_SC_APPLY_AUDIT_FILE"],
+    store_api=learnings_store,
+    generated_at=generated_at,
+)
+sys.stdout.write(md)
+PYEOF
+)"
+
+py_exit=$?
+if [ ${py_exit} -ne 0 ]; then
+    echo "dream-scorecard: renderer failed (exit ${py_exit})" >&2
+    exit 2
+fi
+
+SCORECARD_FILE="${SCORECARDS_DIR}/${WEEK_ENDING}.md"
+printf '%s\n' "${OUTPUT}" > "${SCORECARD_FILE}"
+echo "scorecard written: ${SCORECARD_FILE}" >&2
+echo "${SCORECARD_FILE}"
+exit 0

--- a/modules/dreaming/commands/dream-scorecard.md
+++ b/modules/dreaming/commands/dream-scorecard.md
@@ -1,0 +1,64 @@
+# /dream-scorecard - Weekly Observability Scorecard
+
+Render a deterministic weekly scorecard over the memory system's read-path
+signals — the honest answer to "how do I know the memory system is working?"
+
+## Usage
+
+```
+/dream-scorecard             # last 7 days, ending today (UTC)
+/dream-scorecard 2026-06-30  # the 7 days ending 2026-06-30 (inclusive)
+```
+
+## What it does
+
+1. Resolve the week-ending date. With no argument, use today (UTC). With an
+   argument, validate the `YYYY-MM-DD` shape. The window is the 7 calendar
+   days ending on (and including) that date.
+2. Run `bash ~/.claude/bin/dream-scorecard.sh {week-ending}`, which aggregates
+   the existing on-disk read-path telemetry (read-only) and writes
+   `~/.claude/dreaming/scorecards/{week-ending}.md`.
+3. Print the rendered scorecard.
+
+## Sections
+
+- **Captured** — new learnings added in the window (store JSONL `add`/legacy
+  op-events), grouped by type + project.
+- **Injected** — sessions that received injected memory (#782 injection-log
+  telemetry): session count, total learnings injected, top injected learnings.
+- **Reused** — `verify` op-events in the window. This is the key value signal:
+  a reuse means a stored learning paid off across sessions.
+- **Applied** — proposals applied to the store in the window (apply-audit +
+  proposals-dir funnel), by kind.
+- **Store health** — total active learnings, effective-confidence bands, and
+  deprecated/superseded counts.
+
+## When to invoke
+
+- A weekly check on whether the durable-memory system is capturing, injecting,
+  and (most importantly) reusing learnings.
+- Before deciding whether to enable an opt-in (auto-apply, injection): the
+  scorecard shows whether there is enough signal yet to trust it.
+
+## When NOT to invoke
+
+- To act on a specific proposal — use `/dream-apply <id>`.
+- For a per-day proposal digest — use `/dream-digest [date]`.
+- For dates older than the retention window — older injection-log/proposals
+  artifacts are swept by `dream-daily.sh`'s retention step, so an old window
+  will under-count.
+
+## How it interacts with state
+
+Strictly **read-only** over the learnings store, proposals, apply-audit, and
+injection-log. The one write is the rendered markdown at
+`~/.claude/dreaming/scorecards/{week-ending}.md`. All counting lives in
+`lib/scorecard.py` (deterministic, unit-tested); the `.sh` only resolves the
+window + wall clock. The library never reads the wall clock itself.
+
+## Cross-references
+
+- Generator: `~/.claude/bin/dream-scorecard.sh` → `lib/scorecard.py`
+- `/dream-digest [date]` — per-day proposal digest.
+- `/dream-apply [id|list]` — the human-gated write path for proposals.
+- Injection telemetry: `~/.claude/dreaming/injection-log/*.jsonl` (#782).

--- a/modules/dreaming/commands/dream-scorecard.md
+++ b/modules/dreaming/commands/dream-scorecard.md
@@ -23,7 +23,8 @@ signals — the honest answer to "how do I know the memory system is working?"
 ## Sections
 
 - **Captured** — new learnings added in the window (store JSONL `add`/legacy
-  op-events), grouped by type + project.
+  op-events), grouped by type + project. In-window `supersede` refinements are
+  surfaced as a separate sub-line (they are refinements, not new captures).
 - **Injected** — sessions that received injected memory (#782 injection-log
   telemetry): session count, total learnings injected, top injected learnings.
 - **Reused** — `verify` op-events in the window. This is the key value signal:

--- a/modules/dreaming/lib/scorecard.py
+++ b/modules/dreaming/lib/scorecard.py
@@ -237,6 +237,7 @@ def _aggregate_captured_reused(
     captures (add / legacy rows) and reuses (verify events)."""
     captured_by_type_project: dict[tuple[str, str], int] = defaultdict(int)
     captured_total = 0
+    refined_total = 0
     reused_events = 0
     reused_by_target: dict[str, int] = defaultdict(int)
 
@@ -250,6 +251,12 @@ def _aggregate_captured_reused(
                 type_ = ln.get("type") or "unknown"
                 captured_by_type_project[(type_, slug)] += 1
                 captured_total += 1
+            elif op == "supersede":
+                # A supersede is a REFINEMENT of an existing learning, not a
+                # new capture -- counted separately so a week of refinements
+                # is not invisible (it would read as 0 "new") while keeping
+                # "Captured" strictly add-only.
+                refined_total += 1
             elif op == "verify":
                 target = ln.get("target_id")
                 if target:
@@ -259,6 +266,7 @@ def _aggregate_captured_reused(
     return {
         "captured_total": captured_total,
         "captured_by_type_project": dict(captured_by_type_project),
+        "refined_total": refined_total,
         "reused_events": reused_events,
         "reused_learnings": len(reused_by_target),
         "reused_by_target": dict(reused_by_target),
@@ -491,8 +499,15 @@ def render(
     # --- 1. Captured -------------------------------------------------------
     out.append(f"## Captured — {cap['captured_total']} new learnings this window")
     out.append("")
+    if cap["refined_total"]:
+        # Refinements are real activity but not "new"; surface them so a week
+        # of supersede-only work does not read as an empty capture section.
+        out.append(f"_(+ {cap['refined_total']} refined via supersede)_")
+        out.append("")
     if not cap["captured_total"]:
-        out.append(_NO_DATA)
+        # Only "no data" when there is neither a new capture NOR a refinement.
+        if not cap["refined_total"]:
+            out.append(_NO_DATA)
     else:
         out.append("| type | project | new |")
         out.append("|------|---------|-----|")

--- a/modules/dreaming/lib/scorecard.py
+++ b/modules/dreaming/lib/scorecard.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+"""Deterministic weekly observability scorecard for the dreaming/read-path
+memory system.
+
+The honest answer to "how do I know the memory system is working": a
+deterministic weekly aggregation over the read-path signals that are ALREADY
+being recorded on disk. Every number here is a count of something that
+happened -- captured / injected / reused / applied -- so this is a script,
+not model work (latent-vs-deterministic: pure mechanical counting, no
+judgment). It is testable to exact counts by feeding fixture JSONL to
+`render()`.
+
+READ-ONLY, by contract. This module never writes to the learnings store, the
+proposals, the apply-audit, or any dreaming state. It only reads. The `.sh`
+wrapper is the only thing that writes -- and only the rendered markdown, to
+~/.claude/dreaming/scorecards/{date}.md.
+
+NO `Date.now()` in this library. The window bounds AND the generated-at
+timestamp are passed in by the caller (`render(..., generated_at=...)`), so a
+test can pin a fixed clock and assert byte-stable output. The `.sh` wrapper
+supplies the real wall clock.
+
+Data sources (all read-only):
+  - Captured / Reused: raw op-event JSONL under `learnings_dir`
+    ({slug}/learnings.jsonl + {slug}/agents/*.jsonl). These sections are
+    WINDOW-scoped and need each op-event's own `timestamp`, which the store's
+    projected head view does not expose (a head records `uses`/`last_verified`
+    only, not each individual verify's time) -- so they are read from the raw
+    lines directly, exactly as the issue's §1/§3 specify ("from the store
+    JSONL timestamp", "verify op-events in the window").
+  - Store health: the SAME raw lines, projected through `store_api`'s existing
+    projection engine (`_project_lines`) and scored with its existing
+    `effective_confidence`. `store_api` is used purely as a pair of pure
+    functions here -- it never touches its own global LEARNINGS_ROOT, so the
+    scorecard has a single data source (`learnings_dir`) and stays trivially
+    testable.
+  - Injected: ~/.claude/dreaming/injection-log/*.jsonl (#782 telemetry).
+  - Applied: the apply-audit (~/.claude/dreaming/state/apply-audit.jsonl,
+    which carries the authoritative applied-at `ts`) cross-referenced with the
+    proposals dir (~/.claude/dreaming/proposals/*.jsonl) for the
+    generated->applied funnel.
+
+Every section degrades gracefully: a missing/empty source prints
+"_no data this window._" and never raises.
+"""
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+# Effective-confidence bands for the store-health section. Documented here so
+# the thresholds are one obvious place, not scattered magic numbers. The
+# store's own read path skips entries below its deprecate_threshold (default
+# 2.0) -- low-band entries at the bottom of this range are effectively dormant
+# even though they are structurally still "active".
+_BAND_HIGH = 7.0   # >= 7.0  -> "high"
+_BAND_MEDIUM = 4.0  # >= 4.0 and < 7.0 -> "medium"; < 4.0 -> "low"
+
+# A learning-store op-event is "captured" (a new learning) when it is a v2
+# `add` event OR a legacy v1 row (which carries no `op` field and seeds a head
+# verbatim -- see learnings_store._fold).
+_CAPTURE_OPS = (None, "add")
+
+_NO_DATA = "_no data this window._"
+
+
+# ---------------------------------------------------------------------------
+# Time helpers (no wall-clock reads -- everything is passed in)
+# ---------------------------------------------------------------------------
+
+def _to_epoch(value: "datetime | date | str | float | int") -> float:
+    """Normalize a window bound / generated-at value to epoch seconds.
+
+    Accepts an aware or naive datetime (naive is assumed UTC), a date
+    (midnight UTC), an ISO-8601 string, or a raw epoch number. Deterministic:
+    no `now()` fallback -- an unparseable value yields 0.0.
+    """
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, datetime):
+        dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc).timestamp()
+    if isinstance(value, str):
+        return _parse_ts(value)
+    return 0.0
+
+
+def _parse_ts(s: str) -> float:
+    """Parse an on-disk ISO-8601 UTC timestamp to epoch seconds; 0.0 on
+    failure. Handles the store/injection-log forms (second- or
+    millisecond-precision, trailing `Z`) plus a general `fromisoformat`
+    fallback for anything else that lands on disk."""
+    if not s or not isinstance(s, str):
+        return 0.0
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ"):
+        try:
+            return datetime.strptime(s, fmt).replace(tzinfo=timezone.utc).timestamp()
+        except ValueError:
+            continue
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except ValueError:
+        return 0.0
+
+
+def _in_window(ts: float, start: float, end: float) -> bool:
+    """Half-open window [start, end): a record stamped exactly at `end` belongs
+    to the NEXT window, so consecutive weekly windows partition time without
+    double-counting a boundary event."""
+    return start <= ts < end
+
+
+def _fmt_dt(value: "datetime | date | str | float") -> str:
+    """Human-readable UTC stamp for the header (deterministic from input)."""
+    epoch = _to_epoch(value)
+    if epoch <= 0:
+        return str(value)
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _fmt_date(value: "datetime | date | str | float") -> str:
+    epoch = _to_epoch(value)
+    if epoch <= 0:
+        return str(value)
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).date().isoformat()
+
+
+# ---------------------------------------------------------------------------
+# JSONL reading (defensive -- never raises on a bad/missing file)
+# ---------------------------------------------------------------------------
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Parse every line of one JSONL file, skipping malformed/blank lines.
+    Missing file -> []."""
+    rows: list[dict[str, Any]] = []
+    try:
+        if not path.is_file():
+            return rows
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict):
+                    rows.append(obj)
+    except OSError:
+        return rows
+    return rows
+
+
+def _load_jsonl_dir(directory: Path) -> list[dict[str, Any]]:
+    """Concatenate every `*.jsonl` file in a directory (sorted for
+    determinism). Missing dir -> []."""
+    rows: list[dict[str, Any]] = []
+    try:
+        if not directory.is_dir():
+            return rows
+        for path in sorted(directory.glob("*.jsonl")):
+            rows.extend(_load_jsonl(path))
+    except OSError:
+        return rows
+    return rows
+
+
+def _dedupe_by_id(lines: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop duplicate op-events by event `id` (first occurrence wins),
+    mirroring learnings_store._dedupe_lines_by_id so a physically duplicated
+    line (e.g. from a future git union-merge) can never double-count a capture
+    or a reuse. Lines without an `id` are kept as-is."""
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+    for ln in lines:
+        _id = ln.get("id")
+        if _id is not None:
+            if _id in seen:
+                continue
+            seen.add(_id)
+        out.append(ln)
+    return out
+
+
+def _slug_sources(learnings_dir: Path) -> list[tuple[str, list[Path]]]:
+    """Enumerate (slug, [jsonl paths]) for every project dir under the store
+    root, mirroring learnings_store.list_project_slugs' detection (a legacy
+    learnings.jsonl and/or an agents/ shard dir). Single source of truth: the
+    scorecard reads ONLY from `learnings_dir`."""
+    out: list[tuple[str, list[Path]]] = []
+    try:
+        if not learnings_dir.is_dir():
+            return out
+        for d in sorted(learnings_dir.iterdir()):
+            if not d.is_dir():
+                continue
+            paths: list[Path] = []
+            legacy = d / "learnings.jsonl"
+            if legacy.is_file():
+                paths.append(legacy)
+            agents = d / "agents"
+            if agents.is_dir():
+                paths.extend(sorted(agents.glob("*.jsonl")))
+            if paths:
+                out.append((d.name, paths))
+    except OSError:
+        return out
+    return out
+
+
+def _read_slug_lines(paths: list[Path]) -> list[dict[str, Any]]:
+    lines: list[dict[str, Any]] = []
+    for p in paths:
+        lines.extend(_load_jsonl(p))
+    return _dedupe_by_id(lines)
+
+
+# ---------------------------------------------------------------------------
+# Section aggregators (each pure over already-read rows; individually testable)
+# ---------------------------------------------------------------------------
+
+def _aggregate_captured_reused(
+    slug_lines: dict[str, list[dict[str, Any]]],
+    start: float,
+    end: float,
+) -> dict[str, Any]:
+    """Walk every slug's raw op-events once and bucket the window-scoped
+    captures (add / legacy rows) and reuses (verify events)."""
+    captured_by_type_project: dict[tuple[str, str], int] = defaultdict(int)
+    captured_total = 0
+    reused_events = 0
+    reused_by_target: dict[str, int] = defaultdict(int)
+
+    for slug, lines in slug_lines.items():
+        for ln in lines:
+            ts = _parse_ts(ln.get("timestamp", ""))
+            if not _in_window(ts, start, end):
+                continue
+            op = ln.get("op")
+            if op in _CAPTURE_OPS:
+                type_ = ln.get("type") or "unknown"
+                captured_by_type_project[(type_, slug)] += 1
+                captured_total += 1
+            elif op == "verify":
+                target = ln.get("target_id")
+                if target:
+                    reused_by_target[target] += 1
+                    reused_events += 1
+
+    return {
+        "captured_total": captured_total,
+        "captured_by_type_project": dict(captured_by_type_project),
+        "reused_events": reused_events,
+        "reused_learnings": len(reused_by_target),
+        "reused_by_target": dict(reused_by_target),
+    }
+
+
+def _aggregate_injected(rows: list[dict[str, Any]], start: float, end: float) -> dict[str, Any]:
+    sessions: set[str] = set()
+    total_injected = 0
+    id_freq: Counter[str] = Counter()
+    records = 0
+    for r in rows:
+        if not _in_window(_parse_ts(r.get("timestamp", "")), start, end):
+            continue
+        records += 1
+        sid = str(r.get("session_id") or "")
+        if sid:
+            sessions.add(sid)
+        try:
+            total_injected += int(r.get("injected_count") or 0)
+        except (TypeError, ValueError):
+            pass
+        for lid in r.get("injected_ids") or []:
+            if lid:
+                id_freq[str(lid)] += 1
+    return {
+        "records": records,
+        "sessions": len(sessions),
+        "total_injected": total_injected,
+        "top_injected": id_freq.most_common(10),
+    }
+
+
+def _aggregate_applied(
+    audit_rows: list[dict[str, Any]],
+    proposal_rows: list[dict[str, Any]],
+    start: float,
+    end: float,
+) -> dict[str, Any]:
+    """Applied = apply-audit records whose outcome is a successful apply and
+    whose `ts` is in-window (the audit carries the authoritative applied-at
+    time). Cross-referenced with proposals generated in-window for the
+    generated->applied funnel."""
+    applied_by_kind: Counter[str] = Counter()
+    applied_total = 0
+    for r in audit_rows:
+        if not (r.get("ok") is True or r.get("outcome") == "applied"):
+            continue
+        if not _in_window(_parse_ts(r.get("ts", "")), start, end):
+            continue
+        applied_total += 1
+        applied_by_kind[str(r.get("kind") or "unknown")] += 1
+
+    generated = 0
+    still_pending = 0
+    for p in proposal_rows:
+        if not _in_window(_parse_ts(p.get("generated_at", "")), start, end):
+            continue
+        generated += 1
+        if p.get("status", "pending") == "pending":
+            still_pending += 1
+
+    return {
+        "applied_total": applied_total,
+        "applied_by_kind": dict(applied_by_kind),
+        "generated": generated,
+        "still_pending": still_pending,
+    }
+
+
+def _aggregate_health(
+    slug_lines: dict[str, list[dict[str, Any]]],
+    store_api: Any,
+    now_epoch: float,
+) -> dict[str, Any]:
+    """Project every slug's raw lines through the store's own projection
+    engine and band the ACTIVE heads (not deprecated, not superseded) by
+    effective confidence. Uses `store_api` as two pure functions only
+    (_project_lines + effective_confidence) -- no disk writes, no snapshot
+    cache, no global-path coupling."""
+    high = medium = low = 0
+    active = deprecated = superseded = 0
+    for lines in slug_lines.values():
+        try:
+            heads = store_api._project_lines(lines).get("heads", [])
+        except Exception:
+            # A pathological shard must never sink the whole scorecard.
+            continue
+        for head in heads:
+            if head.get("deprecated"):
+                deprecated += 1
+                continue
+            if head.get("superseded_by"):
+                superseded += 1
+                continue
+            active += 1
+            try:
+                eff = float(store_api.effective_confidence(head, now=now_epoch))
+            except Exception:
+                eff = 0.0
+            if eff >= _BAND_HIGH:
+                high += 1
+            elif eff >= _BAND_MEDIUM:
+                medium += 1
+            else:
+                low += 1
+    return {
+        "active": active,
+        "high": high,
+        "medium": medium,
+        "low": low,
+        "deprecated": deprecated,
+        "superseded": superseded,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Markdown renderers
+# ---------------------------------------------------------------------------
+
+def _sanitize(store_api: Any, text: str) -> str:
+    """Render-time defense-in-depth for any store CONTENT surfaced in the
+    scorecard (the reused-learnings section). Reuses the store's own
+    sanitizer if available, matching dream-digest.sh's render-time
+    neutralization; falls back to the raw text if the hook is unavailable."""
+    fn = getattr(store_api, "sanitize_content", None)
+    if callable(fn):
+        try:
+            return fn(text)
+        except Exception:
+            return text
+    return text
+
+
+def _excerpt(text: str, limit: int = 90) -> str:
+    text = " ".join((text or "").split())
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def render(
+    window_start: "datetime | date | str",
+    window_end: "datetime | date | str",
+    *,
+    learnings_dir: "Path | str",
+    injection_log_dir: "Path | str",
+    proposals_dir: "Path | str",
+    apply_audit_path: "Path | str",
+    store_api: Any,
+    generated_at: "datetime | date | str",
+    now: "datetime | date | str | None" = None,
+) -> str:
+    """Render the weekly observability scorecard as a markdown string.
+
+    Args:
+        window_start / window_end: half-open window [start, end). Accept a
+            datetime, date, or ISO string.
+        learnings_dir: learnings-store root (contains {slug}/learnings.jsonl
+            and/or {slug}/agents/*.jsonl).
+        injection_log_dir: ~/.claude/dreaming/injection-log.
+        proposals_dir: ~/.claude/dreaming/proposals.
+        apply_audit_path: ~/.claude/dreaming/state/apply-audit.jsonl.
+        store_api: the learnings_store module (used only for the pure
+            functions _project_lines + effective_confidence + optional
+            sanitize_content).
+        generated_at: report generation time, PASSED IN (no Date.now here).
+        now: decay anchor for effective_confidence; defaults to window_end.
+
+    All aggregation is deterministic; feed fixtures and assert exact counts.
+    """
+    learnings_dir = Path(learnings_dir)
+    injection_log_dir = Path(injection_log_dir)
+    proposals_dir = Path(proposals_dir)
+    apply_audit_path = Path(apply_audit_path)
+
+    start = _to_epoch(window_start)
+    end = _to_epoch(window_end)
+    now_epoch = _to_epoch(now) if now is not None else end
+
+    # --- Read every data source ONCE (read-only) ---------------------------
+    slug_lines: dict[str, list[dict[str, Any]]] = {
+        slug: _read_slug_lines(paths) for slug, paths in _slug_sources(learnings_dir)
+    }
+    injection_rows = _load_jsonl_dir(injection_log_dir)
+    proposal_rows = _load_jsonl_dir(proposals_dir)
+    audit_rows = _load_jsonl(apply_audit_path)
+
+    # --- Aggregate ---------------------------------------------------------
+    cap = _aggregate_captured_reused(slug_lines, start, end)
+    inj = _aggregate_injected(injection_rows, start, end)
+    app = _aggregate_applied(audit_rows, proposal_rows, start, end)
+    health = _aggregate_health(slug_lines, store_api, now_epoch)
+
+    # Build an id -> content map only from the reused targets, so the reused
+    # section can name what got reinforced. Projected across all slugs.
+    reused_targets = set(cap["reused_by_target"])
+    id_content: dict[str, str] = {}
+    if reused_targets:
+        for lines in slug_lines.values():
+            try:
+                heads = store_api._project_lines(lines).get("heads", [])
+            except Exception:
+                continue
+            for head in heads:
+                hid = head.get("id")
+                if hid in reused_targets and hid not in id_content:
+                    id_content[hid] = head.get("content") or ""
+
+    out: list[str] = []
+
+    # --- Header + one-line run summary (§6) --------------------------------
+    # The window is half-open [start, end); the "week ending" date a human
+    # cares about (and the filename the wrapper uses) is the LAST day actually
+    # included -- one second before the exclusive end -- not the end bound
+    # itself (which is next week's first instant).
+    week_ending = _fmt_date(end - 1) if end > 0 else _fmt_date(window_end)
+    out.append(f"# Dreaming scorecard — week ending {week_ending}")
+    out.append("")
+    out.append(
+        f"_Window: {_fmt_dt(window_start)} → {_fmt_dt(window_end)} "
+        f"· generated {_fmt_dt(generated_at)}_"
+    )
+    out.append("")
+    out.append(
+        f"**{cap['captured_total']} captured · {inj['sessions']} sessions injected "
+        f"· {cap['reused_learnings']} learnings reused ({cap['reused_events']} events) "
+        f"· {app['applied_total']} applied**"
+    )
+    out.append("")
+
+    # --- 1. Captured -------------------------------------------------------
+    out.append(f"## Captured — {cap['captured_total']} new learnings this window")
+    out.append("")
+    if not cap["captured_total"]:
+        out.append(_NO_DATA)
+    else:
+        out.append("| type | project | new |")
+        out.append("|------|---------|-----|")
+        for (type_, slug), n in sorted(
+            cap["captured_by_type_project"].items(), key=lambda kv: (-kv[1], kv[0])
+        ):
+            out.append(f"| {type_} | {slug} | {n} |")
+    out.append("")
+
+    # --- 2. Injected -------------------------------------------------------
+    out.append("## Injected")
+    out.append("")
+    if not inj["records"]:
+        out.append(_NO_DATA)
+    else:
+        out.append(
+            f"- {inj['sessions']} session(s) received injected memory "
+            f"({inj['records']} injection event(s))"
+        )
+        out.append(f"- {inj['total_injected']} total learnings injected")
+        if inj["top_injected"]:
+            out.append("- top injected learnings:")
+            for lid, freq in inj["top_injected"]:
+                out.append(f"  - `{lid}` — {freq}×")
+    out.append("")
+
+    # --- 3. Reused (the key value signal) ----------------------------------
+    out.append(
+        f"## Reused — {cap['reused_learnings']} learnings reinforced "
+        f"({cap['reused_events']} reuse events)"
+    )
+    out.append("")
+    out.append(
+        "_Recurrence is the signal that memory is paying off across sessions: "
+        "a `verify` op-event means a stored learning got reused._"
+    )
+    out.append("")
+    if not cap["reused_events"]:
+        out.append(_NO_DATA)
+    else:
+        ranked = sorted(cap["reused_by_target"].items(), key=lambda kv: (-kv[1], kv[0]))
+        for target, n in ranked:
+            content = _excerpt(_sanitize(store_api, id_content.get(target, "")))
+            suffix = f" — {content}" if content else ""
+            out.append(f"- `{target}` — {n}× reused{suffix}")
+    out.append("")
+
+    # --- 4. Applied --------------------------------------------------------
+    out.append(f"## Applied — {app['applied_total']} proposals applied this window")
+    out.append("")
+    if not app["applied_total"] and not app["generated"]:
+        out.append(_NO_DATA)
+    else:
+        out.append(
+            f"- generated this window: {app['generated']} "
+            f"({app['still_pending']} still pending review)"
+        )
+        out.append(f"- applied this window: {app['applied_total']}")
+        if app["applied_by_kind"]:
+            for kind, n in sorted(app["applied_by_kind"].items(), key=lambda kv: (-kv[1], kv[0])):
+                out.append(f"  - {kind}: {n}")
+    out.append("")
+
+    # --- 5. Store health ---------------------------------------------------
+    out.append(f"## Store health — {health['active']} active learnings")
+    out.append("")
+    out.append("- effective-confidence bands (active heads):")
+    out.append(f"  - high (≥{_BAND_HIGH:.0f}): {health['high']}")
+    out.append(f"  - medium (≥{_BAND_MEDIUM:.0f}): {health['medium']}")
+    out.append(f"  - low (<{_BAND_MEDIUM:.0f}): {health['low']}")
+    out.append(f"- deprecated: {health['deprecated']}")
+    out.append(f"- superseded: {health['superseded']}")
+    out.append("")
+
+    out.append("---")
+    out.append("")
+    out.append("- `/dream` — status")
+    out.append("- `/dream-digest` — today's proposal digest")
+    out.append("")
+
+    return "\n".join(out)

--- a/modules/dreaming/module.json
+++ b/modules/dreaming/module.json
@@ -58,6 +58,11 @@
       "type": "lib",
       "template": false
     },
+    "lib/scorecard.py": {
+      "target": "lib/scorecard.py",
+      "type": "lib",
+      "template": false
+    },
     "lib/com.__USERNAME__.ccgm.dreaming.daily.plist.template": {
       "target": "lib/com.__USERNAME__.ccgm.dreaming.daily.plist",
       "type": "lib",
@@ -93,6 +98,11 @@
       "type": "script",
       "template": false
     },
+    "bin/dream-scorecard.sh": {
+      "target": "bin/dream-scorecard.sh",
+      "type": "script",
+      "template": false
+    },
     "commands/dream.md": {
       "target": "commands/dream.md",
       "type": "command",
@@ -105,6 +115,11 @@
     },
     "commands/dream-apply.md": {
       "target": "commands/dream-apply.md",
+      "type": "command",
+      "template": false
+    },
+    "commands/dream-scorecard.md": {
+      "target": "commands/dream-scorecard.md",
       "type": "command",
       "template": false
     },

--- a/modules/dreaming/tests/test_scorecard.py
+++ b/modules/dreaming/tests/test_scorecard.py
@@ -9,9 +9,10 @@ structural counts. All fixture data is invented (no personal data): slugs like
 
 Determinism: render() takes the window bounds AND generated-at as arguments
 (no Date.now in the library), so every assertion here is pinned to a fixed
-2026-06-24 → 2026-07-01 window (week ending 2026-06-30). A record stamped
-exactly at the window end belongs to the next window and must be excluded --
-several fixtures probe that boundary.
+2026-06-24 → 2026-07-01 window (week ending 2026-06-30). The window is
+half-open [start, end): a timestamp exactly at `window_start` is INCLUDED, one
+exactly at `window_end` is EXCLUDED. `ScorecardWindowBoundaryTest` pins both
+edges directly.
 
 `learnings_store` is used by render() only as a pure projection engine
 (_project_lines + effective_confidence), so no CCGM_LEARNINGS_DIR redirection
@@ -192,6 +193,15 @@ class ScorecardRenderTest(unittest.TestCase):
         self.assertNotIn("6 new learnings", md)
         self.assertNotIn("7 new learnings", md)
 
+    def test_supersede_refinements_surface(self):
+        md = self._render()
+        # L5b supersedes L5 in-window: a REFINEMENT, not a new capture.
+        # It must count under refined, never inflate the "new" total (still 5).
+        self.assertIn("## Captured — 5 new learnings this window", md)
+        self.assertIn("_(+ 1 refined via supersede)_", md)
+        # The supersede must not appear as a new-capture table row.
+        self.assertNotIn("| tool | demo_app | 2 |", md)
+
     def test_injected_exact(self):
         md = self._render()
         self.assertIn("2 session(s) received injected memory (3 injection event(s))", md)
@@ -257,6 +267,46 @@ class ScorecardDegradeTest(unittest.TestCase):
         self.assertIn("## Store health — 0 active learnings", md)
         self.assertEqual(md.count(scorecard._NO_DATA), 4)  # captured/injected/reused/applied
         self.assertNotIn("Traceback", md)
+
+
+class ScorecardWindowBoundaryTest(unittest.TestCase):
+    """Pin the half-open [start, end) convention at BOTH edges: a timestamp
+    exactly at window_start is included; exactly at window_end is excluded."""
+
+    START = datetime(2026, 6, 24, tzinfo=UTC)
+    END = datetime(2026, 7, 1, tzinfo=UTC)
+
+    def _render_with(self, learnings_dir: Path) -> str:
+        empty = learnings_dir.parent / "empty"
+        return scorecard.render(
+            self.START, self.END,
+            learnings_dir=learnings_dir,
+            injection_log_dir=empty / "inj",
+            proposals_dir=empty / "prop",
+            apply_audit_path=empty / "audit.jsonl",
+            store_api=learnings_store,
+            generated_at=datetime(2026, 7, 1, tzinfo=UTC),
+        )
+
+    def test_start_edge_included_end_edge_excluded(self):
+        root = Path(tempfile.mkdtemp(prefix="ccgm-scorecard-edge-"))
+        learnings_dir = root / "learnings"
+        _write_jsonl(learnings_dir / "edge_proj" / "agents" / "e.jsonl", [
+            # timestamp == window_start (00:00:00 on 2026-06-24) -> INCLUDED
+            {"id": "E_START", "op": "add", "target_id": None,
+             "timestamp": "2026-06-24T00:00:00.000Z", "type": "pattern",
+             "content": "exactly at window start", "confidence": 8, "project": "edge_proj"},
+            # timestamp == window_end (00:00:00 on 2026-07-01) -> EXCLUDED
+            {"id": "E_END", "op": "add", "target_id": None,
+             "timestamp": "2026-07-01T00:00:00.000Z", "type": "pattern",
+             "content": "exactly at window end", "confidence": 8, "project": "edge_proj"},
+        ])
+        md = self._render_with(learnings_dir)
+        # Only the start-edge add is captured; the end-edge add belongs to the
+        # next window.
+        self.assertIn("## Captured — 1 new learnings this window", md)
+        self.assertIn("| pattern | edge_proj | 1 |", md)
+        self.assertNotIn("2 new learnings", md)
 
 
 class ScorecardWrapperSmokeTest(unittest.TestCase):

--- a/modules/dreaming/tests/test_scorecard.py
+++ b/modules/dreaming/tests/test_scorecard.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Tests for modules/dreaming/lib/scorecard.py.
+
+Feeds fixture JSONL (a small learnings store + an injection-log dir + a
+proposals dir + an apply-audit file) to scorecard.render() and asserts the
+EXACT captured / injected / reused / applied counts, plus the store-health
+structural counts. All fixture data is invented (no personal data): slugs like
+`acme_widget`, session ids like `sess-1`, learning ids like `L1`.
+
+Determinism: render() takes the window bounds AND generated-at as arguments
+(no Date.now in the library), so every assertion here is pinned to a fixed
+2026-06-24 → 2026-07-01 window (week ending 2026-06-30). A record stamped
+exactly at the window end belongs to the next window and must be excluded --
+several fixtures probe that boundary.
+
+`learnings_store` is used by render() only as a pure projection engine
+(_project_lines + effective_confidence), so no CCGM_LEARNINGS_DIR redirection
+is required for correctness; we still point it at a tempdir defensively so the
+import can never touch the real store.
+
+Run with: python3 -m pytest modules/dreaming/tests/test_scorecard.py -q
+      or: python3 modules/dreaming/tests/test_scorecard.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[2]
+sys.path.insert(0, str(HERE.parent / "lib"))                       # dreaming/lib -> scorecard
+sys.path.insert(0, str(REPO_ROOT / "modules" / "self-improving" / "lib"))  # -> learnings_store
+sys.path.insert(0, str(REPO_ROOT / "modules" / "hooks" / "lib"))           # -> hook_utils
+
+# Defensive: never let the store import bind to the real ~/.claude/learnings.
+sys.modules.pop("learnings_store", None)
+_TMP_STORE_IMPORT = tempfile.mkdtemp(prefix="ccgm-scorecard-import-")
+os.environ["CCGM_LEARNINGS_DIR"] = _TMP_STORE_IMPORT
+
+import scorecard  # noqa: E402
+import learnings_store  # noqa: E402
+
+
+UTC = timezone.utc
+
+
+def _ts(day: int, hour: int = 9) -> str:
+    """A millisecond-precision UTC timestamp on 2026-06-{day}, matching the
+    store/injection-log serialization form."""
+    return f"2026-06-{day:02d}T{hour:02d}:00:00.000Z"
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for r in rows:
+            fh.write(json.dumps(r) + "\n")
+
+
+class ScorecardRenderTest(unittest.TestCase):
+    # Week ending 2026-06-30 -> window [2026-06-24 00:00Z, 2026-07-01 00:00Z).
+    WINDOW_START = datetime(2026, 6, 24, tzinfo=UTC)
+    WINDOW_END = datetime(2026, 7, 1, tzinfo=UTC)
+    GENERATED_AT = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="ccgm-scorecard-test-"))
+        self.learnings_dir = self.root / "learnings"
+        self.injection_dir = self.root / "dreaming" / "injection-log"
+        self.proposals_dir = self.root / "dreaming" / "proposals"
+        self.audit_path = self.root / "dreaming" / "state" / "apply-audit.jsonl"
+
+        # --- Store op-events across two slugs ------------------------------
+        # acme_widget: captures L1,L2 (pattern), L3 (pitfall, later deprecated),
+        # plus L4 (pattern) stamped BEFORE the window (must not be captured).
+        _write_jsonl(self.learnings_dir / "acme_widget" / "agents" / "agent-a.jsonl", [
+            self._add("L1", _ts(25), "pattern", "quote reserved keywords", 9, "acme_widget"),
+            self._add("L2", _ts(26), "pattern", "prefer rev-parse over pwd", 9, "acme_widget"),
+            self._add("L3", _ts(27), "pitfall", "stash drops untracked files", 9, "acme_widget"),
+            self._add("L4", _ts(22), "pattern", "stamped before the window", 9, "acme_widget"),
+            self._deprecate("D1", _ts(27, 10), "L3"),
+            # Reuses of L1 (x2 in-window) + L2 (x1 in-window); one out-of-window.
+            self._verify("V1", _ts(25, 12), "L1"),
+            self._verify("V2", _ts(26, 12), "L1"),
+            self._verify("V3", _ts(27, 12), "L2"),
+            self._verify("V4", _ts(20, 12), "L1"),   # before window -> excluded
+        ])
+        # demo_app: L5 (tool) superseded by L5b; legacy row L7 (no op field);
+        # L6 stamped AFTER the window (must not be captured).
+        _write_jsonl(self.learnings_dir / "demo_app" / "agents" / "agent-b.jsonl", [
+            self._add("L5", _ts(28), "tool", "tailwind v4 omits cursor pointer", 9, "demo_app"),
+            self._supersede("L5b", _ts(30), "L5", "tool",
+                            "tailwind v4 preflight omits cursor:pointer", 9, "demo_app"),
+            self._add("L6", "2026-07-02T09:00:00.000Z", "tool", "after the window", 9, "demo_app"),
+        ])
+        _write_jsonl(self.learnings_dir / "demo_app" / "learnings.jsonl", [
+            self._legacy("L7", _ts(29), "architecture", "auth runs before rate limiting", 8, "demo_app"),
+        ])
+
+        # --- Injection-log telemetry (#782) --------------------------------
+        _write_jsonl(self.injection_dir / "2026-06-28.jsonl", [
+            self._inj(_ts(25, 8), "sess-1", 2, ["L1", "L2"]),
+            self._inj(_ts(26, 8), "sess-1", 1, ["L1"]),          # same session
+            self._inj(_ts(27, 8), "sess-2", 3, ["L1", "L3", "L5"]),
+            self._inj(_ts(20, 8), "sess-9", 5, ["L1"]),          # before window -> excluded
+        ])
+
+        # --- Apply audit + proposals funnel --------------------------------
+        _write_jsonl(self.audit_path, [
+            self._audit(_ts(25, 13), "learning_verify", ok=True),
+            self._audit(_ts(26, 13), "learning_add", ok=True),
+            self._audit(_ts(27, 13), "learning_verify", ok=True),
+            self._audit(_ts(25, 14), "learning_add", ok=False, outcome="failed_cas"),  # not applied
+            self._audit(_ts(20, 13), "learning_add", ok=True),   # before window -> excluded
+        ])
+        _write_jsonl(self.proposals_dir / "2026-06-28.jsonl", [
+            self._proposal(_ts(25, 7), "accepted", "learning_add"),
+            self._proposal(_ts(26, 7), "pending", "learning_verify"),
+            self._proposal(_ts(27, 7), "auto_applied", "learning_verify"),
+            self._proposal(_ts(20, 7), "pending", "learning_add"),  # before window -> excluded
+        ])
+
+    # -- op-event / record builders ----------------------------------------
+    @staticmethod
+    def _add(id_, ts, type_, content, conf, project):
+        return {"id": id_, "op": "add", "target_id": None, "timestamp": ts,
+                "type": type_, "content": content, "confidence": conf, "project": project}
+
+    @staticmethod
+    def _legacy(id_, ts, type_, content, conf, project):
+        # A pre-v2 row carries no `op` field and seeds a head verbatim.
+        return {"id": id_, "timestamp": ts, "type": type_, "content": content,
+                "confidence": conf, "project": project}
+
+    @staticmethod
+    def _verify(id_, ts, target):
+        return {"id": id_, "op": "verify", "target_id": target, "timestamp": ts}
+
+    @staticmethod
+    def _deprecate(id_, ts, target):
+        return {"id": id_, "op": "deprecate", "target_id": target, "timestamp": ts}
+
+    @staticmethod
+    def _supersede(id_, ts, target, type_, content, conf, project):
+        return {"id": id_, "op": "supersede", "target_id": target, "timestamp": ts,
+                "type": type_, "content": content, "confidence": conf, "project": project}
+
+    @staticmethod
+    def _inj(ts, session, count, ids):
+        return {"timestamp": ts, "session_id": session, "source": "startup",
+                "project_slug": "acme_widget", "injected_count": count, "injected_ids": ids}
+
+    @staticmethod
+    def _audit(ts, kind, *, ok, outcome="applied"):
+        return {"id": f"audit_{kind}_{ts}", "ts": ts, "kind": kind,
+                "outcome": outcome if ok else outcome, "ok": ok,
+                "method": "human_accept", "proposal_id": "p-x"}
+
+    @staticmethod
+    def _proposal(generated_at, status, kind):
+        return {"id": f"prop-{generated_at}", "generated_at": generated_at,
+                "status": status, "kind": kind, "project": "acme_widget"}
+
+    def _render(self) -> str:
+        return scorecard.render(
+            self.WINDOW_START,
+            self.WINDOW_END,
+            learnings_dir=self.learnings_dir,
+            injection_log_dir=self.injection_dir,
+            proposals_dir=self.proposals_dir,
+            apply_audit_path=self.audit_path,
+            store_api=learnings_store,
+            generated_at=self.GENERATED_AT,
+        )
+
+    # -- assertions --------------------------------------------------------
+    def test_captured_exact(self):
+        md = self._render()
+        self.assertIn("## Captured — 5 new learnings this window", md)
+        self.assertIn("| pattern | acme_widget | 2 |", md)
+        self.assertIn("| pitfall | acme_widget | 1 |", md)
+        self.assertIn("| tool | demo_app | 1 |", md)
+        self.assertIn("| architecture | demo_app | 1 |", md)
+        # Out-of-window adds (L4 before, L6 after) are NOT captured.
+        self.assertNotIn("6 new learnings", md)
+        self.assertNotIn("7 new learnings", md)
+
+    def test_injected_exact(self):
+        md = self._render()
+        self.assertIn("2 session(s) received injected memory (3 injection event(s))", md)
+        self.assertIn("6 total learnings injected", md)
+        # L1 injected in all three in-window records; the pre-window record excluded.
+        self.assertIn("`L1` — 3×", md)
+
+    def test_reused_exact(self):
+        md = self._render()
+        self.assertIn("## Reused — 2 learnings reinforced (3 reuse events)", md)
+        self.assertIn("`L1` — 2× reused", md)
+        self.assertIn("`L2` — 1× reused", md)
+
+    def test_applied_exact(self):
+        md = self._render()
+        self.assertIn("## Applied — 3 proposals applied this window", md)
+        self.assertIn("generated this window: 3 (1 still pending review)", md)
+        self.assertIn("applied this window: 3", md)
+        self.assertIn("learning_verify: 2", md)
+        self.assertIn("learning_add: 1", md)
+
+    def test_store_health_structural(self):
+        md = self._render()
+        # active = L1,L2,L4,L5b,L6,L7 = 6; L3 deprecated; L5 superseded.
+        self.assertIn("## Store health — 6 active learnings", md)
+        self.assertIn("deprecated: 1", md)
+        self.assertIn("superseded: 1", md)
+        # Band counts must partition the active heads.
+        bands = {b: int(n) for b, n in re.findall(r"(high|medium|low) \([^)]*\): (\d+)", md)}
+        self.assertEqual(sum(bands.values()), 6)
+
+    def test_run_summary_line(self):
+        md = self._render()
+        self.assertIn(
+            "**5 captured · 2 sessions injected · 2 learnings reused (3 events) · 3 applied**",
+            md,
+        )
+        self.assertIn("generated 2026-07-01 12:00 UTC", md)
+
+    def test_returns_str_no_traceback(self):
+        md = self._render()
+        self.assertIsInstance(md, str)
+        self.assertNotIn("Traceback", md)
+
+
+class ScorecardDegradeTest(unittest.TestCase):
+    """Missing/empty sources must render 'no data this window', never raise."""
+
+    def test_all_sources_missing(self):
+        root = Path(tempfile.mkdtemp(prefix="ccgm-scorecard-empty-"))
+        md = scorecard.render(
+            datetime(2026, 6, 24, tzinfo=UTC),
+            datetime(2026, 7, 1, tzinfo=UTC),
+            learnings_dir=root / "nope-learnings",
+            injection_log_dir=root / "nope-injection",
+            proposals_dir=root / "nope-proposals",
+            apply_audit_path=root / "nope-audit.jsonl",
+            store_api=learnings_store,
+            generated_at=datetime(2026, 7, 1, tzinfo=UTC),
+        )
+        self.assertIsInstance(md, str)
+        self.assertIn("## Captured — 0 new learnings this window", md)
+        self.assertIn("## Store health — 0 active learnings", md)
+        self.assertEqual(md.count(scorecard._NO_DATA), 4)  # captured/injected/reused/applied
+        self.assertNotIn("Traceback", md)
+
+
+class ScorecardWrapperSmokeTest(unittest.TestCase):
+    """The .sh wrapper resolves the window + wall clock, imports the store via
+    the sibling-import helper, writes the file, and prints its path."""
+
+    def test_wrapper_writes_file_and_prints_path(self):
+        dreaming_dir = Path(tempfile.mkdtemp(prefix="ccgm-scorecard-wrap-dreaming-"))
+        store_dir = Path(tempfile.mkdtemp(prefix="ccgm-scorecard-wrap-store-"))
+        # Minimal real store so the health section has something to project.
+        _write_jsonl(store_dir / "acme_widget" / "agents" / "agent-a.jsonl", [
+            {"id": "W1", "op": "add", "target_id": None, "timestamp": _ts(28),
+             "type": "pattern", "content": "smoke test learning", "confidence": 7,
+             "project": "acme_widget"},
+        ])
+        env = dict(os.environ)
+        env["CCGM_DREAMING_DIR"] = str(dreaming_dir)
+        env["CCGM_LEARNINGS_DIR"] = str(store_dir)
+        proc = subprocess.run(
+            ["bash", str(REPO_ROOT / "modules" / "dreaming" / "bin" / "dream-scorecard.sh"),
+             "2026-06-30"],
+            capture_output=True, text=True, env=env,
+        )
+        self.assertEqual(proc.returncode, 0, msg=f"stderr: {proc.stderr}")
+        printed = proc.stdout.strip()
+        self.assertTrue(printed.endswith("scorecards/2026-06-30.md"), msg=printed)
+        out_file = Path(printed)
+        self.assertTrue(out_file.is_file())
+        body = out_file.read_text(encoding="utf-8")
+        self.assertIn("# Dreaming scorecard — week ending 2026-06-30", body)
+        self.assertIn("## Store health — 1 active learnings", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #790

## Summary

A deterministic weekly scorecard over the read-path signals the dreaming/read-path memory system already records — the honest answer to "how do I know the memory system is working?" All aggregation is mechanical counting (latent-vs-deterministic: a script, not model work). **Read-only**: never writes to the learnings store or dreaming state; the only write is the rendered markdown.

## Changes

- `modules/dreaming/lib/scorecard.py` — `render(window_start, window_end, *, learnings_dir, injection_log_dir, proposals_dir, apply_audit_path, store_api, generated_at, now=None)` returns the markdown. No `Date.now()` in the library — window bounds and generated-at are passed in. Sections: run-summary line, Captured, Injected, Reused, Applied, Store health. Every section degrades to `_no data this window._` on a missing/empty source, never a traceback.
- `modules/dreaming/bin/dream-scorecard.sh` — thin wrapper mirroring `dream-digest.sh`: resolves the 7-day window (default today UTC; optional `YYYY-MM-DD` week-ending arg) + wall clock, imports `learnings_store` via `transcript_miner._import_sibling_module`, writes `~/.claude/dreaming/scorecards/{date}.md`, prints the path.
- `modules/dreaming/commands/dream-scorecard.md` — `/dream-scorecard [week]` slash command.
- `modules/dreaming/tests/test_scorecard.py` — fixture-driven tests asserting exact captured/injected/reused/applied counts (incl. half-open window boundary exclusion), graceful degradation on empty sources, and a wrapper smoke test.
- `modules/dreaming/module.json` — registers the three new installable files.

### Data sources (all read-only)

- **Captured / Reused**: raw op-event JSONL under `learnings_dir` (window-scoped `add`/legacy and `verify` events need each event's own `timestamp`, which the projected head view does not expose).
- **Store health**: the same raw lines projected through `learnings_store`'s own `_project_lines` + `effective_confidence` (used purely as pure functions — no global-path coupling, no snapshot-cache writes).
- **Injected**: `~/.claude/dreaming/injection-log/*.jsonl` (#782 telemetry).
- **Applied**: `~/.claude/dreaming/state/apply-audit.jsonl` (authoritative applied-at `ts`) cross-referenced with `proposals/*.jsonl` for the generated→applied funnel.

## Test plan

- `python3 -m pytest modules/dreaming/tests/ -q` → 238 passed (9 new).
- `bash tests/test-no-personal-data.sh` → PASS (fixtures use invented slugs/content only).
- `bash tests/test-modules.sh` → 1554 passed; `bash tests/test-installer.sh` → 54 passed.
- Ran `bash modules/dreaming/bin/dream-scorecard.sh` against real live data → readable markdown with all six sections populated.