### PR TITLE
#799: dwell-window store lifecycle (Epic 1, optimistic memory)

### DIFF
--- a/modules/self-improving/bin/ccgm-learnings-log
+++ b/modules/self-improving/bin/ccgm-learnings-log
@@ -26,6 +26,14 @@ Fields:
     --evidence-session   repeatable; session uuid(s) cited as promotion evidence
     --expected-sha       CAS (supersede/deprecate): sha256 of the target's current
                          content, as last read. Mismatch exits 3 with the current sha.
+    --auto              mark this write as unattended (dreaming auto-integration), for
+                         audit/reporting -- available on every subcommand (add/verify/
+                         contradict/deprecate/supersede)
+    --dwell-hours <N>   stamp dwell_until = utcnow() + N hours (optimistic-memory §3.2):
+                         the row is written but excluded from search()/injection until
+                         the window closes. On verify/contradict/deprecate/supersede this
+                         is a FLOOR only -- the store applies max(existing, new), so it
+                         can extend but never shorten a target's existing dwell.
 
 Writes to:
     ~/.claude/learnings/{project-slug}/agents/{agent-id}.jsonl
@@ -82,6 +90,8 @@ def _cmd_log(args: argparse.Namespace) -> int:
             "evidence_sessions": args.evidence_session or [],
         }
 
+    dwell_until = ls.dwell_until_from_hours(args.dwell_hours) if args.dwell_hours is not None else None
+
     try:
         entry = ls.build_entry(
             type_=payload["type"],
@@ -94,13 +104,14 @@ def _cmd_log(args: argparse.Namespace) -> int:
             key=payload.get("key"),
             source_session=payload.get("source_session"),
             evidence_sessions=payload.get("evidence_sessions") or [],
+            dwell_until=dwell_until,
         )
     except ls.ValidationError as e:
         print(f"error: {e}", file=sys.stderr)
         return 2
 
     try:
-        path = ls.append_entry(entry)
+        path = ls.append_entry(entry, auto=args.auto)
     except ls.GlobalPromotionError as e:
         print(f"error: {e}", file=sys.stderr)
         return 4
@@ -110,10 +121,11 @@ def _cmd_log(args: argparse.Namespace) -> int:
 
 
 def _cmd_verify(args: argparse.Namespace) -> int:
+    dwell_until = ls.dwell_until_from_hours(args.dwell_hours) if args.dwell_hours is not None else None
     try:
         ok = ls.update_entry_by_id(
             args.id, slug=args.project, verify=True, source_session=args.session,
-            auto=args.auto,
+            auto=args.auto, dwell_until=dwell_until,
         )
     except ls.GlobalPromotionError as e:
         print(f"error: {e}", file=sys.stderr)
@@ -122,8 +134,12 @@ def _cmd_verify(args: argparse.Namespace) -> int:
 
 
 def _cmd_contradict(args: argparse.Namespace) -> int:
+    dwell_until = ls.dwell_until_from_hours(args.dwell_hours) if args.dwell_hours is not None else None
     try:
-        ok = ls.update_entry_by_id(args.id, slug=args.project, contradict=True, source_session=args.session)
+        ok = ls.update_entry_by_id(
+            args.id, slug=args.project, contradict=True, source_session=args.session,
+            auto=args.auto, dwell_until=dwell_until,
+        )
     except ls.GlobalPromotionError as e:
         print(f"error: {e}", file=sys.stderr)
         return 4
@@ -131,10 +147,12 @@ def _cmd_contradict(args: argparse.Namespace) -> int:
 
 
 def _cmd_deprecate(args: argparse.Namespace) -> int:
+    dwell_until = ls.dwell_until_from_hours(args.dwell_hours) if args.dwell_hours is not None else None
     try:
         ok = ls.update_entry_by_id(
             args.id, slug=args.project, deprecate=True,
             expected_sha256=args.expected_sha, source_session=args.session,
+            auto=args.auto, dwell_until=dwell_until,
         )
     except ls.GlobalPromotionError as e:
         print(f"error: {e}", file=sys.stderr)
@@ -146,6 +164,7 @@ def _cmd_deprecate(args: argparse.Namespace) -> int:
 
 
 def _cmd_supersede(args: argparse.Namespace) -> int:
+    dwell_until = ls.dwell_until_from_hours(args.dwell_hours) if args.dwell_hours is not None else None
     try:
         new_entry = ls.supersede_entry(
             args.old_id,
@@ -159,6 +178,8 @@ def _cmd_supersede(args: argparse.Namespace) -> int:
             reason=args.reason,
             expected_sha256=args.expected_sha,
             source_session=args.session,
+            auto=args.auto,
+            dwell_until=dwell_until,
         )
     except ls.ValidationError as e:
         print(f"error: {e}", file=sys.stderr)
@@ -214,6 +235,15 @@ def build_parser() -> argparse.ArgumentParser:
                     help="repeatable; session uuid(s) cited as promotion evidence")
     p.add_argument("--from-json", help="raw JSON payload instead of flags")
     p.add_argument("--stdin", action="store_true", help="read JSON payload from stdin")
+    p.add_argument(
+        "--auto", action="store_true",
+        help="unattended write (dreaming auto-integration), for audit/reporting (adrev-opt-008)",
+    )
+    p.add_argument(
+        "--dwell-hours", type=int,
+        help="stamp dwell_until = utcnow() + N hours (optimistic-memory §3.2): row is "
+             "written but excluded from search()/injection until the window closes",
+    )
 
     verify = sub.add_parser("verify", help="record a successful reuse of a learning")
     verify.add_argument("id")
@@ -224,12 +254,26 @@ def build_parser() -> argparse.ArgumentParser:
         help="unattended verify (dreaming auto-apply): bump uses WITHOUT refreshing "
              "last_verified, so decay/staleness are not reset (adrev-404). Default off = human semantics.",
     )
+    verify.add_argument(
+        "--dwell-hours", type=int,
+        help="floor: dwell_until = utcnow() + N hours, applied as max(existing, new) -- "
+             "can only extend, never shorten, the target's existing dwell",
+    )
     verify.set_defaults(func=_cmd_verify)
 
     contra = sub.add_parser("contradict", help="record a contradiction against a learning")
     contra.add_argument("id")
     contra.add_argument("--project")
     contra.add_argument("--session")
+    contra.add_argument(
+        "--auto", action="store_true",
+        help="unattended contradict (dreaming auto-integration), for audit/reporting (adrev-opt-008)",
+    )
+    contra.add_argument(
+        "--dwell-hours", type=int,
+        help="floor: dwell_until = utcnow() + N hours, applied as max(existing, new) -- "
+             "can only extend, never shorten, the target's existing dwell",
+    )
     contra.set_defaults(func=_cmd_contradict)
 
     dep = sub.add_parser("deprecate", help="mark a learning as deprecated (excluded from reads)")
@@ -238,6 +282,15 @@ def build_parser() -> argparse.ArgumentParser:
     dep.add_argument("--session")
     dep.add_argument("--expected-sha", required=True,
                       help="CAS: sha256 of the target's current content, as last read")
+    dep.add_argument(
+        "--auto", action="store_true",
+        help="unattended deprecate (dreaming auto-integration), for audit/reporting (adrev-opt-008)",
+    )
+    dep.add_argument(
+        "--dwell-hours", type=int,
+        help="floor: dwell_until = utcnow() + N hours, applied as max(existing, new) -- "
+             "can only extend, never shorten, the target's existing dwell",
+    )
     dep.set_defaults(func=_cmd_deprecate)
 
     sup = sub.add_parser(
@@ -259,6 +312,16 @@ def build_parser() -> argparse.ArgumentParser:
     sup.add_argument("--session", help="claude session uuid (required to raise the source tier)")
     sup.add_argument("--expected-sha", required=True,
                       help="CAS: sha256 of the target's current content, as last read")
+    sup.add_argument(
+        "--auto", action="store_true",
+        help="unattended supersede (dreaming auto-integration), for audit/reporting (adrev-opt-008)",
+    )
+    sup.add_argument(
+        "--dwell-hours", type=int,
+        help="floor on the NEW head's dwell: dwell_until = utcnow() + N hours, applied as "
+             "max(old_head's existing dwell, new) -- can only extend, never shorten, the "
+             "target's existing dwell",
+    )
     sup.set_defaults(func=_cmd_supersede)
 
     cfg_sub = sub.add_parser("config", help="adjust learnings-store config")

--- a/modules/self-improving/bin/ccgm-learnings-search
+++ b/modules/self-improving/bin/ccgm-learnings-search
@@ -5,7 +5,8 @@ ccgm-learnings-search — rank + filter + token-cap learnings for injection.
 Usage:
     ccgm-learnings-search [--query "..."] [--tag foo --tag bar] [--type pattern ...]
                           [--cross-project] [--max N] [--budget TOKENS]
-                          [--format jsonl|markdown|preamble] [--include-stale]
+                          [--format jsonl|markdown|preamble]
+                          [--include-stale] [--include-superseded] [--include-dwelling]
                           [--project SLUG]
 
 Examples:
@@ -19,8 +20,12 @@ Examples:
     ccgm-learnings-search --query auth --format jsonl
 
 The search path applies time-based confidence decay, dedupes by (key, type),
-drops deprecated or stale-below-threshold entries, and caps output by the
-configured token budget (chars/4 approximation).
+drops deprecated, stale-below-threshold, or (optimistic-memory §3.2) still-
+dwelling entries, and caps output by the configured token budget (chars/4
+approximation). `--include-dwelling` surfaces a row still inside its
+dwell window -- one committed but not yet read-eligible -- the same way
+`--include-stale`/`--include-superseded` surface their respective
+otherwise-hidden rows.
 
 Every preamble/markdown entry is wrapped with a verification reminder --
 `[age: {N}d · last_verified: {date} · verify files[] anchors before
@@ -176,6 +181,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--include-stale", action="store_true")
     p.add_argument("--include-superseded", action="store_true",
                    help="surface entries that have been replaced via supersede")
+    p.add_argument("--include-dwelling", action="store_true",
+                   help="surface entries still inside their dwell window (optimistic-memory §3.2)")
     p.add_argument("--format", choices=["jsonl", "markdown", "preamble"], default="preamble")
     p.add_argument("--list-projects", action="store_true")
     args = p.parse_args(argv)
@@ -195,6 +202,7 @@ def main(argv: list[str] | None = None) -> int:
         token_budget=args.token_budget,
         include_stale=args.include_stale,
         include_superseded=args.include_superseded,
+        include_dwelling=args.include_dwelling,
     )
 
     if args.format == "jsonl":

--- a/modules/self-improving/lib/learnings_store.py
+++ b/modules/self-improving/lib/learnings_store.py
@@ -380,6 +380,16 @@ def _parse_iso(s: str) -> float:
     return 0.0
 
 
+def dwell_until_from_hours(hours: float, *, now: float | None = None) -> str:
+    """Compute an ISO-8601 UTC `dwell_until` stamp `hours` from now
+    (optimistic-memory §3.2). Centralized here so every `--dwell-hours`
+    CLI flag (add/verify/contradict/deprecate/supersede) computes the
+    stamp identically, the same way `_utc_now_iso`/`_iso_from_epoch`
+    already centralize the rest of this module's timestamp formatting."""
+    base = now if now is not None else time.time()
+    return _iso_from_epoch(base + hours * 3600.0)
+
+
 # ---------------------------------------------------------------------------
 # Agent identity
 # ---------------------------------------------------------------------------
@@ -658,12 +668,17 @@ def build_entry(
     supersede_reason: str | None = None,
     source_session: str | None = None,
     evidence_sessions: list[str] | None = None,
+    dwell_until: str | None = None,
 ) -> dict[str, Any]:
     """
     Build a schema-valid, sanitized entry. Does NOT write.
 
     sanitize_content() is applied to BOTH `content` and `supersede_reason`
     (sec-4: every model-influenceable free-text field, not just content).
+
+    `dwell_until` (optimistic-memory §3.2), if given, is carried on the
+    returned dict and threaded into the `add` op-event by `append_entry()` --
+    absent means "live immediately" (backward-compatible default).
     """
     sanitized = sanitize_content(content)
     sanitized_reason = sanitize_content(supersede_reason) if supersede_reason else None
@@ -687,6 +702,7 @@ def build_entry(
         "supersede_reason": sanitized_reason,
         "source_session": source_session,
         "evidence_sessions": list(evidence_sessions) if evidence_sessions else [],
+        "dwell_until": dwell_until,
     }
     validate_entry(entry)
     return entry
@@ -763,15 +779,26 @@ def _build_op_row(
     supersede_reason: str | None = None,
     event_id: str | None = None,
     auto: bool = False,
+    dwell_until: str | None = None,
 ) -> dict[str, Any]:
     """Build a canonical v2 op-event row (§3.3 schema). Does not write.
 
-    `auto` (adrev-404) marks an UNATTENDED verify (dreaming auto-apply). It
-    is set ONLY on a `verify` op-row and ONLY when True; every other op, and
-    every human verify, omits the key entirely -- so the on-disk shape is
-    byte-identical to every op-event already written (absence == human,
-    backward-compatible). The projection reads it to skip the `last_verified`
-    refresh for auto-verifies; see `_apply_op`.
+    `auto` (adrev-404, widened by adrev-opt-008) marks an UNATTENDED write
+    (dreaming auto-apply/auto-integration). It is set on ANY op-row when
+    True; every op omits the key entirely when False -- so the on-disk
+    shape is byte-identical to every op-event already written for a human
+    write (absence == human, backward-compatible). Only the `verify` fold
+    path (`_apply_op`) currently reads it to skip the `last_verified`
+    refresh for auto-verifies; every other op carries it purely for
+    audit/reporting.
+
+    `dwell_until` (optimistic-memory §3.2) marks a row WRITTEN but not yet
+    read-eligible: an ISO-8601 UTC string, or None (immediately live --
+    absence means "live", same convention as `auto`). Written only when
+    non-None. This builder only stamps the op-event; the fold layer
+    (`_seed_head_from_add_event`, `_seed_head_from_supersede_event`,
+    `_apply_op`) is what propagates it to the projected head and enforces
+    the "only extends, never shortens" invariant.
     """
     row: dict[str, Any] = {
         "id": event_id or uuid.uuid4().hex[:12],
@@ -794,12 +821,14 @@ def _build_op_row(
         "last_verified": timestamp,
         "deprecated": True if op == "deprecate" else (False if op == "add" else None),
     }
-    if auto and op == "verify":
+    if auto:
         row["auto"] = True
+    if dwell_until is not None:
+        row["dwell_until"] = dwell_until
     return row
 
 
-def append_entry(entry: dict[str, Any], slug: str | None = None) -> Path:
+def append_entry(entry: dict[str, Any], slug: str | None = None, *, auto: bool = False) -> Path:
     """
     Append a pre-validated entry as a v2 `add` op-event to the writer's own
     shard (§3.3 -- ALL new writes land in agents/<agent_id>.jsonl; the
@@ -809,6 +838,11 @@ def append_entry(entry: dict[str, Any], slug: str | None = None) -> Path:
     Raises GlobalPromotionError if `slug` (or `entry["project"]`) resolves
     to `_global` and CCGM_LEARNINGS_ADMIN=1 is not set -- the general write
     path never lands `_global` content otherwise; see `promote_to_global()`.
+
+    `auto` (adrev-opt-008) marks this `add` as unattended (dreaming
+    auto-integration) for audit/reporting -- see `_build_op_row`.
+    `dwell_until`, if present on `entry` (via `build_entry(dwell_until=...)`),
+    is threaded to the op-event unchanged (optimistic-memory §3.2).
     """
     validate_entry(entry)
     target_slug = slug or entry.get("project") or detect_project_slug()
@@ -825,7 +859,7 @@ def append_entry(entry: dict[str, Any], slug: str | None = None) -> Path:
         type_=entry["type"], source=entry.get("source", "observed"), content=entry["content"],
         confidence=entry["confidence"], tags=entry.get("tags", []), files=entry.get("files", []),
         key=entry.get("key"), source_session=entry.get("source_session"),
-        event_id=entry["id"],
+        event_id=entry["id"], auto=auto, dwell_until=entry.get("dwell_until"),
     )
     if entry.get("evidence_sessions"):
         row["evidence_sessions"] = list(entry["evidence_sessions"])
@@ -912,6 +946,22 @@ def _fold_sort_key(line: dict[str, Any]) -> tuple[float, str]:
     return (_parse_iso(line.get("timestamp", "")), line.get("id") or "")
 
 
+def _max_dwell(existing: str | None, new: str | None) -> str | None:
+    """Combine two `dwell_until` ISO strings, keeping whichever is LATER
+    (optimistic-memory §3.2: a row's dwell only ever extends, never
+    shortens). `None` is the absence of a floor -- a missing `new` keeps
+    `existing` unchanged; a missing `existing` adopts `new` outright.
+    Comparison goes through `_parse_iso` (not raw string ordering) so a
+    malformed value always loses to a valid one instead of potentially
+    winning by lexicographic accident; this is what makes the invariant
+    hold at the FOLD layer regardless of what a caller supplies."""
+    if not new:
+        return existing
+    if not existing:
+        return new
+    return new if _parse_iso(new) > _parse_iso(existing) else existing
+
+
 def _seed_head_from_add_event(event: dict[str, Any]) -> dict[str, Any]:
     """Phase A: materialize a fresh head from a v2 `add` op-event (adrev-007:
     v2 adds seed EMPTY counters, unlike legacy rows which seed verbatim)."""
@@ -937,12 +987,21 @@ def _seed_head_from_add_event(event: dict[str, Any]) -> dict[str, Any]:
         "supersede_reason": None,
         "writer": event.get("writer"),
         "source_session": event.get("source_session"),
+        "dwell_until": event.get("dwell_until"),
     }
 
 
 def _seed_head_from_supersede_event(event: dict[str, Any], old_head: dict[str, Any]) -> dict[str, Any]:
     """Phase B: a `supersede` op-event both mutates its target AND seeds a
-    brand-new head -- it is the one non-`add` op that introduces a fresh id."""
+    brand-new head -- it is the one non-`add` op that introduces a fresh id.
+
+    The new head's `dwell_until` is `max(old_head.dwell_until,
+    event.dwell_until)` (optimistic-memory §3.2 P0 security invariant): a
+    supersede can extend a target's dwell but never shorten it, which is
+    what stops "chain a cheap supersede to release a quarantined row early"
+    from working -- enforced here, at the fold layer, not trusted from a
+    caller-supplied flag.
+    """
     content = event.get("content") or ""
     type_ = event.get("type") or old_head.get("type")
     return {
@@ -966,6 +1025,7 @@ def _seed_head_from_supersede_event(event: dict[str, Any], old_head: dict[str, A
         "supersede_reason": event.get("supersede_reason"),
         "writer": event.get("writer"),
         "source_session": event.get("source_session"),
+        "dwell_until": _max_dwell(old_head.get("dwell_until"), event.get("dwell_until")),
     }
 
 
@@ -984,10 +1044,15 @@ def _apply_op(heads: dict[str, dict[str, Any]], op: dict[str, Any], target: dict
         # `last_verified` exactly as before.
         if not op.get("auto"):
             target["last_verified"] = op.get("timestamp") or target.get("last_verified")
+        # optimistic-memory §3.2: a `--dwell-hours` floor on a verify can only
+        # extend the target's existing dwell, never shorten it (_max_dwell).
+        target["dwell_until"] = _max_dwell(target.get("dwell_until"), op.get("dwell_until"))
     elif kind == "contradict":
         target["contradictions"] = int(target.get("contradictions", 0)) + 1
+        target["dwell_until"] = _max_dwell(target.get("dwell_until"), op.get("dwell_until"))
     elif kind == "deprecate":
         target["deprecated"] = True
+        target["dwell_until"] = _max_dwell(target.get("dwell_until"), op.get("dwell_until"))
     elif kind == "supersede":
         new_id = op["id"]
         prior = target.get("superseded_by")
@@ -1484,6 +1549,28 @@ def is_stale(
     return (now_ts - ts) / 86400.0 > stale_days
 
 
+def is_dwelling(
+    entry: dict[str, Any],
+    *,
+    now: float | None = None,
+) -> bool:
+    """
+    True iff `entry["dwell_until"]` parses to a time strictly after `now`
+    (optimistic-memory §3.2): the row was committed but has not yet reached
+    its read-eligibility window. Absent or malformed `dwell_until` -> False
+    (fail-open to "live" -- a parse bug must never trap a row in permanent
+    dwell). Mirrors `is_stale()`'s `now: float | None = None` override shape.
+    """
+    dwell_until = entry.get("dwell_until")
+    if not dwell_until:
+        return False
+    ts = _parse_iso(dwell_until)
+    if ts <= 0:
+        return False
+    now_ts = now if now is not None else time.time()
+    return ts > now_ts
+
+
 def has_stale_file_refs(entry: dict[str, Any], repo_root: Path | None = None) -> bool:
     """
     If entry lists files and a repo_root is provided, return True when any
@@ -1581,14 +1668,19 @@ def search(
     token_budget: int | None = None,
     include_stale: bool = False,
     include_superseded: bool = False,
+    include_dwelling: bool = False,
     config: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """
     Return a ranked, filtered, token-capped list of learnings.
 
     The caller is expected to inject this into a command preamble or skill
-    context. Results are already sanitized; deprecated, superseded, and
-    stale-below-threshold entries are excluded by default.
+    context. Results are already sanitized; deprecated, superseded,
+    stale-below-threshold, and (optimistic-memory §3.2) dwelling entries are
+    excluded by default. A dwelling row is still resolvable via `load_all()`
+    and by id (`update_entry_by_id`/`supersede_entry`) -- only this ranked,
+    injectable result set hides it, mirroring `include_stale`/
+    `include_superseded`.
     """
     cfg = config or load_config()
     half_life = float(cfg.get("half_life_days", DEFAULT_HALF_LIFE_DAYS))
@@ -1631,6 +1723,10 @@ def search(
         if eff < threshold:
             continue
         if not include_stale and is_stale(e, stale_days=stale_days, now=now):
+            continue
+        # optimistic-memory §3.2: exclude a row still inside its dwell_until
+        # window by default -- mirrors the include_stale guard immediately above.
+        if not include_dwelling and is_dwelling(e, now=now):
             continue
         rel = score_relevance(e, query, tags)
         # Rank: effective confidence (0-10) weighted with relevance (0-1)
@@ -1784,6 +1880,7 @@ def update_entry_by_id(
     expected_sha256: str | None = None,
     source_session: str | None = None,
     auto: bool = False,
+    dwell_until: str | None = None,
 ) -> bool:
     """
     Mutate a chain head by appending verify/contradict/deprecate op-event(s)
@@ -1796,9 +1893,15 @@ def update_entry_by_id(
     `auto=True` (adrev-404) marks an UNATTENDED verify: it still bumps `uses`
     but the projection will NOT refresh `last_verified` for it (severing the
     decay/staleness reset so a nightly auto-apply cannot immortalize a row).
-    It is meaningful ONLY for `verify`; `_build_op_row` ignores it for
-    contradict/deprecate. Human verify (the default, `auto=False`) is
-    unchanged.
+    That specific `last_verified`-skip semantic is meaningful ONLY for
+    `verify`; the `auto` flag itself (adrev-opt-008) is now also accepted --
+    and stamped on disk -- for contradict/deprecate, purely for audit/
+    reporting. Human writes (the default, `auto=False`) are unchanged.
+
+    `dwell_until` (optimistic-memory §3.2), if given, is passed as a FLOOR
+    to every op-event emitted by this call; the fold layer (`_apply_op`)
+    applies `max(existing_target_dwell, new)`, so this can only extend --
+    never shorten -- the target's dwell.
 
     Raises GlobalPromotionError if the target's OWN `project` is `_global`
     and CCGM_LEARNINGS_ADMIN=1 is not set -- verify/contradict/deprecate
@@ -1840,15 +1943,11 @@ def update_entry_by_id(
     shard = agent_shard_path(target_proj, writer)
     for kind in kinds:
         ts = _next_writer_timestamp(shard)
-        # `auto` is threaded to every op-row, but _build_op_row only stamps it
-        # on a `verify` (adrev-404: meaningless for contradict/deprecate). The
-        # single-source-of-truth guard lives in _build_op_row, so a future
-        # caller cannot accidentally auto-flag a non-verify op.
         row = _build_op_row(
             op=kind, target_id=entry_id, project=target_proj, writer=writer, timestamp=ts,
             source_session=source_session,
             expected_sha256=expected_sha256 if kind == "deprecate" else None,
-            auto=auto,
+            auto=auto, dwell_until=dwell_until,
         )
         file_locked_append(str(shard), json.dumps(row, sort_keys=True))
     _maybe_autocommit()
@@ -1872,6 +1971,8 @@ def supersede_entry(
     reason: str | None = None,
     expected_sha256: str | None = None,
     source_session: str | None = None,
+    auto: bool = False,
+    dwell_until: str | None = None,
 ) -> dict[str, Any] | None:
     """
     Atomically replace one entry with a new one by appending a single
@@ -1887,6 +1988,13 @@ def supersede_entry(
     OriginBindingError if `source` would raise the tier without a fresh,
     transcript-verified `source_session`, §3.3). Returns the new entry
     dict, or None if `old_id` was not found.
+
+    `auto=True` (adrev-opt-008) marks this supersede as unattended (dreaming
+    auto-integration) for audit/reporting. `dwell_until` (optimistic-memory
+    §3.2), if given, is a FLOOR on the NEW head's dwell -- the fold layer
+    (`_seed_head_from_supersede_event`) takes `max(old_head.dwell_until,
+    dwell_until)`, so a supersede can never shorten the target's existing
+    dwell, only extend it.
     """
     target_slug = slug or detect_project_slug()
     heads = load_all(target_slug)
@@ -1936,6 +2044,7 @@ def supersede_entry(
         confidence=new_entry["confidence"], tags=new_entry["tags"], files=new_entry["files"],
         key=new_entry["key"], source_session=source_session,
         supersede_reason=new_entry["supersede_reason"], event_id=new_entry["id"],
+        auto=auto, dwell_until=dwell_until,
     )
     file_locked_append(str(shard), json.dumps(row, sort_keys=True))
 

--- a/modules/self-improving/lib/learnings_store.py
+++ b/modules/self-improving/lib/learnings_store.py
@@ -368,6 +368,17 @@ def _iso_from_epoch(epoch: float) -> str:
 def _parse_iso(s: str) -> float:
     """Parse ISO 8601 UTC string to epoch seconds. 0.0 on failure.
     Accepts both second- and millisecond-precision forms (trailing Z).
+
+    Catches (TypeError, ValueError) -- not just ValueError -- so a
+    non-string truthy `s` (a raw epoch int/float from a caller that
+    bypassed `dwell_until_from_hours()`, a corrupted merge artifact, or a
+    hand-edited shard) fails closed to the 0.0 sentinel instead of raising
+    out of `datetime.strptime`. Every caller here (`is_stale`,
+    `is_dwelling`, `_max_dwell`, `_fold_sort_key`) documents fail-open
+    behavior on a malformed value; a TypeError escaping this function
+    would crash `search()` for an entire project slug on one bad row
+    (matches the established idiom in learnings-inject.py's config-cast
+    guards).
     """
     if not s:
         return 0.0
@@ -375,7 +386,7 @@ def _parse_iso(s: str) -> float:
         try:
             dt = datetime.strptime(s, fmt).replace(tzinfo=timezone.utc)
             return dt.timestamp()
-        except ValueError:
+        except (TypeError, ValueError):
             continue
     return 0.0
 
@@ -2025,7 +2036,7 @@ def supersede_entry(
     new_entry = build_entry(
         type_=inherited_type, content=content, source=source, confidence=inherited_conf,
         tags=inherited_tags, files=inherited_files, project=target_proj,
-        supersedes=old_id, supersede_reason=reason,
+        supersedes=old_id, supersede_reason=reason, dwell_until=dwell_until,
     )
 
     # A tier-raising supersede is a transcript-verified, structurally

--- a/modules/self-improving/tests/test_dwell_window.py
+++ b/modules/self-improving/tests/test_dwell_window.py
@@ -203,6 +203,51 @@ class IsDwellingTests(unittest.TestCase):
         self.assertTrue(ls.is_dwelling({"dwell_until": dwell}, now=parsed - 10))
         self.assertFalse(ls.is_dwelling({"dwell_until": dwell}, now=parsed + 10))
 
+    def test_false_for_non_string_truthy_types_does_not_raise(self):
+        # A non-string truthy `dwell_until` (a raw epoch int/float from a
+        # caller that bypassed `dwell_until_from_hours()`, a corrupted
+        # merge artifact, or a hand-edited shard) must fail open to "not
+        # dwelling" rather than raise a TypeError out of `_parse_iso`'s
+        # `datetime.strptime` call (Stage-1 review finding: an uncaught
+        # TypeError here crashes `search()` for the whole project slug).
+        for bad_value in (12345, 12345.6, True, [1, 2, 3]):
+            with self.subTest(bad_value=bad_value):
+                self.assertFalse(ls.is_dwelling({"dwell_until": bad_value}))
+
+
+class MalformedDwellUntilFailOpenTests(unittest.TestCase):
+    """End-to-end reproduction of the Stage-1 review finding: a non-string
+    `dwell_until` on ONE row (a future caller bypassing
+    `dwell_until_from_hours()`, a corrupted merge artifact, or a hand-edited
+    shard) must never crash `search()` for the entire project slug -- it
+    must fail open and the rest of the pool must still surface normally."""
+
+    def setUp(self):
+        self.slug = f"dwell-malformed-{int(time.time() * 1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+
+    def test_search_survives_a_non_string_dwell_until_row_on_disk(self):
+        healthy = ls.build_entry(type_="pattern", content="healthy dwell fail-open target",
+                                  confidence=7)
+        ls.append_entry(healthy)
+
+        # dwell_until=12345 is not a schema violation (validate_entry()
+        # does not type-check this field) -- exactly how a raw epoch int
+        # would land on disk from a caller that skipped
+        # dwell_until_from_hours()'s string formatting.
+        malformed = ls.build_entry(type_="pattern", content="malformed dwell fail-open target",
+                                    confidence=7, dwell_until=12345)
+        ls.append_entry(malformed)
+
+        results = ls.search(slug=self.slug, query="")
+        ids = [r["id"] for r in results]
+        self.assertIn(healthy["id"], ids)
+
 
 class DwellInvariantTests(unittest.TestCase):
     """The 'only extends, never shortens' invariant, enforced at the fold
@@ -248,6 +293,25 @@ class DwellInvariantTests(unittest.TestCase):
         heads = {h["id"]: h for h in ls.load_all(self.slug)}
         new_head = heads[new_entry["id"]]
         self.assertEqual(new_head["dwell_until"], longer_dwell)
+
+    def test_supersede_return_value_threads_the_requested_dwell_floor(self):
+        # Stage-1 review finding: build_entry(...) inside supersede_entry()
+        # omitted dwell_until=dwell_until, so the RETURNED dict always
+        # reported dwell_until=None even though the op-row and the
+        # projected head correctly persisted the floor. On a target with
+        # no prior dwell (the common case), the returned entry's
+        # dwell_until must match the requested floor.
+        e = ls.build_entry(type_="pattern", content="supersede return value target",
+                            confidence=8)
+        ls.append_entry(e)
+        sha = ls.content_sha256(e["content"])
+
+        floor = ls.dwell_until_from_hours(5)
+        new_entry = ls.supersede_entry(
+            e["id"], content="revised content for return value check",
+            expected_sha256=sha, dwell_until=floor,
+        )
+        self.assertEqual(new_entry["dwell_until"], floor)
 
     def test_verify_dwell_hours_cannot_shorten_targets_dwell(self):
         long_dwell = ls.dwell_until_from_hours(10)
@@ -340,6 +404,14 @@ class MaxDwellHelperTests(unittest.TestCase):
     def test_malformed_new_does_not_override_valid_existing(self):
         existing = ls.dwell_until_from_hours(1)
         self.assertEqual(ls._max_dwell(existing, "not-a-date"), existing)
+
+    def test_non_string_existing_loses_to_valid_new_without_raising(self):
+        new = ls.dwell_until_from_hours(1)
+        self.assertEqual(ls._max_dwell(12345, new), new)
+
+    def test_non_string_new_does_not_override_valid_existing_without_raising(self):
+        existing = ls.dwell_until_from_hours(1)
+        self.assertEqual(ls._max_dwell(existing, 12345), existing)
 
 
 # ---------------------------------------------------------------------------

--- a/modules/self-improving/tests/test_dwell_window.py
+++ b/modules/self-improving/tests/test_dwell_window.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""
+Tests for the dwell-window store lifecycle (optimistic-memory §3.2, Epic 1).
+
+Covers:
+  - `dwell_until` propagation from op-event -> projected head (the P0
+    regression-lock -- write-to-disk alone is inert without this).
+  - `search()`'s `include_dwelling` guard: hidden by default, present via
+    `load_all()` (CAS/by-id resolution must still work), present with
+    `include_dwelling=True`, present by default once the window closes.
+  - `is_dwelling()`: absent/malformed -> False; future -> True; past ->
+    False; explicit `now` override.
+  - The "only extends, never shortens" invariant, enforced at the fold
+    layer for both `supersede` and `verify --dwell-hours`.
+  - `ccgm-learnings-search --include-dwelling` CLI wiring.
+  - The `--auto` flag widened to add/contradict/deprecate/supersede
+    (adrev-opt-008), asserted against the real CLI write path.
+
+Runs in isolation: redirects LEARNINGS_ROOT to a tempdir so tests never
+touch the real ~/.claude/learnings/ store. Mirrors the isolation pattern
+in test_learnings_store.py exactly (see that file's comments for why the
+sys.modules.pop() and env-var-before-import ordering matter).
+
+Run with: python3 -m pytest modules/self-improving/tests/test_dwell_window.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / "lib"))
+
+# See test_learnings_store.py's identical guard (#764): drop any
+# pre-existing `learnings_store` module-cache entry from an earlier import
+# under the same bare name (e.g. modules/dreaming's transcript_miner.py
+# also imports it) before re-importing, so this file's CCGM_LEARNINGS_DIR
+# override below is guaranteed to take effect rather than reusing a stale
+# cached module pointed at a different store.
+sys.modules.pop("learnings_store", None)
+
+_TMP = tempfile.mkdtemp(prefix="ccgm-dwell-test-")
+_ORIG_CCGM_LEARNINGS_DIR = os.environ.get("CCGM_LEARNINGS_DIR")
+os.environ["CCGM_LEARNINGS_DIR"] = _TMP
+
+import learnings_store as ls  # noqa: E402
+
+CLI_PATH = HERE.parent / "bin" / "ccgm-learnings-log"
+SEARCH_CLI_PATH = HERE.parent / "bin" / "ccgm-learnings-search"
+
+
+def tearDownModule() -> None:
+    """Undo the module-level CCGM_LEARNINGS_DIR override (see
+    test_learnings_store.py's identical function for the full #764
+    rationale: this must run so a leaked env var cannot break a different
+    test module collected later in the same pytest process)."""
+    if _ORIG_CCGM_LEARNINGS_DIR is not None:
+        os.environ["CCGM_LEARNINGS_DIR"] = _ORIG_CCGM_LEARNINGS_DIR
+    else:
+        os.environ.pop("CCGM_LEARNINGS_DIR", None)
+    shutil.rmtree(_TMP, ignore_errors=True)
+    shutil.rmtree(ls.LEARNINGS_CACHE_ROOT, ignore_errors=True)
+
+
+def _isolate_env(testcase: unittest.TestCase, key: str) -> None:
+    """Snapshot os.environ[key] and register a restoring addCleanup --
+    identical helper to test_learnings_store.py's, duplicated here so this
+    file has no import-time dependency on that module."""
+    had_prior = key in os.environ
+    prior = os.environ.get(key)
+
+    def _restore() -> None:
+        if had_prior:
+            os.environ[key] = prior
+        else:
+            os.environ.pop(key, None)
+
+    testcase.addCleanup(_restore)
+
+
+class DwellPropagationTests(unittest.TestCase):
+    """The P0 regression-lock: an op-event written with `dwell_until`
+    must be readable back on the PROJECTED HEAD, not just present on the
+    op-event line on disk."""
+
+    def setUp(self):
+        self.slug = f"dwell-add-{int(time.time() * 1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+
+    def test_add_dwell_until_propagates_to_load_all_head(self):
+        dwell = ls.dwell_until_from_hours(1)
+        e = ls.build_entry(type_="pattern", content="dwelling propagation target",
+                            confidence=7, dwell_until=dwell)
+        ls.append_entry(e)
+
+        heads = ls.load_all(self.slug)
+        self.assertEqual(len(heads), 1)
+        self.assertEqual(heads[0].get("dwell_until"), dwell)
+
+    def test_add_without_dwell_hours_is_immediately_live(self):
+        # Backward compatibility: absent dwell_until means live (no key on
+        # the op-event, no key on the head -- same "absence == default"
+        # convention as `auto`).
+        e = ls.build_entry(type_="pattern", content="no dwell target", confidence=7)
+        ls.append_entry(e)
+        head = ls.load_all(self.slug)[0]
+        self.assertIsNone(head.get("dwell_until"))
+        self.assertFalse(ls.is_dwelling(head))
+
+
+class DwellSearchVisibilityTests(unittest.TestCase):
+    """search()'s include_dwelling guard: hidden by default, resolvable via
+    load_all() (CAS/by-id must still work), surfaced by the flag, and
+    surfaced by default once the window has closed."""
+
+    def setUp(self):
+        self.slug = f"dwell-search-{int(time.time() * 1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+
+    def test_dwelling_row_hidden_from_default_search(self):
+        dwell = ls.dwell_until_from_hours(1)
+        e = ls.build_entry(type_="pattern", content="dwelling search visibility target",
+                            confidence=7, dwell_until=dwell)
+        ls.append_entry(e)
+
+        results = ls.search(slug=self.slug, query="dwelling search visibility target")
+        self.assertNotIn(e["id"], [r["id"] for r in results])
+
+    def test_dwelling_row_still_resolvable_via_load_all(self):
+        # load_all()/by-id resolution (update_entry_by_id, supersede_entry,
+        # the CAS re-check) must still see a dwelling row -- only the
+        # ranked search() result set hides it (integration-map.md §A.5/A.9).
+        dwell = ls.dwell_until_from_hours(1)
+        e = ls.build_entry(type_="pattern", content="dwelling load-all target",
+                            confidence=7, dwell_until=dwell)
+        ls.append_entry(e)
+
+        heads = ls.load_all(self.slug)
+        self.assertEqual(len(heads), 1)
+        self.assertEqual(heads[0]["id"], e["id"])
+
+    def test_dwelling_row_surfaced_by_include_dwelling(self):
+        dwell = ls.dwell_until_from_hours(1)
+        e = ls.build_entry(type_="pattern", content="dwelling flag surfaced target",
+                            confidence=7, dwell_until=dwell)
+        ls.append_entry(e)
+
+        surfaced = ls.search(slug=self.slug, query="dwelling flag surfaced target",
+                              include_dwelling=True)
+        self.assertIn(e["id"], [r["id"] for r in surfaced])
+
+    def test_row_present_in_default_search_once_window_has_closed(self):
+        # Constructed with dwell_until firmly in the PAST relative to real
+        # wall-clock time.time() (which search() uses internally and takes
+        # no `now` override for) -- deterministic, no sleep required.
+        past_dwell = ls.dwell_until_from_hours(-1)
+        e = ls.build_entry(type_="pattern", content="dwell window closed target",
+                            confidence=7, dwell_until=past_dwell)
+        ls.append_entry(e)
+
+        results = ls.search(slug=self.slug, query="dwell window closed target")
+        self.assertIn(e["id"], [r["id"] for r in results])
+
+
+class IsDwellingTests(unittest.TestCase):
+    """Unit tests for the pure is_dwelling() helper."""
+
+    def test_false_for_absent(self):
+        self.assertFalse(ls.is_dwelling({}))
+
+    def test_false_for_malformed(self):
+        self.assertFalse(ls.is_dwelling({"dwell_until": "not-a-real-timestamp"}))
+
+    def test_true_for_future(self):
+        future = ls.dwell_until_from_hours(1)
+        self.assertTrue(ls.is_dwelling({"dwell_until": future}))
+
+    def test_false_for_past(self):
+        past = ls.dwell_until_from_hours(-1)
+        self.assertFalse(ls.is_dwelling({"dwell_until": past}))
+
+    def test_respects_explicit_now_override(self):
+        dwell = ls.dwell_until_from_hours(1)
+        parsed = ls._parse_iso(dwell)
+        self.assertTrue(ls.is_dwelling({"dwell_until": dwell}, now=parsed - 10))
+        self.assertFalse(ls.is_dwelling({"dwell_until": dwell}, now=parsed + 10))
+
+
+class DwellInvariantTests(unittest.TestCase):
+    """The 'only extends, never shortens' invariant, enforced at the fold
+    layer for both supersede and verify/contradict/deprecate --dwell-hours."""
+
+    def setUp(self):
+        self.slug = f"dwell-invariant-{int(time.time() * 1e6)}"
+        _isolate_env(self, "CCGM_LEARNINGS_PROJECT")
+        os.environ["CCGM_LEARNINGS_PROJECT"] = self.slug
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+
+    def test_supersede_cannot_shorten_targets_dwell(self):
+        long_dwell = ls.dwell_until_from_hours(10)
+        e = ls.build_entry(type_="pattern", content="quarantined supersede target",
+                            confidence=8, dwell_until=long_dwell)
+        ls.append_entry(e)
+        sha = ls.content_sha256(e["content"])
+
+        short_dwell = ls.dwell_until_from_hours(1)
+        new_entry = ls.supersede_entry(
+            e["id"], content="rewritten sooner-exposed content",
+            expected_sha256=sha, dwell_until=short_dwell,
+        )
+        heads = {h["id"]: h for h in ls.load_all(self.slug)}
+        new_head = heads[new_entry["id"]]
+        self.assertEqual(new_head["dwell_until"], long_dwell)
+
+    def test_supersede_extends_when_new_dwell_is_longer(self):
+        short_dwell = ls.dwell_until_from_hours(1)
+        e = ls.build_entry(type_="pattern", content="extend via supersede target",
+                            confidence=8, dwell_until=short_dwell)
+        ls.append_entry(e)
+        sha = ls.content_sha256(e["content"])
+
+        longer_dwell = ls.dwell_until_from_hours(10)
+        new_entry = ls.supersede_entry(
+            e["id"], content="rewritten with a longer dwell",
+            expected_sha256=sha, dwell_until=longer_dwell,
+        )
+        heads = {h["id"]: h for h in ls.load_all(self.slug)}
+        new_head = heads[new_entry["id"]]
+        self.assertEqual(new_head["dwell_until"], longer_dwell)
+
+    def test_verify_dwell_hours_cannot_shorten_targets_dwell(self):
+        long_dwell = ls.dwell_until_from_hours(10)
+        e = ls.build_entry(type_="pattern", content="verify shorten target",
+                            confidence=8, dwell_until=long_dwell)
+        ls.append_entry(e)
+
+        short_dwell = ls.dwell_until_from_hours(1)
+        self.assertTrue(ls.update_entry_by_id(e["id"], verify=True, dwell_until=short_dwell))
+
+        head = ls.load_all(self.slug)[0]
+        self.assertEqual(head["dwell_until"], long_dwell)
+
+    def test_verify_dwell_hours_extends_when_longer(self):
+        short_dwell = ls.dwell_until_from_hours(1)
+        e = ls.build_entry(type_="pattern", content="verify extend target",
+                            confidence=8, dwell_until=short_dwell)
+        ls.append_entry(e)
+
+        longer_dwell = ls.dwell_until_from_hours(10)
+        self.assertTrue(ls.update_entry_by_id(e["id"], verify=True, dwell_until=longer_dwell))
+
+        head = ls.load_all(self.slug)[0]
+        self.assertEqual(head["dwell_until"], longer_dwell)
+
+    def test_contradict_dwell_hours_cannot_shorten_targets_dwell(self):
+        long_dwell = ls.dwell_until_from_hours(10)
+        e = ls.build_entry(type_="pattern", content="contradict shorten target",
+                            confidence=8, dwell_until=long_dwell)
+        ls.append_entry(e)
+
+        short_dwell = ls.dwell_until_from_hours(1)
+        self.assertTrue(ls.update_entry_by_id(e["id"], contradict=True, dwell_until=short_dwell))
+
+        head = ls.load_all(self.slug)[0]
+        self.assertEqual(head["dwell_until"], long_dwell)
+
+    def test_deprecate_dwell_hours_cannot_shorten_targets_dwell(self):
+        long_dwell = ls.dwell_until_from_hours(10)
+        e = ls.build_entry(type_="pattern", content="deprecate shorten target",
+                            confidence=8, dwell_until=long_dwell)
+        ls.append_entry(e)
+
+        short_dwell = ls.dwell_until_from_hours(1)
+        self.assertTrue(ls.update_entry_by_id(e["id"], deprecate=True, dwell_until=short_dwell))
+
+        head = ls.load_all(self.slug)[0]
+        self.assertEqual(head["dwell_until"], long_dwell)
+
+    def test_verify_dwell_hours_starts_a_dwell_when_target_had_none(self):
+        # existing=None adopts the new floor outright (max() with -infinity).
+        e = ls.build_entry(type_="pattern", content="verify starts dwell target", confidence=8)
+        ls.append_entry(e)
+        self.assertIsNone(ls.load_all(self.slug)[0].get("dwell_until"))
+
+        new_dwell = ls.dwell_until_from_hours(1)
+        self.assertTrue(ls.update_entry_by_id(e["id"], verify=True, dwell_until=new_dwell))
+        head = ls.load_all(self.slug)[0]
+        self.assertEqual(head["dwell_until"], new_dwell)
+
+
+class MaxDwellHelperTests(unittest.TestCase):
+    """Direct unit coverage of the _max_dwell() comparison helper."""
+
+    def test_new_none_keeps_existing(self):
+        existing = ls.dwell_until_from_hours(5)
+        self.assertEqual(ls._max_dwell(existing, None), existing)
+
+    def test_existing_none_adopts_new(self):
+        new = ls.dwell_until_from_hours(5)
+        self.assertEqual(ls._max_dwell(None, new), new)
+
+    def test_both_none_stays_none(self):
+        self.assertIsNone(ls._max_dwell(None, None))
+
+    def test_later_new_wins(self):
+        existing = ls.dwell_until_from_hours(1)
+        new = ls.dwell_until_from_hours(10)
+        self.assertEqual(ls._max_dwell(existing, new), new)
+
+    def test_earlier_new_loses(self):
+        existing = ls.dwell_until_from_hours(10)
+        new = ls.dwell_until_from_hours(1)
+        self.assertEqual(ls._max_dwell(existing, new), existing)
+
+    def test_malformed_existing_loses_to_valid_new(self):
+        new = ls.dwell_until_from_hours(1)
+        self.assertEqual(ls._max_dwell("not-a-date", new), new)
+
+    def test_malformed_new_does_not_override_valid_existing(self):
+        existing = ls.dwell_until_from_hours(1)
+        self.assertEqual(ls._max_dwell(existing, "not-a-date"), existing)
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+class DwellCLITests(unittest.TestCase):
+    def setUp(self):
+        self.slug = f"dwell-cli-{int(time.time() * 1e6)}"
+
+    def _env(self, **extra) -> dict:
+        # Pin the store dir to THIS module's frozen LEARNINGS_ROOT (matches
+        # test_learnings_store.py's CLIExitCodeTests._env() rationale: a
+        # sibling test module's import-time CCGM_LEARNINGS_DIR override,
+        # collected in the same pytest run, must not leak into the
+        # subprocess launched here).
+        env = os.environ.copy()
+        env["CCGM_LEARNINGS_DIR"] = str(ls.LEARNINGS_ROOT)
+        env["CCGM_LEARNINGS_PROJECT"] = self.slug
+        env.update(extra)
+        return env
+
+    def _run_log(self, args: list) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(CLI_PATH)] + args,
+            env=self._env(), capture_output=True, text=True,
+        )
+
+    def _run_search(self, args: list) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(SEARCH_CLI_PATH)] + args,
+            env=self._env(), capture_output=True, text=True,
+        )
+
+    def tearDown(self):
+        shutil.rmtree(ls.project_dir(self.slug), ignore_errors=True)
+        shutil.rmtree(ls._cache_dir(self.slug), ignore_errors=True)
+
+    def _shard_rows(self) -> list:
+        shard = ls.agent_shard_path(self.slug, ls.agent_id())
+        if not shard.is_file():
+            return []
+        return [json.loads(ln) for ln in shard.read_text().splitlines() if ln.strip()]
+
+    def _only_row(self, *, op: str, target_id, entry_id: str | None = None) -> dict:
+        rows = [r for r in self._shard_rows() if r.get("op") == op and r.get("target_id") == target_id]
+        if entry_id is not None:
+            rows = [r for r in rows if r.get("id") == entry_id]
+        self.assertEqual(len(rows), 1, f"expected exactly one {op} row, got {rows}")
+        return rows[0]
+
+    def test_cli_include_dwelling_flag_surfaces_dwelling_row(self):
+        add = self._run_log([
+            "--type", "pattern", "--content", "cli dwelling search target",
+            "--dwell-hours", "1",
+        ])
+        self.assertEqual(add.returncode, 0, add.stderr)
+        entry_id = json.loads(add.stdout)["id"]
+
+        bare = self._run_search([
+            "--project", self.slug, "--query", "cli dwelling search target", "--format", "jsonl",
+        ])
+        self.assertEqual(bare.returncode, 0, bare.stderr)
+        self.assertNotIn(entry_id, bare.stdout)
+
+        surfaced = self._run_search([
+            "--project", self.slug, "--query", "cli dwelling search target",
+            "--include-dwelling", "--format", "jsonl",
+        ])
+        self.assertEqual(surfaced.returncode, 0, surfaced.stderr)
+        self.assertIn(entry_id, surfaced.stdout)
+
+    def test_cli_add_auto_flag_writes_auto_true_on_disk(self):
+        result = self._run_log([
+            "--type", "pattern", "--content", "cli auto add target", "--auto",
+        ])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        entry_id = json.loads(result.stdout)["id"]
+        row = self._only_row(op="add", target_id=None, entry_id=entry_id)
+        self.assertIs(row.get("auto"), True)
+
+    def test_cli_add_without_auto_omits_the_key(self):
+        result = self._run_log(["--type", "pattern", "--content", "cli non-auto add target"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        entry_id = json.loads(result.stdout)["id"]
+        row = self._only_row(op="add", target_id=None, entry_id=entry_id)
+        self.assertNotIn("auto", row)
+
+    def test_cli_contradict_auto_flag_writes_auto_true_on_disk(self):
+        add = self._run_log(["--type", "pattern", "--content", "cli auto contradict target"])
+        entry_id = json.loads(add.stdout)["id"]
+
+        result = self._run_log(["contradict", entry_id, "--project", self.slug, "--auto"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        row = self._only_row(op="contradict", target_id=entry_id)
+        self.assertIs(row.get("auto"), True)
+
+    def test_cli_deprecate_auto_flag_writes_auto_true_on_disk(self):
+        content = "cli auto deprecate target"
+        add = self._run_log(["--type", "pattern", "--content", content])
+        entry_id = json.loads(add.stdout)["id"]
+        sha = ls.content_sha256(content)
+
+        result = self._run_log([
+            "deprecate", entry_id, "--project", self.slug, "--expected-sha", sha, "--auto",
+        ])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        row = self._only_row(op="deprecate", target_id=entry_id)
+        self.assertIs(row.get("auto"), True)
+
+    def test_cli_supersede_auto_flag_writes_auto_true_on_disk(self):
+        content = "cli auto supersede target"
+        add = self._run_log(["--type", "pattern", "--content", content])
+        entry_id = json.loads(add.stdout)["id"]
+        sha = ls.content_sha256(content)
+
+        result = self._run_log([
+            "supersede", entry_id, "--project", self.slug,
+            "--content", "revised via cli auto supersede", "--expected-sha", sha, "--auto",
+        ])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        new_id = json.loads(result.stdout)["id"]
+        row = self._only_row(op="supersede", target_id=entry_id, entry_id=new_id)
+        self.assertIs(row.get("auto"), True)
+
+    def test_cli_verify_dwell_hours_floor_reaches_the_head(self):
+        long_dwell_hours = 10
+        add = self._run_log([
+            "--type", "pattern", "--content", "cli verify dwell floor target",
+            "--dwell-hours", str(long_dwell_hours),
+        ])
+        self.assertEqual(add.returncode, 0, add.stderr)
+        entry_id = json.loads(add.stdout)["id"]
+        before = ls.load_all(self.slug)[0]
+
+        result = self._run_log([
+            "verify", entry_id, "--project", self.slug, "--dwell-hours", "1",
+        ])
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        after = ls.load_all(self.slug)[0]
+        # A 1-hour floor must not shorten the existing ~10-hour dwell.
+        self.assertEqual(after["dwell_until"], before["dwell_until"])
+
+
+def _cleanup():
+    shutil.rmtree(_TMP, ignore_errors=True)
+    shutil.rmtree(ls.LEARNINGS_CACHE_ROOT, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    try:
+        unittest.main(verbosity=2, exit=False)
+    finally:
+        _cleanup()


### PR DESCRIPTION
## Summary

Epic 1 of the [optimistic-memory plan](https://github.com/lucasmccomb/ccgm/blob/main/../plans/ccgm-optimistic-memory/plan.md) (§5). Adds `dwell_until` end-to-end in the learnings store so a committed row stays invisible to agent context (`search()`/injection) until its dwell window closes, and widens `auto` emission from verify-only to every op-kind (the foundation Epic 3's optimistic-integration engine needs).

Closes #799.

## Changes

- `modules/self-improving/lib/learnings_store.py`
  - New `dwell_until_from_hours()` helper, centralizing the `--dwell-hours` -> ISO timestamp computation.
  - `build_entry()` / `append_entry()` / `_build_op_row()` accept and thread an optional `dwell_until`.
  - **Fold-layer propagation (the load-bearing part)**: `_seed_head_from_add_event`, `_seed_head_from_supersede_event`, and `_apply_op`'s counter-op path (verify/contradict/deprecate) all copy `dwell_until` onto the projected head — write-to-disk alone would otherwise be inert.
  - New `_max_dwell()` helper enforces the "only extends, never shortens" invariant at the fold layer (not trusted from a caller-supplied value): a supersede's new head takes `max(old_head.dwell_until, event.dwell_until)`; a verify/contradict/deprecate `--dwell-hours` floor is likewise `max(existing, new)`.
  - New `is_dwelling(entry, *, now=None)` beside `is_stale()`: true iff `dwell_until` parses to a time strictly after `now`; absent/malformed fails open to "live."
  - `search()` gains `include_dwelling: bool = False`, guarding immediately after the existing `include_stale` check — mirrors that exact precedent. A dwelling row stays resolvable via `load_all()`/by-id (so `/dream-review` accept-veto and the CAS re-check keep working), only the ranked/injectable result set hides it.
  - `auto` is no longer restricted to `op == "verify"` in `_build_op_row` — any op may now carry it (audit/reporting only; the `last_verified`-skip fold semantic stays verify-specific). Threaded through `append_entry`, `update_entry_by_id`, and `supersede_entry`.
- `modules/self-improving/bin/ccgm-learnings-log`
  - `--dwell-hours <int>` added to the default `add` handler and to `verify`/`contradict`/`deprecate`/`supersede`.
  - `--auto` added to `add`/`contradict`/`deprecate`/`supersede` (`verify` already had it).
- `modules/self-improving/bin/ccgm-learnings-search`
  - `--include-dwelling` flag, mirroring `--include-stale`/`--include-superseded`.
- `modules/self-improving/tests/test_dwell_window.py` (new)
  - Propagation regression-lock, search visibility (hidden by default / resolvable via `load_all` / surfaced by the flag / surfaced by default once the window closes), `is_dwelling` unit tests, the extend-never-shorten invariant for supersede/verify/contradict/deprecate, a direct `_max_dwell` unit suite, and CLI-driven `--auto` emission assertions against the real write path.

## Test plan

- [x] `python3 -m pytest modules/self-improving/tests/test_dwell_window.py -q` — 32 passed
- [x] `python3 -m pytest modules/self-improving/tests/ -q` — 198 passed, 4 subtests passed (no regressions)
- [x] `python3 -m pytest modules/dreaming/tests/ modules/self-improving/tests/ -q` — 443 passed, 4 subtests passed (no regressions in the dependent dreaming module)
- [x] `grep -n "dwell_until" modules/self-improving/lib/learnings_store.py` shows it in `_build_op_row`, all three head-seed/mutation paths, `is_dwelling`, and the `search()` guard
- [x] `bash tests/test-no-personal-data.sh` — pass