### PR TITLE
#812: human-minimization tenet + follow-up-completion contract + autonomous decision context

### DIFF
--- a/modules/adversarial-review/README.md
+++ b/modules/adversarial-review/README.md
@@ -51,6 +51,16 @@ Files installed globally to `~/.claude/`:
 
 Findings carry severity (P0-P3) and confidence (0.0-1.0), matching the document-review conventions. The report also lists what the target **survived** - a clean verdict is only credible when the attacks are shown.
 
+## Plan Execution Tenets (plan targets)
+
+Beyond the battery, a plan is a contract for *autonomous* execution, so `plan` targets get three additional checks that are **requirements, not judgment calls** - if the plan fails one, apply mode fixes it (adds/expands the section), it is not merely noted:
+
+1. **Human interaction is minimized and bucketed to the edges** - no human step an agent could do via CLI/API; unavoidable human work is front-loaded before execution or deferred to the end, never wedged mid-run where it stalls the whole run.
+2. **A follow-up-completion contract is present** - the plan requires that any follow-on work discovered during execution is completed before execution is reported complete; the completion checklist includes "no open in-scope follow-up work"; only genuinely human-blocked items may remain open.
+3. **Enough decision context to direct unplanned work without a human** - the plan carries the software's mission, the codebase's governing conventions, and its own decision principles, so an agent can deduce how to handle an unplanned follow-on item. Missing context is expanded into the plan on apply.
+
+The three reinforce each other: decision context (3) lets an agent finish follow-on work (2) without a human, which is what keeps execution human-free mid-run (1).
+
 ## The Apply Protocol (plans)
 
 - P0/P1 at confidence >= 0.80 → affected sections revised directly, integrated as if considered from the start

--- a/modules/adversarial-review/agents/adrev-reviewer.md
+++ b/modules/adversarial-review/agents/adrev-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: adrev-reviewer
 description: >
-  Adversarial review of any entity - plan, spec, doc, PR, issue, code, directory, or stated concept. Attacks premises, hunts failure modes, steelmans the strongest case against, and checks falsifiability and reversal cost. Returns structured JSON findings with severity and confidence. When the target is a plan and apply is enabled, incorporates the findings into the plan itself and reports exactly what changed.
+  Adversarial review of any entity - plan, spec, doc, PR, issue, code, directory, or stated concept. Attacks premises, hunts failure modes, steelmans the strongest case against, and checks falsifiability and reversal cost. For plan targets it also enforces the autonomous-execution tenets: minimal and edge-bucketed human involvement, a follow-up-completion contract, and enough decision context to direct unplanned work without a human. Returns structured JSON findings with severity and confidence. When the target is a plan and apply is enabled, incorporates the findings into the plan itself and reports exactly what changed.
 tools: Read, Write, Edit, Glob, Grep, Bash
 ---
 
@@ -60,6 +60,39 @@ Which decisions are expensive to undo (schema, public API contracts, file format
 
 Assume it ships and works. What happens next? Who or what adapts to it, games it, or becomes load-bearing on it? What maintenance, migration, or support burden appears in month two? For incentives-shaped entities (metrics, quotas, automation that grades things), assume they will be gamed and ask how.
 
+## Plan Execution Tenets (target_kind == plan only)
+
+Beyond the generic battery, a plan is a contract for *autonomous* execution. Run these three tenets against every `plan` target. Unlike the battery — where a clean survival is a valid outcome — these are **requirements**: if the plan does not satisfy one, that is a finding, and in `apply` mode you make the plan satisfy it. A plan that fails a tenet is not ready to execute.
+
+### T1. Human interaction is minimized and bucketed to the edges
+
+The human should not be a step in the plan unless the step genuinely requires their credentials, their browser session, or a judgment only they can make. For every human-epic, human-step, prerequisite, or mid-execution approval:
+
+- **Can the executing agent do it via CLI/API instead?** If yes, it is not human work — flag every human step an agent could do itself.
+- **If it genuinely needs the human, is it bucketed to the start or the end?** Unavoidable human work belongs *before* execution begins (front-loaded prerequisites) or *after* all agent work completes (final human steps) — never mid-stream, where it stalls the whole run waiting on a person. Flag any human step wedged into the middle of execution that could be front-loaded or deferred.
+- Target state: once started, the run proceeds to done without pausing for a human — every human touch already happened up front or is queued for the end.
+
+### T2. The follow-up-completion contract is present and clearly defined
+
+Execution always surfaces work the plan did not enumerate — a bug found while integrating, a missing prerequisite, a gap between two epics. The plan MUST state, in a clearly-defined and locatable way, that **any such follow-on work is completed before execution is reported complete**: the run is not "done" while discovered, in-scope follow-on work remains open. Verify the plan contains this contract:
+
+- A named section or explicit clause requiring discovered follow-on work to be tracked (as issues) and completed — with the same review discipline as planned work — before the run is declared complete.
+- The completion criteria / final verification checklist must include "no open in-scope follow-up work." A run with open, non-human-blocked follow-ups is incomplete.
+- The only follow-on work allowed to remain open at completion is genuinely human-blocked (needs a credential, dashboard action, or decision the agent cannot supply), and those must be surfaced explicitly, not buried.
+- If this contract is absent or vague, that is a **P1** finding. In `apply` mode, add it.
+
+### T3. The plan carries enough context to decide follow-on direction without a human
+
+To complete follow-on work autonomously (T2), the agent must be able to *decide the right direction* for that work without asking the human. The plan must therefore carry:
+
+- **The software's mission** — what the system is for, who it serves, what "good" looks like — so an agent can judge whether a discovered change serves the goal.
+- **The codebase's governing context** — the conventions, patterns, and constraints the code already follows (or, for greenfield, the ones this plan establishes) — so a follow-on change matches the codebase rather than diverging from it.
+- **The plan's own intent and decision principles** — the "why" behind the scope, plus the heuristics for resolving ambiguity (what to prefer, what to reject as out-of-scope, when a matter is genuinely human-blocked) — so an agent triages and directs unplanned work the way the plan's author would.
+
+If a reader could not, from the plan alone, deduce how to handle a plausible unplanned follow-on item, the plan is under-specified for autonomous execution — a **P1** finding. In `apply` mode, **expand the plan** to add the missing mission / codebase-context / decision-principles content; do not merely note that it is missing. This is explicit: if the information is not there to begin with, the plan is expanded to incorporate it.
+
+The three tenets reinforce each other: T3 (decision context) is what lets an agent resolve T2 (follow-on work) without a human, which is what achieves T1 (no mid-run human interaction). A plan that satisfies all three executes to done on its own.
+
 ## Findings Format
 
 Return findings as JSON:
@@ -109,7 +142,9 @@ When `apply` is true, you incorporate your findings into the plan after the revi
 4. **Do not touch** `progress.md`, completed-work records, decision-log history, or any section recording what already happened. Append to `decisions.md` (if it exists) with one line per incorporated finding.
 5. **Report the ledger:** for every finding - `incorporated` (with the section edited), `deferred-to-risks`, or `artifact-only`. If you rejected your own finding during incorporation (it dissolved on closer reading), say so and why.
 
-When `apply` is false, step 1 only (or inline report if no artifact path): you never modify the target.
+**Enforce the plan execution tenets (T1–T3), do not defer them.** These are requirements, not judgment calls, so they are *fixed by editing*, not parked in the Risk Register: for a missing or vague follow-up-completion contract (T2) or insufficient decision context (T3), **add the section or expand the plan** so the tenet is satisfied — integrated as a first-class part of the plan, as if it had been there from the start. For agent-doable or misplaced human work (T1), revise the plan to drop the human step (when an agent can do it) or move it to the start/end (when it is genuinely unavoidable). Record each as `incorporated`. Drop a tenet finding to the Risk Register only when you genuinely cannot resolve it by editing (e.g., closing a T3 gap needs a product decision only the author can make) — and say so explicitly in the ledger.
+
+When `apply` is false, step 1 only (or inline report if no artifact path): you never modify the target. Report the T1–T3 gaps as findings so the caller can fix them.
 
 ## Status
 

--- a/modules/adversarial-review/skills/adrev/SKILL.md
+++ b/modules/adversarial-review/skills/adrev/SKILL.md
@@ -60,11 +60,17 @@ For a `concept` target, include the full concept text in the prompt (it has no p
 
 The agent runs the full attack battery (premises, falsification, failure modes, strongest opposing case, reversal cost, second-order effects) and - when `apply` - incorporates findings into the plan per its apply protocol, returning a ledger of what changed.
 
+**For `plan` targets, the agent additionally enforces three plan-execution tenets** (requirements, not judgment calls — it adds or expands sections when the plan is missing them):
+
+1. **Human interaction is minimized and bucketed to the edges** — no human step an agent could do via CLI/API; any unavoidable human work is front-loaded before execution or deferred to the end, never mid-run.
+2. **A follow-up-completion contract is present** — the plan requires that any follow-on work discovered during execution is completed before execution is reported complete; only genuinely human-blocked work may remain open.
+3. **Enough decision context to direct unplanned work without a human** — the plan carries the software's mission, the codebase's governing conventions, and its own decision principles, so an agent can deduce how to handle unplanned follow-on work. If that context is missing, the agent expands the plan to add it.
+
 ## Phase 3: Verify and Report
 
 The agent's DONE is a claim, not evidence:
 
-- **Applied (plan)**: run `git diff` on the plan (or re-read the edited sections if untracked). Confirm the review artifact exists and every `incorporated` ledger entry corresponds to a real edit. Then present: findings table (id, test, severity, confidence, one-line what), the ledger (incorporated / deferred-to-risks / artifact-only), what the target survived, and the artifact path.
+- **Applied (plan)**: run `git diff` on the plan (or re-read the edited sections if untracked). Confirm the review artifact exists and every `incorporated` ledger entry corresponds to a real edit. Confirm the three plan-execution tenets are satisfied in the edited plan — human work is minimized and bucketed to the edges, the follow-up-completion contract is present and clearly located, and the mission / codebase-context / decision-principles content is concrete enough to direct unplanned work. If the reviewer parked a tenet in the Risk Register instead of fixing it, verify it named a genuine reason (a decision only the author can make). Then present: findings table (id, test, severity, confidence, one-line what), the ledger (incorporated / deferred-to-risks / artifact-only), what the target survived, and the artifact path.
 - **Report-only**: present the findings table and survived list. For an `issue` or `pr` target, offer - do not auto-post - `gh issue comment` / `gh pr review --comment` with the findings.
 - **BLOCKED / NEEDS_CONTEXT**: relay the missing piece verbatim and stop. Do not invent a target or substitute your own review in the main context - that breaks the separation that makes the review trustworthy.
 

--- a/modules/xplan/README.md
+++ b/modules/xplan/README.md
@@ -33,6 +33,14 @@ xplan is a human-in-the-loop planning framework with mandatory confirmation gate
 
 Reviews run in two stages: Phase 4 standard peer review against the draft, then the Phase 5.7 adversarial sequence (3 sequential passes) against the finished plan. A completed plan has survived **6 independent reviews in the full configuration** (3 standard + 3 adversarial).
 
+### Autonomous-Execution Tenets
+
+Every plan carries three requirements that let it execute with minimal human involvement — written during planning (Phase 3), verified by the self-review (Phase 5.6), and enforced by the adversarial reviewer (Phase 5.7 / `adrev-reviewer` tenets T1–T3), which expands the plan when any is thin:
+
+1. **Human work at the edges** (T1) — human involvement is minimized (anything an agent can do via CLI/API is not human work) and what remains is bucketed to the start (front-loaded prerequisites) or the end (deferred steps), never mid-run. Once execution starts, it does not pause for a person.
+2. **Follow-up-completion contract** (T2, plan §9.5) — any follow-on work discovered during execution is tracked, triaged, and — if in-scope — completed before execution is reported complete. Only genuinely human-blocked work may remain open. Phase 7 gates completion on it.
+3. **Autonomous decision context** (T3, plan §1.4) — the plan carries the software's mission, the codebase's governing conventions, and its decision principles, so an execution agent directs unplanned follow-on work itself instead of stopping to ask. `/etp` reads this context (its Phase 1.5) to triage and reason.
+
 **`--light`**: fast path. Reduced depth, minimal interaction. Skips Phases 0.5, 1.5, 2.5, 2.6, and 2.7. Traditional section-by-section walkthrough at the end.
 
 **`--autonomous`**: deep path. Maximum depth, zero interruption until the final gate. Runs the full research pipeline (all 7 agents), full standard review (security + architecture + business logic), the self-review loop, and the Phase 5.7 adversarial review sequence (3 sequential `adrev-reviewer` passes on Opus 4.8 at max effort, each incorporating its fixes before the next; the third judges the fully-hardened plan). Tech stack, scope, naming, and multi-agent setup are inferred and documented in `decisions.md`. At Phase 6 the completed plan is presented as a single structured artifact with every inferred default called out, then the (non-bypassable) Phase 6.5 final execution gate fires. Pick this when you know exactly what you want to plan and prefer reviewing a finished artifact over answering questions during creation. Correct any wrong inferences with `/xplan --deepen ~/code/plans/{concept-name}` rather than re-running from scratch.

--- a/modules/xplan/commands/etp.md
+++ b/modules/xplan/commands/etp.md
@@ -148,9 +148,23 @@ Group independent units into **waves** (parallel within a wave, sequential acros
 
   Do not impose plan-scale ceremony (multi-clone provisioning, wave checkpoints, bring-up runbooks) on a single issue. Do not skip it for a real multi-epic plan.
 
-### 1.4 Surface prerequisites and human-only steps
+### 1.4 Surface prerequisites and human-only steps (bucket them to the edges)
 
-Scan for anything the work needs that an agent cannot do: credentials, API keys, OAuth/dashboard setup, DNS, paid-service signups. List them now. They become Phase 5 blockers (notify-and-continue), not silent failures mid-run.
+Scan for anything the work needs that an agent cannot do: credentials, API keys, OAuth/dashboard setup, DNS, paid-service signups. First apply the minimization test — anything an agent *can* do via CLI/API is not human work; do it, don't ask. Whatever genuinely remains is **bucketed to the edges**, never left to stall the run mid-stream:
+
+- **Front-loaded** — surface every up-front human-only step *now*, before any unit runs, so the human can clear them once and the run then proceeds untouched.
+- **Deferred** — human steps that only make sense at the end (final DNS cutover, store submission, a human sign-off) are queued for after all agent work completes.
+
+They become Phase 5 blockers (notify-and-continue), not silent failures mid-run. The user should not be a step *inside* the run: never pause the whole run waiting on human work that could have been front-loaded.
+
+### 1.5 Establish the decision context (so follow-on calls need no human)
+
+Execution will surface unplanned follow-on work (Phase 5). To triage and direct it *without stopping to ask the user*, ground yourself in the decision context first:
+
+- **Plan target**: read the plan's **Mission & Guiding Decision Principles** (xplan plans: §1.4) — the software's mission, the codebase's governing conventions, and the plan's decision heuristics. This is what lets you decide follow-on direction the way the plan's author would.
+- **Issue target, or a plan missing that section**: derive the equivalent from the codebase — its `CLAUDE.md`, `README.md`, and the conventions visible in the code — plus the issue's own stated intent. If you cannot form a confident decision context this way, that gap itself is a Phase 5 human-blocked item (a product decision with no right answer), not a reason to guess.
+
+Hold this context for Phases 5 and 6: it is the reference you triage and reason against.
 
 ---
 
@@ -284,14 +298,14 @@ Record progress so the run is resumable, matched to the ceremony level (1.3):
 
 ## Phase 5: Follow-Up Work That Arises
 
-Execution surfaces work the target did not enumerate: a bug found while integrating, a missing prerequisite, a gap between two units, a flaky test that is really a real bug. Handle every one - do not let it evaporate. This is the directive's "complete any follow-up issues that arise."
+Execution surfaces work the target did not enumerate: a bug found while integrating, a missing prerequisite, a gap between two units, a flaky test that is really a real bug. Handle every one - do not let it evaporate. This is the directive's "complete any follow-up issues that arise," and for an xplan-authored plan it is that plan's **Follow-Up Work Completion Contract (§9.5)**: execution is **not complete** while an in-scope follow-up remains open.
 
 For each arising item:
-1. **Track it** - open a GitHub issue, so nothing is lost.
-2. **Triage scope**:
+1. **Track it** - open a GitHub issue (label it `follow-up`), so nothing is lost.
+2. **Triage scope against the decision context (Phase 1.5)** - decide this *yourself* from the plan's §1.4 / the codebase's mission and conventions; do NOT stop to ask the user how to direct in-scope follow-on work. That is what the decision context is for.
    - **In-scope-now** (the work cannot be called complete, or reasonable+valid, without it) → treat it as a first-class unit: branch, implement (`implementer`), then the **same adversarial review** as any other PR (Phase 4.2-4.4), then merge. Follow-up PRs get adversarially reviewed too - this is explicit in the directive.
    - **Out-of-scope / speculative** (a nice-to-have, an unrelated improvement, a v2 idea) → log it as a deferred issue and leave it. Surface the deferred list in the final report. Scope discipline: finish the work and what it necessitates, not every improvement you can see.
-3. **Absolute blocker** (needs a credential you do not have, a human-only dashboard action, an external dependency) → notify the user immediately with the exact ask, file a `blocked` issue, and **continue all non-blocked work**. A blocker stops one unit, never the run.
+3. **Absolute blocker** (needs a credential you do not have, a human-only dashboard action, a product decision with no right answer) → notify the user immediately with the exact ask, file a `blocked` issue, and **continue all non-blocked work**. A blocker stops one unit, never the run. Human-blocked follow-ups are the *only* work allowed to remain open when the run is reported complete.
 
 ---
 
@@ -303,7 +317,7 @@ When a unit fails - red CI, merge conflict, failing test, an ambiguous step - do
 3. Form one hypothesis, make the minimal change, verify it.
 4. If three focused attempts fail (three-strike rule), stop guessing: question the assumption, re-read the relevant source/docs, or escalate that single unit as a blocker - then continue the rest.
 
-Distinguish "something I can reason through" (the overwhelming majority - ambiguous wording, an obvious-once-traced bug, a missing import) from "an absolute blocker that genuinely needs the human" (missing credentials, a product decision with no right answer, an irreversible action the work does not authorize). Reason through the first kind. Notify on the second. Never conflate "this is hard" with "this is blocked."
+Distinguish "something I can reason through" (the overwhelming majority - ambiguous wording, an obvious-once-traced bug, a missing import) from "an absolute blocker that genuinely needs the human" (missing credentials, a product decision with no right answer, an irreversible action the work does not authorize). Reason through the first kind — ground the call in the decision context (Phase 1.5): the plan's mission and decision principles, or the codebase's conventions, tell you which direction the author would take. Notify on the second. Never conflate "this is hard" with "this is blocked."
 
 ---
 
@@ -355,6 +369,8 @@ A plan run: mark the progress file `COMPLETE`, or `BLOCKED - WAITING ON HUMAN` w
 **Scope discipline.** Execute the work plus the follow-ups it necessitates. Reject "while I'm here" work, speculative features, and review suggestions with no caller. Finishing the job is not expanding the job.
 
 **Notify-and-continue.** Absolute blockers are reported the moment they are found and never halt non-blocked work. The run degrades gracefully around blockers; it does not stop dead.
+
+**Human work at the edges.** The user is not a step inside the run. Anything an agent can do via CLI/API is done, not asked. Genuine human-only work is surfaced up front (front-loaded, Phase 1.4) or queued for the end (deferred), never left to stall the run mid-stream. In-scope follow-on work is reasoned through against the decision context (Phase 1.5), not bounced to the user — only genuinely human-blocked items remain open at completion, each surfaced with its exact ask.
 
 **Safety on irreversible / outward actions.** Even in autonomous mode, anything destructive or externally-visible that the work did not clearly authorize - production deploys, resource deletion, force-pushing shared branches, sending external communications - requires notifying the user first. The work authorizes its own scope; it does not authorize off-scope irreversible acts.
 

--- a/modules/xplan/commands/xplan.md
+++ b/modules/xplan/commands/xplan.md
@@ -870,6 +870,18 @@ If "workspace model" is chosen, add workspace migration as a prerequisite step i
 
 **Goal**: Create a comprehensive, parallelized execution plan divided into agent-epics.
 
+### 3.0 Mission & Guiding Decision Principles
+
+Before designing epics, capture the context an execution agent needs to **make follow-on decisions without you**. During execution, work always surfaces that the plan did not enumerate (a bug found while integrating, a missing prerequisite, a gap between two epics). For the agent to complete that work autonomously — instead of stopping to ask — it must be able to deduce the right *direction* from the plan alone. Write that context now; it becomes plan.md Section 1.4 and is the reference the follow-up-completion contract (3.4.5) points at.
+
+Capture three things:
+
+1. **The software's mission** — what the system is for, who it serves, and what "good" looks like. One paragraph an agent can hold in context while judging whether a discovered change serves the goal.
+2. **The codebase's governing context** — the conventions, patterns, and hard constraints the code already follows (from Phase 0.4 repo analysis) or, for greenfield, the ones this plan establishes (from the approved tech stack and architecture). So a follow-on change matches the codebase rather than diverging from it.
+3. **Decision principles** — the heuristics an agent uses to triage and direct unplanned work: what to prefer, what to reject as out-of-scope ("while I'm here" work, speculative features), when a matter is genuinely human-blocked (needs a credential, a dashboard action, or a product decision with no right answer) versus something to reason through. State them concretely enough that two different agents would resolve the same ambiguity the same way.
+
+The test: *could a fresh agent, reading only plan.md, decide how to handle a plausible unplanned follow-on item the way you would?* If not, this section is too thin — expand it until it can. This is the same context the Phase 5.7 adversarial reviewer (tenet T3) will check for and expand if missing; writing it well here avoids that rework.
+
 ### 3.1 Tech Stack Documentation
 
 **If default interactive mode (neither flag)**: The tech stack was already approved in Phase 2.5. Use the approved stack as the basis for architecture and epic design. Do not re-propose it.
@@ -931,7 +943,25 @@ For each human-epic:
 - Whether it can be done in parallel with agent execution
 - Links to relevant dashboards/services
 
-**Minimize human-epics.** For each, ask: "Can this be done via CLI/API instead?" Only create human-epics for things that genuinely require browser-based human action (OAuth app setup in Google Console, payment provider setup, etc.).
+**Minimize human-epics.** For each, ask: "Can this be done via CLI/API instead?" Only create human-epics for things that genuinely require browser-based human action (OAuth app setup in Google Console, payment provider setup, etc.). If an agent can do it with a CLI or API, it is not a human-epic.
+
+**Bucket unavoidable human work to the edges.** The user should not be a step *inside* the execution run. Every human-epic that survives the minimization test is scheduled to one of two buckets, never the middle:
+
+- **Front-loaded** — done *before* Wave 1 begins, as a prerequisite (API keys, service signups, OAuth setup, DNS). Preferred: the human does their part once, up front, and then execution runs to done untouched.
+- **Deferred** — done *after* all agent work completes (final DNS cutover, store submission, a human sign-off on the finished product).
+
+Only place a human-epic mid-execution when it *genuinely* blocks a specific wave and cannot be front-loaded (rare — most "mid" human work can be pulled forward). When one is unavoidable mid-run, say so explicitly and justify why it could not move to an edge. The goal: once execution starts, it does not pause waiting on a person.
+
+### 3.4.5 Follow-Up Work Completion Contract
+
+The plan must state, in a clearly-defined and locatable clause, that **any follow-on work discovered during execution is completed before execution is reported complete.** This becomes plan.md Section 9.5 and is enforced in Phase 7 (execution) and Section 13 (completion checklist).
+
+Define the contract concretely:
+
+- **Discover & track** — anything an agent finds that the plan did not enumerate but that the work needs (a bug, a missing prerequisite, a gap between epics) is opened as a tracked GitHub issue labeled `follow-up`, so nothing evaporates.
+- **Triage by the decision principles (§3.0 / plan §1.4)** — the agent decides *in-scope-now* (the work cannot be called complete or valid without it), *out-of-scope/deferred* (a nice-to-have or v2 idea — logged, not done), or *human-blocked* (needs a credential/dashboard/decision the agent cannot supply). Because §3.0 gives the mission + principles, the agent makes this call itself instead of asking.
+- **Complete before done** — every in-scope-now follow-up is implemented, reviewed with the same discipline as planned work, and merged. Execution is **not complete** while any in-scope, non-human-blocked follow-up remains open.
+- **Only human-blocked may remain** — human-blocked follow-ups are surfaced explicitly (bucketed and notified, per 3.4), never buried, and are the only work allowed to be open at completion.
 
 ### 3.5 Define Prerequisites
 
@@ -1065,6 +1095,12 @@ Create `~/code/plans/{concept-name}/plan.md`:
 ### 1.1 Vision
 ### 1.2 Key Insights from Research
 ### 1.3 Scope (v1 in / v1 out)
+### 1.4 Mission & Guiding Decision Principles
+[From Phase 3.0. The context an execution agent uses to make follow-on decisions WITHOUT the user. Three parts, all concrete:
+- **Mission**: what the system is for, who it serves, what "good" looks like.
+- **Codebase governing context**: conventions, patterns, and hard constraints a follow-on change must match (from repo analysis, or established by this plan for greenfield).
+- **Decision principles**: heuristics for triaging unplanned work — what to prefer, what to reject as out-of-scope, when a matter is genuinely human-blocked vs. reason-through. Concrete enough that two agents resolve the same ambiguity the same way.
+This section is what makes the Section 9.5 follow-up contract executable autonomously.]
 
 ## 2. Tech Stack
 [Each choice with rationale - pull from approved stack in Phase 2.5]
@@ -1094,8 +1130,9 @@ Create `~/code/plans/{concept-name}/plan.md`:
 - **Checkpoint notes**: [Key context to preserve if session compacts]
 
 ## 6. Human-Epics
+[Minimized (anything an agent can do via CLI/API is NOT here) and bucketed to the edges — see §3.4.]
 ### Human-Epic 1: {Name}
-- **When**: Before Wave N / During Wave N / After Wave N
+- **When (bucket)**: Front-loaded (before Wave 1) / Deferred (after all agent work) / Mid-run (only if genuinely unavoidable — justify why it cannot move to an edge)
 - **Blocks**: Epic N, Epic M
 - **Instructions**: [Step-by-step]
 
@@ -1148,6 +1185,22 @@ For each wave's bring-up, specify the rollback: how to revert migrations, redepl
 
 The last-wave bring-up runbook that takes the fully-merged project to a confirmed-live state. This is the single source of truth for "app is ready to test". Anything that was deferred or flagged during waves gets resolved here.
 
+### 9.5 Follow-Up Work Completion Contract
+
+[From Phase 3.4.5. Execution is NOT complete while in-scope follow-on work discovered during the run remains open.]
+
+Any work that surfaces during execution but was not enumerated in this plan is handled as follows, and this run is not reported complete until the contract is satisfied:
+
+1. **Track** — open a GitHub issue labeled `follow-up` for every discovered item so nothing is lost.
+2. **Triage against §1.4** — using the Mission & Decision Principles, classify each item:
+   - **In-scope-now** — the work cannot be called complete or valid without it. Implement it, review it with the same discipline as planned work, merge it.
+   - **Out-of-scope / deferred** — a nice-to-have, unrelated improvement, or v2 idea. Log it as a deferred issue; do not do it. Surface the deferred list in the final report.
+   - **Human-blocked** — needs a credential, a browser/dashboard action, or a product decision with no right answer. Notify the user with the exact ask, file a `blocked` issue, and continue all non-blocked work.
+3. **Complete before done** — every in-scope-now follow-up is DONE (implemented, reviewed, merged, verified) before execution is reported complete.
+4. **Only human-blocked may remain open** at completion, and each is surfaced explicitly (never buried).
+
+The agent decides the triage itself using §1.4 — it does not stop to ask the user how to direct in-scope follow-on work. The completion checklist (Section 13) gates on "no open in-scope follow-up work."
+
 ## 10. Review Findings
 [Only sections for reviews selected in Phase 4.0]
 ### 10.1 Security Review Summary (if selected)
@@ -1170,6 +1223,8 @@ The last-wave bring-up runbook that takes the fully-merged project to a confirme
 - [ ] No open PRs (except human-blocked)
 - [ ] No uncommitted changes in any clone
 - [ ] No open issues (except human-agent/human-epic)
+- [ ] **All in-scope follow-up work (Section 9.5) completed — no open `follow-up` issues except genuinely human-blocked ones**
+- [ ] **Every human-blocked follow-up surfaced to the user with the exact ask (not buried)**
 - [ ] CI/CD pipeline green
 - [ ] **Final Bring-Up runbook (Section 9.4) executed end-to-end**
 - [ ] **All app layers confirmed live: frontend loads, backend responds, DB reachable, migrations applied, deploys current**
@@ -1298,6 +1353,14 @@ Each agent-epic must be executable by a sub-agent without needing to ask the orc
 
 If any epic fails these checks, rewrite it until it passes. An epic that cannot be scoped concretely belongs in a different epic structure - consider splitting or merging.
 
+**Autonomous-execution readiness** (plan-level, not per-epic) — verify the plan can be executed without the user having to direct unplanned work:
+
+- **§1.4 Mission & Guiding Decision Principles is present and concrete** - the mission, codebase governing context, and decision principles are all filled in, not placeholders. The test: could a fresh agent, reading only plan.md, triage a plausible unplanned follow-on item the way the author would? If not, expand §1.4 until it can.
+- **§9.5 Follow-Up Work Completion Contract is present** - the plan states that in-scope follow-on work discovered during execution is completed before the run is reported complete, and Section 13's checklist includes "no open in-scope follow-up work."
+- **Human work is bucketed to the edges** - every human-epic is scheduled front-loaded (before Wave 1) or deferred (after all agent work), or carries an explicit justification for why it must sit mid-run. No agent-doable step is labeled human work.
+
+These are the same three tenets the Phase 5.7 adversarial reviewer enforces (T1–T3); satisfying them here means the adversarial pass confirms rather than reworks them.
+
 #### 5.6.4 Loop Until Clean
 
 Re-run 5.6.1, 5.6.2, and 5.6.3 after every round of fixes. Do not advance to Phase 6 until all three scans report zero findings. If three consecutive passes do not converge (new placeholders or drift keep appearing), stop and surface the specific section(s) to the user - the plan likely has a structural ambiguity that needs a human decision.
@@ -1357,8 +1420,8 @@ Each pass runs the full attack battery. Give each a **distinct lead lens** via `
 | Pass | Lead lens (`focus`) |
 |------|---------------------|
 | **1 — premises** | "The plan's load-bearing *unstated* premises, the falsifiability of its claims, and the strongest opposing case including do-nothing. What does this assume about users, scale, data shape, ordering, and the behavior of other systems that nobody examined?" |
-| **2 — execution & failure modes** | "How execution breaks: which step fails first when an assumption is wrong and whether the plan notices or plows on; partial failure mid-wave; concurrency and merge conflicts across parallel agent-epics; retries and idempotency; the gap between 'PR merged' and 'app live' in the bring-up runbook. Also check whether Pass 1's revisions introduced any new weakness." |
-| **3 — final / reversal cost & second-order** | "This is the FINAL adversarial pass on a plan already hardened by two prior reviews. Decisions expensive to undo (schema, public API contracts, file formats, dependency choices, naming that leaks into URLs/configs/env vars) with thin justification; second-order effects once it ships — what becomes load-bearing, what gets gamed, what maintenance burden appears in month two. Then do a holistic final read: do the two prior passes' edits hang together, or did they leave seams? Anything P0/P1 you raise here is the last chance to catch it before the gate." |
+| **2 — execution & failure modes** | "How execution breaks: which step fails first when an assumption is wrong and whether the plan notices or plows on; partial failure mid-wave; concurrency and merge conflicts across parallel agent-epics; retries and idempotency; the gap between 'PR merged' and 'app live' in the bring-up runbook. Press tenets T1 and T2: is human work minimized and bucketed to the edges (plan §6 Human-Epics) rather than wedged mid-run, and is the follow-up-completion contract (§9.5) present, clearly defined, and gated by the Section 13 checklist? Also check whether Pass 1's revisions introduced any new weakness." |
+| **3 — final / reversal cost & second-order** | "This is the FINAL adversarial pass on a plan already hardened by two prior reviews. Decisions expensive to undo (schema, public API contracts, file formats, dependency choices, naming that leaks into URLs/configs/env vars) with thin justification; second-order effects once it ships — what becomes load-bearing, what gets gamed, what maintenance burden appears in month two. Press tenet T3: does §1.4 carry enough mission + codebase + decision-principles context that an agent can direct unplanned follow-on work without the user? If it cannot, expand it. Then do a holistic final read: do the prior passes' edits hang together, or did they leave seams? Anything P0/P1 you raise here is the last chance to catch it before the gate." |
 
 ### 5.7.2 Dispatch One Pass
 
@@ -1379,6 +1442,8 @@ Reference files (read as needed):
 You are pass {k} of 3 sequential adversarial reviews. The plan you are reading already incorporates the fixes from passes 1..{k-1}. Reason at maximum depth. A review that returns "looks good, minor nits" is a FAILED review unless you genuinely attacked from every angle and the plan survived — and then your report must show the attacks in `survived`, not just the verdict.
 
 Apply protocol: write the full review artifact first, then incorporate. P0/P1 (confidence ≥0.80) → revise the affected plan section directly, marking any premise fork with `> **Revised {date} (adversarial review):** ...`. P1/P2 (0.60–0.79) → add a row to the plan's existing Risk Register (Section 11), citing the finding id; do NOT create a separate "Risks & Open Questions" section — this plan already has Section 11. Confidence <0.60 → artifact-only. Append one line per incorporated finding to decisions.md. Never touch progress.md or completed-work records.
+
+Plan-execution tenets (T1–T3) are requirements, not judgment calls: enforce them by editing plan.md. If human work is agent-doable or wedged mid-run, revise the plan's Human-Epics (§6) / Prerequisites (§4) to drop or edge-bucket it (T1). If the follow-up-completion contract (§9.5) is missing or vague, add it (T2). If §1.4's mission/codebase/decision-principles context is too thin for an agent to direct unplanned follow-on work, expand it (T3). Park a tenet in the Risk Register only if it genuinely needs an author decision you cannot make — and say so.
 ```
 
 **Anchor propagation (only when `--repo` was given).** Append the same `SOURCE FRESHNESS — repo facts` block used for the Phase 4 review agents (verification anchor `{DEFAULT_REF} @ {ANCHOR}`; read every repo fact from `{WORKTREE}` or `git -C {REPO} show {DEFAULT_REF}:<path>`, never the stale working tree; flag any plan claim that disagrees with the anchor as a finding).
@@ -1745,6 +1810,7 @@ Each agent:
 - **Verifies the work actually functions** end-to-end (not just unit tests passing)
 - Creates a PR
 - Reports completion with verification evidence
+- **Reports any follow-on work it discovered but did not fix in-scope** (a bug found while integrating, a missing prerequisite, a gap between epics) so the orchestrator can triage it per §9.5 — nothing discovered is allowed to evaporate
 
 #### 7.3.3 Monitor & Report
 
@@ -1788,6 +1854,17 @@ This checkpoint enables `/xplan-resume` to pick up where execution left off.
 
 #### 7.3.6 Update progress.md table and proceed to next wave.
 
+#### 7.3.7 Triage & Complete Follow-Up Work (§9.5 contract)
+
+Collect everything the wave's agents surfaced but did not fix in-scope (7.3.2), plus anything the integration verification (7.4) turns up. For each item, execute the plan's Section 9.5 Follow-Up Work Completion Contract:
+
+1. **Track** — open a `follow-up`-labeled issue so nothing is lost.
+2. **Triage against plan §1.4** — using the Mission & Guiding Decision Principles, classify it: **in-scope-now** (the work cannot be called complete or valid without it), **out-of-scope/deferred** (a nice-to-have or v2 idea), or **human-blocked** (needs a credential, dashboard action, or a product decision with no right answer). Decide this yourself from the plan's context — do NOT stop to ask the user how to direct in-scope follow-on work. That is exactly what §1.4 exists to let you do.
+3. **Complete in-scope-now items** — branch, implement, review with the same discipline as planned work, merge. Fold a small in-scope follow-up into the current wave; spin a dedicated agent for a larger one.
+4. **Log deferred, notify human-blocked** — deferred items stay as open issues surfaced in the final report; human-blocked items get a notification with the exact ask, then continue-around (never halt non-blocked work).
+
+A wave is not "done" while an in-scope-now follow-up it produced is still open. Record the follow-up disposition in the wave checkpoint (7.3.5).
+
 ### 7.4 Integration Verification
 
 After each wave, AFTER the Bring-Up Runbook (7.3.4) has executed:
@@ -1813,10 +1890,11 @@ After each wave, AFTER the Bring-Up Runbook (7.3.4) has executed:
 - No open PRs
 - CI is green
 - Deployment working
+- **All in-scope follow-up work completed (plan.md Section 9.5)** - do a final follow-up sweep: no open `follow-up` issue remains except genuinely human-blocked ones, and each of those has been surfaced to the user with the exact ask. Execution is NOT complete while an in-scope, non-human-blocked follow-up is open.
 - **Final Bring-Up (plan.md Section 9.4) executed** - all migrations applied, all services running current code, all layers confirmed live
 - **End-to-end smoke test passes** against the running system - the user should be able to open the app and use it immediately
 
-If blocked by a human-epic: create a P0 issue with exact instructions, notify the user, continue non-blocked work.
+If blocked by a human-epic or a human-blocked follow-up: create a P0 issue with exact instructions, notify the user, continue non-blocked work. Human-required work is the *only* thing allowed to remain open at completion — reason through everything else yourself using plan §1.4 rather than deferring it to the user.
 
 ---
 
@@ -1826,6 +1904,8 @@ If blocked by a human-epic: create a P0 issue with exact instructions, notify th
 
 ```bash
 gh issue list --state open --repo {username}/{project-name}
+# Follow-up issues must all be closed except genuinely human-blocked ones (§9.5 contract):
+gh issue list --state open --label follow-up --repo {username}/{project-name}
 gh pr list --state open --repo {username}/{project-name}
 for i in 0 1 2 3; do
   echo "=== Clone $i ==="
@@ -1834,6 +1914,8 @@ done
 cd ~/code/{project-name}-repos/{project-name}-0
 npm test && npm run build
 ```
+
+Any open `follow-up` issue that is NOT human-blocked means execution is not complete — return to Phase 7.3.7 and finish it before reporting. Only human-blocked follow-ups may remain, each surfaced with its exact ask.
 
 ### 8.2 Report
 
@@ -1964,6 +2046,10 @@ Maximize parallel agents based on the setup confirmed in Phase 2.7:
 
 Do as much as possible without human intervention. Only create human-epics for things that genuinely require the user's browser session or credentials you don't have. CLI/API access replaces human actions wherever possible.
 
+### Human Work at the Edges
+
+The user should not be a step *inside* an execution run. Minimize required human interaction first (anything an agent can do via CLI/API is not human work), then bucket whatever genuinely remains to the **beginning** (front-loaded prerequisites) or the **end** (final human steps) — never mid-run, where it stalls the whole run waiting on a person. Once execution starts, it proceeds to done without pausing for a human. This is tenet T1 the adversarial review (Phase 5.7) enforces.
+
 ### Quality Over Speed
 
 - Every piece of code has tests
@@ -1984,6 +2070,14 @@ Epic sizing is about isolation, testability, and merge safety - not clock time. 
 ### Complete Execution
 
 Plans execute until ALL completable work is done. No stopping halfway. No leaving broken or half-finished work. Every session ends with a clean state.
+
+### Follow-Up Completion Before Done
+
+Execution always surfaces work the plan did not enumerate. Execution is **not complete** while in-scope follow-on work discovered during the run remains open. Every such item is tracked as a `follow-up` issue, triaged against plan §1.4, and — if in-scope — completed and reviewed before the run is reported done (plan §9.5). The only work allowed to remain open at completion is genuinely human-blocked, and it is surfaced explicitly. This is tenet T2 the adversarial review (Phase 5.7) enforces.
+
+### Autonomous Follow-On Decisions
+
+An agent triages and directs unplanned follow-on work *itself*, using the plan's Mission & Guiding Decision Principles (§1.4) — the software's mission, the codebase's governing context, and the plan's decision heuristics. It does not stop to ask the user how to handle in-scope follow-on work; the plan carries enough context to deduce the direction. If it does not, the plan is under-specified and §1.4 must be expanded — this is tenet T3 the adversarial review (Phase 5.7) enforces.
 
 ### Resumability
 

--- a/modules/xplan/commands/xplana.md
+++ b/modules/xplan/commands/xplana.md
@@ -55,9 +55,18 @@ Autonomous mode affects these xplan phases:
 | 6 (Walkthrough) | Runs the new **Phase 6.A Autonomous Plan Walkthrough** - structured plan-as-artifact presentation with explicit assumption callouts. |
 | 6.5 (Final Execution Gate) | **Always fires**, same as any xplan run. Autonomous mode does NOT bypass this gate. |
 
+## Built-In Execution Tenets (matter most here)
+
+Autonomous mode is where these three plan tenets matter most: there is no human in the loop during creation *or* execution, so the plan must stand entirely on its own. They apply in every xplan mode, but `/xplana` leans on them hardest. The Phase 5.7 adversarial reviewer enforces all three (T1–T3), expanding the plan when any is thin:
+
+1. **Human interaction is minimized and bucketed to the edges** (T1). No human step an agent could do via CLI/API; unavoidable human work is front-loaded before Wave 1 or deferred to the end, never wedged mid-run. Once execution starts, it runs to done without pausing for a person.
+2. **Follow-up-completion contract** (T2, plan §9.5). Any follow-on work discovered during execution is tracked, triaged, and — if in-scope — completed before execution is reported complete. Only genuinely human-blocked work may remain open, surfaced with its exact ask.
+3. **Autonomous decision context** (T3, plan §1.4). The plan carries the software's mission, the codebase's governing context, and its decision principles, so an execution agent deduces the direction for unplanned follow-on work *itself* — critical in autonomous mode, where there is no user to ask mid-run. If that context is thin, the adversarial review expands the plan to add it.
+
 ## What This Command Does NOT Do
 
 - It does NOT skip research, naming, the standard reviews, the self-review loop, or the Phase 5.7 adversarial review sequence. Autonomous is the *deep* mode, not the fast one — the finished plan has survived 6 reviews (3 standard + 3 sequential adversarial) before you see it.
+- It does NOT skip the three execution tenets above. The adversarial review enforces minimal edge-bucketed human work (T1), a follow-up-completion contract (T2), and enough decision context to direct unplanned work without a human (T3) — expanding the plan when any is missing.
 - It does NOT skip the final execution gate. 6.5 is non-bypassable.
 - It does NOT automatically proceed to execution. The default recommendation at 6.5 in autonomous mode leans toward "save plan, don't execute yet" so the user can review before committing to multi-agent work.
 


### PR DESCRIPTION
Closes #812.

Adds three cross-cutting requirements to the adversarial-review surface and the xplan/xplana/etp execution framework. These make a plan executable with minimal human involvement and enforce that discovered work is finished before a run is called done.

## The three tenets (T1–T3)
1. **Human interaction is minimized and bucketed to the edges** — anything an agent can do via CLI/API is not human work; unavoidable human work is front-loaded (before Wave 1) or deferred (after all agent work), never wedged mid-run.
2. **Follow-up-completion contract** — any follow-on work discovered during execution is tracked, triaged, and (if in-scope) completed before execution is reported complete. Only genuinely human-blocked work may remain open.
3. **Autonomous decision context** — the plan carries the software's mission, the codebase's governing conventions, and its decision principles, so an execution agent directs unplanned follow-on work itself. If that context is missing, the plan is expanded to add it.

## Changes by file
- **`agents/adrev-reviewer.md`** — new **Plan Execution Tenets (T1–T3)** section (plan targets only) + apply protocol enforces them by editing (adds/expands the plan), never just noting; description updated.
- **`skills/adrev/SKILL.md`** — dispatch + verification note the reviewer enforces the three tenets on plan targets.
- **`adversarial-review/README.md`** — doc sync (new tenets section).
- **`commands/xplan.md`** — Phase 3.0 (Mission & Decision Principles), 3.4 edge-bucketing + 3.4.5 follow-up contract, plan template §1.4 and §9.5, Section 13 checklist items, 5.6.3 readiness check, 5.7 lens/dispatch enforcement, Phase 7 execution follow-up loop (7.3.2, 7.3.7, 7.5) + 8.1 audit, three new Important Principles.
- **`commands/xplana.md`** — autonomous inherits all three; new "Built-In Execution Tenets" section (matter most with no human in the loop).
- **`commands/etp.md`** — Phase 1.4 edge-bucketing + new 1.5 decision context; Phase 5 triage grounded in §1.4/decision context and the §9.5 contract; Phase 6 reasoning grounded in decision context; "Human work at the edges" guardrail.
- **`xplan/README.md`** — doc sync (Autonomous-Execution Tenets).

## Verification
- `tests/test-no-personal-data.sh` — PASS
- `tests/test-modules.sh` — 1556 passed, 0 failed
- All introduced section anchors (§1.4, §3.4.5, §9.5, T1–T3) cross-checked to resolve.