### PR TITLE
#801: optimistic auto-integration engine + blast caps + batch anomaly + windowed circuit breaker (Epic 3)

### DIFF
--- a/modules/dreaming/bin/dream-daily.sh
+++ b/modules/dreaming/bin/dream-daily.sh
@@ -125,14 +125,16 @@ run_step() {
 # ---------------------------------------------------------------------
 # Shared config gate: is optimistic auto-integration active?
 #
-# True iff EITHER `optimistic_integration.enabled` (the real, post-Epic-3
-# flag) OR the legacy `auto_apply_counters` (pre-Epic-3, still read by
-# Epic 8's not-yet-landed migration) is true. Epic 8 will formally migrate
-# a `true` `auto_apply_counters` into `optimistic_integration.enabled` on
-# first read; until that lands, this OR keeps existing
-# `auto_apply_counters:true` configurations (and the fail-closed behavior
-# they depend on) working exactly as before, rather than silently going
-# inert the moment the retired verify-only auto-apply step stops running.
+# True iff ONLY `optimistic_integration.enabled` is true -- enabled-only,
+# no legacy bridge (review fix for #801, PR #810). The legacy
+# `auto_apply_counters` flag is intentionally NOT read here: migrating a
+# `true` legacy flag into `optimistic_integration.enabled` is Epic 8's job
+# (memory-setup.sh offers optimistic mode as an explicit, logged opt-in
+# prompt, plan.md §3.5), not an implicit OR-bridge in this gate. Bridging
+# the two would let the new engine -- and its ~$2/night eval-refresh API
+# spend -- silently activate on a machine that only ever opted into the
+# OLD verify-only auto-apply step, without the operator ever seeing or
+# confirming the migration.
 # Both new steps below (eval-refresh, optimistic-integrate) share this one
 # gate so they turn on and off together.
 # ---------------------------------------------------------------------
@@ -155,8 +157,7 @@ if not isinstance(cfg, dict):
     sys.exit(0)
 opt = cfg.get('optimistic_integration')
 enabled = isinstance(opt, dict) and bool(opt.get('enabled', False))
-legacy = bool(cfg.get('auto_apply_counters', False))
-print('true' if (enabled or legacy) else 'false')
+print('true' if enabled else 'false')
 " "${cfg}" 2>/dev/null || echo false
 }
 
@@ -211,6 +212,15 @@ run_eval_refresh_step() {
 # here -- this function's job is only the two gates above, then a single
 # CLI invocation for the day.
 #
+# Red-gate-as-anomaly (review fix for #801, PR #810): plan.md §3.5 says the
+# breaker trips on "batch-anomaly fire OR red eval gate" -- but a red
+# `--gate` result short-circuits BEFORE `apply_dream_proposal.py
+# optimistic-integrate` is ever invoked, so the breaker's own anomaly_log
+# previously had zero memory of a red-gate streak. When gate (b) fails,
+# this function now ALSO calls `apply_dream_proposal.py record-anomaly
+# --reason red_eval_gate` before returning -- still fail-closed (no
+# integration on a red gate; only the anomaly itself is recorded).
+#
 # Always returns 0: a stand-down (disabled, gate missing, gate red) is a
 # successful, expected outcome, never a chain failure (mirrors
 # autoheal-auto-apply.sh's own "Exit codes: 0 always" contract).
@@ -238,6 +248,11 @@ run_optimistic_integrate_step() {
     gate_rc=$?
     if [ "${gate_rc}" -ne 0 ]; then
         log "optimistic-integrate: dream-eval.sh --gate exit=${gate_rc}; failing closed (${gate_out})"
+        local anomaly_out anomaly_rc
+        anomaly_out="$(python3 "${MODULE_ROOT}/lib/apply_dream_proposal.py" record-anomaly --reason red_eval_gate 2>&1)"
+        anomaly_rc=$?
+        printf '%s\n' "${anomaly_out}" >>"${DAILY_LOG}"
+        log "optimistic-integrate: recorded red_eval_gate anomaly (exit=${anomaly_rc})"
         return 0
     fi
 

--- a/modules/dreaming/bin/dream-daily.sh
+++ b/modules/dreaming/bin/dream-daily.sh
@@ -1,15 +1,28 @@
 #!/usr/bin/env bash
-# CCGM dreaming — daily chain wrapper (Epic 6).
+# CCGM dreaming — daily chain wrapper (Epic 6; chain order revised by the
+# optimistic-memory plan.md Epic 3).
 #
-# Full nightly chain (plan.md §5 Epic 6):
-#   1. bin/dream-analyze.sh    (Epic 3) — mine + map/reduce -> proposals
-#   2. bin/dream-digest.sh     (Epic 3) — render today's digest
-#   3. bin/dream-reconcile.sh  (Epic 8) — read-only auto-memory reconciliation.
+# Full nightly chain (plan.md §5 Epic 3/6):
+#   1. bin/dream-analyze.sh       (Epic 3) — mine + map/reduce -> proposals
+#   2. eval-refresh                — opt-in, weekly, cost-capped live eval
+#      refresh so dream-eval.sh --gate's 14-day freshness bound stays met
+#      without manual intervention (fix (b) for adrev-opt-001). Runs BEFORE
+#      optimistic-integrate so a freshly-refreshed result is available to
+#      the SAME night's gate check.
+#   3. optimistic-integrate        — opt-in, config- AND eval-gated (see
+#      below). The full per-op-kind posture engine
+#      (apply_dream_proposal.run_optimistic_integrate) -- supersedes the
+#      retired verify-only auto-apply step. Runs BEFORE digest so the
+#      digest reports tonight's batch while its dwell window is still
+#      entirely ahead of it (the pre-Epic-3 order ran auto-apply AFTER
+#      digest, which meant a batch was never reported until its own dwell
+#      had already expired).
+#   4. bin/dream-digest.sh        (Epic 3) — render today's digest
+#   5. bin/dream-reconcile.sh     (Epic 8) — read-only auto-memory reconciliation.
 #      Does not exist yet; run_step's "missing -> skip, return 0" makes this
 #      a harmless no-op until Epic 8 lands it (mirrors autoheal-daily.sh's
 #      own "steps that land in later epics" tolerance).
-#   4. auto-apply              — opt-in, config- AND eval-gated (see below).
-#   5. retention                — gzip >30d, delete >60d (mirrors
+#   6. retention                   — gzip >30d, delete >60d (mirrors
 #      modules/autoheal/bin/autoheal-retention.sh, scoped to dreaming's dirs).
 #
 # Each step is exit-tolerant: a failure of one step does not kill the rest.
@@ -23,9 +36,9 @@
 #
 # All flags are forwarded VERBATIM to dream-analyze.sh, which already owns
 # this exact surface (bin/dream-analyze.sh --help). --force-day additionally
-# tells this wrapper which day the digest/auto-apply/retention steps are
-# "for", so `--force-day 2026-01-01` produces a fully self-consistent run
-# for that single day end to end.
+# tells this wrapper which day the digest/optimistic-integrate/eval-refresh/
+# retention steps are "for", so `--force-day 2026-01-01` produces a fully
+# self-consistent run for that single day end to end.
 #
 # Env overrides (tests):
 #   CCGM_DREAMING_DIR          default ~/.claude/dreaming
@@ -34,9 +47,13 @@
 #                               --force-day when given
 #   CCGM_DREAMING_BIN_DIR      default to dirname of this script
 #   CCGM_DREAMING_EVAL_SCRIPT  default ${CCGM_DREAMING_BIN_DIR}/dream-eval.sh
-#                               (Epic 7); override to test the auto-apply
-#                               fail-closed gate independent of whether
-#                               that file exists in this checkout
+#                               (Epic 7); override to test the optimistic-
+#                               integrate fail-closed gate independent of
+#                               whether that file exists in this checkout
+#   CCGM_DREAMING_EVAL_REFRESH_SCRIPT  override for the live eval harness
+#                               the eval-refresh step invokes (tests only --
+#                               see apply_dream_proposal.py's
+#                               _eval_script_path())
 
 set -u
 
@@ -106,47 +123,102 @@ run_step() {
 }
 
 # ---------------------------------------------------------------------
-# Step 4: opt-in, config- AND eval-gated auto-apply.
+# Shared config gate: is optimistic auto-integration active?
 #
-# Two independent gates must BOTH pass before anything is applied:
-#   (a) config gate: ~/.claude/dreaming/config.json's `auto_apply_counters`
-#       must be true (default false — auto-apply stays off until a human
-#       opts in).
-#   (b) eval gate: `bin/dream-eval.sh --gate` must exit 0. dream-eval.sh is
-#       Epic 7's deliverable and does not exist in this branch yet — a
-#       missing eval harness FAILS CLOSED (no auto-apply this run) rather
-#       than being treated as "no gate configured, proceed anyway". This is
-#       the same fail-closed posture modules/autoheal/bin/autoheal-auto-apply.sh
-#       uses for its own missing-evaluator case.
-#
-# Per plan.md Epic 6 / sec-5, the per-proposal STRUCTURAL predicate (kind ==
-# learning_verify AND confidence >= 9 AND status == pending — NEVER
-# learning_add/supersede/deprecate/contradict at any confidence) lives in
-# apply_dream_proposal.py's run_auto_apply(), not here — this function's job
-# is only the two gates above, then a single CLI invocation for the day.
-#
-# Always returns 0: an auto-apply stand-down (disabled, gate missing, gate
-# red) is a successful, expected outcome, never a chain failure (mirrors
-# autoheal-auto-apply.sh's own "Exit codes: 0 always" contract).
+# True iff EITHER `optimistic_integration.enabled` (the real, post-Epic-3
+# flag) OR the legacy `auto_apply_counters` (pre-Epic-3, still read by
+# Epic 8's not-yet-landed migration) is true. Epic 8 will formally migrate
+# a `true` `auto_apply_counters` into `optimistic_integration.enabled` on
+# first read; until that lands, this OR keeps existing
+# `auto_apply_counters:true` configurations (and the fail-closed behavior
+# they depend on) working exactly as before, rather than silently going
+# inert the moment the retired verify-only auto-apply step stops running.
+# Both new steps below (eval-refresh, optimistic-integrate) share this one
+# gate so they turn on and off together.
 # ---------------------------------------------------------------------
 
-run_auto_apply_step() {
+_optimistic_integration_active() {
     local cfg="${DREAMING_DIR}/config.json"
-    local enabled="false"
-    if [ -f "${cfg}" ]; then
-        enabled="$(python3 -c "
+    if [ ! -f "${cfg}" ]; then
+        echo false
+        return
+    fi
+    python3 -c "
 import json, sys
 try:
     cfg = json.load(open(sys.argv[1], encoding='utf-8'))
 except Exception:
     print('false')
     sys.exit(0)
-print('true' if isinstance(cfg, dict) and bool(cfg.get('auto_apply_counters', False)) else 'false')
-" "${cfg}" 2>/dev/null || echo false)"
+if not isinstance(cfg, dict):
+    print('false')
+    sys.exit(0)
+opt = cfg.get('optimistic_integration')
+enabled = isinstance(opt, dict) and bool(opt.get('enabled', False))
+legacy = bool(cfg.get('auto_apply_counters', False))
+print('true' if (enabled or legacy) else 'false')
+" "${cfg}" 2>/dev/null || echo false
+}
+
+# ---------------------------------------------------------------------
+# Step 2: weekly, cost-capped eval refresh (fix (b) for adrev-opt-001).
+#
+# Gated on _optimistic_integration_active() only -- the preconditions that
+# actually decide whether a refresh RUNS (results-file age, API key
+# presence, its own eval_refresh_cost_cap_usd budget) live in
+# apply_dream_proposal.py's run_eval_refresh(), not here, so this step is
+# a thin, always-safe wrapper: it never blocks the rest of the chain and
+# never itself decides whether to spend money. Placed BEFORE
+# optimistic-integrate so a freshly-refreshed result is available to the
+# SAME night's --gate check.
+#
+# Always returns 0: any stand-down (inactive, too fresh, no key, cap
+# exhausted) is a successful, expected outcome, never a chain failure.
+# ---------------------------------------------------------------------
+
+run_eval_refresh_step() {
+    if [ "$(_optimistic_integration_active)" != "true" ]; then
+        log "eval-refresh: optimistic integration inactive; skipping ${TODAY}"
+        return 0
     fi
 
-    if [ "${enabled}" != "true" ]; then
-        log "auto-apply: auto_apply_counters=false (default off); skipping ${TODAY}"
+    log "eval-refresh: running apply_dream_proposal.py eval-refresh for ${TODAY}"
+    local refresh_out refresh_rc
+    refresh_out="$(python3 "${MODULE_ROOT}/lib/apply_dream_proposal.py" eval-refresh --day "${TODAY}" 2>&1)"
+    refresh_rc=$?
+    printf '%s\n' "${refresh_out}" >>"${DAILY_LOG}"
+    log "eval-refresh: exit=${refresh_rc} (${refresh_out})"
+    return 0
+}
+
+# ---------------------------------------------------------------------
+# Step 3: opt-in, config- AND eval-gated optimistic auto-integration.
+# Supersedes the retired verify-only auto-apply step.
+#
+# Two independent gates must BOTH pass before anything is applied:
+#   (a) config gate: _optimistic_integration_active() above (default false
+#       -- optimistic integration stays off until a human opts in).
+#   (b) eval gate: `bin/dream-eval.sh --gate` must exit 0. dream-eval.sh is
+#       Epic 7's deliverable; a missing eval harness FAILS CLOSED (no
+#       integration this run) rather than being treated as "no gate
+#       configured, proceed anyway". This is the same fail-closed posture
+#       modules/autoheal/bin/autoheal-auto-apply.sh uses for its own
+#       missing-evaluator case, and the same posture the retired
+#       run_auto_apply_step used.
+#
+# Per plan.md Epic 3, the full per-op-kind posture/cap/anomaly/breaker
+# engine lives in apply_dream_proposal.py's run_optimistic_integrate(), not
+# here -- this function's job is only the two gates above, then a single
+# CLI invocation for the day.
+#
+# Always returns 0: a stand-down (disabled, gate missing, gate red) is a
+# successful, expected outcome, never a chain failure (mirrors
+# autoheal-auto-apply.sh's own "Exit codes: 0 always" contract).
+# ---------------------------------------------------------------------
+
+run_optimistic_integrate_step() {
+    if [ "$(_optimistic_integration_active)" != "true" ]; then
+        log "optimistic-integrate: optimistic_integration.enabled=false (default off); skipping ${TODAY}"
         return 0
     fi
 
@@ -157,7 +229,7 @@ print('true' if isinstance(cfg, dict) and bool(cfg.get('auto_apply_counters', Fa
     # this checkout yet.
     local eval_script="${CCGM_DREAMING_EVAL_SCRIPT:-${BIN_DIR}/dream-eval.sh}"
     if [ ! -f "${eval_script}" ]; then
-        log "auto-apply: ${eval_script} missing (Epic 7 not yet installed); failing closed -- no auto-apply this run"
+        log "optimistic-integrate: ${eval_script} missing (Epic 7 not yet installed); failing closed -- no integration this run"
         return 0
     fi
 
@@ -165,19 +237,19 @@ print('true' if isinstance(cfg, dict) and bool(cfg.get('auto_apply_counters', Fa
     gate_out="$(bash "${eval_script}" --gate 2>&1)"
     gate_rc=$?
     if [ "${gate_rc}" -ne 0 ]; then
-        log "auto-apply: dream-eval.sh --gate exit=${gate_rc}; failing closed (${gate_out})"
+        log "optimistic-integrate: dream-eval.sh --gate exit=${gate_rc}; failing closed (${gate_out})"
         return 0
     fi
 
-    log "auto-apply: eval gate passed; running apply_dream_proposal.py auto-apply for ${TODAY}"
-    local apply_out apply_rc
-    apply_out="$(python3 "${MODULE_ROOT}/lib/apply_dream_proposal.py" auto-apply --day "${TODAY}" 2>&1)"
-    apply_rc=$?
-    printf '%s\n' "${apply_out}" >>"${DAILY_LOG}"
-    if [ "${apply_rc}" -ne 0 ]; then
-        log "auto-apply: apply_dream_proposal.py exit=${apply_rc} (see log for details)"
+    log "optimistic-integrate: eval gate passed; running apply_dream_proposal.py optimistic-integrate for ${TODAY}"
+    local integrate_out integrate_rc
+    integrate_out="$(python3 "${MODULE_ROOT}/lib/apply_dream_proposal.py" optimistic-integrate --day "${TODAY}" 2>&1)"
+    integrate_rc=$?
+    printf '%s\n' "${integrate_out}" >>"${DAILY_LOG}"
+    if [ "${integrate_rc}" -ne 0 ]; then
+        log "optimistic-integrate: apply_dream_proposal.py exit=${integrate_rc} (see log for details)"
     else
-        log "auto-apply: done (${apply_out})"
+        log "optimistic-integrate: done (${integrate_out})"
     fi
     return 0
 }
@@ -272,17 +344,23 @@ log "dream-daily start (${TODAY})"
 steps_total=$((steps_total + 1))
 run_step "analyze" "${BIN_DIR}/dream-analyze.sh" "$@" || steps_failed=$((steps_failed + 1))
 
+# eval-refresh, optimistic-integrate, and retention always return 0 (see
+# comments above) -- their own internal stand-down/failure reasons are
+# logged, never surfaced as a chain step failure.
+steps_total=$((steps_total + 1))
+run_eval_refresh_step || steps_failed=$((steps_failed + 1))
+
+steps_total=$((steps_total + 1))
+run_optimistic_integrate_step || steps_failed=$((steps_failed + 1))
+
+# digest runs AFTER optimistic-integrate (chain order revised by
+# optimistic-memory plan.md Epic 3) so tonight's just-integrated batch is
+# reported while its dwell window is still entirely ahead of it.
 steps_total=$((steps_total + 1))
 run_step "digest" "${BIN_DIR}/dream-digest.sh" "${TODAY}" || steps_failed=$((steps_failed + 1))
 
 steps_total=$((steps_total + 1))
 run_step "reconcile" "${BIN_DIR}/dream-reconcile.sh" || steps_failed=$((steps_failed + 1))
-
-# Auto-apply and retention always return 0 (see comments above) — their own
-# internal stand-down/failure reasons are logged, never surfaced as a chain
-# step failure.
-steps_total=$((steps_total + 1))
-run_auto_apply_step || steps_failed=$((steps_failed + 1))
 
 steps_total=$((steps_total + 1))
 run_retention_step || steps_failed=$((steps_failed + 1))

--- a/modules/dreaming/lib/apply_dream_proposal.py
+++ b/modules/dreaming/lib/apply_dream_proposal.py
@@ -107,6 +107,17 @@ commit (after the loop) each acquire the lock in their OWN, non-nested
 critical section. `fcntl.flock` is non-reentrant; nesting a batch-wide lock
 around per-proposal `apply_proposal()` calls would self-deadlock on the
 very first row.
+
+Red-gate-as-anomaly (review fix for #801, PR #810): plan.md §3.5 says the
+breaker trips on "batch-anomaly fire OR red eval gate", but a red
+`dream-eval.sh --gate` result short-circuits `dream-daily.sh` BEFORE the
+`optimistic-integrate` CLI subcommand (and therefore `run_optimistic_
+integrate()`) is ever invoked, so a red-gate streak previously left zero
+trace in `anomaly_log`. `record_anomaly()` (the `record-anomaly` CLI
+subcommand) closes that gap: it records one anomaly directly into
+`state/optimistic.json` and evaluates the SAME windowed breaker via the
+shared `_evaluate_breaker_trip()` helper, independent of any proposal
+batch.
 """
 from __future__ import annotations
 
@@ -1139,13 +1150,19 @@ def _maybe_auto_resume(state: dict[str, Any], cfg: dict[str, Any], batch_id: str
     transition. Returns the (possibly updated) state. Caller MUST already
     hold `_apply_lock()`.
 
-    "Quiet" needs no separate tracking: while suspended, the engine applies
-    nothing (see run_optimistic_integrate's early return below), so no NEW
-    anomaly can be recorded during the suspension window -- the mere
-    passage of `circuit_breaker_auto_resume_nights` is sufficient. An
-    ambiguous state (suspended but no parseable `suspended_at`, e.g. a
-    hand-edited file) never auto-resumes -- fails closed, requires a
-    manual `optimistic-resume`.
+    "Quiet" needs no separate tracking: while suspended, run_optimistic_
+    integrate() itself applies nothing (see its early return below), so no
+    NEW batch-anomaly/rolling-rate anomaly can be recorded during the
+    suspension window from THAT path -- the mere passage of
+    `circuit_breaker_auto_resume_nights` is sufficient. `record_anomaly()`
+    (review fix for #801, PR #810 -- a red eval gate never reaches
+    run_optimistic_integrate() at all) is an INDEPENDENT path that CAN
+    still append to `anomaly_log` while suspended; that does not change
+    this function's own check, which only ever looks at wall-clock time
+    since `suspended_at`, never at `anomaly_log` contents. An ambiguous
+    state (suspended but no parseable `suspended_at`, e.g. a hand-edited
+    file) never auto-resumes -- fails closed, requires a manual
+    `optimistic-resume`.
     """
     if not state.get("suspended"):
         return state
@@ -1183,6 +1200,107 @@ def optimistic_resume() -> dict[str, Any]:
     record = {"outcome": "circuit_breaker_manual_resume", "was_suspended": was_suspended, "ok": True}
     _write_audit(record)
     return record
+
+
+def _evaluate_breaker_trip(state: dict[str, Any], cfg: dict[str, Any], *, batch_id: str) -> bool:
+    """Shared windowed-breaker evaluation (plan.md §3.5: "the breaker trips
+    on batch-anomaly fire OR red eval gate").
+
+    Given `state` whose `anomaly_log` already reflects every anomaly this
+    caller wants considered (including any just appended for this call),
+    checks whether `circuit_breaker_max_anomalies` anomalies fall within
+    the trailing `circuit_breaker_window_nights` window and, if so and the
+    breaker is not already suspended, trips it -- mutating
+    `state["suspended"]`/`state["suspended_at"]` IN PLACE -- and writes the
+    `circuit_breaker_tripped` audit record. Returns True iff THIS call is
+    what tripped it (already-suspended is a no-op, matching the previous
+    inline behavior in `run_optimistic_integrate()`).
+
+    Extracted (review fix for #801, PR #810) so `run_optimistic_
+    integrate()`'s end-of-batch breaker check and `record_anomaly()`'s
+    standalone (non-batch) breaker check -- e.g. a red eval gate, which
+    never reaches `run_optimistic_integrate()` at all since dream-daily.sh's
+    gate check happens BEFORE the `optimistic-integrate` CLI subcommand is
+    ever invoked -- share the exact same windowed-threshold math rather
+    than reimplementing it.
+
+    Caller MUST already hold `_apply_lock()` and remains responsible for
+    persisting `state` via `_write_optimistic_state_atomic()` afterward --
+    this function only mutates the in-memory dict and writes the audit
+    record.
+    """
+    window_nights = int(cfg.get("circuit_breaker_window_nights", 7))
+    window_start = time.time() - (window_nights * 86400.0)
+    recent = [
+        t for t in state.get("anomaly_log", [])
+        if learnings_store._parse_iso(t) >= window_start  # noqa: SLF001 -- see _rolling_auto_add_supersede_count
+    ]
+    max_anomalies = int(cfg.get("circuit_breaker_max_anomalies", 2))
+    if len(recent) >= max_anomalies and not state.get("suspended"):
+        state["suspended"] = True
+        state["suspended_at"] = _utc_now_iso()
+        _write_audit({
+            "outcome": "circuit_breaker_tripped", "batch_id": batch_id,
+            "detail": f"{len(recent)} anomalies within {window_nights} night window "
+                      f"(threshold {max_anomalies})",
+        })
+        return True
+    return False
+
+
+def record_anomaly(reason: str) -> dict[str, Any]:
+    """Records ONE anomaly -- independent of any proposal batch -- into
+    `state/optimistic.json` and evaluates the windowed circuit breaker
+    (plan.md §3.5: "the breaker trips on batch-anomaly fire OR red eval
+    gate"). This is the `record-anomaly` CLI subcommand's entry point
+    (review fix for #801, PR #810).
+
+    dream-daily.sh's `run_optimistic_integrate_step()` calls this directly
+    when `dream-eval.sh --gate` itself reports red: that fail-closed branch
+    returns BEFORE ever invoking the `optimistic-integrate` CLI subcommand
+    (and therefore before `run_optimistic_integrate()` -- and the breaker
+    logic it drives -- ever runs), so without this function a red-gate
+    streak left ZERO trace in `anomaly_log`; the breaker had no memory of
+    it.
+
+    REUSES `_read_optimistic_state()` / `_write_optimistic_state_atomic()`
+    / the same windowed-breaker evaluation `run_optimistic_integrate()`
+    uses (via `_evaluate_breaker_trip()`) rather than re-deriving any of
+    that logic.
+
+    Always audited: one `anomaly_recorded` record unconditionally, plus a
+    `circuit_breaker_tripped` record (written by `_evaluate_breaker_trip`,
+    inside the SAME lock) if this is the anomaly that trips it -- matching
+    every other breaker-state transition in this module (never silent).
+    Still records the anomaly (for history) even if the breaker is ALREADY
+    suspended -- `_evaluate_breaker_trip`'s own `not state.get("suspended")`
+    guard simply makes that case a no-op for the "tripped" audit/return,
+    exactly as an already-suspended breaker is a no-op in
+    `run_optimistic_integrate()` today.
+
+    Returns a `batch_id` (a fresh, uniquely-generated `anomaly_<uuid>` id,
+    distinct from `run_optimistic_integrate()`'s `optbatch_<uuid>` batch
+    ids) so a caller -- or a test -- can correlate this exact call with its
+    own audit record(s) in the shared, cumulative apply-audit log.
+    """
+    cfg = da.load_config().get("optimistic_integration") or {}
+    context_id = f"anomaly_{uuid.uuid4().hex[:12]}"
+
+    with _apply_lock():
+        state = _read_optimistic_state()
+        state.setdefault("anomaly_log", [])
+        state["anomaly_log"].append(_utc_now_iso())
+
+        tripped = _evaluate_breaker_trip(state, cfg, batch_id=context_id)
+        _write_optimistic_state_atomic(state)
+        suspended_after = bool(state.get("suspended"))
+
+    _write_audit({"outcome": "anomaly_recorded", "batch_id": context_id, "reason": reason})
+
+    return {
+        "outcome": "anomaly_recorded", "reason": reason, "ok": True, "batch_id": context_id,
+        "circuit_breaker": "tripped" if tripped else ("suspended" if suspended_after else None),
+    }
 
 
 def _process_one_proposal(
@@ -1429,22 +1547,8 @@ def run_optimistic_integrate(day: str) -> dict[str, Any]:
         state["anomaly_log"].extend(run_anomaly_timestamps)
         state["last_run"] = _utc_now_iso()
 
-        window_nights = int(cfg.get("circuit_breaker_window_nights", 7))
-        window_start = time.time() - (window_nights * 86400.0)
-        recent = [
-            t for t in state["anomaly_log"]
-            if learnings_store._parse_iso(t) >= window_start  # noqa: SLF001 -- see _rolling_auto_add_supersede_count
-        ]
-        max_anomalies = int(cfg.get("circuit_breaker_max_anomalies", 2))
-        if len(recent) >= max_anomalies and not state.get("suspended"):
-            state["suspended"] = True
-            state["suspended_at"] = _utc_now_iso()
+        if _evaluate_breaker_trip(state, cfg, batch_id=batch_id):
             summary["circuit_breaker"] = "tripped"
-            _write_audit({
-                "outcome": "circuit_breaker_tripped", "batch_id": batch_id,
-                "detail": f"{len(recent)} anomalies within {window_nights} night window "
-                          f"(threshold {max_anomalies})",
-            })
 
         _write_optimistic_state_atomic(state)
 
@@ -1660,6 +1764,12 @@ def _cmd_optimistic_resume(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_record_anomaly(args: argparse.Namespace) -> int:
+    result = record_anomaly(args.reason)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
 def _cmd_eval_refresh(args: argparse.Namespace) -> int:
     day = args.day or today_iso()
     summary = run_eval_refresh(day)
@@ -1707,6 +1817,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "optimistic-resume", help="force-clear a tripped optimistic-integration circuit breaker immediately",
     )
     resume_p.set_defaults(func=_cmd_optimistic_resume)
+
+    record_anomaly_p = sub.add_parser(
+        "record-anomaly",
+        help="record a single anomaly (e.g. a red eval gate) into state/optimistic.json and evaluate "
+             "the windowed circuit breaker, independent of any proposal batch (optimistic-memory "
+             "plan.md §3.5: the breaker trips on batch-anomaly fire OR a red eval gate)",
+    )
+    record_anomaly_p.add_argument("--reason", required=True, help="short machine-readable reason, e.g. red_eval_gate")
+    record_anomaly_p.set_defaults(func=_cmd_record_anomaly)
 
     refresh_p = sub.add_parser(
         "eval-refresh",

--- a/modules/dreaming/lib/apply_dream_proposal.py
+++ b/modules/dreaming/lib/apply_dream_proposal.py
@@ -82,6 +82,31 @@ concurrent invocations of the same id -- same process or two separate OS
 processes (e.g. the nightly auto-apply LaunchAgent racing a human's
 `/dream-apply accept`) -- can never both observe `pending` and both mutate
 the store.
+
+Optimistic auto-integration engine (optimistic-memory plan.md Epic 3):
+`run_optimistic_integrate()` supersedes `run_auto_apply()`'s narrow
+verify-only predicate with a full per-op-kind posture engine
+(`dream_analyze.resolve_posture()`), per-slug blast-radius caps, a batch
+eviction-concentration anomaly check, a cross-night accumulation signal,
+and a windowed circuit breaker (`state/optimistic.json`). `run_auto_apply()`
+itself is left UNCHANGED (still reachable via the `auto-apply` CLI
+subcommand) for backward compatibility with its existing callers/tests;
+`dream-daily.sh`'s nightly chain now calls `optimistic-integrate` instead.
+Every proposal this engine applies goes through the SAME `apply_proposal()`
+this module already uses for human accepts, so the existing human-race
+lock (adrev-013, above) and per-outcome audit trail cover the new path for
+free -- the engine adds three NEW optional `apply_proposal()` parameters
+(`dwell_hours`, `batch_id`, `posture`) that are no-ops (None) for every
+existing caller.
+
+Lock topology (adrev-opt-011): the engine NEVER holds `_apply_lock()` across
+the batch -- each proposal is applied through `apply_proposal()`, which
+takes/releases the lock per call exactly as it does today. The breaker
+state read (before the loop) and the breaker state write + single batch
+commit (after the loop) each acquire the lock in their OWN, non-nested
+critical section. `fcntl.flock` is non-reentrant; nesting a batch-wide lock
+around per-proposal `apply_proposal()` calls would self-deadlock on the
+very first row.
 """
 from __future__ import annotations
 
@@ -93,6 +118,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 import traceback
 import uuid
 from pathlib import Path
@@ -166,7 +192,37 @@ def _run_learnings_log(args: list[str]) -> subprocess.CompletedProcess:
     )
 
 
-def _run_sync_commit() -> dict[str, Any]:
+_AUTOCOMMIT_ENV_KEY = "CCGM_LEARNINGS_AUTOCOMMIT"
+
+
+@contextlib.contextmanager
+def _suppressed_autocommit():
+    """Force `CCGM_LEARNINGS_AUTOCOMMIT=false` for every `ccgm-learnings-log`
+    subprocess spawned while this context is active (adrev-opt-013).
+
+    `subprocess.run(..., env=None)` inherits the CURRENT `os.environ` at
+    call time, so mutating `os.environ` itself for the duration of a batch
+    is sufficient -- no need to thread an `env=` override through
+    `_run_learnings_log()`. The optimistic engine commits the WHOLE batch
+    exactly once at the end (`_run_sync_commit()`); if the operator's
+    ambient environment has per-write autocommit enabled, it must not fire
+    mid-batch and turn an N-write batch into up to N separate commits
+    (which would make Epic 5's single-SHA "revert this batch" UX revert
+    only one of the N writes). Restores whatever value (or absence) the key
+    had on entry, even if the body raises.
+    """
+    previous = os.environ.get(_AUTOCOMMIT_ENV_KEY)
+    os.environ[_AUTOCOMMIT_ENV_KEY] = "false"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(_AUTOCOMMIT_ENV_KEY, None)
+        else:
+            os.environ[_AUTOCOMMIT_ENV_KEY] = previous
+
+
+def _run_sync_commit(message: str | None = None) -> dict[str, Any]:
     """Blocking `ccgm-learnings-sync commit` -- the spec's "runs
     ccgm-learnings-sync commit after a batch" requirement. Called once per
     CLI invocation (a single accept/reject IS a batch of one; auto-apply
@@ -178,14 +234,23 @@ def _run_sync_commit() -> dict[str, Any]:
     boolean"). Never raises: a sync failure (no git repo yet, no remote,
     binary missing) must not crash the apply CLI -- the store write itself
     already landed regardless of whether this commit succeeds.
+
+    `message`, if given, is passed as `-m <message>` (adrev-opt-013): the
+    optimistic engine tags its one-commit-per-batch with the `batch_id` so
+    a human reading `git log` in the learnings store can identify -- and
+    revert -- one night's whole batch by its commit message. `None` (every
+    existing caller) preserves the CLI's own default message.
     """
     try:
         binpath = _resolve_sibling_bin("ccgm-learnings-sync")
     except FileNotFoundError as exc:
         return {"ok": False, "reason": str(exc)}
+    argv = [sys.executable, binpath, "commit"]
+    if message:
+        argv += ["-m", message]
     try:
         proc = subprocess.run(
-            [sys.executable, binpath, "commit"],
+            argv,
             capture_output=True, text=True, check=False,
         )
     except OSError as exc:
@@ -304,8 +369,11 @@ def _apply_lock():
         os.close(fd)
 
 
-def _rewrite_status_locked(path: Path, proposal_id: str, new_status: str) -> dict[str, Any] | None:
-    """Read-modify-write of exactly the `status` field on one row.
+def _rewrite_status_locked(
+    path: Path, proposal_id: str, new_status: str, *, extra_fields: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Read-modify-write of exactly the `status` field (plus, optionally,
+    `extra_fields`) on one row.
 
     Callers MUST already hold `_apply_lock()` -- this function never
     acquires it itself (acquiring the same fcntl.flock a second time via a
@@ -314,9 +382,16 @@ def _rewrite_status_locked(path: Path, proposal_id: str, new_status: str) -> dic
     now holds the lock across its whole critical section and calls this
     directly instead of the locking `_rewrite_status()` wrapper below).
 
+    `extra_fields` (optimistic-memory plan.md §3.4): the optimistic engine
+    additionally records `batch_id`, `posture`, and (for dwell postures)
+    `dwell_until` onto a proposal it auto-applies, so Epic 5's report can
+    group tonight's batch and Epic 6's rollback can filter by `batch_id`.
+    `None` (every pre-Epic-3 caller) writes only `status`, unchanged from
+    before this parameter existed.
+
     Every parseable row is re-serialized (not hand-patched as a text diff),
     so the frozen proposal-schema.json shape Epic 3 owns is round-tripped
-    exactly as dream_analyze.py wrote it, plus the one field this module is
+    exactly as dream_analyze.py wrote it, plus the field(s) this module is
     licensed to touch. A line that fails to parse as a JSON object (a
     corrupt or torn write from an unrelated, sibling proposal) is preserved
     VERBATIM rather than crashing the rewrite -- mirrors `_read_jsonl()`'s
@@ -349,6 +424,8 @@ def _rewrite_status_locked(path: Path, proposal_id: str, new_status: str) -> dic
             continue
         if row.get("id") == proposal_id:
             row["status"] = new_status
+            if extra_fields:
+                row.update(extra_fields)
             updated = row
         out_lines.append(json.dumps(row, sort_keys=True))
     if updated is None:
@@ -396,7 +473,8 @@ def _first_evidence_session(row: dict[str, Any]) -> str | None:
 
 
 def _apply_learning_add(
-    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept"
+    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept",
+    dwell_hours: float | None = None,
 ) -> dict[str, Any]:
     if row.get("project") == GLOBAL_SLUG:
         return _apply_global_add(row, reviewed_by=reviewed_by)
@@ -408,6 +486,18 @@ def _apply_learning_add(
         "--source", DEFAULT_MINED_SOURCE,
         "--project", row["project"],
     ]
+    if method == "auto_apply":
+        # adrev-opt-008: tag the engine's own optimistic writes `auto: true`
+        # so memory_eval.py's freshness clock (Epic 4) can skip them --
+        # only reachable because Epic 1 extended `--auto` to every
+        # ccgm-learnings-log subcommand, not just verify.
+        args.append("--auto")
+    if dwell_hours is not None:
+        # optimistic-memory §3.2: needs_dwell postures (add/supersede/
+        # contradict/deprecate) thread the engine's configured dwell_hours
+        # as a FLOOR -- the store applies max(existing, new) at the fold
+        # layer, so this can only extend, never shorten, a target's dwell.
+        args += ["--dwell-hours", str(int(dwell_hours))]
     session = _first_evidence_session(row)
     if session:
         args += ["--session", session]
@@ -473,13 +563,23 @@ def _looks_like_uncaught_exception(stderr: str) -> bool:
     return "Traceback (most recent call last):" in stderr
 
 
-def _apply_counter_op(row: dict[str, Any], op: str, *, auto: bool = False) -> dict[str, Any]:
+def _apply_counter_op(
+    row: dict[str, Any], op: str, *, auto: bool = False, dwell_hours: float | None = None,
+) -> dict[str, Any]:
     args = [op, row["target_id"], "--project", row["project"]]
     if auto:
         # adrev-404: an unattended auto-apply verify must NOT refresh
-        # last_verified. `--auto` is a verify-only flag on ccgm-learnings-log;
-        # only _apply_learning_verify ever passes auto=True here.
+        # last_verified. For verify specifically, `--auto` means "bump uses
+        # only" (VF6). For contradict (the other _apply_counter_op caller,
+        # optimistic-memory Epic 3), `--auto` just tags the write as
+        # unattended for audit/reporting -- adrev-opt-008 extended `--auto`
+        # to every subcommand in Epic 1, it is no longer verify-only.
         args.append("--auto")
+    if dwell_hours is not None:
+        # optimistic-memory §3.2: contradict is `dwell-quarantine` --
+        # dwell is MANDATORY for this kind. Floor semantics (max-with-
+        # existing) are enforced at the store's fold layer, not here.
+        args += ["--dwell-hours", str(int(dwell_hours))]
     session = _first_evidence_session(row)
     if session:
         args += ["--session", session]
@@ -494,19 +594,32 @@ def _apply_counter_op(row: dict[str, Any], op: str, *, auto: bool = False) -> di
 
 
 def _apply_learning_verify(
-    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept"
+    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept",
+    dwell_hours: float | None = None,
 ) -> dict[str, Any]:
     # adrev-404: an unattended auto-apply (method == "auto_apply") issues an
     # AUTO verify (bump uses, do NOT refresh last_verified). A human accept
     # (method == "human_accept", the /dream-apply accept path) issues a normal
-    # verify that refreshes last_verified exactly as before.
-    return _apply_counter_op(row, "verify", auto=(method == "auto_apply"))
+    # verify that refreshes last_verified exactly as before. `verify`'s
+    # posture is `optimistic-immediate` (needs_dwell=False, plan.md §3.3),
+    # so the optimistic engine never passes a real dwell_hours here -- this
+    # parameter exists only for signature parity with the other handlers in
+    # `_HANDLERS` (apply_proposal() calls every handler uniformly) and so a
+    # human accept could, in principle, extend a target's existing dwell
+    # floor via the same `--dwell-hours` flag ccgm-learnings-log already
+    # exposes on `verify`.
+    return _apply_counter_op(row, "verify", auto=(method == "auto_apply"), dwell_hours=dwell_hours)
 
 
 def _apply_learning_contradict(
-    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept"
+    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept",
+    dwell_hours: float | None = None,
 ) -> dict[str, Any]:
-    return _apply_counter_op(row, "contradict")
+    # optimistic-memory §3.3: contradict is `dwell-quarantine` -- the
+    # optimistic engine (method == "auto_apply") tags the write `auto` and
+    # supplies a mandatory dwell_hours; a human accept (the existing
+    # /dream-apply path) passes neither, identical to pre-Epic-3 behavior.
+    return _apply_counter_op(row, "contradict", auto=(method == "auto_apply"), dwell_hours=dwell_hours)
 
 
 def _current_content_sha_if_live(project: str, target_id: str) -> tuple[str, None] | tuple[None, str]:
@@ -575,10 +688,19 @@ def _apply_cas_op(row: dict[str, Any], *, build_argv: Callable[[str], list[str]]
 
 
 def _apply_learning_deprecate(
-    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept"
+    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept",
+    dwell_hours: float | None = None,
 ) -> dict[str, Any]:
+    # optimistic-memory §3.3: deprecate is `dwell-quarantine`, same shape as
+    # contradict but blunter (hard-excludes vs. soft confidence cut).
+    auto = method == "auto_apply"
+
     def build_argv(sha: str) -> list[str]:
         args = ["deprecate", row["target_id"], "--project", row["project"], "--expected-sha", sha]
+        if auto:
+            args.append("--auto")
+        if dwell_hours is not None:
+            args += ["--dwell-hours", str(int(dwell_hours))]
         session = _first_evidence_session(row)
         if session:
             args += ["--session", session]
@@ -588,8 +710,16 @@ def _apply_learning_deprecate(
 
 
 def _apply_learning_supersede(
-    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept"
+    row: dict[str, Any], *, reviewed_by: str, method: str = "human_accept",
+    dwell_hours: float | None = None,
 ) -> dict[str, Any]:
+    # optimistic-memory §3.3: supersede is `optimistic-dwell`, the same
+    # posture as add -- the surgical-rewrite-of-a-trusted-row attack the
+    # compaction guard (compact_preserves_facts, checked upstream in
+    # dream_analyze.py before this proposal was even written) already
+    # defends against.
+    auto = method == "auto_apply"
+
     def build_argv(sha: str) -> list[str]:
         args = [
             "supersede", row["target_id"],
@@ -601,6 +731,10 @@ def _apply_learning_supersede(
         ]
         if row.get("justification"):
             args += ["--reason", row["justification"]]
+        if auto:
+            args.append("--auto")
+        if dwell_hours is not None:
+            args += ["--dwell-hours", str(int(dwell_hours))]
         session = _first_evidence_session(row)
         if session:
             args += ["--session", session]
@@ -623,7 +757,10 @@ _HANDLERS: dict[str, Callable[..., dict[str, Any]]] = {
 # ---------------------------------------------------------------------------
 
 
-def apply_proposal(proposal_id: str, *, method: str = "human_accept", reviewed_by: str | None = None) -> dict[str, Any]:
+def apply_proposal(
+    proposal_id: str, *, method: str = "human_accept", reviewed_by: str | None = None,
+    dwell_hours: float | None = None, batch_id: str | None = None, posture: str | None = None,
+) -> dict[str, Any]:
     """The single write entry point for accepting a pending proposal.
 
     Refuses (adrev-013) any proposal whose status is not 'pending' rather
@@ -633,6 +770,17 @@ def apply_proposal(proposal_id: str, *, method: str = "human_accept", reviewed_b
     states this path is licensed to write. Every OTHER outcome leaves the
     row 'pending' (schema-safe, retry-visible). Always writes exactly one
     audit record, whatever the outcome (adrev-012/adrev-302: never silent).
+
+    `dwell_hours`/`batch_id`/`posture` (optimistic-memory plan.md §3.2/§3.4,
+    Epic 3): optional, `None` for every pre-Epic-3 caller (human accept via
+    `/dream-apply`, `run_auto_apply()`'s verify-only path). `dwell_hours` is
+    threaded into the handler so a `needs_dwell` posture's
+    `ccgm-learnings-log` invocation carries `--dwell-hours` (the store
+    applies it as a FLOOR, never a shortening, at the fold layer --
+    learnings_store.py's `_max_dwell`). `batch_id`/`posture` are recorded
+    onto the proposal row itself (not threaded into the handler -- they do
+    not affect the store write) so Epic 5's report can group tonight's
+    batch and Epic 6's rollback can filter by `batch_id`.
 
     The ENTIRE read -> not-pending-check -> handler-dispatch -> status-
     rewrite sequence runs under a single `_apply_lock()` acquisition, so two
@@ -644,9 +792,15 @@ def apply_proposal(proposal_id: str, *, method: str = "human_accept", reviewed_b
     itself is never allowed to raise past this function: an unexpected
     exception (a malformed/schema-drifted proposal row, for example) is
     caught and turned into an audited `internal_error` outcome rather than
-    crashing the process -- which matters doubly for `run_auto_apply()`,
-    whose per-row loop calls this function and depends on one bad row never
-    aborting evaluation of the rest of the batch.
+    crashing the process -- which matters doubly for `run_auto_apply()` and
+    `run_optimistic_integrate()`, whose per-row loops call this function and
+    depend on one bad row never aborting evaluation of the rest of the batch.
+
+    Lock topology note (adrev-opt-011): this function's own `_apply_lock()`
+    acquisition is per-proposal, exactly as before Epic 3. The optimistic
+    engine calls this function once per proposal inside its loop -- it never
+    wraps a whole batch of these calls in an OUTER `_apply_lock()`, which
+    would self-deadlock (flock is non-reentrant).
     """
     reviewed_by = reviewed_by or os.environ.get("USER") or os.environ.get("LOGNAME") or "human"
 
@@ -678,7 +832,7 @@ def apply_proposal(proposal_id: str, *, method: str = "human_accept", reviewed_b
             return record
 
         try:
-            result = handler(row, reviewed_by=reviewed_by, method=method)
+            result = handler(row, reviewed_by=reviewed_by, method=method, dwell_hours=dwell_hours)
         except Exception:  # noqa: BLE001 -- deliberate: a handler crash must become
             # an audited outcome, never an uncaught exception (adrev-012/adrev-302
             # "never silent"; also what keeps run_auto_apply's batch loop alive).
@@ -688,13 +842,24 @@ def apply_proposal(proposal_id: str, *, method: str = "human_accept", reviewed_b
 
         if ok:
             new_status = "auto_applied" if method == "auto_apply" else "accepted"
-            _rewrite_status_locked(path, proposal_id, new_status)
+            extra_fields: dict[str, Any] = {}
+            if batch_id is not None:
+                extra_fields["batch_id"] = batch_id
+            if posture is not None:
+                extra_fields["posture"] = posture
+            if dwell_hours is not None:
+                extra_fields["dwell_until"] = learnings_store.dwell_until_from_hours(dwell_hours)
+            _rewrite_status_locked(path, proposal_id, new_status, extra_fields=extra_fields or None)
 
         record = {
             "proposal_id": proposal_id, "kind": kind, "project": row.get("project"),
             "target_id": row.get("target_id"), "method": method, "reviewed_by": reviewed_by,
             "ok": ok, **result,
         }
+        if batch_id is not None:
+            record["batch_id"] = batch_id
+        if posture is not None:
+            record["posture"] = posture
         _write_audit(record)
         return record
 
@@ -746,6 +911,12 @@ def run_auto_apply(day: str) -> dict[str, Any]:
     handled the same as any other failed_promotion, not special-cased,
     since the store's own guard is the real backstop, not this predicate.
     Never raises; a single proposal's failure does not abort the batch.
+
+    RETAINED for backward compatibility (its own CLI subcommand and test
+    coverage predate Epic 3) but no longer called by dream-daily.sh's
+    nightly chain -- `run_optimistic_integrate()` below supersedes it
+    there, applying `learning_verify` through the SAME posture engine
+    (`optimistic-immediate`, no dwell) as every other op-kind.
     """
     path = proposals_dir() / f"{day}.jsonl"
     summary: dict[str, Any] = {
@@ -769,6 +940,668 @@ def run_auto_apply(day: str) -> dict[str, Any]:
             summary["applied"] += 1
         else:
             summary["failed"] += 1
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Optimistic auto-integration engine (optimistic-memory plan.md Epic 3).
+#
+# run_optimistic_integrate() supersedes run_auto_apply()'s narrow verify-
+# only predicate with the full per-op-kind posture engine
+# (dream_analyze.resolve_posture()), per-slug blast-radius caps, a batch
+# eviction-concentration anomaly check, a cross-night accumulation signal,
+# and a windowed circuit breaker. Config/eval-gate checking lives in
+# dream-daily.sh (bash), exactly as it did for the retired
+# run_auto_apply_step -- this module's job is the structural per-proposal
+# predicate plus the actual apply loop.
+# ---------------------------------------------------------------------------
+
+OPTIMISTIC_STATE_FILENAME = "optimistic.json"
+
+# An eviction batch of size 1 cannot be "concentrated" -- every possible
+# grouping of a single item is trivially 100% of that item, which would
+# make every lone quarantine proposal a false anomaly. The batch-anomaly
+# check (plan.md §3.3) requires at least this many contradict/deprecate
+# candidates in a slug's pending batch before the configured fraction
+# threshold is even meaningful.
+MIN_EVICTION_BATCH_FOR_ANOMALY_CHECK = 2
+
+# Ledger `model` field value the eval-refresh step tags its own cost.log
+# rows with (see run_eval_refresh below) -- distinguishes its spend from
+# the nightly analyzer's map_model/reduce_model rows in the SAME shared
+# ledger file (adrev-opt-010).
+EVAL_REFRESH_COST_LABEL = "eval-refresh"
+
+
+def optimistic_state_path() -> Path:
+    return state_dir() / OPTIMISTIC_STATE_FILENAME
+
+
+def _default_optimistic_state() -> dict[str, Any]:
+    return {"suspended": False, "suspended_at": None, "anomaly_log": [], "last_run": None}
+
+
+def _read_optimistic_state() -> dict[str, Any]:
+    """Fail-CLOSED on any parse problem (adrev-opt-014): a corrupt or
+    unreadable state file must never silently un-suspend the breaker -- it
+    is treated as an immediate, freshly-timestamped suspension instead. A
+    missing file (never tripped, or first run ever) is the one case that
+    legitimately means "not suspended"; that is `_default_optimistic_state()`
+    verbatim, not a parse failure.
+    """
+    path = optimistic_state_path()
+    if not path.is_file():
+        return _default_optimistic_state()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {**_default_optimistic_state(), "suspended": True, "suspended_at": _utc_now_iso()}
+    if not isinstance(data, dict):
+        return {**_default_optimistic_state(), "suspended": True, "suspended_at": _utc_now_iso()}
+    merged = _default_optimistic_state()
+    merged.update(data)
+    if not isinstance(merged.get("anomaly_log"), list):
+        # A valid-JSON-but-wrong-shape anomaly_log (e.g. hand-edited) must
+        # not crash the rolling-window computation below -- coerce to an
+        # empty list rather than fail the whole read (the top-level parse
+        # guard above already covers the "file is garbage" case).
+        merged["anomaly_log"] = []
+    return merged
+
+
+def _write_optimistic_state_atomic(state: dict[str, Any]) -> None:
+    """Temp-file + `Path.replace()` (an atomic rename on POSIX) -- adrev-
+    opt-014: never an in-place partial write. Mirrors dream_analyze.py's
+    `_write_json_atomic()` (same three-line pattern, reimplemented here
+    rather than imported since this module does not otherwise depend on
+    that helper)."""
+    path = optimistic_state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(state, sort_keys=True, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _live_head_count(slug: str) -> int:
+    """Count of `slug`'s currently-live heads: not deprecated, not already
+    superseded (mirrors search()'s own superseded-exclusion and
+    effective_confidence()'s deprecated -> 0.0 treatment -- "real,
+    currently relevant store content"). A still-dwelling row counts as live
+    (it IS real store content, just not yet read-eligible) -- only
+    deprecated/superseded rows are excluded.
+
+    This is the eviction cap's denominator (plan.md §3.3:
+    min(max_eviction_absolute, max_eviction_fraction_per_run x
+    live_head_count(slug))) and MUST be computed once per slug, before ANY
+    write in the whole batch (P2, security review) -- see
+    run_optimistic_integrate(), which computes this for every slug up
+    front, before the apply loop begins.
+    """
+    heads = learnings_store.load_all(slug)
+    return sum(1 for h in heads if not h.get("deprecated") and not h.get("superseded_by"))
+
+
+def _raw_op_events(slug: str) -> list[dict[str, Any]]:
+    """Union of every raw JSONL row for `slug`: the legacy file + every
+    agent shard, UNFOLDED (not projected through the fold/quarantine
+    layer). Used only for read-only signals that must be derived from
+    committed op-events on disk rather than a mutable in-memory/JSON
+    counter (adrev-opt-014's crash-consistency requirement for the
+    cross-night accumulation signal, §3.8) -- never for anything that needs
+    the deduped/folded head view (use learnings_store.load_all() for that).
+    Mirrors memory_eval.py's own `latest_content_shaping_mutation_epoch()`,
+    which walks the same two file classes directly for the same reason.
+    """
+    rows = _read_jsonl(learnings_store.project_jsonl(slug))
+    for shard in learnings_store.list_agent_shards(slug):
+        rows.extend(_read_jsonl(shard))
+    return rows
+
+
+def _batch_anomaly_fires(
+    eviction_rows: list[dict[str, Any]], heads_by_id: dict[str, dict[str, Any]], cfg: dict[str, Any],
+) -> bool:
+    """Batch-anomaly check (plan.md §3.3), scoped to EVICTION CONCENTRATION
+    only -- never add-tag overlap (adrev-opt-006/007: a same-tag `add`
+    fraction check false-positives on a solo dev's legitimate focused
+    single-project night and, per SMSR, is trivially bypassed by fluent
+    poisoning; dropped from v1 entirely, not merely de-scoped here).
+
+    Fires when `eviction_rows` (a slug's pending learning_contradict +
+    learning_deprecate proposals) concentrate on ONE target row, or on rows
+    sharing ONE tag -- tags are resolved from the TARGET's current head via
+    `heads_by_id`, since contradict/deprecate proposals carry no tags of
+    their own (proposal-schema.json) -- above
+    `batch_anomaly_max_same_tag_fraction`.
+
+    Requires at least `MIN_EVICTION_BATCH_FOR_ANOMALY_CHECK` candidates.
+    """
+    total = len(eviction_rows)
+    if total < MIN_EVICTION_BATCH_FOR_ANOMALY_CHECK:
+        return False
+    threshold = float(cfg.get("batch_anomaly_max_same_tag_fraction", 0.6))
+
+    target_counts: dict[Any, int] = {}
+    for row in eviction_rows:
+        tid = row.get("target_id")
+        target_counts[tid] = target_counts.get(tid, 0) + 1
+    if target_counts and (max(target_counts.values()) / total) >= threshold:
+        return True
+
+    tag_counts: dict[str, int] = {}
+    for row in eviction_rows:
+        head = heads_by_id.get(row.get("target_id")) or {}
+        for tag in set(head.get("tags") or []):
+            tag_counts[tag] = tag_counts.get(tag, 0) + 1
+    if tag_counts and (max(tag_counts.values()) / total) >= threshold:
+        return True
+
+    return False
+
+
+def _rolling_auto_add_supersede_count(slug: str, *, window_nights: int, now: float | None = None) -> int:
+    """Count of `auto: true` add/supersede op-events for `slug` committed
+    within the last `window_nights` days -- derived FRESH from committed
+    op-events on disk every call (adrev-opt-014: NOT a mutable counter, so
+    a mid-batch crash can never desync it; a re-run simply re-derives the
+    same answer from whatever is actually on disk)."""
+    now_ts = now if now is not None else time.time()
+    cutoff = now_ts - (window_nights * 86400.0)
+    count = 0
+    for raw in _raw_op_events(slug):
+        if raw.get("op") not in ("add", "supersede"):
+            continue
+        if raw.get("auto") is not True:
+            continue
+        ts = learnings_store._parse_iso(raw.get("timestamp") or "")  # noqa: SLF001 -- cross-module reuse of self-improving's ISO parser, mirroring memory_eval.py's own precedent for the same private helper
+        if ts and ts >= cutoff:
+            count += 1
+    return count
+
+
+def _rolling_rate_exceeded(slug: str, cfg: dict[str, Any], *, now: float | None = None) -> bool:
+    """§3.8 cross-night accumulation signal: the patient-drip-attacker
+    residual. A single per-run cap cannot see a slow trickle spread across
+    many nights; this signal looks back `rolling_add_rate_window_nights`
+    and treats exceeding `rolling_add_rate_max` as an anomaly feeding the
+    circuit breaker. Bounded, not eliminated -- a plausible, prevalence-
+    backed drip that stays under this threshold still gets through; the
+    risk register names this honestly rather than claiming a guarantee.
+    """
+    window = int(cfg.get("rolling_add_rate_window_nights", 14))
+    max_rate = int(cfg.get("rolling_add_rate_max", 40))
+    return _rolling_auto_add_supersede_count(slug, window_nights=window, now=now) > max_rate
+
+
+def _maybe_auto_resume(state: dict[str, Any], cfg: dict[str, Any], batch_id: str) -> dict[str, Any]:
+    """If `state['suspended']` and enough quiet time has elapsed since
+    `suspended_at`, clears the suspension, persists it, and audits the
+    transition. Returns the (possibly updated) state. Caller MUST already
+    hold `_apply_lock()`.
+
+    "Quiet" needs no separate tracking: while suspended, the engine applies
+    nothing (see run_optimistic_integrate's early return below), so no NEW
+    anomaly can be recorded during the suspension window -- the mere
+    passage of `circuit_breaker_auto_resume_nights` is sufficient. An
+    ambiguous state (suspended but no parseable `suspended_at`, e.g. a
+    hand-edited file) never auto-resumes -- fails closed, requires a
+    manual `optimistic-resume`.
+    """
+    if not state.get("suspended"):
+        return state
+    suspended_at = state.get("suspended_at")
+    if not suspended_at:
+        return state
+    ts = learnings_store._parse_iso(suspended_at)  # noqa: SLF001 -- see _rolling_auto_add_supersede_count
+    if ts <= 0:
+        return state
+    resume_after_s = float(cfg.get("circuit_breaker_auto_resume_nights", 7)) * 86400.0
+    if (time.time() - ts) < resume_after_s:
+        return state
+    state = dict(state)
+    state["suspended"] = False
+    state["suspended_at"] = None
+    _write_optimistic_state_atomic(state)
+    _write_audit({
+        "outcome": "circuit_breaker_auto_resumed", "batch_id": batch_id,
+        "detail": f"quiet for >= {cfg.get('circuit_breaker_auto_resume_nights', 7)} night(s) since suspension",
+    })
+    return state
+
+
+def optimistic_resume() -> dict[str, Any]:
+    """Manual, immediate re-enable (plan.md §3.5) -- the
+    `apply_dream_proposal.py optimistic-resume` CLI subcommand. Always
+    audited (never a silent un-suspend, matching every other breaker-state
+    transition)."""
+    with _apply_lock():
+        state = _read_optimistic_state()
+        was_suspended = bool(state.get("suspended"))
+        state["suspended"] = False
+        state["suspended_at"] = None
+        _write_optimistic_state_atomic(state)
+    record = {"outcome": "circuit_breaker_manual_resume", "was_suspended": was_suspended, "ok": True}
+    _write_audit(record)
+    return record
+
+
+def _process_one_proposal(
+    row: dict[str, Any], *, slug: str, cfg: dict[str, Any], live_count: int,
+    anomaly_slugs: set[str], add_supersede_counts: dict[str, int],
+    eviction_counts: dict[str, int], batch_id: str,
+) -> dict[str, Any]:
+    """Per-proposal posture/floor/cap/anomaly gate, then apply via the SAME
+    `apply_proposal()` human accepts use (so the human-race lock and
+    per-outcome audit trail cover this path for free).
+
+    Returns a result dict `run_optimistic_integrate()` tallies via:
+      - `applied: True`   -- apply_proposal() succeeded.
+      - `attempted: True` (applied absent) -- apply_proposal() was CALLED
+        but did not succeed (a real failure: CAS mismatch, target gone,
+        etc.) -- distinct from a proposal this function decided NOT to
+        attempt at all (gated/floor/prevalence/compaction-guard/cap/
+        anomaly), which sets neither key.
+
+    Never raises: every branch is inside a try/except so one malformed row
+    (an unhashable `kind`, a non-dict `prevalence`, etc.) can never abort
+    the rest of the batch -- mirrors apply_proposal()'s own handler-crash
+    guard, one layer up.
+    """
+    proposal_id = row.get("id")
+    try:
+        kind = row.get("kind")
+        project = row.get("project")
+
+        posture = da.resolve_posture(kind, project)
+        if posture["posture"] == "gated":
+            _write_audit({
+                "outcome": "skipped_gated", "batch_id": batch_id, "proposal_id": proposal_id,
+                "kind": kind, "project": project,
+            })
+            return {"outcome": "skipped_gated", "proposal_id": proposal_id}
+
+        floor_key = posture.get("confidence_floor")
+        floor = int(cfg.get(floor_key, 0)) if floor_key else 0
+        conf = _confidence_of(row)
+        if conf < floor:
+            _write_audit({
+                "outcome": "skipped_floor", "batch_id": batch_id, "proposal_id": proposal_id,
+                "kind": kind, "project": project, "detail": f"confidence {conf} < floor {floor}",
+            })
+            return {"outcome": "skipped_floor", "proposal_id": proposal_id}
+
+        if kind == "learning_add":
+            prevalence = row.get("prevalence") or {}
+            sessions = prevalence.get("sessions") if isinstance(prevalence, dict) else None
+            min_sessions = int(cfg.get("add_min_sessions", 2))
+            if not isinstance(sessions, int) or isinstance(sessions, bool) or sessions < min_sessions:
+                _write_audit({
+                    "outcome": "skipped_prevalence", "batch_id": batch_id, "proposal_id": proposal_id,
+                    "kind": kind, "project": project, "detail": f"sessions={sessions!r} < {min_sessions}",
+                })
+                return {"outcome": "skipped_prevalence", "proposal_id": proposal_id}
+
+        if kind == "learning_supersede" and row.get("compaction_guard_failed"):
+            _write_audit({
+                "outcome": "skipped_compaction_guard", "batch_id": batch_id, "proposal_id": proposal_id,
+                "kind": kind, "project": project,
+            })
+            return {"outcome": "skipped_compaction_guard", "proposal_id": proposal_id}
+
+        per_run_cap = posture.get("per_run_cap")
+        is_eviction = isinstance(per_run_cap, tuple)
+        if is_eviction:
+            if slug in anomaly_slugs:
+                _write_audit({
+                    "outcome": "skipped_anomaly", "batch_id": batch_id, "proposal_id": proposal_id,
+                    "kind": kind, "project": project,
+                })
+                return {"outcome": "skipped_anomaly", "proposal_id": proposal_id}
+            abs_key, frac_key = per_run_cap
+            cap = min(float(cfg.get(abs_key, 0)), float(cfg.get(frac_key, 0)) * live_count)
+            if eviction_counts[slug] >= cap:
+                _write_audit({
+                    "outcome": "skipped_over_cap", "batch_id": batch_id, "proposal_id": proposal_id,
+                    "kind": kind, "project": project, "detail": f"eviction cap {cap} reached for {slug!r}",
+                })
+                return {"outcome": "skipped_over_cap", "proposal_id": proposal_id}
+        elif isinstance(per_run_cap, str):
+            cap = float(cfg.get(per_run_cap, 0))
+            if add_supersede_counts[slug] >= cap:
+                _write_audit({
+                    "outcome": "skipped_over_cap", "batch_id": batch_id, "proposal_id": proposal_id,
+                    "kind": kind, "project": project, "detail": f"add/supersede cap {cap} reached for {slug!r}",
+                })
+                return {"outcome": "skipped_over_cap", "proposal_id": proposal_id}
+
+        dwell_hours = float(cfg.get("dwell_hours", 24)) if posture.get("needs_dwell") else None
+
+        result = apply_proposal(
+            proposal_id, method="auto_apply", reviewed_by="optimistic-integrate",
+            dwell_hours=dwell_hours, batch_id=batch_id, posture=posture["posture"],
+        )
+        if result.get("ok"):
+            if is_eviction:
+                eviction_counts[slug] += 1
+            elif isinstance(per_run_cap, str):
+                add_supersede_counts[slug] += 1
+            return {"outcome": result.get("outcome"), "proposal_id": proposal_id, "applied": True}
+        return {
+            "outcome": result.get("outcome"), "proposal_id": proposal_id, "attempted": True,
+            "detail": result.get("detail"),
+        }
+    except Exception:  # noqa: BLE001 -- deliberate: a malformed row's gating logic must never
+        # abort the rest of the batch (mirrors apply_proposal()'s own handler-crash guard).
+        detail = traceback.format_exc()
+        _write_audit({
+            "outcome": "internal_error", "batch_id": batch_id, "proposal_id": proposal_id, "detail": detail,
+        })
+        return {"outcome": "internal_error", "proposal_id": proposal_id, "detail": detail}
+
+
+def run_optimistic_integrate(day: str) -> dict[str, Any]:
+    """The optimistic auto-integration engine (plan.md §5 Epic 3).
+
+    Lock topology (adrev-opt-011): this function NEVER holds `_apply_lock()`
+    across the batch. Each proposal is applied through `apply_proposal()`,
+    which takes/releases the lock per call. The breaker-state read (before
+    the loop) and the breaker-state write + single batch commit (after the
+    loop) each acquire the lock in their OWN, non-nested critical section.
+
+    Transaction model (adrev-opt-012/013): the whole batch runs with
+    per-write autocommit suppressed (`_suppressed_autocommit()`) and makes
+    at most ONE `ccgm-learnings-sync commit` at the end, tagged with
+    `batch_id` in the commit message. Only `pending` proposals are ever
+    considered (read once, at the top) -- an already-`auto_applied` row
+    from an earlier run is never re-evaluated, so a `--force-day` re-run of
+    a fully-integrated night applies nothing and adds no commit.
+
+    Never raises; a single proposal's failure (or malformation) does not
+    abort the batch -- see `_process_one_proposal()`.
+    """
+    path = proposals_dir() / f"{day}.jsonl"
+    summary: dict[str, Any] = {
+        "day": day, "batch_id": None, "evaluated": 0, "applied": 0, "skipped": 0,
+        "failed": 0, "results": [], "anomalies": [], "circuit_breaker": None,
+    }
+    if not path.is_file():
+        return summary
+
+    rows = _read_jsonl(path)
+    summary["evaluated"] = len(rows)
+    pending = [r for r in rows if r.get("status") == "pending"]
+    if not pending:
+        return summary
+
+    cfg = da.load_config().get("optimistic_integration") or {}
+
+    batch_id = f"optbatch_{uuid.uuid4().hex[:12]}"
+
+    # Circuit-breaker check: OWN, non-nested critical section (adrev-opt-011).
+    with _apply_lock():
+        state = _read_optimistic_state()
+        was_suspended_before = bool(state.get("suspended"))
+        state = _maybe_auto_resume(state, cfg, batch_id)
+    if state.get("suspended"):
+        summary["circuit_breaker"] = "suspended"
+        return summary
+    if was_suspended_before:
+        summary["circuit_breaker"] = "auto_resumed"
+
+    by_slug: dict[str, list[dict[str, Any]]] = {}
+    for row in pending:
+        project = row.get("project")
+        if not isinstance(project, str) or not project:
+            # Defensive (never expected from a schema-valid proposal row,
+            # but a malformed/hand-edited row must not crash the whole
+            # batch's slug-keyed bookkeeping below): treat like any other
+            # proposal this engine declines to touch.
+            _write_audit({
+                "outcome": "skipped_malformed", "batch_id": batch_id, "proposal_id": row.get("id"),
+                "kind": row.get("kind"), "detail": f"invalid project field: {project!r}",
+            })
+            summary["skipped"] += 1
+            summary["results"].append({"outcome": "skipped_malformed", "proposal_id": row.get("id")})
+            continue
+        by_slug.setdefault(project, []).append(row)
+
+    if not by_slug:
+        return summary
+
+    summary["batch_id"] = batch_id
+
+    # P2 (security review): live_head_count is the eviction cap's
+    # denominator -- computed for EVERY slug in the batch ONCE, before any
+    # write, so same-run adds cannot inflate it.
+    live_counts: dict[str, int] = {slug: _live_head_count(slug) for slug in by_slug}
+    heads_by_slug: dict[str, dict[str, dict[str, Any]]] = {
+        slug: {h["id"]: h for h in learnings_store.load_all(slug)} for slug in by_slug
+    }
+
+    # Batch-anomaly check (pre-apply, per slug, eviction-concentration only).
+    anomaly_slugs: set[str] = set()
+    run_anomaly_timestamps: list[str] = []
+    for slug, slug_rows in by_slug.items():
+        eviction_rows = [r for r in slug_rows if r.get("kind") in ("learning_contradict", "learning_deprecate")]
+        if _batch_anomaly_fires(eviction_rows, heads_by_slug[slug], cfg):
+            anomaly_slugs.add(slug)
+            run_anomaly_timestamps.append(_utc_now_iso())
+            summary["anomalies"].append({"slug": slug, "kind": "batch_eviction_concentration"})
+            _write_audit({
+                "outcome": "batch_anomaly_eviction_concentration", "batch_id": batch_id,
+                "project": slug, "detail": f"{len(eviction_rows)} eviction proposal(s) concentrated",
+            })
+
+    add_supersede_counts: dict[str, int] = {slug: 0 for slug in by_slug}
+    eviction_counts: dict[str, int] = {slug: 0 for slug in by_slug}
+
+    with _suppressed_autocommit():  # adrev-opt-013: one commit for the whole batch, not one per write
+        for slug, slug_rows in by_slug.items():
+            for row in slug_rows:
+                outcome = _process_one_proposal(
+                    row, slug=slug, cfg=cfg, live_count=live_counts[slug],
+                    anomaly_slugs=anomaly_slugs, add_supersede_counts=add_supersede_counts,
+                    eviction_counts=eviction_counts, batch_id=batch_id,
+                )
+                summary["results"].append(outcome)
+                if outcome.get("applied"):
+                    summary["applied"] += 1
+                elif outcome.get("attempted"):
+                    summary["failed"] += 1
+                else:
+                    summary["skipped"] += 1
+
+    # Cross-night accumulation signal (§3.8) -- derived AFTER applying, so
+    # it reflects tonight's own contribution too. Feeds the breaker for
+    # FUTURE nights; never retroactively undoes tonight's writes.
+    for slug in by_slug:
+        if _rolling_rate_exceeded(slug, cfg):
+            run_anomaly_timestamps.append(_utc_now_iso())
+            summary["anomalies"].append({"slug": slug, "kind": "rolling_add_rate_exceeded"})
+            _write_audit({"outcome": "rolling_add_rate_exceeded", "batch_id": batch_id, "project": slug})
+
+    # Breaker-state write + single batch commit: ONE non-nested critical
+    # section (adrev-opt-011), acquired AFTER every per-proposal
+    # apply_proposal() call above has already released the lock.
+    with _apply_lock():
+        state = _read_optimistic_state()
+        state.setdefault("anomaly_log", [])
+        state["anomaly_log"].extend(run_anomaly_timestamps)
+        state["last_run"] = _utc_now_iso()
+
+        window_nights = int(cfg.get("circuit_breaker_window_nights", 7))
+        window_start = time.time() - (window_nights * 86400.0)
+        recent = [
+            t for t in state["anomaly_log"]
+            if learnings_store._parse_iso(t) >= window_start  # noqa: SLF001 -- see _rolling_auto_add_supersede_count
+        ]
+        max_anomalies = int(cfg.get("circuit_breaker_max_anomalies", 2))
+        if len(recent) >= max_anomalies and not state.get("suspended"):
+            state["suspended"] = True
+            state["suspended_at"] = _utc_now_iso()
+            summary["circuit_breaker"] = "tripped"
+            _write_audit({
+                "outcome": "circuit_breaker_tripped", "batch_id": batch_id,
+                "detail": f"{len(recent)} anomalies within {window_nights} night window "
+                          f"(threshold {max_anomalies})",
+            })
+
+        _write_optimistic_state_atomic(state)
+
+        if summary["applied"] > 0:
+            commit_result = _run_sync_commit(
+                message=f"dreaming: optimistic-integrate batch {batch_id} ({day})"
+            )
+            summary["commit"] = commit_result
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Weekly, cost-capped eval refresh (optimistic-memory plan.md Epic 3, "fix
+# (b) for adrev-opt-001"): keeps dream-eval.sh --gate's 14-day freshness
+# bound met without manual intervention, without competing with the
+# nightly analyzer for the SAME daily_cost_cap_usd (adrev-opt-010).
+# ---------------------------------------------------------------------------
+
+
+def _eval_script_path() -> Path:
+    """`modules/dreaming/eval/memory_eval.py`, resolved relative to this
+    file (lib/ and eval/ are sibling directories WITHIN the same module --
+    always installed/checked-out together, unlike the self-improving
+    cross-module resolution `_resolve_sibling_bin()` handles above, so no
+    installed-vs-repo-relative fallback dance is needed here).
+    `CCGM_DREAMING_EVAL_REFRESH_SCRIPT` lets tests substitute a fixture
+    script that mimics memory_eval.py's `--date`/results-file contract
+    without ever invoking the real live A/B harness -- mirrors dream-
+    daily.sh's own `CCGM_DREAMING_EVAL_SCRIPT` override for the --gate
+    script.
+    """
+    override = os.environ.get("CCGM_DREAMING_EVAL_REFRESH_SCRIPT")
+    if override:
+        return Path(override)
+    return _HERE.parent / "eval" / "memory_eval.py"
+
+
+def _latest_eval_results_age_days(*, now: float | None = None) -> float | None:
+    """Age in days of the most recently-modified eval results file under
+    dreaming's evals/ dir, or None if none exists yet (treated by the
+    caller as "infinitely stale" -- always eligible to refresh)."""
+    evals_dir = dreaming_dir() / "evals"
+    if not evals_dir.is_dir():
+        return None
+    files = sorted(evals_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True)
+    if not files:
+        return None
+    now_ts = now if now is not None else time.time()
+    return (now_ts - files[0].stat().st_mtime) / 86400.0
+
+
+def _read_cost_spent_today_by_label(path: Path, today: str, label: str) -> float:
+    """Like `dream_analyze._read_cost_spent_today()`, but scoped to ledger
+    rows whose `model` field equals `label` exactly. Lets the eval-refresh
+    step check its OWN spend against its OWN `eval_refresh_cost_cap_usd`
+    without being confused by the analyzer's spend on the SAME shared
+    `cost.log` file (adrev-opt-010: the two must never silently compete
+    for one cap, but they DO share one ledger so total daily spend stays
+    visible in one place)."""
+    if not path.is_file():
+        return 0.0
+    total = 0.0
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) >= 5 and parts[0] == today and parts[4] == label:
+                try:
+                    total += float(parts[3])
+                except ValueError:
+                    continue
+    return total
+
+
+def _eval_refresh_preconditions(day: str, cfg: dict[str, Any]) -> tuple[bool, str]:
+    """Pure(-ish) precondition gate for `run_eval_refresh()`: no
+    subprocess, no network -- only an mtime check, an env var read, and a
+    ledger read. Split out from `run_eval_refresh()` specifically so this
+    gating logic (the part that matters for cost safety) is unit-testable
+    without ever invoking the live eval harness. Returns (should_run,
+    reason).
+    """
+    opt_cfg = cfg.get("optimistic_integration") or {}
+    min_age_days = float(opt_cfg.get("eval_refresh_min_age_days", 7))
+    cost_cap = float(opt_cfg.get("eval_refresh_cost_cap_usd", 2.0))
+
+    age_days = _latest_eval_results_age_days()
+    if age_days is not None and age_days < min_age_days:
+        return False, f"latest eval results are {age_days:.1f}d old (< {min_age_days}d min); skipping"
+
+    da.load_env()  # dreaming's own .env, falling back to autoheal's (mirrors memory_eval.main())
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        return False, "no ANTHROPIC_API_KEY configured; skipping"
+
+    spent = _read_cost_spent_today_by_label(da.cost_log_path(), day, EVAL_REFRESH_COST_LABEL)
+    if spent >= cost_cap:
+        return False, f"eval_refresh_cost_cap_usd exhausted (spent ${spent:.4f} of ${cost_cap:.4f})"
+
+    return True, "ok"
+
+
+def run_eval_refresh(day: str) -> dict[str, Any]:
+    """Fix (b) for adrev-opt-001: runs the full live A/B eval
+    (memory_eval.py, no --offline) to keep dream-eval.sh --gate's 14-day
+    freshness bound met -- but ONLY when `_eval_refresh_preconditions()`
+    passes. If not eligible, logs the reason and returns without touching
+    anything (the 14-day bound then eventually fails the gate closed on
+    its own -- a surfaced, safe degradation, never a silent one;
+    adrev-opt-009's named, accepted drift window).
+
+    Honest limitation: `_eval_refresh_preconditions()`'s cost-cap check is
+    a START gate (refuses to begin if the ledger already shows the cap
+    spent today), not a HARD mid-run stop -- memory_eval.py has no
+    cumulative total-run cost limiter today (only a PER-CALL
+    `--max-budget-usd`, a different knob), and adding one is out of this
+    function's file-touch scope (memory_eval.py is not modified here). A
+    single refresh run can therefore spend somewhat more than
+    `eval_refresh_cost_cap_usd` before the NEXT day's precondition check
+    sees the overage and refuses to run again. Actual spend is always
+    recorded to the shared ledger regardless of whether it overshot, so
+    the overage is visible, not hidden.
+    """
+    cfg = da.load_config()
+    summary: dict[str, Any] = {"day": day, "ran": False, "reason": None}
+
+    should_run, reason = _eval_refresh_preconditions(day, cfg)
+    if not should_run:
+        summary["reason"] = reason
+        return summary
+
+    script = _eval_script_path()
+    if not script.is_file():
+        summary["reason"] = f"eval refresh script not found at {script}"
+        return summary
+
+    proc = subprocess.run(
+        [sys.executable, str(script), "--date", day],
+        capture_output=True, text=True, check=False,
+    )
+    summary["exit_code"] = proc.returncode
+    if proc.stderr:
+        summary["stderr_tail"] = proc.stderr[-2000:]
+
+    results_path = dreaming_dir() / "evals" / f"{day}.jsonl"
+    if results_path.is_file():
+        result_rows = _read_jsonl(results_path)
+        total_cost = sum(float(r.get("cost_usd") or 0.0) for r in result_rows)
+        if total_cost > 0:
+            da._append_cost(  # noqa: SLF001 -- cross-module reuse of the analyzer's own shared cost-ledger writer
+                da.cost_log_path(), day, 0, 0, total_cost, EVAL_REFRESH_COST_LABEL,
+            )
+        summary["cost_usd"] = round(total_cost, 6)
+        summary["rows_written"] = len(result_rows)
+
+    summary["ran"] = proc.returncode == 0
+    if not summary["ran"] and not summary.get("reason"):
+        summary["reason"] = f"memory_eval.py exited {proc.returncode}"
     return summary
 
 
@@ -809,6 +1642,31 @@ def _cmd_auto_apply(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_optimistic_integrate(args: argparse.Namespace) -> int:
+    # No _run_sync_commit() call here -- run_optimistic_integrate() already
+    # makes its own single batch commit internally (adrev-opt-013), under
+    # the same critical section as the breaker-state write. Calling it
+    # again here would either no-op (clean tree) or, worse, fold any
+    # unrelated dirty state into a second, unlabeled commit.
+    day = args.day or today_iso()
+    summary = run_optimistic_integrate(day)
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+def _cmd_optimistic_resume(args: argparse.Namespace) -> int:
+    result = optimistic_resume()
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+def _cmd_eval_refresh(args: argparse.Namespace) -> int:
+    day = args.day or today_iso()
+    summary = run_eval_refresh(day)
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
 def build_arg_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="CCGM dreaming: human-gated apply path (Epic 6).")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -829,10 +1687,34 @@ def build_arg_parser() -> argparse.ArgumentParser:
     auto_p = sub.add_parser(
         "auto-apply",
         help="batch-apply qualifying learning_verify rows for one day "
-             "(config/eval-gating is dream-daily.sh's job, not this CLI's)",
+             "(config/eval-gating is dream-daily.sh's job, not this CLI's; retained for "
+             "backward compatibility -- dream-daily.sh's nightly chain now calls "
+             "optimistic-integrate instead)",
     )
     auto_p.add_argument("--day", help="defaults to today (UTC, or CCGM_DREAMING_TODAY)")
     auto_p.set_defaults(func=_cmd_auto_apply)
+
+    opt_p = sub.add_parser(
+        "optimistic-integrate",
+        help="run the full per-op-kind posture engine over one day's pending proposals "
+             "(config/eval-gating is dream-daily.sh's job, not this CLI's; optimistic-memory "
+             "plan.md Epic 3)",
+    )
+    opt_p.add_argument("--day", help="defaults to today (UTC, or CCGM_DREAMING_TODAY)")
+    opt_p.set_defaults(func=_cmd_optimistic_integrate)
+
+    resume_p = sub.add_parser(
+        "optimistic-resume", help="force-clear a tripped optimistic-integration circuit breaker immediately",
+    )
+    resume_p.set_defaults(func=_cmd_optimistic_resume)
+
+    refresh_p = sub.add_parser(
+        "eval-refresh",
+        help="weekly, cost-capped live eval refresh so dream-eval.sh --gate's 14-day freshness "
+             "bound stays met without manual intervention (fix (b) for adrev-opt-001)",
+    )
+    refresh_p.add_argument("--day", help="defaults to today (UTC, or CCGM_DREAMING_TODAY)")
+    refresh_p.set_defaults(func=_cmd_eval_refresh)
 
     return p
 

--- a/modules/dreaming/lib/apply_dream_proposal.py
+++ b/modules/dreaming/lib/apply_dream_proposal.py
@@ -102,11 +102,14 @@ existing caller.
 Lock topology (adrev-opt-011): the engine NEVER holds `_apply_lock()` across
 the batch -- each proposal is applied through `apply_proposal()`, which
 takes/releases the lock per call exactly as it does today. The breaker
-state read (before the loop) and the breaker state write + single batch
-commit (after the loop) each acquire the lock in their OWN, non-nested
-critical section. `fcntl.flock` is non-reentrant; nesting a batch-wide lock
-around per-proposal `apply_proposal()` calls would self-deadlock on the
-very first row.
+state read (before the loop) and the breaker state write (after the loop)
+each acquire the lock in their OWN, non-nested critical section.
+`fcntl.flock` is non-reentrant; nesting a batch-wide lock around
+per-proposal `apply_proposal()` calls would self-deadlock on the very first
+row. The single batch commit (review fix for #801, PR #810) runs AFTER the
+breaker-state-write section has already released the lock -- see that
+section's own comment in `run_optimistic_integrate()` for why issuing it
+while still holding `_apply_lock()` is unsafe.
 
 Red-gate-as-anomaly (review fix for #801, PR #810): plan.md §3.5 says the
 breaker trips on "batch-anomaly fire OR red eval gate", but a red
@@ -1146,9 +1149,9 @@ def _rolling_rate_exceeded(slug: str, cfg: dict[str, Any], *, now: float | None 
 
 def _maybe_auto_resume(state: dict[str, Any], cfg: dict[str, Any], batch_id: str) -> dict[str, Any]:
     """If `state['suspended']` and enough quiet time has elapsed since
-    `suspended_at`, clears the suspension, persists it, and audits the
-    transition. Returns the (possibly updated) state. Caller MUST already
-    hold `_apply_lock()`.
+    `suspended_at`, clears the suspension, resets `anomaly_log` to a clean
+    slate, persists it, and audits the transition. Returns the (possibly
+    updated) state. Caller MUST already hold `_apply_lock()`.
 
     "Quiet" needs no separate tracking: while suspended, run_optimistic_
     integrate() itself applies nothing (see its early return below), so no
@@ -1157,11 +1160,20 @@ def _maybe_auto_resume(state: dict[str, Any], cfg: dict[str, Any], batch_id: str
     `circuit_breaker_auto_resume_nights` is sufficient. `record_anomaly()`
     (review fix for #801, PR #810 -- a red eval gate never reaches
     run_optimistic_integrate() at all) is an INDEPENDENT path that CAN
-    still append to `anomaly_log` while suspended; that does not change
-    this function's own check, which only ever looks at wall-clock time
-    since `suspended_at`, never at `anomaly_log` contents. An ambiguous
-    state (suspended but no parseable `suspended_at`, e.g. a hand-edited
-    file) never auto-resumes -- fails closed, requires a manual
+    still append to `anomaly_log` while suspended -- and without clearing
+    it here, those stale-but-still-within-window entries would survive the
+    resume and immediately re-trip `_evaluate_breaker_trip()` on this SAME
+    call, applying (and committing) at most one capped batch before
+    re-suspending: "auto-resume" would leak a single batch per cycle
+    instead of actually resuming (review fix for #801, PR #810). Resetting
+    `anomaly_log` to `[]` on a genuine resume gives the breaker a true clean
+    slate -- it re-trips only on anomalies recorded AFTER this point, never
+    on the ones that caused the original trip. This function's OWN decision
+    to resume still depends ONLY on wall-clock time since `suspended_at`,
+    never on `anomaly_log` contents -- clearing the log is an action taken
+    upon resuming, not a new precondition for resuming. An ambiguous state
+    (suspended but no parseable `suspended_at`, e.g. a hand-edited file)
+    never auto-resumes -- fails closed, requires a manual
     `optimistic-resume`.
     """
     if not state.get("suspended"):
@@ -1178,10 +1190,12 @@ def _maybe_auto_resume(state: dict[str, Any], cfg: dict[str, Any], batch_id: str
     state = dict(state)
     state["suspended"] = False
     state["suspended_at"] = None
+    state["anomaly_log"] = []
     _write_optimistic_state_atomic(state)
     _write_audit({
         "outcome": "circuit_breaker_auto_resumed", "batch_id": batch_id,
-        "detail": f"quiet for >= {cfg.get('circuit_breaker_auto_resume_nights', 7)} night(s) since suspension",
+        "detail": f"quiet for >= {cfg.get('circuit_breaker_auto_resume_nights', 7)} night(s) since suspension; "
+                  f"anomaly_log reset to a clean slate",
     })
     return state
 
@@ -1200,6 +1214,31 @@ def optimistic_resume() -> dict[str, Any]:
     record = {"outcome": "circuit_breaker_manual_resume", "was_suspended": was_suspended, "ok": True}
     _write_audit(record)
     return record
+
+
+def _prune_anomaly_log(anomaly_log: list[str], cfg: dict[str, Any], *, now: float | None = None) -> list[str]:
+    """Bounds `anomaly_log`'s otherwise-unbounded growth (review fix for
+    #801, PR #810): it is append-only at every call site
+    (`record_anomaly()`, `run_optimistic_integrate()`) and, absent this
+    prune, would accumulate forever under a sustained anomaly stream (e.g.
+    a long red-eval-gate streak recorded nightly via `record_anomaly()`).
+
+    Drops entries older than `2 * circuit_breaker_window_nights` days -- a
+    generous retention that can NEVER remove anything
+    `_evaluate_breaker_trip()` would otherwise have counted (that
+    function's own window is exactly `circuit_breaker_window_nights`, half
+    this retention), so pruning changes no trip decision; it only keeps the
+    on-disk state file bounded. Each call site is expected to prune
+    immediately after appending/extending, before persisting.
+    """
+    window_nights = int(cfg.get("circuit_breaker_window_nights", 7))
+    retention_s = 2 * window_nights * 86400.0
+    now_ts = now if now is not None else time.time()
+    cutoff = now_ts - retention_s
+    return [
+        t for t in anomaly_log
+        if learnings_store._parse_iso(t) >= cutoff  # noqa: SLF001 -- see _rolling_auto_add_supersede_count
+    ]
 
 
 def _evaluate_breaker_trip(state: dict[str, Any], cfg: dict[str, Any], *, batch_id: str) -> bool:
@@ -1266,7 +1305,10 @@ def record_anomaly(reason: str) -> dict[str, Any]:
     REUSES `_read_optimistic_state()` / `_write_optimistic_state_atomic()`
     / the same windowed-breaker evaluation `run_optimistic_integrate()`
     uses (via `_evaluate_breaker_trip()`) rather than re-deriving any of
-    that logic.
+    that logic. Also prunes `anomaly_log` via `_prune_anomaly_log()`
+    immediately after appending (review fix for #801, PR #810), so a
+    sustained red-eval-gate streak recorded nightly through this function
+    cannot grow the log forever.
 
     Always audited: one `anomaly_recorded` record unconditionally, plus a
     `circuit_breaker_tripped` record (written by `_evaluate_breaker_trip`,
@@ -1290,6 +1332,7 @@ def record_anomaly(reason: str) -> dict[str, Any]:
         state = _read_optimistic_state()
         state.setdefault("anomaly_log", [])
         state["anomaly_log"].append(_utc_now_iso())
+        state["anomaly_log"] = _prune_anomaly_log(state["anomaly_log"], cfg)
 
         tripped = _evaluate_breaker_trip(state, cfg, batch_id=context_id)
         _write_optimistic_state_atomic(state)
@@ -1423,8 +1466,11 @@ def run_optimistic_integrate(day: str) -> dict[str, Any]:
     Lock topology (adrev-opt-011): this function NEVER holds `_apply_lock()`
     across the batch. Each proposal is applied through `apply_proposal()`,
     which takes/releases the lock per call. The breaker-state read (before
-    the loop) and the breaker-state write + single batch commit (after the
-    loop) each acquire the lock in their OWN, non-nested critical section.
+    the loop) and the breaker-state write (after the loop) each acquire the
+    lock in their OWN, non-nested critical section. The single batch commit
+    (review fix for #801, PR #810) is issued AFTER the breaker-state-write
+    section releases the lock -- see that section's own comment below for
+    why committing while still holding `_apply_lock()` is unsafe.
 
     Transaction model (adrev-opt-012/013): the whole batch runs with
     per-write autocommit suppressed (`_suppressed_autocommit()`) and makes
@@ -1538,13 +1584,14 @@ def run_optimistic_integrate(day: str) -> dict[str, Any]:
             summary["anomalies"].append({"slug": slug, "kind": "rolling_add_rate_exceeded"})
             _write_audit({"outcome": "rolling_add_rate_exceeded", "batch_id": batch_id, "project": slug})
 
-    # Breaker-state write + single batch commit: ONE non-nested critical
-    # section (adrev-opt-011), acquired AFTER every per-proposal
-    # apply_proposal() call above has already released the lock.
+    # Breaker-state write: ONE non-nested critical section (adrev-opt-011),
+    # acquired AFTER every per-proposal apply_proposal() call above has
+    # already released the lock.
     with _apply_lock():
         state = _read_optimistic_state()
         state.setdefault("anomaly_log", [])
         state["anomaly_log"].extend(run_anomaly_timestamps)
+        state["anomaly_log"] = _prune_anomaly_log(state["anomaly_log"], cfg)
         state["last_run"] = _utc_now_iso()
 
         if _evaluate_breaker_trip(state, cfg, batch_id=batch_id):
@@ -1552,11 +1599,23 @@ def run_optimistic_integrate(day: str) -> dict[str, Any]:
 
         _write_optimistic_state_atomic(state)
 
-        if summary["applied"] > 0:
-            commit_result = _run_sync_commit(
-                message=f"dreaming: optimistic-integrate batch {batch_id} ({day})"
-            )
-            summary["commit"] = commit_result
+    # Single batch commit, tagged with batch_id -- issued AFTER the
+    # breaker-state lock above has been released, NEVER while holding it
+    # (review fix for #801, PR #810). `ccgm-learnings-sync commit` blocks
+    # on a SEPARATE sync lock that a concurrent pull/push/autocommit can
+    # hold for an unbounded time; holding `_apply_lock()` across that call
+    # would stall every other apply-lock consumer (a human `/dream-apply
+    # accept`, `record_anomaly()`, a second integrate run) behind git-sync
+    # contention this module has no control over. The breaker state above
+    # is already durably persisted (atomic rename) and every write this
+    # batch made is already on disk by this point, so moving the commit
+    # outside the lock changes only WHEN it is issued, never WHAT it
+    # commits.
+    if summary["applied"] > 0:
+        commit_result = _run_sync_commit(
+            message=f"dreaming: optimistic-integrate batch {batch_id} ({day})"
+        )
+        summary["commit"] = commit_result
 
     return summary
 

--- a/modules/dreaming/tests/test-dream-apply.sh
+++ b/modules/dreaming/tests/test-dream-apply.sh
@@ -567,7 +567,7 @@ done
 # ---------------------------------------------------------------------
 
 cat >"${DREAMING_DIR}/config.json" <<'EOF'
-{"auto_apply_counters": true}
+{"optimistic_integration": {"enabled": true}}
 EOF
 
 EMPTY_PROJECTS_ROOT="${SANDBOX}/empty-claude-projects"

--- a/modules/dreaming/tests/test_optimistic_engine.py
+++ b/modules/dreaming/tests/test_optimistic_engine.py
@@ -1,0 +1,930 @@
+#!/usr/bin/env python3
+"""
+Tests for the optimistic auto-integration engine (optimistic-memory
+plan.md Epic 3): modules/dreaming/lib/apply_dream_proposal.py's
+run_optimistic_integrate(), the per-slug blast-radius caps, the batch
+eviction-concentration anomaly check, the cross-night accumulation
+signal, the windowed circuit breaker, and the weekly cost-capped eval
+refresh (run_eval_refresh()).
+
+Runs in isolation: CCGM_LEARNINGS_DIR + CCGM_DREAMING_DIR + HOME are
+redirected to tempdirs BEFORE import (mirrors test_apply_dream_proposal.py
+-- learnings_store.LEARNINGS_ROOT is frozen at import time; HOME is
+sandboxed so _resolve_sibling_bin() falls back to the repo-relative CLIs
+under test, not a possibly-stale installed ~/.claude/bin symlink). No
+network, no ANTHROPIC_API_KEY, never the real store/dreaming dir (#793).
+
+Every test uses a slug (and, where relevant, a day/proposal id) unique to
+that test, so tests never interfere despite sharing one LEARNINGS_ROOT /
+dreaming dir for the whole file. The one shared, mutable piece of state
+that EVERY call to run_optimistic_integrate() touches regardless of slug
+is state/optimistic.json (the circuit breaker) -- setUp() resets it to a
+clean, non-suspended, empty-anomaly-log state before every single test, so
+an anomaly recorded by one test can never leak into another test's breaker
+decision. Tests that specifically exercise the breaker overwrite that
+clean default with their own seeded state afterward.
+
+Run with: python3 -m pytest modules/dreaming/tests/test_optimistic_engine.py -q
+      or: python3 modules/dreaming/tests/test_optimistic_engine.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import uuid
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / "lib"))
+
+# See module docstring: pop first, then point the store + dreaming dir at
+# fresh tempdirs, BEFORE importing apply_dream_proposal (which transitively
+# imports dream_analyze -> learnings_store, whose LEARNINGS_ROOT is frozen
+# at import time). Mirrors test_apply_dream_proposal.py exactly.
+sys.modules.pop("learnings_store", None)
+sys.modules.pop("dream_analyze", None)
+sys.modules.pop("apply_dream_proposal", None)
+
+_TMP_LEARNINGS = tempfile.mkdtemp(prefix="ccgm-dreaming-test-optengine-learnings-")
+_TMP_DREAMING = tempfile.mkdtemp(prefix="ccgm-dreaming-test-optengine-dreaming-")
+_TMP_HOME = tempfile.mkdtemp(prefix="ccgm-dreaming-test-optengine-home-")
+_ORIG_LEARNINGS_DIR = os.environ.get("CCGM_LEARNINGS_DIR")
+_ORIG_DREAMING_DIR = os.environ.get("CCGM_DREAMING_DIR")
+_ORIG_HOME = os.environ.get("HOME")
+os.environ["CCGM_LEARNINGS_DIR"] = _TMP_LEARNINGS
+os.environ["CCGM_DREAMING_DIR"] = _TMP_DREAMING
+os.environ["HOME"] = _TMP_HOME
+
+import apply_dream_proposal as adp  # noqa: E402
+import dream_analyze as da  # noqa: E402
+import learnings_store as ls  # noqa: E402
+
+
+def tearDownModule() -> None:
+    """Undo the module-level env overrides so they cannot leak into
+    whatever test module pytest imports and runs next in the same process
+    (#764)."""
+    for key, orig in (
+        ("CCGM_LEARNINGS_DIR", _ORIG_LEARNINGS_DIR),
+        ("CCGM_DREAMING_DIR", _ORIG_DREAMING_DIR),
+        ("HOME", _ORIG_HOME),
+    ):
+        if orig is not None:
+            os.environ[key] = orig
+        else:
+            os.environ.pop(key, None)
+
+
+def _unique_slug(label: str) -> str:
+    return f"{label}-{uuid.uuid4().hex[:8]}"
+
+
+def _unique_day() -> str:
+    # Not a real calendar date -- nothing in apply_dream_proposal.py parses
+    # `day` as one, it is only ever used as a proposals/{day}.jsonl filename
+    # component. A random suffix guarantees every test's proposals file is
+    # independent of every other test's, with zero manual bookkeeping.
+    return f"2026-test-{uuid.uuid4().hex[:10]}"
+
+
+def _proposal_row(
+    *, pid: str, kind: str, project: str, target_id: str | None = None,
+    content: str | None = None, type_: str | None = None, confidence: int = 8,
+    sessions: int = 2, agents: int = 1, justification: str = "optimistic-engine test",
+    compaction_guard_failed: dict | None = None,
+) -> dict:
+    row: dict = {
+        "id": pid, "kind": kind, "project": project, "target_id": target_id,
+        "content": content, "type": type_, "confidence": confidence,
+        "prevalence": {"sessions": sessions, "agents": agents},
+        "evidence": [{"session_id": f"sess-{pid}", "excerpt": "example"}],
+        "justification": justification, "fingerprint": f"fp-{pid}",
+        "generated_at": "2026-01-01T00:00:00.000Z", "status": "pending",
+    }
+    if compaction_guard_failed is not None:
+        row["compaction_guard_failed"] = compaction_guard_failed
+    return row
+
+
+class OptimisticEngineTestBase(unittest.TestCase):
+    """Shared setUp/helpers for every test class below. Carries no test_
+    methods itself."""
+
+    def setUp(self) -> None:
+        # Re-assert this module's env at RUN time (not just import time):
+        # another test module collected in the same pytest run can have
+        # replaced these os.environ values with ITS tempdirs before we run
+        # (mirrors test_apply_dream_proposal.py's own rationale).
+        self._pin_env("CCGM_LEARNINGS_DIR", str(ls.LEARNINGS_ROOT))
+        self._pin_env("CCGM_DREAMING_DIR", _TMP_DREAMING)
+        self._pin_env("HOME", _TMP_HOME)
+        adp.proposals_dir().mkdir(parents=True, exist_ok=True)
+        # Clean, non-suspended breaker state before EVERY test (see module
+        # docstring) -- every call to run_optimistic_integrate() touches
+        # this one shared file regardless of slug.
+        adp._write_optimistic_state_atomic(adp._default_optimistic_state())
+
+    def _pin_env(self, key: str, value: str) -> None:
+        had = key in os.environ
+        prior = os.environ.get(key)
+        os.environ[key] = value
+
+        def _restore() -> None:
+            if had:
+                os.environ[key] = prior
+            else:
+                os.environ.pop(key, None)
+
+        self.addCleanup(_restore)
+
+    def _write_config(self, overrides: dict | None = None) -> None:
+        """Write only the overrides a test cares about -- da.load_config()'s
+        own (already-tested, Epic 2) deep-merge fills in every other
+        optimistic_integration default."""
+        cfg_path = da.dreaming_dir() / "config.json"
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg_path.write_text(json.dumps({"optimistic_integration": overrides or {}}), encoding="utf-8")
+
+    def _seed_learning(self, slug: str, *, content: str = "seed", confidence: int = 8,
+                        tags: list[str] | None = None) -> str:
+        e = ls.build_entry(type_="pattern", content=content, confidence=confidence, tags=tags or [])
+        e["project"] = slug
+        ls.append_entry(e, slug=slug)
+        return e["id"]
+
+    def _write_day(self, day: str, rows: list[dict]) -> None:
+        path = adp.proposals_dir() / f"{day}.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as fh:
+            for row in rows:
+                fh.write(json.dumps(row, sort_keys=True) + "\n")
+
+    def _read_day(self, day: str) -> list[dict]:
+        return adp._read_jsonl(adp.proposals_dir() / f"{day}.jsonl")
+
+    def _row_by_id(self, day: str, pid: str) -> dict | None:
+        for row in self._read_day(day):
+            if row.get("id") == pid:
+                return row
+        return None
+
+    def _status_of(self, day: str, pid: str) -> str | None:
+        row = self._row_by_id(day, pid)
+        return row.get("status") if row else None
+
+    def _head(self, slug: str, entry_id: str) -> dict | None:
+        heads = ls.project_slug(slug, use_snapshot=False)["heads"]
+        return next((h for h in heads if h["id"] == entry_id), None)
+
+    def _write_optimistic_state(self, state: dict) -> None:
+        adp.optimistic_state_path().parent.mkdir(parents=True, exist_ok=True)
+        adp.optimistic_state_path().write_text(json.dumps(state), encoding="utf-8")
+
+    def _read_optimistic_state_file(self) -> dict:
+        path = adp.optimistic_state_path()
+        if not path.is_file():
+            return {}
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def _read_audit(self) -> list[dict]:
+        path = adp.apply_audit_path()
+        if not path.is_file():
+            return []
+        return [json.loads(ln) for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+    def _iso(self, epoch: float) -> str:
+        return ls._iso_from_epoch(epoch)  # noqa: SLF001 -- test-only convenience, same as production's own reuse
+
+
+# ---------------------------------------------------------------------------
+# Postures (plan.md §3.3): resolve_posture()-driven behavior end to end.
+# ---------------------------------------------------------------------------
+
+
+class PostureTests(OptimisticEngineTestBase):
+    def test_verify_applies_immediately_no_dwell_at_floor(self):
+        slug = _unique_slug("verify-immediate")
+        self._write_config()
+        target_id = self._seed_learning(slug, content="verify target", confidence=5)
+        day = _unique_day()
+        self._write_day(day, [_proposal_row(pid="v1", kind="learning_verify", project=slug,
+                                             target_id=target_id, confidence=7)])
+
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 1, summary)
+        self.assertEqual(self._status_of(day, "v1"), "auto_applied")
+
+        head = self._head(slug, target_id)
+        self.assertIsNotNone(head)
+        self.assertIsNone(head.get("dwell_until"))
+        self.assertEqual(head["uses"], 1)
+
+        row = self._row_by_id(day, "v1")
+        self.assertEqual(row.get("posture"), "optimistic-immediate")
+        self.assertNotIn("dwell_until", row)
+
+    def test_add_applies_with_dwell_at_floor_and_prevalence(self):
+        slug = _unique_slug("add-dwell")
+        self._write_config({"dwell_hours": 24})
+        day = _unique_day()
+        self._write_day(day, [_proposal_row(pid="a1", kind="learning_add", project=slug,
+                                             content="new learning", type_="pattern",
+                                             confidence=8, sessions=2)])
+        before = time.time()
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 1, summary)
+        self.assertEqual(self._status_of(day, "a1"), "auto_applied")
+
+        heads = ls.load_all(slug)
+        self.assertEqual(len(heads), 1)
+        head = heads[0]
+        dwell_ts = ls._parse_iso(head["dwell_until"])  # noqa: SLF001
+        self.assertGreater(dwell_ts, before + 23 * 3600)
+        self.assertLess(dwell_ts, before + 25 * 3600)
+
+        raw_events = adp._raw_op_events(slug)
+        add_events = [e for e in raw_events if e.get("op") == "add"]
+        self.assertEqual(len(add_events), 1)
+        self.assertIs(add_events[0].get("auto"), True)
+
+        row = self._row_by_id(day, "a1")
+        self.assertEqual(row.get("posture"), "optimistic-dwell")
+        self.assertEqual(row.get("batch_id"), summary["batch_id"])
+        self.assertIsNotNone(row.get("dwell_until"))
+
+    def test_contradict_applies_with_mandatory_dwell(self):
+        slug = _unique_slug("contradict-dwell")
+        self._write_config({"dwell_hours": 12})
+        target_id = self._seed_learning(slug, content="to be contradicted", confidence=8)
+        day = _unique_day()
+        self._write_day(day, [_proposal_row(pid="c1", kind="learning_contradict", project=slug,
+                                             target_id=target_id, confidence=8)])
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 1, summary)
+
+        head = self._head(slug, target_id)
+        self.assertIsNotNone(head.get("dwell_until"))
+        self.assertEqual(head["contradictions"], 1)
+
+        # §3.2 end-to-end proof: the row is excluded from search() by
+        # default while it is dwelling.
+        results = ls.search(slug=slug, query="contradicted")
+        self.assertNotIn(target_id, [r["id"] for r in results])
+
+    def test_global_add_stays_pending(self):
+        self._write_config()
+        day = _unique_day()
+        self._write_day(day, [_proposal_row(pid="g1", kind="learning_add", project=ls.GLOBAL_SLUG,
+                                             content="global candidate", type_="pattern",
+                                             confidence=10, sessions=5)])
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 0, summary)
+        self.assertEqual(self._status_of(day, "g1"), "pending")
+
+
+# ---------------------------------------------------------------------------
+# Confidence floors.
+# ---------------------------------------------------------------------------
+
+
+class FloorTests(OptimisticEngineTestBase):
+    def test_add_below_confidence_floor_stays_pending(self):
+        slug = _unique_slug("add-floor")
+        self._write_config()  # confidence_floor_content default 8
+        day = _unique_day()
+        self._write_day(day, [_proposal_row(pid="af1", kind="learning_add", project=slug,
+                                             content="low conf", type_="pattern",
+                                             confidence=7, sessions=5)])
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 0, summary)
+        self.assertEqual(self._status_of(day, "af1"), "pending")
+
+    def test_verify_below_confidence_floor_stays_pending(self):
+        slug = _unique_slug("verify-floor")
+        self._write_config()  # confidence_floor_verify default 7
+        target_id = self._seed_learning(slug)
+        day = _unique_day()
+        self._write_day(day, [_proposal_row(pid="vf1", kind="learning_verify", project=slug,
+                                             target_id=target_id, confidence=6)])
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 0, summary)
+        self.assertEqual(self._status_of(day, "vf1"), "pending")
+
+
+# ---------------------------------------------------------------------------
+# Per-slug blast-radius caps (plan.md §3.3).
+# ---------------------------------------------------------------------------
+
+
+class PerSlugCapTests(OptimisticEngineTestBase):
+    def test_per_slug_cap_limits_within_one_slug(self):
+        slug = _unique_slug("cap-oneslug")
+        self._write_config({"max_add_supersede_per_run": 2})
+        day = _unique_day()
+        rows = [_proposal_row(pid=f"cap{i}", kind="learning_add", project=slug,
+                               content=f"content {i}", type_="pattern", confidence=9, sessions=5)
+                for i in range(5)]
+        self._write_day(day, rows)
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 2, summary)
+        statuses = [self._status_of(day, f"cap{i}") for i in range(5)]
+        self.assertEqual(statuses.count("auto_applied"), 2)
+        self.assertEqual(statuses.count("pending"), 3)
+
+    def test_per_slug_cap_is_not_cross_project(self):
+        self._write_config({"max_add_supersede_per_run": 2})
+        day = _unique_day()
+        rows = []
+        for i in range(5):
+            s = _unique_slug(f"cap-multi-{i}")
+            rows.append(_proposal_row(pid=f"mcap{i}", kind="learning_add", project=s,
+                                       content=f"content {i}", type_="pattern",
+                                       confidence=9, sessions=5))
+        self._write_day(day, rows)
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 5, summary)
+        for i in range(5):
+            self.assertEqual(self._status_of(day, f"mcap{i}"), "auto_applied")
+
+    def test_absolute_eviction_cap_dominates(self):
+        slug = _unique_slug("evict-abs")
+        self._write_config({"max_eviction_absolute": 3, "max_eviction_fraction_per_run": 0.2})
+        target_ids = [self._seed_learning(slug, content=f"seed {i}", confidence=8) for i in range(20)]
+        day = _unique_day()
+        rows = [_proposal_row(pid=f"dep{i}", kind="learning_deprecate", project=slug,
+                               target_id=target_ids[i], confidence=9) for i in range(5)]
+        self._write_day(day, rows)
+        summary = adp.run_optimistic_integrate(day)
+        # cap = min(3, 0.2 * 20) = min(3, 4.0) = 3 -- the absolute ceiling
+        # dominates the fraction, even though 4 > 3 would have allowed one more.
+        self.assertEqual(summary["applied"], 3, summary)
+        statuses = [self._status_of(day, f"dep{i}") for i in range(5)]
+        self.assertEqual(statuses.count("auto_applied"), 3)
+        self.assertEqual(statuses.count("pending"), 2)
+
+    def test_fixed_denominator_same_run_adds_do_not_inflate_eviction_cap(self):
+        # Numbers chosen so a "recompute live_head_count fresh on every
+        # cap check" bug (which self-corrects on the LAST eviction, since
+        # each successful eviction lowers the live count right back down)
+        # is still distinguishable from the correct fixed-once behavior --
+        # a naive test with only 2-3 evictions and a round cap can pass
+        # under BOTH the correct and the buggy implementation by
+        # coincidence (verified empirically while writing this test: the
+        # add inflates the fresh count up, but each eviction's own
+        # decrement claws it back down, and the two effects can cancel out
+        # at the exact boundary a smaller reproduction checks). With 10
+        # seeds, 1 add, 4 evictions, and frac=0.35:
+        #   fixed cap  = 0.35 * 10 = 3.5  -- constant all 4 evictions
+        #                (k=0,1,2,3 all < 3.5) -> ALL 4 apply.
+        #   buggy cap at eviction k = 0.35 * (11 - k) (11 = 10 seeds + the
+        #                just-applied add; -k for each PRIOR eviction's own
+        #                self-decrement) -- at k=3, buggy cap = 0.35*8=2.8,
+        #                and 3 < 2.8 is FALSE -> the 4th eviction is
+        #                wrongly blocked under the buggy denominator.
+        slug = _unique_slug("fixed-denom")
+        self._write_config({
+            "max_eviction_absolute": 100, "max_eviction_fraction_per_run": 0.35,
+            "max_add_supersede_per_run": 100,
+        })
+        target_ids = [self._seed_learning(slug, content=f"seed {i}", confidence=8) for i in range(10)]
+        day = _unique_day()
+        rows = [_proposal_row(pid="fd-add", kind="learning_add", project=slug,
+                               content="new one", type_="pattern", confidence=9, sessions=5)]
+        for i in range(4):
+            rows.append(_proposal_row(pid=f"fd-dep{i}", kind="learning_deprecate", project=slug,
+                                       target_id=target_ids[i], confidence=9))
+        self._write_day(day, rows)
+        summary = adp.run_optimistic_integrate(day)
+
+        self.assertEqual(self._status_of(day, "fd-add"), "auto_applied")
+        dep_statuses = [self._status_of(day, f"fd-dep{i}") for i in range(4)]
+        # Fixed denominator (10, captured before the add landed) yields
+        # cap=3.5 for every eviction in this batch -- ALL 4 apply (0,1,2,3
+        # are each < 3.5). A same-run-inflated OR self-decrementing fresh
+        # recomputation would block the 4th (see arithmetic above).
+        self.assertEqual(dep_statuses.count("auto_applied"), 4, summary)
+        self.assertEqual(dep_statuses.count("pending"), 0, summary)
+
+
+# ---------------------------------------------------------------------------
+# Batch eviction-concentration anomaly check (plan.md §3.3).
+# ---------------------------------------------------------------------------
+
+
+class BatchAnomalyTests(OptimisticEngineTestBase):
+    def test_batch_anomaly_skips_evictions_for_that_slug_only(self):
+        slug_a = _unique_slug("anomaly-a")
+        slug_b = _unique_slug("anomaly-b")
+        self._write_config({
+            "batch_anomaly_max_same_tag_fraction": 0.6,
+            "max_eviction_absolute": 100, "max_eviction_fraction_per_run": 1.0,
+        })
+        # slug_a: 5 deprecate candidates, 4/5 (80%) share "shared-tag".
+        a_targets = []
+        for i in range(5):
+            tags = ["shared-tag"] if i < 4 else ["other-tag"]
+            a_targets.append(self._seed_learning(slug_a, content=f"a-seed {i}", confidence=8, tags=tags))
+        # slug_b: normal, focused batch -- 3 deprecates, each a DIFFERENT tag.
+        b_targets = [self._seed_learning(slug_b, content=f"b-seed {i}", confidence=8, tags=[f"tag-{i}"])
+                     for i in range(3)]
+
+        day = _unique_day()
+        rows = [_proposal_row(pid=f"a-dep{i}", kind="learning_deprecate", project=slug_a,
+                               target_id=a_targets[i], confidence=9) for i in range(5)]
+        rows += [_proposal_row(pid=f"b-dep{i}", kind="learning_deprecate", project=slug_b,
+                                target_id=b_targets[i], confidence=9) for i in range(3)]
+        self._write_day(day, rows)
+        summary = adp.run_optimistic_integrate(day)
+
+        for i in range(5):
+            self.assertEqual(self._status_of(day, f"a-dep{i}"), "pending", f"a-dep{i}")
+        for i in range(3):
+            self.assertEqual(self._status_of(day, f"b-dep{i}"), "auto_applied", f"b-dep{i}")
+
+        self.assertTrue(any(a["slug"] == slug_a for a in summary["anomalies"]), summary)
+        self.assertFalse(any(a["slug"] == slug_b for a in summary["anomalies"]), summary)
+
+    def test_single_eviction_proposal_never_flagged_anomalous(self):
+        # A batch of size 1 is trivially "100% concentrated" on its own
+        # single target -- MIN_EVICTION_BATCH_FOR_ANOMALY_CHECK guards
+        # against treating that as an anomaly.
+        rows = [{"target_id": "t1"}]
+        self.assertFalse(adp._batch_anomaly_fires(rows, {}, {"batch_anomaly_max_same_tag_fraction": 0.6}))
+
+    def test_two_evictions_same_target_flagged_anomalous(self):
+        rows = [{"target_id": "t1"}, {"target_id": "t1"}]
+        self.assertTrue(adp._batch_anomaly_fires(rows, {}, {"batch_anomaly_max_same_tag_fraction": 0.6}))
+
+    def test_two_evictions_different_targets_different_tags_not_anomalous(self):
+        heads_by_id = {"t1": {"tags": ["x"]}, "t2": {"tags": ["y"]}}
+        rows = [{"target_id": "t1"}, {"target_id": "t2"}]
+        self.assertFalse(adp._batch_anomaly_fires(rows, heads_by_id, {"batch_anomaly_max_same_tag_fraction": 0.6}))
+
+
+# ---------------------------------------------------------------------------
+# Windowed, self-healing circuit breaker (plan.md §3.5).
+# ---------------------------------------------------------------------------
+
+
+class CircuitBreakerTests(OptimisticEngineTestBase):
+    def test_breaker_trips_when_two_anomalies_fall_within_window(self):
+        self._write_config({
+            "circuit_breaker_window_nights": 7, "circuit_breaker_max_anomalies": 2,
+            "batch_anomaly_max_same_tag_fraction": 0.5,
+        })
+        now = time.time()
+        self._write_optimistic_state({
+            "suspended": False, "suspended_at": None,
+            "anomaly_log": [self._iso(now - 1 * 86400)],  # 1 day ago -- within a 7-night window
+            "last_run": None,
+        })
+
+        slug = _unique_slug("breaker-trip")
+        t0 = self._seed_learning(slug, content="s0", confidence=8, tags=["x"])
+        t1 = self._seed_learning(slug, content="s1", confidence=8, tags=["x"])
+        day = _unique_day()
+        self._write_day(day, [
+            _proposal_row(pid="bt0", kind="learning_deprecate", project=slug, target_id=t0, confidence=9),
+            _proposal_row(pid="bt1", kind="learning_deprecate", project=slug, target_id=t1, confidence=9),
+        ])
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["circuit_breaker"], "tripped", summary)
+
+        state = self._read_optimistic_state_file()
+        self.assertTrue(state["suspended"])
+        self.assertIsNotNone(state["suspended_at"])
+
+        audit = self._read_audit()
+        self.assertTrue(any(a.get("outcome") == "circuit_breaker_tripped" for a in audit))
+
+    def test_breaker_does_not_trip_when_anomalies_are_outside_window(self):
+        self._write_config({
+            "circuit_breaker_window_nights": 7, "circuit_breaker_max_anomalies": 2,
+            "batch_anomaly_max_same_tag_fraction": 0.5,
+        })
+        now = time.time()
+        self._write_optimistic_state({
+            "suspended": False, "suspended_at": None,
+            "anomaly_log": [self._iso(now - 20 * 86400)],  # 20 days ago -- OUTSIDE a 7-night window
+            "last_run": None,
+        })
+
+        slug = _unique_slug("breaker-notrip")
+        t0 = self._seed_learning(slug, content="s0", confidence=8, tags=["x"])
+        t1 = self._seed_learning(slug, content="s1", confidence=8, tags=["x"])
+        day = _unique_day()
+        self._write_day(day, [
+            _proposal_row(pid="bn0", kind="learning_deprecate", project=slug, target_id=t0, confidence=9),
+            _proposal_row(pid="bn1", kind="learning_deprecate", project=slug, target_id=t1, confidence=9),
+        ])
+        summary = adp.run_optimistic_integrate(day)
+        # This run's own batch anomaly still fires (only 1 within the
+        # window after the 20-day-old entry ages out) -- below max=2.
+        self.assertNotEqual(summary["circuit_breaker"], "tripped", summary)
+        state = self._read_optimistic_state_file()
+        self.assertFalse(state["suspended"])
+
+    def test_breaker_auto_resumes_after_quiet_period(self):
+        self._write_config({"circuit_breaker_auto_resume_nights": 7})
+        now = time.time()
+        self._write_optimistic_state({
+            "suspended": True, "suspended_at": self._iso(now - 8 * 86400),
+            "anomaly_log": [self._iso(now - 8 * 86400), self._iso(now - 8.1 * 86400)],
+            "last_run": None,
+        })
+        slug = _unique_slug("breaker-resume")
+        target_id = self._seed_learning(slug, confidence=8)
+        day = _unique_day()
+        self._write_day(day, [_proposal_row(pid="ar1", kind="learning_verify", project=slug,
+                                             target_id=target_id, confidence=8)])
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["circuit_breaker"], "auto_resumed", summary)
+        self.assertEqual(summary["applied"], 1, summary)  # the resume actually let this batch through
+
+        state = self._read_optimistic_state_file()
+        self.assertFalse(state["suspended"])
+
+        audit = self._read_audit()
+        self.assertTrue(any(a.get("outcome") == "circuit_breaker_auto_resumed" for a in audit))
+
+    def test_breaker_stays_suspended_before_quiet_period_elapses(self):
+        self._write_config({"circuit_breaker_auto_resume_nights": 7})
+        now = time.time()
+        self._write_optimistic_state({
+            "suspended": True, "suspended_at": self._iso(now - 1 * 86400),  # only 1 quiet day, not 7
+            "anomaly_log": [],
+            "last_run": None,
+        })
+        slug = _unique_slug("breaker-still-suspended")
+        target_id = self._seed_learning(slug, confidence=8)
+        day = _unique_day()
+        self._write_day(day, [_proposal_row(pid="ss1", kind="learning_verify", project=slug,
+                                             target_id=target_id, confidence=8)])
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["circuit_breaker"], "suspended", summary)
+        self.assertEqual(summary["applied"], 0, summary)
+        self.assertEqual(self._status_of(day, "ss1"), "pending")
+
+    def test_optimistic_resume_forces_immediate_reenable(self):
+        now = time.time()
+        self._write_optimistic_state({
+            "suspended": True, "suspended_at": self._iso(now),  # just tripped -- would NOT auto-resume
+            "anomaly_log": [self._iso(now)],
+            "last_run": None,
+        })
+        result = adp.optimistic_resume()
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["was_suspended"])
+
+        state = self._read_optimistic_state_file()
+        self.assertFalse(state["suspended"])
+        self.assertIsNone(state["suspended_at"])
+
+        audit = self._read_audit()
+        self.assertTrue(any(a.get("outcome") == "circuit_breaker_manual_resume" for a in audit))
+
+    def test_corrupt_state_file_fails_closed_to_suspended(self):
+        adp.optimistic_state_path().parent.mkdir(parents=True, exist_ok=True)
+        adp.optimistic_state_path().write_text("{not valid json", encoding="utf-8")
+        state = adp._read_optimistic_state()
+        self.assertTrue(state["suspended"])
+        self.assertIsNotNone(state["suspended_at"])
+
+
+# ---------------------------------------------------------------------------
+# Cross-night accumulation signal (plan.md §3.8).
+# ---------------------------------------------------------------------------
+
+
+class CrossNightSignalTests(OptimisticEngineTestBase):
+    def test_cross_night_rate_signal_records_anomaly_when_exceeded(self):
+        self._write_config({"rolling_add_rate_window_nights": 14, "rolling_add_rate_max": 2,
+                             "max_add_supersede_per_run": 100})
+        slug = _unique_slug("rate-signal")
+        day = _unique_day()
+        rows = [_proposal_row(pid=f"rate{i}", kind="learning_add", project=slug,
+                               content=f"c{i}", type_="pattern", confidence=9, sessions=5)
+                for i in range(3)]
+        self._write_day(day, rows)
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 3, summary)
+        self.assertTrue(any(a["kind"] == "rolling_add_rate_exceeded" for a in summary["anomalies"]), summary)
+
+    def test_cross_night_rate_signal_not_recorded_when_under_threshold(self):
+        self._write_config({"rolling_add_rate_window_nights": 14, "rolling_add_rate_max": 10,
+                             "max_add_supersede_per_run": 100})
+        slug = _unique_slug("rate-signal-ok")
+        day = _unique_day()
+        rows = [_proposal_row(pid=f"rateok{i}", kind="learning_add", project=slug,
+                               content=f"c{i}", type_="pattern", confidence=9, sessions=5)
+                for i in range(3)]
+        self._write_day(day, rows)
+        summary = adp.run_optimistic_integrate(day)
+        self.assertFalse(any(a["kind"] == "rolling_add_rate_exceeded" for a in summary["anomalies"]), summary)
+
+
+# ---------------------------------------------------------------------------
+# Human-race lock (adrev-opt-011): a concurrent run_optimistic_integrate()
+# and a human apply_proposal() accept on the SAME pending id must never
+# both invoke the handler. Mirrors test-dream-apply.sh's own white-box
+# monkeypatch technique for the analogous pre-Epic-3 guarantee.
+# ---------------------------------------------------------------------------
+
+
+class HumanRaceLockTests(OptimisticEngineTestBase):
+    def test_concurrent_integrate_and_accept_never_double_apply(self):
+        slug = _unique_slug("race-lock")
+        self._write_config()
+        target_id = self._seed_learning(slug, confidence=8)
+        day = _unique_day()
+        pid = "race1"
+        self._write_day(day, [_proposal_row(pid=pid, kind="learning_verify", project=slug,
+                                             target_id=target_id, confidence=8)])
+
+        invocations = {"n": 0}
+        counter_lock = threading.Lock()
+        original = adp._apply_counter_op
+
+        def slow_apply_counter_op(row, op, *, auto=False, dwell_hours=None):
+            with counter_lock:
+                invocations["n"] += 1
+            time.sleep(0.4)  # widen the race window deterministically
+            return original(row, op, auto=auto, dwell_hours=dwell_hours)
+
+        adp._apply_counter_op = slow_apply_counter_op
+        self.addCleanup(lambda: setattr(adp, "_apply_counter_op", original))
+
+        results: list = [None, None]
+        barrier = threading.Barrier(2)
+
+        def worker_integrate():
+            barrier.wait()
+            results[0] = adp.run_optimistic_integrate(day)
+
+        def worker_accept():
+            barrier.wait()
+            results[1] = adp.apply_proposal(pid, method="human_accept", reviewed_by="tester")
+
+        t1 = threading.Thread(target=worker_integrate)
+        t2 = threading.Thread(target=worker_accept)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        self.assertFalse(t1.is_alive() or t2.is_alive(), "race threads did not complete -- suspected deadlock")
+        self.assertEqual(invocations["n"], 1, "handler invoked exactly once across both paths")
+
+        integrate_summary, accept_result = results
+        applied_via_integrate = bool(integrate_summary) and integrate_summary.get("applied") == 1
+        applied_via_accept = bool(accept_result) and accept_result.get("ok")
+        self.assertEqual(int(applied_via_integrate) + int(applied_via_accept), 1,
+                          f"exactly one path should have applied: {results}")
+        self.assertIn(self._status_of(day, pid), ("auto_applied", "accepted"))
+
+
+# ---------------------------------------------------------------------------
+# Transaction & consistency model (adrev-opt-011/012/013/014).
+# ---------------------------------------------------------------------------
+
+
+class TransactionModelTests(OptimisticEngineTestBase):
+    def _init_learnings_git(self) -> None:
+        sync_bin = str(HERE.parent.parent / "self-improving" / "bin" / "ccgm-learnings-sync")
+        subprocess.run([sys.executable, sync_bin, "init"], check=True, capture_output=True, text=True)
+
+    def _git_log_subjects(self) -> list[str]:
+        proc = subprocess.run(
+            ["git", "-C", str(ls.LEARNINGS_ROOT), "log", "--format=%s"],
+            check=True, capture_output=True, text=True,
+        )
+        return proc.stdout.splitlines()
+
+    def test_suppressed_autocommit_overrides_ambient_env_for_its_duration(self):
+        self._pin_env("CCGM_LEARNINGS_AUTOCOMMIT", "true")
+        self.assertEqual(os.environ.get("CCGM_LEARNINGS_AUTOCOMMIT"), "true")
+        with adp._suppressed_autocommit():
+            self.assertEqual(os.environ.get("CCGM_LEARNINGS_AUTOCOMMIT"), "false")
+        self.assertEqual(os.environ.get("CCGM_LEARNINGS_AUTOCOMMIT"), "true")  # restored
+
+    def test_batch_produces_exactly_one_commit_tagged_with_batch_id(self):
+        self._init_learnings_git()
+        slug = _unique_slug("txn-onecommit")
+        self._write_config({"max_add_supersede_per_run": 100})
+        day = _unique_day()
+        rows = [_proposal_row(pid=f"tx{i}", kind="learning_add", project=slug,
+                               content=f"content {i}", type_="pattern", confidence=9, sessions=5)
+                for i in range(4)]
+        self._write_day(day, rows)
+
+        before_log = self._git_log_subjects()
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 4, summary)
+        self.assertIsNotNone(summary.get("commit"))
+        self.assertTrue(summary["commit"].get("ok"), summary["commit"])
+
+        after_log = self._git_log_subjects()
+        new_commits = after_log[: len(after_log) - len(before_log)]
+        self.assertEqual(len(new_commits), 1, after_log)
+        self.assertIn(summary["batch_id"], new_commits[0])
+
+    def test_force_day_rerun_of_integrated_night_is_idempotent(self):
+        self._init_learnings_git()
+        slug = _unique_slug("txn-idempotent")
+        self._write_config({"max_add_supersede_per_run": 100})
+        day = _unique_day()
+        rows = [_proposal_row(pid=f"idem{i}", kind="learning_add", project=slug,
+                               content=f"content {i}", type_="pattern", confidence=9, sessions=5)
+                for i in range(3)]
+        self._write_day(day, rows)
+
+        first = adp.run_optimistic_integrate(day)
+        self.assertEqual(first["applied"], 3, first)
+
+        log_after_first = self._git_log_subjects()
+        second = adp.run_optimistic_integrate(day)  # simulates a --force-day re-run
+        self.assertEqual(second["applied"], 0, second)
+        self.assertEqual(second["evaluated"], 3, second)  # rows still read
+        self.assertIsNone(second.get("commit"))  # never even attempted a commit
+
+        log_after_second = self._git_log_subjects()
+        self.assertEqual(log_after_first, log_after_second, "no new commit on an idempotent re-run")
+
+    def test_batch_commit_does_not_deadlock_with_per_proposal_lock(self):
+        self._init_learnings_git()
+        slug = _unique_slug("txn-deadlock")
+        self._write_config({"max_add_supersede_per_run": 100})
+        day = _unique_day()
+        rows = [_proposal_row(pid=f"dl{i}", kind="learning_add", project=slug,
+                               content=f"content {i}", type_="pattern", confidence=9, sessions=5)
+                for i in range(6)]
+        self._write_day(day, rows)
+
+        result_holder: dict = {}
+
+        def _run():
+            result_holder["summary"] = adp.run_optimistic_integrate(day)
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+        t.join(timeout=15)
+        self.assertFalse(t.is_alive(), "run_optimistic_integrate hung -- suspected lock self-deadlock")
+        self.assertEqual(result_holder.get("summary", {}).get("applied"), 6)
+
+    def test_state_file_write_is_atomic_no_tmp_left_behind(self):
+        state = {
+            "suspended": True, "suspended_at": "2026-01-01T00:00:00.000Z",
+            "anomaly_log": ["2026-01-01T00:00:00.000Z"], "last_run": "2026-01-01T00:00:00.000Z",
+        }
+        adp._write_optimistic_state_atomic(state)
+        path = adp.optimistic_state_path()
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        self.assertFalse(tmp_path.exists(), "temp file should never survive an atomic write")
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(on_disk, state)
+
+
+# ---------------------------------------------------------------------------
+# Malformed-input defense (a proposal row's own gating logic must never
+# abort the rest of the batch).
+# ---------------------------------------------------------------------------
+
+
+class MalformedInputTests(OptimisticEngineTestBase):
+    def test_missing_proposals_file_returns_empty_summary(self):
+        summary = adp.run_optimistic_integrate(_unique_day())
+        self.assertEqual(summary["applied"], 0)
+        self.assertEqual(summary["evaluated"], 0)
+
+    def test_malformed_project_field_is_skipped_not_crashed(self):
+        self._write_config()
+        day = _unique_day()
+        row = _proposal_row(pid="bad1", kind="learning_add", project="placeholder",
+                             content="x", type_="pattern", confidence=9, sessions=5)
+        row["project"] = None
+        self._write_day(day, [row])
+        summary = adp.run_optimistic_integrate(day)  # must not raise
+        self.assertEqual(summary["applied"], 0, summary)
+        self.assertEqual(self._status_of(day, "bad1"), "pending")
+
+
+# ---------------------------------------------------------------------------
+# Weekly, cost-capped eval refresh (fix (b) for adrev-opt-001).
+#
+# Each test here gets its OWN isolated CCGM_DREAMING_DIR (on top of the
+# base class's env pins) because _latest_eval_results_age_days() and the
+# cost ledger are dreaming-dir-WIDE, not proposal-scoped -- sharing the
+# file-level dreaming dir across these tests would let one test's results
+# file or ledger spend affect another test's freshness/cost-cap check.
+# ---------------------------------------------------------------------------
+
+
+class EvalRefreshTests(OptimisticEngineTestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        fresh_dreaming = tempfile.mkdtemp(prefix="ccgm-dreaming-test-optengine-evalrefresh-")
+        self._pin_env("CCGM_DREAMING_DIR", fresh_dreaming)
+
+    def test_eval_refresh_skips_when_results_too_fresh(self):
+        self._write_config({"eval_refresh_min_age_days": 7})
+        evals_dir = da.dreaming_dir() / "evals"
+        evals_dir.mkdir(parents=True, exist_ok=True)
+        (evals_dir / "2026-05-01.jsonl").write_text("{}\n", encoding="utf-8")  # mtime = now
+        cfg = da.load_config()
+        should_run, reason = adp._eval_refresh_preconditions(_unique_day(), cfg)
+        self.assertFalse(should_run)
+        self.assertIn("old", reason)
+
+    def test_eval_refresh_skips_when_no_api_key(self):
+        self._write_config({"eval_refresh_min_age_days": 7})
+        prior = os.environ.pop("ANTHROPIC_API_KEY", None)
+        self.addCleanup(lambda: os.environ.__setitem__("ANTHROPIC_API_KEY", prior) if prior else None)
+        cfg = da.load_config()
+        should_run, reason = adp._eval_refresh_preconditions(_unique_day(), cfg)
+        self.assertFalse(should_run)
+        self.assertIn("ANTHROPIC_API_KEY", reason)
+
+    def test_eval_refresh_skips_when_cost_cap_exhausted(self):
+        self._write_config({"eval_refresh_min_age_days": 7, "eval_refresh_cost_cap_usd": 1.0})
+        os.environ["ANTHROPIC_API_KEY"] = "fake-key-for-test"
+        self.addCleanup(lambda: os.environ.pop("ANTHROPIC_API_KEY", None))
+        day = _unique_day()
+        adp.da._append_cost(  # noqa: SLF001 -- test-only direct ledger seed
+            adp.da.cost_log_path(), day, 0, 0, 1.50, adp.EVAL_REFRESH_COST_LABEL,
+        )
+        cfg = da.load_config()
+        should_run, reason = adp._eval_refresh_preconditions(day, cfg)
+        self.assertFalse(should_run)
+        self.assertIn("exhausted", reason)
+
+    def test_eval_refresh_preconditions_pass_when_all_clear(self):
+        self._write_config({"eval_refresh_min_age_days": 7, "eval_refresh_cost_cap_usd": 5.0})
+        os.environ["ANTHROPIC_API_KEY"] = "fake-key-for-test"
+        self.addCleanup(lambda: os.environ.pop("ANTHROPIC_API_KEY", None))
+        cfg = da.load_config()
+        should_run, reason = adp._eval_refresh_preconditions(_unique_day(), cfg)
+        self.assertTrue(should_run, reason)
+
+    def _write_fake_eval_refresh_script(self, *, cost_usd: float = 0.42, exit_code: int = 0) -> Path:
+        """A tiny, self-contained fake standing in for memory_eval.py's
+        --date/results-file contract -- written to a fresh tempdir at test
+        run time (not a committed fixture file), so this test file stays
+        fully offline and the only new committed file remains this one."""
+        script_dir = Path(tempfile.mkdtemp(prefix="ccgm-fake-eval-refresh-"))
+        script_path = script_dir / "fake_memory_eval.py"
+        script_path.write_text(
+            "import argparse, json, os, sys\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--date', required=True)\n"
+            "args, _ = p.parse_known_args()\n"
+            f"row = {{'id': 'fake-task', 'bucket': 'high_value', 'cost_usd': {cost_usd}}}\n"
+            "evals_dir = os.path.join(os.environ['CCGM_DREAMING_DIR'], 'evals')\n"
+            "os.makedirs(evals_dir, exist_ok=True)\n"
+            "with open(os.path.join(evals_dir, args.date + '.jsonl'), 'w') as fh:\n"
+            "    fh.write(json.dumps(row) + chr(10))\n"
+            f"sys.exit({exit_code})\n",
+            encoding="utf-8",
+        )
+        return script_path
+
+    def test_run_eval_refresh_end_to_end_with_fake_script(self):
+        self._write_config({"eval_refresh_min_age_days": 7, "eval_refresh_cost_cap_usd": 5.0})
+        os.environ["ANTHROPIC_API_KEY"] = "fake-key-for-test"
+        self.addCleanup(lambda: os.environ.pop("ANTHROPIC_API_KEY", None))
+        script = self._write_fake_eval_refresh_script(cost_usd=0.42)
+        self._pin_env("CCGM_DREAMING_EVAL_REFRESH_SCRIPT", str(script))
+
+        day = _unique_day()
+        summary = adp.run_eval_refresh(day)
+        self.assertTrue(summary["ran"], summary)
+        self.assertAlmostEqual(summary["cost_usd"], 0.42, places=6)
+
+        spent = adp._read_cost_spent_today_by_label(da.cost_log_path(), day, adp.EVAL_REFRESH_COST_LABEL)
+        self.assertAlmostEqual(spent, 0.42, places=6)
+
+    def test_run_eval_refresh_skips_without_invoking_script_when_preconditions_fail(self):
+        self._write_config({"eval_refresh_min_age_days": 7, "eval_refresh_cost_cap_usd": 5.0})
+        prior = os.environ.pop("ANTHROPIC_API_KEY", None)
+        self.addCleanup(lambda: os.environ.__setitem__("ANTHROPIC_API_KEY", prior) if prior else None)
+        # A script that would raise if ever invoked -- proves the
+        # precondition gate short-circuits before any subprocess call.
+        script_dir = Path(tempfile.mkdtemp(prefix="ccgm-fake-eval-refresh-must-not-run-"))
+        script_path = script_dir / "must_not_run.py"
+        script_path.write_text("import sys\nsys.exit(1)\n", encoding="utf-8")
+        self._pin_env("CCGM_DREAMING_EVAL_REFRESH_SCRIPT", str(script_path))
+
+        summary = adp.run_eval_refresh(_unique_day())
+        self.assertFalse(summary["ran"])
+        self.assertIn("ANTHROPIC_API_KEY", summary["reason"])
+        self.assertNotIn("exit_code", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/dreaming/tests/test_optimistic_engine.py
+++ b/modules/dreaming/tests/test_optimistic_engine.py
@@ -676,7 +676,11 @@ class RecordAnomalyTests(OptimisticEngineTestBase):
         self.assertIsNone(result.get("circuit_breaker"), result)
         state = self._read_optimistic_state_file()
         self.assertFalse(state["suspended"])
-        self.assertEqual(len(state["anomaly_log"]), 2)  # old + new, but only 1 "recent"
+        # The 20-day-old entry is also beyond the 2*7=14-day prune retention
+        # (review fix for #801, PR #810 -- see AnomalyLogBoundedGrowthTests)
+        # and is dropped entirely on this append, leaving only the
+        # freshly-recorded anomaly.
+        self.assertEqual(len(state["anomaly_log"]), 1)
 
     def test_record_anomaly_while_already_suspended_does_not_refire_trip_audit(self):
         # Idempotency: a red-gate night that happens while the breaker is
@@ -710,6 +714,151 @@ class RecordAnomalyTests(OptimisticEngineTestBase):
         self.assertTrue(path.is_file())
         on_disk = json.loads(path.read_text(encoding="utf-8"))
         self.assertEqual(len(on_disk["anomaly_log"]), 1)
+
+
+# ---------------------------------------------------------------------------
+# Auto-resume clean slate (review fix for #801, PR #810): _maybe_auto_resume()
+# now clears anomaly_log on a genuine quiet-period resume, so stale-but-
+# still-within-window entries recorded before the original trip cannot
+# immediately re-trip the breaker the moment the engine resumes (which used
+# to apply-and-commit at most one capped batch before re-suspending --
+# "auto-resume" leaking a single batch per cycle instead of actually
+# resuming). anomaly_log accumulated AFTER the resume is unaffected -- it
+# still re-trips normally once it reaches the configured threshold.
+# ---------------------------------------------------------------------------
+
+
+class AutoResumeCleanSlateTests(OptimisticEngineTestBase):
+    def test_resume_clears_anomaly_log_then_new_anomalies_retrip_normally(self):
+        self._write_config({
+            "circuit_breaker_window_nights": 7,
+            "circuit_breaker_max_anomalies": 2,
+            "circuit_breaker_auto_resume_nights": 7,
+            "batch_anomaly_max_same_tag_fraction": 0.5,
+        })
+        now = time.time()
+        # Suspended long enough ago to auto-resume, but anomaly_log still
+        # carries entries that are STALE (recorded before the original
+        # trip) yet still fall inside the 7-night trip-window -- exactly
+        # the condition that used to cause an immediate re-trip on resume.
+        self._write_optimistic_state({
+            "suspended": True, "suspended_at": self._iso(now - 8 * 86400),
+            "anomaly_log": [self._iso(now - 2 * 86400), self._iso(now - 3 * 86400)],
+            "last_run": None,
+        })
+
+        # Phase 1: quiet-period resume with a harmless verify-only batch --
+        # must resume, reset anomaly_log to a clean slate, and NOT re-trip
+        # within this same run.
+        slug = _unique_slug("resume-cleanslate")
+        target_id = self._seed_learning(slug, confidence=8)
+        day1 = _unique_day()
+        self._write_day(day1, [_proposal_row(pid="rc1", kind="learning_verify", project=slug,
+                                              target_id=target_id, confidence=8)])
+        summary1 = adp.run_optimistic_integrate(day1)
+        self.assertEqual(summary1["circuit_breaker"], "auto_resumed", summary1)
+        self.assertEqual(summary1["applied"], 1, summary1)  # the resume actually let this batch through
+
+        state_after_resume = self._read_optimistic_state_file()
+        self.assertFalse(state_after_resume["suspended"])
+        self.assertEqual(state_after_resume["anomaly_log"], [],
+                          "resume must reset the window, not carry stale entries forward")
+
+        # Phase 2: exactly ONE new anomaly after the resume -- below
+        # max_anomalies=2, must not trip.
+        slug2 = _unique_slug("resume-cleanslate-evict1")
+        t0 = self._seed_learning(slug2, content="s0", confidence=8, tags=["x"])
+        t1 = self._seed_learning(slug2, content="s1", confidence=8, tags=["x"])
+        day2 = _unique_day()
+        self._write_day(day2, [
+            _proposal_row(pid="rc2a", kind="learning_deprecate", project=slug2, target_id=t0, confidence=9),
+            _proposal_row(pid="rc2b", kind="learning_deprecate", project=slug2, target_id=t1, confidence=9),
+        ])
+        summary2 = adp.run_optimistic_integrate(day2)
+        self.assertNotEqual(summary2["circuit_breaker"], "tripped", summary2)
+        state_after_one_new = self._read_optimistic_state_file()
+        self.assertFalse(state_after_one_new["suspended"])
+        self.assertEqual(len(state_after_one_new["anomaly_log"]), 1, state_after_one_new)
+
+        # Phase 3: a SECOND new anomaly reaches max_anomalies=2 -- the
+        # breaker re-trips normally, exactly as it would with no prior
+        # suspension history.
+        slug3 = _unique_slug("resume-cleanslate-evict2")
+        t2 = self._seed_learning(slug3, content="s2", confidence=8, tags=["y"])
+        t3 = self._seed_learning(slug3, content="s3", confidence=8, tags=["y"])
+        day3 = _unique_day()
+        self._write_day(day3, [
+            _proposal_row(pid="rc3a", kind="learning_deprecate", project=slug3, target_id=t2, confidence=9),
+            _proposal_row(pid="rc3b", kind="learning_deprecate", project=slug3, target_id=t3, confidence=9),
+        ])
+        summary3 = adp.run_optimistic_integrate(day3)
+        self.assertEqual(summary3["circuit_breaker"], "tripped", summary3)
+        state_after_retrip = self._read_optimistic_state_file()
+        self.assertTrue(state_after_retrip["suspended"])
+
+
+# ---------------------------------------------------------------------------
+# Bounded anomaly_log growth (review fix for #801, PR #810): every append
+# site (record_anomaly(), run_optimistic_integrate()) prunes entries older
+# than 2 * circuit_breaker_window_nights days so the state file cannot grow
+# forever under a sustained anomaly stream, without ever pruning an entry
+# _evaluate_breaker_trip() would still count (its own window is exactly
+# circuit_breaker_window_nights -- half this retention).
+# ---------------------------------------------------------------------------
+
+
+class AnomalyLogBoundedGrowthTests(OptimisticEngineTestBase):
+    def test_record_anomaly_prunes_entries_beyond_retention(self):
+        self._write_config({"circuit_breaker_window_nights": 7, "circuit_breaker_max_anomalies": 100})
+        now = time.time()
+        # Retention = 2 * 7 = 14 days. Seed a mix spanning well beyond that.
+        old_entries = [self._iso(now - 40 * 86400), self._iso(now - 15 * 86400)]
+        kept_entries = [self._iso(now - 10 * 86400), self._iso(now - 1 * 86400)]
+        self._write_optimistic_state({
+            "suspended": False, "suspended_at": None,
+            "anomaly_log": old_entries + kept_entries,
+            "last_run": None,
+        })
+
+        result = adp.record_anomaly("red_eval_gate")
+        self.assertTrue(result["ok"], result)
+
+        log = self._read_optimistic_state_file()["anomaly_log"]
+        for old in old_entries:
+            self.assertNotIn(old, log, log)
+        for kept in kept_entries:
+            self.assertIn(kept, log, log)
+        # kept_entries plus this call's own freshly-appended anomaly.
+        self.assertEqual(len(log), len(kept_entries) + 1, log)
+
+    def test_run_optimistic_integrate_prunes_entries_beyond_retention(self):
+        self._write_config({
+            "circuit_breaker_window_nights": 7, "circuit_breaker_max_anomalies": 100,
+            "batch_anomaly_max_same_tag_fraction": 0.5,
+        })
+        now = time.time()
+        old_entry = self._iso(now - 40 * 86400)  # far beyond the 14-day retention
+        kept_entry = self._iso(now - 5 * 86400)  # within retention
+        self._write_optimistic_state({
+            "suspended": False, "suspended_at": None,
+            "anomaly_log": [old_entry, kept_entry],
+            "last_run": None,
+        })
+
+        slug = _unique_slug("prune-viaintegrate")
+        t0 = self._seed_learning(slug, content="s0", confidence=8, tags=["x"])
+        t1 = self._seed_learning(slug, content="s1", confidence=8, tags=["x"])
+        day = _unique_day()
+        self._write_day(day, [
+            _proposal_row(pid="pv0", kind="learning_deprecate", project=slug, target_id=t0, confidence=9),
+            _proposal_row(pid="pv1", kind="learning_deprecate", project=slug, target_id=t1, confidence=9),
+        ])
+        adp.run_optimistic_integrate(day)
+
+        log = self._read_optimistic_state_file()["anomaly_log"]
+        self.assertNotIn(old_entry, log, log)
+        self.assertIn(kept_entry, log, log)
+        self.assertEqual(len(log), 2, log)  # kept_entry plus this run's own new anomaly
 
 
 # ---------------------------------------------------------------------------

--- a/modules/dreaming/tests/test_optimistic_engine.py
+++ b/modules/dreaming/tests/test_optimistic_engine.py
@@ -599,6 +599,120 @@ class CircuitBreakerTests(OptimisticEngineTestBase):
 
 
 # ---------------------------------------------------------------------------
+# `record-anomaly` (review fix for #801, PR #810): plan.md §3.5 says the
+# breaker trips on "batch-anomaly fire OR red eval gate" -- but a red
+# `dream-eval.sh --gate` result short-circuits dream-daily.sh BEFORE
+# run_optimistic_integrate() is ever invoked, so a red-gate streak
+# previously left zero trace in anomaly_log. record_anomaly() closes that
+# gap: it records one anomaly directly into state/optimistic.json and
+# evaluates the SAME windowed breaker via the shared _evaluate_breaker_trip()
+# helper -- these tests exercise record_anomaly() directly (the Python
+# path); the bash-side wiring (dream-daily.sh calling the `record-anomaly`
+# CLI on a red gate) is covered by GatingTests below.
+# ---------------------------------------------------------------------------
+
+
+class RecordAnomalyTests(OptimisticEngineTestBase):
+    """apply-audit.jsonl is a single, cumulative, never-reset file shared
+    by every test in this module (mirrors CircuitBreakerTests, which for
+    the same reason only ever asserts existence via `any(...)`, never an
+    exact count or an absence, against the whole file). `record_anomaly()`
+    returns a fresh, unique `batch_id` per call precisely so these tests
+    (and any real caller) can scope their audit assertions to THEIR OWN
+    call's records instead of the whole shared log.
+    """
+
+    def _audit_for(self, batch_id: str) -> list[dict]:
+        return [a for a in self._read_audit() if a.get("batch_id") == batch_id]
+
+    def test_single_anomaly_recorded_does_not_trip_below_threshold(self):
+        self._write_config({"circuit_breaker_window_nights": 7, "circuit_breaker_max_anomalies": 2})
+        result = adp.record_anomaly("red_eval_gate")
+        self.assertTrue(result["ok"], result)
+        self.assertIsNone(result.get("circuit_breaker"))
+
+        state = self._read_optimistic_state_file()
+        self.assertFalse(state["suspended"])
+        self.assertEqual(len(state["anomaly_log"]), 1)
+
+        own_audit = self._audit_for(result["batch_id"])
+        self.assertEqual(len(own_audit), 1, own_audit)
+        self.assertEqual(own_audit[0]["outcome"], "anomaly_recorded")
+        self.assertEqual(own_audit[0]["reason"], "red_eval_gate")
+
+    def test_two_red_gate_anomalies_within_window_trip_the_breaker(self):
+        self._write_config({"circuit_breaker_window_nights": 7, "circuit_breaker_max_anomalies": 2})
+        first = adp.record_anomaly("red_eval_gate")
+        self.assertIsNone(first.get("circuit_breaker"), first)
+        second = adp.record_anomaly("red_eval_gate")
+        self.assertEqual(second.get("circuit_breaker"), "tripped", second)
+
+        state = self._read_optimistic_state_file()
+        self.assertTrue(state["suspended"])
+        self.assertIsNotNone(state["suspended_at"])
+        self.assertEqual(len(state["anomaly_log"]), 2)
+
+        first_audit = self._audit_for(first["batch_id"])
+        self.assertEqual(len(first_audit), 1, first_audit)
+        self.assertEqual(first_audit[0]["outcome"], "anomaly_recorded")
+
+        second_audit = self._audit_for(second["batch_id"])
+        # The SECOND call is the one that trips the breaker: its own
+        # anomaly_recorded record plus the circuit_breaker_tripped record
+        # (written under the same batch_id via _evaluate_breaker_trip).
+        self.assertEqual(len(second_audit), 2, second_audit)
+        outcomes = {a["outcome"] for a in second_audit}
+        self.assertEqual(outcomes, {"anomaly_recorded", "circuit_breaker_tripped"})
+
+    def test_anomaly_outside_window_does_not_contribute_to_trip(self):
+        self._write_config({"circuit_breaker_window_nights": 7, "circuit_breaker_max_anomalies": 2})
+        now = time.time()
+        self._write_optimistic_state({
+            "suspended": False, "suspended_at": None,
+            "anomaly_log": [self._iso(now - 20 * 86400)],  # 20 days ago -- outside a 7-night window
+            "last_run": None,
+        })
+        result = adp.record_anomaly("red_eval_gate")
+        self.assertIsNone(result.get("circuit_breaker"), result)
+        state = self._read_optimistic_state_file()
+        self.assertFalse(state["suspended"])
+        self.assertEqual(len(state["anomaly_log"]), 2)  # old + new, but only 1 "recent"
+
+    def test_record_anomaly_while_already_suspended_does_not_refire_trip_audit(self):
+        # Idempotency: a red-gate night that happens while the breaker is
+        # ALREADY suspended still records the anomaly (for history), but
+        # must never double-fire a SECOND circuit_breaker_tripped record
+        # for a breaker that is already tripped (mirrors the same
+        # not-already-suspended guard run_optimistic_integrate's own
+        # breaker check applies).
+        self._write_config({"circuit_breaker_window_nights": 7, "circuit_breaker_max_anomalies": 2})
+        now = time.time()
+        self._write_optimistic_state({
+            "suspended": True, "suspended_at": self._iso(now),
+            "anomaly_log": [self._iso(now), self._iso(now)],
+            "last_run": None,
+        })
+        result = adp.record_anomaly("red_eval_gate")
+        self.assertEqual(result.get("circuit_breaker"), "suspended", result)
+
+        own_audit = self._audit_for(result["batch_id"])
+        self.assertEqual(len(own_audit), 1, own_audit)  # anomaly_recorded ONLY -- no re-trip
+        self.assertEqual(own_audit[0]["outcome"], "anomaly_recorded")
+
+        state = self._read_optimistic_state_file()
+        self.assertEqual(len(state["anomaly_log"]), 3)  # still appended, even while suspended
+
+    def test_state_write_is_atomic_after_record_anomaly(self):
+        adp.record_anomaly("red_eval_gate")
+        path = adp.optimistic_state_path()
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        self.assertFalse(tmp_path.exists(), "temp file should never survive an atomic write")
+        self.assertTrue(path.is_file())
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(len(on_disk["anomaly_log"]), 1)
+
+
+# ---------------------------------------------------------------------------
 # Cross-night accumulation signal (plan.md §3.8).
 # ---------------------------------------------------------------------------
 
@@ -924,6 +1038,119 @@ class EvalRefreshTests(OptimisticEngineTestBase):
         self.assertFalse(summary["ran"])
         self.assertIn("ANTHROPIC_API_KEY", summary["reason"])
         self.assertNotIn("exit_code", summary)
+
+
+# ---------------------------------------------------------------------------
+# Enabled-only gating (review fix for #801, PR #810): dream-daily.sh's
+# `_optimistic_integration_active()` must activate ONLY on
+# `optimistic_integration.enabled` -- the legacy `auto_apply_counters` flag
+# alone must NOT activate the new engine (that migration is Epic 8's job, a
+# deliberate/logged opt-in via memory-setup.sh, not an implicit OR-bridge
+# in dream-daily.sh).
+#
+# `_optimistic_integration_active()` is a bash-only function embedded in
+# dream-daily.sh -- not an importable Python symbol -- so it is exercised
+# here by invoking the REAL script end to end against a fully isolated
+# sandbox and asserting on its own log output, exactly like
+# test-dream-apply.sh's existing fail-closed scenarios do, rather than
+# re-deriving the gating logic in Python and asserting against a second,
+# possibly-drifted copy.
+# ---------------------------------------------------------------------------
+
+
+class GatingTests(OptimisticEngineTestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        fresh_dreaming = tempfile.mkdtemp(prefix="ccgm-dreaming-test-optengine-gating-")
+        self._pin_env("CCGM_DREAMING_DIR", fresh_dreaming)
+        self._dreaming_dir = Path(fresh_dreaming)
+        (self._dreaming_dir / "proposals").mkdir(parents=True, exist_ok=True)
+
+    def _run_dream_daily(self, day: str, *, eval_script: Path | None = None) -> tuple[int, str]:
+        """Invokes the REAL dream-daily.sh end to end against an isolated,
+        offline sandbox (mirrors test-dream-apply.sh's fail-closed
+        scenarios: an empty --projects-root with no ANTHROPIC_API_KEY/
+        --offline so dream-analyze.sh's own "nothing to do" short-circuit
+        fires before ever touching a proposals file). Returns
+        (exit_code, daily_log_body).
+        """
+        sandbox = Path(tempfile.mkdtemp(prefix="ccgm-dreaming-test-optengine-gating-run-"))
+        logs_dir = sandbox / "logs"
+        empty_projects_root = sandbox / "empty-claude-projects"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        empty_projects_root.mkdir(parents=True, exist_ok=True)
+        script = HERE.parent / "bin" / "dream-daily.sh"
+
+        eval_script_path = eval_script if eval_script is not None else (
+            sandbox / "definitely-does-not-exist" / "dream-eval.sh"
+        )
+
+        env = dict(os.environ)
+        env["CCGM_DREAMING_LOGS_DIR"] = str(logs_dir)
+        env["CCGM_DREAMING_EVAL_SCRIPT"] = str(eval_script_path)
+        env.pop("ANTHROPIC_API_KEY", None)  # keep this test fully offline/deterministic
+
+        proc = subprocess.run(
+            ["bash", str(script), "--force-day", day, "--projects-root", str(empty_projects_root)],
+            capture_output=True, text=True, env=env,
+        )
+        log_path = logs_dir / f"dreaming-daily-{day}.log"
+        log_body = log_path.read_text(encoding="utf-8") if log_path.is_file() else ""
+        return proc.returncode, log_body
+
+    def test_legacy_flag_alone_does_not_activate_optimistic_integration(self):
+        (self._dreaming_dir / "config.json").write_text(
+            json.dumps({"auto_apply_counters": True}), encoding="utf-8",
+        )
+        rc, log_body = self._run_dream_daily(_unique_day())
+        self.assertEqual(rc, 0, log_body)
+        self.assertIn("optimistic_integration.enabled=false (default off); skipping", log_body)
+        self.assertIn("eval-refresh: optimistic integration inactive; skipping", log_body)
+        # Never even reaches the eval-gate/script-presence check for either step.
+        self.assertNotIn("missing (Epic 7 not yet installed)", log_body)
+        self.assertNotIn("eval-refresh: running apply_dream_proposal.py eval-refresh", log_body)
+
+    def test_enabled_flag_alone_activates_optimistic_integration(self):
+        (self._dreaming_dir / "config.json").write_text(
+            json.dumps({"optimistic_integration": {"enabled": True}}), encoding="utf-8",
+        )
+        rc, log_body = self._run_dream_daily(_unique_day())
+        self.assertEqual(rc, 0, log_body)
+        self.assertNotIn("optimistic_integration.enabled=false (default off); skipping", log_body)
+        self.assertNotIn("eval-refresh: optimistic integration inactive; skipping", log_body)
+        # Both steps get PAST the config gate -- optimistic-integrate then
+        # fails closed on the (deliberately) missing eval script, and
+        # eval-refresh actually starts (its own preconditions handle the
+        # no-API-key stand-down separately, already covered by
+        # EvalRefreshTests above).
+        self.assertIn("missing (Epic 7 not yet installed); failing closed", log_body)
+        self.assertIn("eval-refresh: running apply_dream_proposal.py eval-refresh", log_body)
+
+    def test_red_eval_gate_records_anomaly_via_record_anomaly_cli(self):
+        (self._dreaming_dir / "config.json").write_text(
+            json.dumps({"optimistic_integration": {"enabled": True}}), encoding="utf-8",
+        )
+        script_dir = Path(tempfile.mkdtemp(prefix="ccgm-fake-red-eval-gate-"))
+        fake_red_eval = script_dir / "fake-dream-eval-red.sh"
+        fake_red_eval.write_text(
+            "#!/usr/bin/env bash\necho 'fake gate: no results (simulated red)' >&2\nexit 1\n",
+            encoding="utf-8",
+        )
+        fake_red_eval.chmod(0o755)
+
+        rc, log_body = self._run_dream_daily(_unique_day(), eval_script=fake_red_eval)
+        self.assertEqual(rc, 0, log_body)
+        self.assertIn("dream-eval.sh --gate exit=1; failing closed", log_body)
+        self.assertIn("recorded red_eval_gate anomaly", log_body)
+
+        state = self._read_optimistic_state_file()
+        self.assertEqual(len(state.get("anomaly_log", [])), 1, state)
+        self.assertFalse(state.get("suspended"), state)  # 1 anomaly, below the default threshold of 2
+
+        audit = self._read_audit()
+        self.assertTrue(any(
+            a.get("outcome") == "anomaly_recorded" and a.get("reason") == "red_eval_gate" for a in audit
+        ), audit)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements Epic 3 of the optimistic-memory plan: the engine that replaces `run_auto_apply`'s narrow verify-only predicate with the full per-op-kind posture engine, plus the three new safety rails.

- `run_optimistic_integrate(day)` in `apply_dream_proposal.py`: per-slug grouping, `resolve_posture()`-driven gating (floor + `add`-prevalence + supersede compaction-guard), per-slug blast-radius caps (`optimistic-dwell` vs the compound eviction cap `min(absolute, fraction × live_head_count)`), a fixed-denominator `live_head_count` computed once per slug before any write in the batch, a per-slug eviction-concentration batch-anomaly check, a post-apply cross-night accumulation signal, and a windowed, self-healing, `_apply_lock()`-guarded circuit breaker (`state/optimistic.json`).
- `run_eval_refresh(day)`: weekly, cost-capped live eval refresh (fix (b) for adrev-opt-001) with its own `eval_refresh_cost_cap_usd` line, sharing but not competing with the analyzer's cost ledger.
- `dream-daily.sh`: chain now runs `analyze → eval-refresh → optimistic-integrate → digest → reconcile → retention` (optimistic-integrate before digest, per the plan's revised chain order, so tonight's batch is reported while its dwell window is still ahead). The old `run_auto_apply_step` bash function is retired; the Python `run_auto_apply()` function and its `auto-apply` CLI subcommand are left in place, untouched, for backward compatibility.
- `apply_proposal()` gains three new optional parameters (`dwell_hours`, `batch_id`, `posture`) that every pre-existing caller leaves at their default (`None`), so human-accept and the legacy auto-apply path are behaviorally unchanged.

## Transaction & consistency model (adrev-opt-011/012/013/014)

- **Lock topology (011):** the engine never holds `_apply_lock()` across the batch — each proposal goes through the existing `apply_proposal()`, which takes/releases the lock per call. The breaker-state read (before the loop) and the breaker-state write + single batch commit (after the loop) are each their own, non-nested critical section.
- **One commit per batch (013):** `_suppressed_autocommit()` forces `CCGM_LEARNINGS_AUTOCOMMIT=false` for the duration of the batch's subprocess calls, and the engine makes exactly one `ccgm-learnings-sync commit`, tagged with `batch_id` in the message.
- **Idempotency (012):** only `pending` proposals are considered; a `--force-day` re-run of an already-integrated night applies nothing and adds no commit.
- **State-file atomicity (014):** `state/optimistic.json` is written via temp-file + atomic rename; a parse failure fails **closed** (suspended), never open.

## Test plan

- [x] `python3 -m pytest modules/dreaming/tests/test_optimistic_engine.py -q` — 36 new tests, all passing (postures, floors, per-slug caps, absolute eviction cap, fixed denominator, per-slug batch anomaly, windowed breaker incl. auto-resume/manual-resume/corrupt-state, cross-night signal, human-race lock, transaction model, malformed-input defense, eval-refresh preconditions + end-to-end fake-script run).
- [x] `python3 -m pytest modules/dreaming/tests/ modules/self-improving/tests/ -q` — 499 passed, 13 subtests passed (463 pre-existing + 36 new); zero regressions.
- [x] `bash modules/dreaming/tests/test-dream-pipeline.sh` — 40/40 passed (unaffected; never invokes `dream-daily.sh`).
- [x] `bash modules/dreaming/tests/test-dream-reconcile.sh` — 18/18 passed.
- [x] `bash modules/dreaming/tests/test-dream-apply.sh` — 95/97 passed. The 2 failures are a **pre-existing bug on `origin/main`**, unrelated to this PR: a white-box monkeypatch test's fake `_apply_counter_op` replacement doesn't accept the `auto` keyword `_apply_counter_op` has carried since PR #777 (well before this PR). Verified by running the identical, unmodified test file against a clean checkout of `origin/main`'s modules — same "95 passed, 2 failed" result. Not touched here since `test-dream-apply.sh` is outside this PR's file scope.
- [x] Chain ordering: `grep -n` confirms `optimistic-integrate` runs before `digest` in `dream-daily.sh`.
- [x] Adversarial mutation testing: reintroduced the exact P2 same-run-inflated-denominator bug and the adrev-opt-011 wrong-lock-topology bug by hand; confirmed the corresponding tests fail loudly (the deadlock test catches a real self-deadlock within its bounded 15s timeout) before reverting.
- [x] Live end-to-end verification: ran the real `dream-daily.sh` chain with `optimistic_integration.enabled=true` and a fake green eval-gate script against a sandboxed store/dreaming dir — a pending `learning_add` proposal was auto-integrated (`status: auto_applied`, `batch_id`, `posture`, `dwell_until` all recorded), the store head carries `auto: true` + a propagated `dwell_until`, the row is correctly hidden from `ccgm-learnings-search`'s default output and visible with `--include-dwelling`, and `digest`/`reconcile`/`retention` all completed after it.

## Honest gaps / concerns

- **adrev-opt-019 (red-eval-gate as a breaker anomaly source):** plan.md §3.5 mentions a red eval gate should also count as an anomaly feeding the circuit breaker. Since `dream-daily.sh`'s two-gate sequence already fails closed (skips calling the Python engine entirely) when the gate is red, this never reaches `run_optimistic_integrate`, and I did not wire a separate anomaly-recording hook for that case in `dream-daily.sh`. This is a deliberate, narrower scope than the plan's full discussion — flagging for review rather than silently omitting it.
- **Eval-refresh cost cap is a start-gate, not a hard mid-run stop.** `memory_eval.py` has no cumulative total-run cost limiter (only a per-call `--max-budget-usd`), and adding one is out of this PR's file-touch scope. `_eval_refresh_preconditions()` refuses to *start* a refresh once the ledger shows the cap already spent, but a single refresh run that starts under budget can still finish somewhat over `eval_refresh_cost_cap_usd`. Actual spend is always recorded to the shared ledger regardless.
- **Legacy `auto_apply_counters` compatibility bridge.** Since Epic 8's formal migration hasn't landed yet, and `test-dream-apply.sh` (untouchable, outside this PR's scope) configures the old `auto_apply_counters: true` flag and expects `dream-daily.sh`'s fail-closed-on-red-gate behavior to still fire, `_optimistic_integration_active()` in `dream-daily.sh` treats `optimistic_integration.enabled` OR legacy `auto_apply_counters` as "active." This is consistent with the plan's own stated migration intent, but is a bridge I introduced rather than something explicitly spelled out in the Epic 3 spec — noting it for review.