### PR TITLE
#800: per-op-kind posture policy + config + proposal fields

### DIFF
--- a/modules/dreaming/lib/dream_analyze.py
+++ b/modules/dreaming/lib/dream_analyze.py
@@ -212,6 +212,31 @@ def _utc_now_iso() -> str:
 # dream-install.sh owns bootstrapping a real config.json)
 # ---------------------------------------------------------------------------
 
+# optimistic-memory plan.md §3.5 config block. Kept as its own named
+# constant (rather than an inline literal inside DEFAULT_CONFIG) so
+# load_config() can deep-merge it independently of the rest of the file
+# (see the merge fix in load_config() below) and so resolve_posture()'s
+# per-op-kind table (further down) can document which config keys its
+# floors/caps name without a forward reference into DEFAULT_CONFIG.
+DEFAULT_OPTIMISTIC_INTEGRATION: dict[str, Any] = {
+    "enabled": False,
+    "dwell_hours": 24,
+    "max_add_supersede_per_run": 10,
+    "max_eviction_absolute": 3,
+    "max_eviction_fraction_per_run": 0.20,
+    "confidence_floor_verify": 7,
+    "confidence_floor_content": 8,
+    "add_min_sessions": 2,
+    "batch_anomaly_max_same_tag_fraction": 0.6,
+    "circuit_breaker_window_nights": 7,
+    "circuit_breaker_max_anomalies": 2,
+    "circuit_breaker_auto_resume_nights": 7,
+    "rolling_add_rate_window_nights": 14,
+    "rolling_add_rate_max": 40,
+    "eval_refresh_min_age_days": 7,
+    "eval_refresh_cost_cap_usd": 2.00,
+}
+
 DEFAULT_CONFIG: dict[str, Any] = {
     "enabled": True,
     "map_model": DEFAULT_MAP_MODEL,
@@ -230,11 +255,31 @@ DEFAULT_CONFIG: dict[str, Any] = {
     # store. Set an explicit list here to pin dreaming to specific projects.
     "scopes": [],
     "cost_pricing": {},
+    # optimistic-memory plan.md §3.5. `enabled: false` here is the
+    # shipped-module default (CCGM's existing "auto-apply off by default"
+    # posture) -- a DIFFERENT flag from the top-level `enabled` above, which
+    # gates the mining/analyze pipeline itself, not auto-integration. Inert
+    # until Epic 3's engine reads it and Epic 8 flips it on via
+    # memory-setup.sh (never via a hand JSON edit -- see the plan's §3.5
+    # rationale for why that activation path matters).
+    "optimistic_integration": dict(DEFAULT_OPTIMISTIC_INTEGRATION),
 }
 
 
 def load_config() -> dict[str, Any]:
     cfg = dict(DEFAULT_CONFIG)
+    # Deep-merge fill (optimistic-memory plan.md §3.5 Epic 2 requirement):
+    # optimistic_integration is the one sub-dict that ships with real,
+    # non-empty defaults (blast-radius caps, confidence floors,
+    # circuit-breaker knobs). A shallow `cfg.update(loaded)` below would let
+    # a user's partial override -- e.g. {"optimistic_integration":
+    # {"dwell_hours": 6}} -- silently wipe every other key in the sub-dict
+    # instead of just overriding the one they set. Re-copying here (rather
+    # than relying on DEFAULT_CONFIG's own nested dict) also means this
+    # function never hands back a dict whose "optimistic_integration" value
+    # is the same object as DEFAULT_OPTIMISTIC_INTEGRATION -- a caller
+    # mutating the returned config can never corrupt the shared default.
+    cfg["optimistic_integration"] = dict(DEFAULT_OPTIMISTIC_INTEGRATION)
     path = config_path()
     if path.is_file():
         try:
@@ -242,8 +287,86 @@ def load_config() -> dict[str, Any]:
         except (OSError, json.JSONDecodeError):
             loaded = {}
         if isinstance(loaded, dict):
-            cfg.update(loaded)
+            overlay = dict(loaded)
+            optimistic_overlay = overlay.pop("optimistic_integration", None)
+            cfg.update(overlay)
+            if isinstance(optimistic_overlay, dict):
+                cfg["optimistic_integration"].update(optimistic_overlay)
     return cfg
+
+
+# ---------------------------------------------------------------------------
+# Per-op-kind posture policy (optimistic-memory plan.md §3.3 -- the policy
+# spine). OPTIMISTIC_POSTURE is the single source of truth: every downstream
+# gate (Epic 3's run_optimistic_integrate) is meant to read resolve_posture()
+# instead of hardcoding an `if kind == ...` check. Table values name *config
+# keys* (looked up in the optimistic_integration block above at the point of
+# use), not resolved numbers -- resolving a cap against live config and live
+# store state (e.g. live_head_count(slug) for the eviction cap) is Epic 3's
+# job, not this policy table's.
+# ---------------------------------------------------------------------------
+
+GATED_POSTURE: dict[str, Any] = {
+    "posture": "gated",
+    "needs_dwell": False,
+    "confidence_floor": None,
+    "per_run_cap": None,
+}
+
+OPTIMISTIC_POSTURE: dict[str, dict[str, Any]] = {
+    "learning_verify": {
+        "posture": "optimistic-immediate",
+        "needs_dwell": False,
+        "confidence_floor": "confidence_floor_verify",
+        "per_run_cap": None,
+    },
+    "learning_add": {
+        "posture": "optimistic-dwell",
+        "needs_dwell": True,
+        "confidence_floor": "confidence_floor_content",
+        "per_run_cap": "max_add_supersede_per_run",
+    },
+    "learning_supersede": {
+        "posture": "optimistic-dwell",
+        "needs_dwell": True,
+        "confidence_floor": "confidence_floor_content",
+        "per_run_cap": "max_add_supersede_per_run",
+    },
+    "learning_contradict": {
+        "posture": "dwell-quarantine",
+        "needs_dwell": True,
+        "confidence_floor": "confidence_floor_content",
+        # Eviction cap is a compound formula (§3.3): min(max_eviction_absolute,
+        # max_eviction_fraction_per_run x live_head_count(slug)). Two config
+        # keys, not one -- Epic 3 reads both off this tuple rather than this
+        # table inventing a single derived number (that computation needs
+        # live_head_count(slug), which is live store state, not policy).
+        "per_run_cap": ("max_eviction_absolute", "max_eviction_fraction_per_run"),
+    },
+    "learning_deprecate": {
+        "posture": "dwell-quarantine",
+        "needs_dwell": True,
+        "confidence_floor": "confidence_floor_content",
+        "per_run_cap": ("max_eviction_absolute", "max_eviction_fraction_per_run"),
+    },
+}
+
+
+def resolve_posture(kind: str, project: str) -> dict[str, Any]:
+    """Pure lookup -- the single source of truth for per-op-kind posture
+    (optimistic-memory plan.md §3.3). `_global` always resolves to `gated`
+    regardless of kind: defense-in-depth over promote_to_global()'s existing
+    human-accept gate (VF9), not a replacement for it. An unrecognized kind
+    also resolves to `gated` (fail-safe -- an op-kind this table does not
+    know must never be treated as auto-integrable). Returns a fresh copy so
+    callers can never mutate the shared policy table.
+    """
+    if project == GLOBAL_SLUG:
+        return dict(GATED_POSTURE)
+    entry = OPTIMISTIC_POSTURE.get(kind)
+    if entry is None:
+        return dict(GATED_POSTURE)
+    return dict(entry)
 
 
 # ---------------------------------------------------------------------------

--- a/modules/dreaming/lib/proposal-schema.json
+++ b/modules/dreaming/lib/proposal-schema.json
@@ -122,6 +122,19 @@
         }
       },
       "description": "OPTIONAL. Present only on 'learning_supersede' proposals where learnings_store.compact_preserves_facts(old_content, new_content) returned false (sec-11). The proposal stays 'pending' but is flagged for extra human scrutiny rather than treated as an ordinary supersede."
+    },
+    "dwell_until": {
+      "type": "string",
+      "description": "OPTIONAL. ISO-8601 UTC timestamp (optimistic-memory plan.md §3.4). Set when the optimistic-integration engine (Epic 3) auto-applies a 'needs_dwell' posture (learning_add/learning_supersede/learning_contradict/learning_deprecate, per resolve_posture()'s OPTIMISTIC_POSTURE table). Mirrors the op-event/head field of the same name that learnings_store.py's fold layer inherits via the max-with-target rule; absent means the proposal was never auto-applied under a dwelling posture."
+    },
+    "batch_id": {
+      "type": "string",
+      "description": "OPTIONAL. Correlates every proposal auto-applied in one nightly optimistic-integration run (optimistic-memory plan.md §3.4), for the batch-anomaly check and for grouping in the daily report. Absent for proposals that were never auto-applied."
+    },
+    "posture": {
+      "type": "string",
+      "enum": ["optimistic-immediate", "optimistic-dwell", "dwell-quarantine", "gated"],
+      "description": "OPTIONAL. The posture string resolve_posture(kind, project) returned for this proposal at apply time (optimistic-memory plan.md §3.3/§3.4). Recorded for audit/report purposes; absent for proposals produced before Epic 3 or never routed through the optimistic-integration engine."
     }
   }
 }

--- a/modules/dreaming/tests/test_posture_policy.py
+++ b/modules/dreaming/tests/test_posture_policy.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Tests for the per-op-kind posture policy in modules/dreaming/lib/dream_analyze.py
+(optimistic-memory plan.md §5 Epic 2): OPTIMISTIC_POSTURE, resolve_posture(),
+and the optimistic_integration config block's deep-merge behavior in
+load_config().
+
+Runs in isolation: CCGM_LEARNINGS_DIR is redirected to a tempdir before
+import (dream_analyze imports learnings_store transitively at module load
+time -- mirrors test_dream_analyze.py's own pattern). CCGM_DREAMING_DIR is
+redirected per-test for any config-file I/O; neither the real
+~/.claude/dreaming nor ~/.claude/learnings is ever touched.
+
+Run with: python3 -m pytest modules/dreaming/tests/test_posture_policy.py -q
+      or: python3 modules/dreaming/tests/test_posture_policy.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / "lib"))
+
+# Point the learnings store at a tempdir BEFORE importing dream_analyze,
+# which imports learnings_store transitively at module load time.
+_TMP_LEARNINGS = tempfile.mkdtemp(prefix="ccgm-dreaming-test-posture-learnings-")
+os.environ["CCGM_LEARNINGS_DIR"] = _TMP_LEARNINGS
+
+import dream_analyze as da  # noqa: E402
+
+
+def _isolate_dreaming_dir(test: unittest.TestCase) -> Path:
+    """Fresh CCGM_DREAMING_DIR per test; restores the prior value on
+    cleanup. Mirrors test_dream_analyze.py's _isolate_env() helper, scoped
+    to just the one env var these tests need (no --offline/API calls here,
+    so the .env-path overrides that helper also sets are not needed)."""
+    tmp = tempfile.mkdtemp(prefix="ccgm-dreaming-test-posture-")
+    previous = os.environ.get("CCGM_DREAMING_DIR")
+    os.environ["CCGM_DREAMING_DIR"] = tmp
+
+    def _restore():
+        if previous is None:
+            os.environ.pop("CCGM_DREAMING_DIR", None)
+        else:
+            os.environ["CCGM_DREAMING_DIR"] = previous
+
+    test.addCleanup(_restore)
+    return Path(tmp)
+
+
+# ---------------------------------------------------------------------------
+# resolve_posture(): the per-op-kind policy table (§3.3).
+# ---------------------------------------------------------------------------
+
+
+class ResolvePostureTests(unittest.TestCase):
+    def test_verify_is_optimistic_immediate(self):
+        result = da.resolve_posture("learning_verify", "some-project")
+        self.assertEqual(result["posture"], "optimistic-immediate")
+        self.assertFalse(result["needs_dwell"])
+
+    def test_add_is_optimistic_dwell(self):
+        result = da.resolve_posture("learning_add", "some-project")
+        self.assertEqual(result["posture"], "optimistic-dwell")
+        self.assertTrue(result["needs_dwell"])
+
+    def test_supersede_is_optimistic_dwell(self):
+        result = da.resolve_posture("learning_supersede", "some-project")
+        self.assertEqual(result["posture"], "optimistic-dwell")
+        self.assertTrue(result["needs_dwell"])
+
+    def test_contradict_is_dwell_quarantine(self):
+        result = da.resolve_posture("learning_contradict", "some-project")
+        self.assertEqual(result["posture"], "dwell-quarantine")
+        self.assertTrue(result["needs_dwell"])
+
+    def test_deprecate_is_dwell_quarantine(self):
+        result = da.resolve_posture("learning_deprecate", "some-project")
+        self.assertEqual(result["posture"], "dwell-quarantine")
+        self.assertTrue(result["needs_dwell"])
+
+    def test_unknown_kind_is_gated_fail_safe(self):
+        result = da.resolve_posture("bogus_kind", "some-project")
+        self.assertEqual(result["posture"], "gated")
+
+    def test_add_targeting_global_is_gated(self):
+        result = da.resolve_posture("learning_add", da.GLOBAL_SLUG)
+        self.assertEqual(result["posture"], "gated")
+
+    def test_global_gates_every_known_op_kind(self):
+        # §3.3: "any -> _global" is `gated` regardless of kind. Assert it
+        # for every kind the policy table actually knows about, not just
+        # one representative sample.
+        for kind in da.OPTIMISTIC_POSTURE:
+            with self.subTest(kind=kind):
+                result = da.resolve_posture(kind, da.GLOBAL_SLUG)
+                self.assertEqual(result["posture"], "gated")
+
+    def test_global_gates_unknown_kind_too(self):
+        result = da.resolve_posture("bogus_kind", da.GLOBAL_SLUG)
+        self.assertEqual(result["posture"], "gated")
+
+    def test_returned_dict_is_a_copy_not_the_shared_constant(self):
+        result = da.resolve_posture("learning_verify", "some-project")
+        result["posture"] = "mutated"
+        fresh = da.resolve_posture("learning_verify", "some-project")
+        self.assertEqual(fresh["posture"], "optimistic-immediate")
+
+
+# ---------------------------------------------------------------------------
+# load_config(): optimistic_integration deep-merge (§3.5).
+# ---------------------------------------------------------------------------
+
+
+class LoadConfigOptimisticIntegrationTests(unittest.TestCase):
+    def test_defaults_present_with_no_config_file(self):
+        _isolate_dreaming_dir(self)
+        cfg = da.load_config()
+        self.assertIn("optimistic_integration", cfg)
+        self.assertEqual(cfg["optimistic_integration"]["enabled"], False)
+        self.assertEqual(cfg["optimistic_integration"]["max_add_supersede_per_run"], 10)
+
+    def test_partial_override_deep_merges_with_defaults(self):
+        tmp = _isolate_dreaming_dir(self)
+        (tmp / "config.json").write_text(
+            json.dumps({"optimistic_integration": {"dwell_hours": 6}}),
+            encoding="utf-8",
+        )
+        cfg = da.load_config()
+        self.assertEqual(cfg["optimistic_integration"]["dwell_hours"], 6)
+        # Every other default in the sub-dict must survive the partial
+        # override -- this is the deep-merge requirement itself.
+        self.assertEqual(cfg["optimistic_integration"]["max_add_supersede_per_run"], 10)
+        self.assertEqual(cfg["optimistic_integration"]["max_eviction_absolute"], 3)
+        self.assertEqual(cfg["optimistic_integration"]["confidence_floor_verify"], 7)
+
+    def test_partial_override_does_not_mutate_shared_default_constant(self):
+        tmp = _isolate_dreaming_dir(self)
+        (tmp / "config.json").write_text(
+            json.dumps({"optimistic_integration": {"dwell_hours": 999}}),
+            encoding="utf-8",
+        )
+        da.load_config()
+        self.assertEqual(da.DEFAULT_OPTIMISTIC_INTEGRATION["dwell_hours"], 24)
+
+    def test_top_level_override_still_works_alongside_optimistic_integration(self):
+        tmp = _isolate_dreaming_dir(self)
+        (tmp / "config.json").write_text(
+            json.dumps({"lookback_days": 3, "optimistic_integration": {"dwell_hours": 6}}),
+            encoding="utf-8",
+        )
+        cfg = da.load_config()
+        self.assertEqual(cfg["lookback_days"], 3)
+        self.assertEqual(cfg["optimistic_integration"]["dwell_hours"], 6)
+
+    def test_config_without_optimistic_integration_key_still_gets_full_defaults(self):
+        tmp = _isolate_dreaming_dir(self)
+        (tmp / "config.json").write_text(json.dumps({"lookback_days": 3}), encoding="utf-8")
+        cfg = da.load_config()
+        self.assertEqual(cfg["lookback_days"], 3)
+        self.assertEqual(cfg["optimistic_integration"], da.DEFAULT_OPTIMISTIC_INTEGRATION)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Epic 2 of the CCGM Optimistic Memory plan (`~/code/plans/ccgm-optimistic-memory/plan.md` §5 Epic 2): the single source-of-truth posture policy, the new config block, and the proposal-row fields the auto-integration engine (Epic 3) will read.

- `OPTIMISTIC_POSTURE: dict[str, dict]` in `dream_analyze.py` encodes the §3.3 policy table (posture string, `needs_dwell` bool, `confidence_floor` config-key name, `per_run_cap` config-key name) for every `learning_*` op-kind. Posture is data — Epic 3 reads `resolve_posture()`, not scattered `if kind ==` checks.
- `resolve_posture(kind, project) -> dict` is a pure lookup: `_global` always resolves to `gated` regardless of kind (defense-in-depth over `promote_to_global()`'s existing human-accept gate); an unrecognized kind also resolves to `gated` (fail-safe).
- `DEFAULT_CONFIG` gains the `optimistic_integration` sub-dict from §3.5 (`enabled: false` by default). `load_config()` now deep-merges this sub-dict specifically, so a partial user override (e.g. only `dwell_hours`) keeps every other default intact instead of the previous shallow `cfg.update()` wiping the rest.
- `proposal-schema.json` gains three optional properties: `dwell_until`, `batch_id`, `posture` — documented the same way `needs_manual_promotion`/`compaction_guard_failed` already are, no `required`/`additionalProperties` change.

Closes #800.

## Test plan

- [x] `python3 -m pytest modules/dreaming/tests/test_posture_policy.py -q` — 15 passed, 5 subtests passed
- [x] `python3 -c "import json; json.load(open('modules/dreaming/lib/proposal-schema.json'))"` — parses
- [x] `python3 -m pytest modules/dreaming/tests/ -q` — 260 passed, 5 subtests passed (full dreaming suite, no regressions)
- [x] `python3 -m py_compile modules/dreaming/lib/dream_analyze.py modules/dreaming/tests/test_posture_policy.py` — compiles clean

No bring-up steps: these defaults are inert until Epic 3's engine reads them and Epic 8 flips `enabled` on.