### PR TITLE
#814: mandate comprehensive autonomous E2E test suites in every plan (tenet T4)

### DIFF
--- a/modules/adversarial-review/README.md
+++ b/modules/adversarial-review/README.md
@@ -53,13 +53,14 @@ Findings carry severity (P0-P3) and confidence (0.0-1.0), matching the document-
 
 ## Plan Execution Tenets (plan targets)
 
-Beyond the battery, a plan is a contract for *autonomous* execution, so `plan` targets get three additional checks that are **requirements, not judgment calls** - if the plan fails one, apply mode fixes it (adds/expands the section), it is not merely noted:
+Beyond the battery, a plan is a contract for *autonomous* execution, so `plan` targets get four additional checks that are **requirements, not judgment calls** - if the plan fails one, apply mode fixes it (adds/expands the section), it is not merely noted:
 
 1. **Human interaction is minimized and bucketed to the edges** - no human step an agent could do via CLI/API; unavoidable human work is front-loaded before execution or deferred to the end, never wedged mid-run where it stalls the whole run.
 2. **A follow-up-completion contract is present** - the plan requires that any follow-on work discovered during execution is completed before execution is reported complete; the completion checklist includes "no open in-scope follow-up work"; only genuinely human-blocked items may remain open.
 3. **Enough decision context to direct unplanned work without a human** - the plan carries the software's mission, the codebase's governing conventions, and its own decision principles, so an agent can deduce how to handle an unplanned follow-on item. Missing context is expanded into the plan on apply.
+4. **A comprehensive autonomous E2E test suite** - every testable surface maps to a real end-to-end test (not mocks), wired into CI as a blocking merge gate, so the suite (not the user) is the ready-to-merge oracle. For existing repos, coverage gaps in touched areas are filled optimistically. Thin coverage is expanded into Section 8 on apply.
 
-The three reinforce each other: decision context (3) lets an agent finish follow-on work (2) without a human, which is what keeps execution human-free mid-run (1).
+The four reinforce each other: decision context (3) lets an agent finish follow-on work (2) without a human, which keeps execution human-free mid-run (1); the E2E suite (4) makes "done" verifiable without the user, so the whole run can certify itself green.
 
 ## The Apply Protocol (plans)
 

--- a/modules/adversarial-review/agents/adrev-reviewer.md
+++ b/modules/adversarial-review/agents/adrev-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: adrev-reviewer
 description: >
-  Adversarial review of any entity - plan, spec, doc, PR, issue, code, directory, or stated concept. Attacks premises, hunts failure modes, steelmans the strongest case against, and checks falsifiability and reversal cost. For plan targets it also enforces the autonomous-execution tenets: minimal and edge-bucketed human involvement, a follow-up-completion contract, and enough decision context to direct unplanned work without a human. Returns structured JSON findings with severity and confidence. When the target is a plan and apply is enabled, incorporates the findings into the plan itself and reports exactly what changed.
+  Adversarial review of any entity - plan, spec, doc, PR, issue, code, directory, or stated concept. Attacks premises, hunts failure modes, steelmans the strongest case against, and checks falsifiability and reversal cost. For plan targets it also enforces the autonomous-execution tenets: minimal and edge-bucketed human involvement, a follow-up-completion contract, enough decision context to direct unplanned work without a human, and a comprehensive autonomous E2E test suite over every testable surface. Returns structured JSON findings with severity and confidence. When the target is a plan and apply is enabled, incorporates the findings into the plan itself and reports exactly what changed.
 tools: Read, Write, Edit, Glob, Grep, Bash
 ---
 
@@ -62,7 +62,7 @@ Assume it ships and works. What happens next? Who or what adapts to it, games it
 
 ## Plan Execution Tenets (target_kind == plan only)
 
-Beyond the generic battery, a plan is a contract for *autonomous* execution. Run these three tenets against every `plan` target. Unlike the battery — where a clean survival is a valid outcome — these are **requirements**: if the plan does not satisfy one, that is a finding, and in `apply` mode you make the plan satisfy it. A plan that fails a tenet is not ready to execute.
+Beyond the generic battery, a plan is a contract for *autonomous* execution. Run these four tenets against every `plan` target. Unlike the battery — where a clean survival is a valid outcome — these are **requirements**: if the plan does not satisfy one, that is a finding, and in `apply` mode you make the plan satisfy it. A plan that fails a tenet is not ready to execute.
 
 ### T1. Human interaction is minimized and bucketed to the edges
 
@@ -91,7 +91,17 @@ To complete follow-on work autonomously (T2), the agent must be able to *decide 
 
 If a reader could not, from the plan alone, deduce how to handle a plausible unplanned follow-on item, the plan is under-specified for autonomous execution — a **P1** finding. In `apply` mode, **expand the plan** to add the missing mission / codebase-context / decision-principles content; do not merely note that it is missing. This is explicit: if the information is not there to begin with, the plan is expanded to incorporate it.
 
-The three tenets reinforce each other: T3 (decision context) is what lets an agent resolve T2 (follow-on work) without a human, which is what achieves T1 (no mid-run human interaction). A plan that satisfies all three executes to done on its own.
+### T4. A comprehensive autonomous E2E test suite covers every testable surface
+
+The plan must build an **autonomous end-to-end test suite** that is the oracle for "broken" vs. "clean and ready to merge" — so the user never does manual testing. Verify:
+
+- **Coverage** — every testable surface the plan adds or changes (HTTP endpoints, UI flows, CLI invocations, background jobs, auth, webhooks, cross-surface journeys) maps to an E2E test against the *running* system, not mocks. Attack this hardest: which surface has no real end-to-end test? Which "test" only exercises mocks and would stay green while the real system is broken? A plan that tests internals but not the real end-to-end path fails this tenet.
+- **SDLC integration** — the suite runs in CI as a **required, blocking merge gate**, and the completion checklist gates on a green suite. A suite that exists but does not block merges is not a gate.
+- **Existing repos** — if the plan touches an area with no E2E coverage, the plan must add it. This gap-fill is **optimistic**: the standing assumption is the user always wants more E2E coverage, so it is added by default (surfaced for veto), never deferred to a question. Flag any touched surface left uncovered.
+- **Infrastructure** — where certainty needs it, the plan provisions it (testing agents for flows that can't be asserted programmatically, third-party compute like RunPod or a cloud Mac, real devices). "We couldn't test this platform" is not an acceptable gap when infra could close it — there is no resource constraint on testing.
+- If coverage is missing, not CI-gated, or an existing-repo gap is unfilled, that is a **P1** finding. In `apply` mode, **expand the plan's Section 8 (and add E2E-coverage epics/tasks)** to close it, optimistically — do not merely note it.
+
+The four tenets reinforce each other: decision context (T3) lets an agent resolve follow-on work (T2) without a human, which is what achieves human-free mid-run execution (T1); the autonomous E2E suite (T4) is what makes "done" verifiable without the user, so the whole run — including follow-on fixes — can certify itself green. A plan that satisfies all four executes to a trustworthy, ready-to-merge state on its own.
 
 ## Findings Format
 
@@ -142,9 +152,9 @@ When `apply` is true, you incorporate your findings into the plan after the revi
 4. **Do not touch** `progress.md`, completed-work records, decision-log history, or any section recording what already happened. Append to `decisions.md` (if it exists) with one line per incorporated finding.
 5. **Report the ledger:** for every finding - `incorporated` (with the section edited), `deferred-to-risks`, or `artifact-only`. If you rejected your own finding during incorporation (it dissolved on closer reading), say so and why.
 
-**Enforce the plan execution tenets (T1–T3), do not defer them.** These are requirements, not judgment calls, so they are *fixed by editing*, not parked in the Risk Register: for a missing or vague follow-up-completion contract (T2) or insufficient decision context (T3), **add the section or expand the plan** so the tenet is satisfied — integrated as a first-class part of the plan, as if it had been there from the start. For agent-doable or misplaced human work (T1), revise the plan to drop the human step (when an agent can do it) or move it to the start/end (when it is genuinely unavoidable). Record each as `incorporated`. Drop a tenet finding to the Risk Register only when you genuinely cannot resolve it by editing (e.g., closing a T3 gap needs a product decision only the author can make) — and say so explicitly in the ledger.
+**Enforce the plan execution tenets (T1–T4), do not defer them.** These are requirements, not judgment calls, so they are *fixed by editing*, not parked in the Risk Register: for a missing or vague follow-up-completion contract (T2) or insufficient decision context (T3), **add the section or expand the plan** so the tenet is satisfied — integrated as a first-class part of the plan, as if it had been there from the start. For agent-doable or misplaced human work (T1), revise the plan to drop the human step (when an agent can do it) or move it to the start/end (when it is genuinely unavoidable). For missing E2E coverage, a non-blocking suite, or an existing-repo coverage gap (T4), **expand Section 8 and add the E2E-coverage epics/tasks** optimistically (the user wants more coverage). Record each as `incorporated`. Drop a tenet finding to the Risk Register only when you genuinely cannot resolve it by editing (e.g., closing a T3 gap needs a product decision only the author can make) — and say so explicitly in the ledger.
 
-When `apply` is false, step 1 only (or inline report if no artifact path): you never modify the target. Report the T1–T3 gaps as findings so the caller can fix them.
+When `apply` is false, step 1 only (or inline report if no artifact path): you never modify the target. Report the T1–T4 gaps as findings so the caller can fix them.
 
 ## Status
 

--- a/modules/adversarial-review/skills/adrev/SKILL.md
+++ b/modules/adversarial-review/skills/adrev/SKILL.md
@@ -60,17 +60,18 @@ For a `concept` target, include the full concept text in the prompt (it has no p
 
 The agent runs the full attack battery (premises, falsification, failure modes, strongest opposing case, reversal cost, second-order effects) and - when `apply` - incorporates findings into the plan per its apply protocol, returning a ledger of what changed.
 
-**For `plan` targets, the agent additionally enforces three plan-execution tenets** (requirements, not judgment calls — it adds or expands sections when the plan is missing them):
+**For `plan` targets, the agent additionally enforces four plan-execution tenets** (requirements, not judgment calls — it adds or expands sections when the plan is missing them):
 
 1. **Human interaction is minimized and bucketed to the edges** — no human step an agent could do via CLI/API; any unavoidable human work is front-loaded before execution or deferred to the end, never mid-run.
 2. **A follow-up-completion contract is present** — the plan requires that any follow-on work discovered during execution is completed before execution is reported complete; only genuinely human-blocked work may remain open.
 3. **Enough decision context to direct unplanned work without a human** — the plan carries the software's mission, the codebase's governing conventions, and its own decision principles, so an agent can deduce how to handle unplanned follow-on work. If that context is missing, the agent expands the plan to add it.
+4. **A comprehensive autonomous E2E test suite** — every testable surface maps to a real end-to-end test, wired into CI as a blocking merge gate, so the user never tests manually. For existing repos, coverage gaps in touched areas are filled optimistically (the user always wants more coverage). If coverage is thin, the agent expands the plan's Section 8 to close it.
 
 ## Phase 3: Verify and Report
 
 The agent's DONE is a claim, not evidence:
 
-- **Applied (plan)**: run `git diff` on the plan (or re-read the edited sections if untracked). Confirm the review artifact exists and every `incorporated` ledger entry corresponds to a real edit. Confirm the three plan-execution tenets are satisfied in the edited plan — human work is minimized and bucketed to the edges, the follow-up-completion contract is present and clearly located, and the mission / codebase-context / decision-principles content is concrete enough to direct unplanned work. If the reviewer parked a tenet in the Risk Register instead of fixing it, verify it named a genuine reason (a decision only the author can make). Then present: findings table (id, test, severity, confidence, one-line what), the ledger (incorporated / deferred-to-risks / artifact-only), what the target survived, and the artifact path.
+- **Applied (plan)**: run `git diff` on the plan (or re-read the edited sections if untracked). Confirm the review artifact exists and every `incorporated` ledger entry corresponds to a real edit. Confirm the four plan-execution tenets are satisfied in the edited plan — human work is minimized and bucketed to the edges, the follow-up-completion contract is present and clearly located, the mission / codebase-context / decision-principles content is concrete enough to direct unplanned work, and the autonomous E2E suite (Section 8) covers every testable surface with a CI-blocking merge gate. If the reviewer parked a tenet in the Risk Register instead of fixing it, verify it named a genuine reason (a decision only the author can make). Then present: findings table (id, test, severity, confidence, one-line what), the ledger (incorporated / deferred-to-risks / artifact-only), what the target survived, and the artifact path.
 - **Report-only**: present the findings table and survived list. For an `issue` or `pr` target, offer - do not auto-post - `gh issue comment` / `gh pr review --comment` with the findings.
 - **BLOCKED / NEEDS_CONTEXT**: relay the missing piece verbatim and stop. Do not invent a target or substitute your own review in the main context - that breaks the separation that makes the review trustworthy.
 

--- a/modules/xplan/README.md
+++ b/modules/xplan/README.md
@@ -35,11 +35,12 @@ Reviews run in two stages: Phase 4 standard peer review against the draft, then 
 
 ### Autonomous-Execution Tenets
 
-Every plan carries three requirements that let it execute with minimal human involvement — written during planning (Phase 3), verified by the self-review (Phase 5.6), and enforced by the adversarial reviewer (Phase 5.7 / `adrev-reviewer` tenets T1–T3), which expands the plan when any is thin:
+Every plan carries four requirements that let it execute with minimal human involvement and self-certify — written during planning (Phase 3), verified by the self-review (Phase 5.6), and enforced by the adversarial reviewer (Phase 5.7 / `adrev-reviewer` tenets T1–T4), which expands the plan when any is thin:
 
 1. **Human work at the edges** (T1) — human involvement is minimized (anything an agent can do via CLI/API is not human work) and what remains is bucketed to the start (front-loaded prerequisites) or the end (deferred steps), never mid-run. Once execution starts, it does not pause for a person.
 2. **Follow-up-completion contract** (T2, plan §9.5) — any follow-on work discovered during execution is tracked, triaged, and — if in-scope — completed before execution is reported complete. Only genuinely human-blocked work may remain open. Phase 7 gates completion on it.
 3. **Autonomous decision context** (T3, plan §1.4) — the plan carries the software's mission, the codebase's governing conventions, and its decision principles, so an execution agent directs unplanned follow-on work itself instead of stopping to ask. `/etp` reads this context (its Phase 1.5) to triage and reason.
+4. **Comprehensive autonomous E2E testing** (T4, plan §8) — every plan ships a full autonomous E2E suite over all testable surfaces, wired into CI as a blocking merge gate, so the suite (not the user) is the ready-to-merge oracle and no manual testing is required. New projects build it in from the ground up (a Wave-1 harness epic); existing repos get optimistic gap-fill for any touched area lacking coverage. The plan provisions whatever infra certainty needs (testing agents, RunPod, cloud Mac, real devices) — no resource constraint on testing. Phase 7 and `/etp` gate completion on a green suite.
 
 **`--light`**: fast path. Reduced depth, minimal interaction. Skips Phases 0.5, 1.5, 2.5, 2.6, and 2.7. Traditional section-by-section walkthrough at the end.
 

--- a/modules/xplan/commands/etp.md
+++ b/modules/xplan/commands/etp.md
@@ -285,7 +285,9 @@ Merge a PR only when: it passed review (both stages, or Stage 1 under `--light-r
 
 ### 4.5 Bring-up & integration verification (when applicable)
 
-If the work specifies bring-up (migrations, dependency installs, type regen, env/secret sets, dev-server/worker restarts, deploys), execute it and verify every layer is actually live - DB migrated, backend responding, frontend loading, workers running, deploy current - then run a smoke test against the running system, not just CI. A single issue usually has no bring-up; confirm that is true rather than assuming. A plan wave does not advance against a degraded system.
+If the work specifies bring-up (migrations, dependency installs, type regen, env/secret sets, dev-server/worker restarts, deploys), execute it and verify every layer is actually live - DB migrated, backend responding, frontend loading, workers running, deploy current - then run the **autonomous E2E suite against the running system**, not just CI. For a plan, that is its Section 8 suite; for an issue, the E2E tests covering the changed surface. The E2E suite (not a bare smoke test) is the certainty gate: green ⇒ clean / mergeable, red ⇒ broken. A single issue usually has no bring-up; confirm that is true rather than assuming. A plan wave does not advance against a degraded system or a red suite.
+
+**If the touched surface has no E2E coverage**, adding it is an in-scope follow-up (Phase 5), not an optional extra — the standing assumption is that more autonomous E2E coverage is always wanted, so the changed behavior gets a real end-to-end test before the work is called complete. This is the executor's side of the plan's E2E mandate (adrev tenet T4).
 
 ### 4.6 Checkpoint
 
@@ -329,7 +331,7 @@ Loop Phases 4-6 until every condition holds:
 - All PRs merged (or frozen-and-recorded as blocked); all target issues closed by their merged PRs.
 - Every merged PR reached CI-green via the bounded loop (4.35); any PR that could not be driven green within the bound is among the frozen-and-recorded blockers, not silently merged.
 - CI green, no uncommitted changes in any clone, no unexpected open PRs.
-- All layers confirmed live (where the work has runtime impact); smoke test passes.
+- All layers confirmed live (where the work has runtime impact); the **autonomous E2E suite is green** against the running system (the plan's §8 suite, or the E2E tests covering a changed issue surface) — the certainty oracle, not a bare smoke test. Any surface a plan's §8.5 names as not-certified is the only acceptable manual residue.
 
 "Don't stop until everything is complete" means: do not stop while completable work remains. Blocked units are set aside with a clear notification; they do not end the run. The run ends when the only thing left is genuinely human-blocked, and the user has been told exactly what each blocker needs.
 
@@ -347,7 +349,7 @@ gh issue list --state open
 
 ### 8.2 Report to the user
 
-- **Completed**: units finished, PRs merged, issues closed - with evidence (test output, smoke-test result, live URLs).
+- **Completed**: units finished, PRs merged, issues closed - with evidence (test output, **autonomous E2E suite result (green)**, live URLs).
 - **Blocked**: each blocker, why, and the exact human action that unblocks it.
 - **Deferred**: out-of-scope follow-ups logged but intentionally not done.
 - **Live state**: the verification that the system actually runs end-to-end (where applicable).
@@ -371,6 +373,8 @@ A plan run: mark the progress file `COMPLETE`, or `BLOCKED - WAITING ON HUMAN` w
 **Notify-and-continue.** Absolute blockers are reported the moment they are found and never halt non-blocked work. The run degrades gracefully around blockers; it does not stop dead.
 
 **Human work at the edges.** The user is not a step inside the run. Anything an agent can do via CLI/API is done, not asked. Genuine human-only work is surfaced up front (front-loaded, Phase 1.4) or queued for the end (deferred), never left to stall the run mid-stream. In-scope follow-on work is reasoned through against the decision context (Phase 1.5), not bounced to the user — only genuinely human-blocked items remain open at completion, each surfaced with its exact ask.
+
+**The E2E suite is the completion oracle — no manual testing bounced to the user.** "Done" means the autonomous end-to-end suite is green against the running system, not "I believe it works" or "the user can check." Provision whatever the suite needs — testing agents for flows that can't be asserted programmatically, third-party compute (RunPod, cloud Mac, real devices) as a front-loaded prerequisite; there is no resource constraint on testing. A changed surface without an E2E test gets one before completion (adrev tenet T4 / plan §8). The only manual residue permitted is a surface a plan's §8.5 explicitly names as not-certified.
 
 **Safety on irreversible / outward actions.** Even in autonomous mode, anything destructive or externally-visible that the work did not clearly authorize - production deploys, resource deletion, force-pushing shared branches, sending external communications - requires notifying the user first. The work authorizes its own scope; it does not authorize off-scope irreversible acts.
 

--- a/modules/xplan/commands/xplan.md
+++ b/modules/xplan/commands/xplan.md
@@ -226,7 +226,8 @@ Reading **from `$WORKTREE` (the anchor), not the original clone**:
 2. Map its architecture, tech stack, and current state
 3. Check `gh issue list` and `gh pr list` for open work (these query the remote, so they are already current)
 4. Read recent agent logs from the log repo for the project
-5. This context feeds into Phase 1 research and Phase 0.5 interview
+5. **Inventory the existing autonomous test coverage** — the E2E harness/runner in use (Playwright, XCUITest, a CLI harness, etc.), which surfaces have end-to-end tests, whether they run in CI, and — critically — whether the **areas this plan will touch are covered by E2E tests**. Record the coverage gaps in the touched areas: they become optimistic E2E-coverage work in Phase 3.3.5 (the assumption is the user always wants more E2E coverage). If the repo has *no* autonomous E2E suite at all, that is itself a gap to close for everything this plan touches.
+6. This context feeds into Phase 1 research and Phase 0.5 interview
 
 Every load-bearing fact pulled from the repo in this phase is anchored to `{file}:{line}` as read at `$WORKTREE`. Do not assert a repo fact from memory or from a stale working-tree Read.
 
@@ -702,6 +703,7 @@ Present a full tech stack proposal with justifications. Apply these defaults unl
 - **Validation**: zod
 - **Monorepo**: pnpm workspaces (if multiple apps/packages)
 - **AI integration**: Provider SDKs directly (`@anthropic-ai/sdk`, `openai`, `@google/generative-ai`)
+- **E2E test infrastructure**: Playwright (web/browser); XCUITest + a cloud Mac or the paired real device for macOS & iOS; a stdin/stdout harness for CLIs & daemons. Add third-party compute whenever the surface needs it — RunPod (GPU / heavy E2E), cloud Mac instances, or a device/browser matrix. There is **no resource constraint on test infrastructure**: provision whatever gives high-certainty end-to-end coverage so the user never has to test manually.
 
 **Banned** (never suggest, no exceptions):
 - Anything from Vercel's ecosystem: `ai`, `@ai-sdk/*`, `next`, `@next/*`, `@vercel/*`, `v0`, `turbo`, `turborepo`, `swr`
@@ -924,16 +926,35 @@ Do NOT split just because work is large. A 3-hour focused epic is better than th
 
 Rules:
 - Each epic results in **working, tested code** (unit + integration tests included)
+- Each epic **contributes autonomous end-to-end coverage** for the surface it adds or changes — not just unit + integration. A feature epic is not "done" until an E2E test exercises its real behavior through the running system (real API, real DB, real UI/CLI). Its acceptance criteria include the E2E test(s) it adds to the suite (§8 / Phase 3.3.5).
 - Define clear **inputs** (what must exist) and **outputs** (what results)
 - Identify **dependency order** - parallel vs. sequential
 - Define **bring-up steps** - the concrete actions required to get the app (local and/or production) into a testable state once this epic merges: migrations to run, dev servers to restart, deploys to trigger, env vars/secrets to set, caches to invalidate, seed data to load. "Code merged" is not "change testable"; the plan must close that gap explicitly.
 
 Epic categories:
-- **Foundation epics**: Repo setup, CI/CD, shared types, config - run first
+- **Foundation epics**: Repo setup, CI/CD, shared types, config - run first. **For a new project, the autonomous E2E test harness is a foundation epic** (Wave 1): the runner, the CI wiring that runs it on every PR, and any test infrastructure (ephemeral env, seeded DB, third-party compute) the surface needs. Feature epics build on it from the first wave.
 - **Parallel epics**: Independent feature work running simultaneously
 - **Integration epics**: Connecting parallel streams - run after dependencies
-- **Testing epics**: E2E test suites, load testing
+- **Testing epics**: The autonomous E2E suite and its infrastructure — the harness, cross-cutting user-journey tests, coverage gap-fill for existing surfaces (Phase 3.3.5), load/soak tests, and any agent-driven exploratory testing. The suite is the certainty oracle (green = ready-to-merge / clean; red = broken), so these are first-class epics, never optional add-ons.
 - **Human-epics**: Work requiring human intervention
+
+### 3.3.5 Autonomous E2E Test Strategy (MANDATORY)
+
+Every plan builds a **comprehensive, autonomous end-to-end test suite** covering all testable surfaces of what it touches. This is not optional and does not scale down with project size — it exists so the suite, not the user, is the oracle for "broken" vs. "clean and ready to merge." **The user does not do manual testing.** If certainty requires spinning up testing agents or third-party infrastructure, the plan provisions it — there is no resource constraint on testing.
+
+Design the suite now; it becomes plan.md Section 8 and is enforced by the execution gates (Phase 7), the self-review (5.6.3), and the adversarial review (5.7 tenet T4).
+
+**1. Coverage target — every testable surface.** Enumerate the surfaces this plan adds or changes and the end-to-end journey through each: HTTP endpoints (real request → real DB → real response), UI flows (real browser, real backend), CLI invocations (real args → real stdout/exit code), background jobs/queues, auth flows, webhooks, and any cross-surface user journey. Each becomes an E2E test that runs against the *running system*, not mocks. Mocked tests prove internal consistency; they say nothing about whether the real system works.
+
+**2. New project — build it in from the ground up.** The E2E harness is a Wave-1 foundation epic (Phase 3.3): the runner, CI wiring that runs the suite on every PR, and a reproducible test environment (ephemeral deploy or local stack, seeded DB, test credentials). Every feature epic thereafter adds its E2E tests to that harness from the first wave — the suite grows with the code, never bolted on at the end.
+
+**3. Existing project — audit and optimistically fill gaps.** Using the Phase 0.4.1 coverage inventory, for every area this plan touches that lacks E2E coverage, **add E2E-coverage work into the plan by default — assume the user signs off.** The standing assumption is that the user always wants more autonomous E2E coverage, so gap-fill is opt-out (surfaced in the walkthrough and decisions.md), never a mid-flow yes/no question. If the repo has no E2E suite at all, the plan stands one up for the touched surfaces (and wires it into CI) as part of the work. Record each added E2E-coverage epic/task in decisions.md under "Optimistic E2E coverage additions" so the user can veto specific ones at the final gate.
+
+**4. Platform-appropriate execution + infrastructure.** Match the harness to the surface and provision whatever infra gives high certainty (Phase 2.5.2): Playwright for web; XCUITest on a **cloud Mac instance or the paired real device** for macOS/iOS; a stdin/stdout harness for CLIs/daemons; **RunPod or equivalent** for GPU/heavy compute E2E; a device/browser matrix where it matters. Where a flow genuinely cannot be asserted programmatically, **dispatch a testing agent to drive it and report** (browser automation, device automation) rather than handing the user a manual checklist — an agent doing exploratory/manual-substitute testing is still autonomous.
+
+**5. SDLC integration — the suite is a merge gate.** The suite runs in CI on every PR and is a **required, blocking check**: a PR does not merge until its E2E tests (and the existing suite) are green. Post-wave bring-up and final bring-up (Section 9) run the full suite against the reactivated system. "High degree of certainty" means: green suite ⇒ safe to merge / clean; red suite ⇒ broken, do not proceed.
+
+**6. Certainty, not coverage theater.** Prefer a smaller set of tests that exercise real end-to-end behavior over a large set of shallow mocked ones. The bar is: if the suite is green, the user can ship without opening the app. State explicitly in Section 8 what the suite does and does not certify, so any residual manual check is named rather than silently assumed.
 
 ### 3.4 Define Human-Epics
 
@@ -980,8 +1001,8 @@ Define:
 - **Wave 2+**: Parallel epic groups with dependency constraints
 - **Agent allocation**: How many agents per wave (based on Phase 2.7 decision)
 - **Integration points**: Where parallel streams merge
-- **Verification gates**: Checkpoints before proceeding
-- **Post-wave bring-up**: Aggregate the bring-up steps from every epic in the wave into a single ordered runbook. Include: migrations (with correct order if multiple), which services to restart (local dev servers, workers, background jobs), which deploys to trigger and verify, env vars/secrets to set, and the smoke-test command(s) that prove all layers are live. This runbook executes between waves - agents do not advance to the next wave until the previous wave's app state is reactivated and verified working.
+- **Verification gates**: Checkpoints before proceeding. **The autonomous E2E suite (§8) is the gate**: no PR merges until its E2E tests are green in CI, and no wave advances until the full suite passes against the reactivated system. Green suite ⇒ proceed; red ⇒ stop and fix.
+- **Post-wave bring-up**: Aggregate the bring-up steps from every epic in the wave into a single ordered runbook. Include: migrations (with correct order if multiple), which services to restart (local dev servers, workers, background jobs), which deploys to trigger and verify, env vars/secrets to set, and the command that runs the **full autonomous E2E suite** against the reactivated system (superseding a bare smoke test). This runbook executes between waves - agents do not advance to the next wave until the previous wave's app state is reactivated and the E2E suite is green.
 
 ### 3.7 Create decisions.md
 
@@ -1144,10 +1165,31 @@ This section is what makes the Section 9.5 follow-up contract executable autonom
 ### 7.5 Verification Gates
 
 ## 8. Testing Strategy
+
+[From Phase 3.3.5. This section specifies the **comprehensive autonomous E2E suite** that lets the user ship without manual testing. It is the certainty oracle: green ⇒ clean / ready-to-merge, red ⇒ broken.]
+
 ### 8.1 Unit Tests (per epic)
+[Per-epic unit coverage — the fast inner loop.]
+
 ### 8.2 Integration Tests
-### 8.3 E2E Tests (Playwright)
-### 8.4 Test Coverage Targets
+[Cross-module/service integration — real collaborators where practical.]
+
+### 8.3 Autonomous End-to-End Suite (the certainty oracle)
+- **Surfaces covered**: [every testable surface this plan touches — HTTP endpoints, UI flows, CLI invocations, background jobs/queues, auth, webhooks, cross-surface journeys. Each row: surface → the real end-to-end journey the test drives.]
+- **Harness & environment**: [runner (Playwright / XCUITest / CLI harness / …), the reproducible test environment (ephemeral deploy or local stack, seeded DB, test credentials), and how it is torn up/down.]
+- **Test infrastructure**: [any third-party compute the surface requires — cloud Mac instance, RunPod, real device (the paired iPhone), device/browser matrix. "None beyond CI" only if genuinely none.]
+- **Agent-driven testing** (if any): [flows that cannot be asserted purely programmatically and are driven by a testing agent (browser/device automation) that reports pass/fail — never handed to the user as a manual checklist.]
+- **Existing-repo gap-fill** (if `--repo`): [E2E coverage added optimistically for touched areas that lacked it — see decisions.md "Optimistic E2E coverage additions".]
+
+### 8.4 CI Integration & Merge Gate
+- The suite runs on **every PR** as a **required, blocking check**; a PR does not merge while it is red.
+- Post-wave and final bring-up (Section 9) run the **full** suite against the reactivated system.
+- [exact commands to run the suite locally and in CI.]
+
+### 8.5 Coverage Targets & What the Suite Certifies
+- [coverage targets per layer.]
+- **Certifies**: [what a green suite guarantees — the flows the user can trust without opening the app.]
+- **Does NOT certify**: [any residual surface not covered and why — named explicitly, never silently assumed. The goal is zero residual manual testing; any exception is justified here.]
 
 ## 9. Post-Implementation Integration
 
@@ -1168,7 +1210,7 @@ Wave N Bring-Up:
 7. Trigger/verify production deploys: `{commands or dashboard links}`
 8. Invalidate caches if needed: `{exact commands}`
 9. Load/update seed data if needed: `{exact commands}`
-10. Smoke test: `{exact command or manual steps that prove all layers are live}`
+10. Run the full autonomous E2E suite (Section 8): `{exact command}` — must be green before the next wave. This is the certainty gate; it supersedes a bare smoke test and proves all layers are live end-to-end.
 ```
 
 Every step has an exact command or link. Vague instructions like "restart the server" do not belong here.
@@ -1183,7 +1225,7 @@ For each wave's bring-up, specify the rollback: how to revert migrations, redepl
 
 ### 9.4 Final Bring-Up (end of execution)
 
-The last-wave bring-up runbook that takes the fully-merged project to a confirmed-live state. This is the single source of truth for "app is ready to test". Anything that was deferred or flagged during waves gets resolved here.
+The last-wave bring-up runbook that takes the fully-merged project to a confirmed-live state, ending with a **full run of the autonomous E2E suite (Section 8) that must be green**. This is the single source of truth for "app is ready" — because the suite is green, "ready to test" means the user can use it, not that they still need to test it. Anything that was deferred or flagged during waves gets resolved here.
 
 ### 9.5 Follow-Up Work Completion Contract
 
@@ -1220,6 +1262,9 @@ The agent decides the triage itself using §1.4 — it does not stop to ask the 
 ## 13. Post-Execution Verification Checklist
 - [ ] All agent-epics completed and merged
 - [ ] All tests passing (unit, integration, e2e)
+- [ ] **Full autonomous E2E suite (Section 8) green against the running system — every covered surface passes; this is the ready-to-merge / clean oracle, not a smoke test**
+- [ ] **E2E suite is a required, blocking CI check on every PR**
+- [ ] **Every E2E coverage gap for touched surfaces filled (optimistic additions per §3.3.5) or explicitly listed in §8.5 as not-certified with justification**
 - [ ] No open PRs (except human-blocked)
 - [ ] No uncommitted changes in any clone
 - [ ] No open issues (except human-agent/human-epic)
@@ -1358,8 +1403,9 @@ If any epic fails these checks, rewrite it until it passes. An epic that cannot 
 - **§1.4 Mission & Guiding Decision Principles is present and concrete** - the mission, codebase governing context, and decision principles are all filled in, not placeholders. The test: could a fresh agent, reading only plan.md, triage a plausible unplanned follow-on item the way the author would? If not, expand §1.4 until it can.
 - **§9.5 Follow-Up Work Completion Contract is present** - the plan states that in-scope follow-on work discovered during execution is completed before the run is reported complete, and Section 13's checklist includes "no open in-scope follow-up work."
 - **Human work is bucketed to the edges** - every human-epic is scheduled front-loaded (before Wave 1) or deferred (after all agent work), or carries an explicit justification for why it must sit mid-run. No agent-doable step is labeled human work.
+- **§8 specifies a comprehensive autonomous E2E suite** - every testable surface this plan touches maps to an E2E test against the running system; the suite is wired into CI as a blocking merge gate; for `--repo`, coverage gaps in touched areas are filled (optimistic additions) or explicitly listed in §8.5 as not-certified with justification. The test: could the user ship on a green suite without opening the app? If not, expand §8 until they can. No surface is left to manual testing without a named §8.5 exception.
 
-These are the same three tenets the Phase 5.7 adversarial reviewer enforces (T1–T3); satisfying them here means the adversarial pass confirms rather than reworks them.
+These map to the four tenets the Phase 5.7 adversarial reviewer enforces (T1–T4); satisfying them here means the adversarial pass confirms rather than reworks them.
 
 #### 5.6.4 Loop Until Clean
 
@@ -1420,7 +1466,7 @@ Each pass runs the full attack battery. Give each a **distinct lead lens** via `
 | Pass | Lead lens (`focus`) |
 |------|---------------------|
 | **1 — premises** | "The plan's load-bearing *unstated* premises, the falsifiability of its claims, and the strongest opposing case including do-nothing. What does this assume about users, scale, data shape, ordering, and the behavior of other systems that nobody examined?" |
-| **2 — execution & failure modes** | "How execution breaks: which step fails first when an assumption is wrong and whether the plan notices or plows on; partial failure mid-wave; concurrency and merge conflicts across parallel agent-epics; retries and idempotency; the gap between 'PR merged' and 'app live' in the bring-up runbook. Press tenets T1 and T2: is human work minimized and bucketed to the edges (plan §6 Human-Epics) rather than wedged mid-run, and is the follow-up-completion contract (§9.5) present, clearly defined, and gated by the Section 13 checklist? Also check whether Pass 1's revisions introduced any new weakness." |
+| **2 — execution & failure modes** | "How execution breaks: which step fails first when an assumption is wrong and whether the plan notices or plows on; partial failure mid-wave; concurrency and merge conflicts across parallel agent-epics; retries and idempotency; the gap between 'PR merged' and 'app live' in the bring-up runbook. Press tenets T1, T2, and T4: is human work minimized and bucketed to the edges (plan §6 Human-Epics) rather than wedged mid-run (T1); is the follow-up-completion contract (§9.5) present, clearly defined, and gated by the Section 13 checklist (T2); and does §8 specify a comprehensive autonomous E2E suite covering every testable surface, wired into CI as a blocking merge gate, with existing-repo gaps filled — such that the user need never test manually (T4)? Attack the testing claim hardest: which surface has no real end-to-end test, which 'test' only exercises mocks, where would a green suite still let a broken build merge? Also check whether Pass 1's revisions introduced any new weakness." |
 | **3 — final / reversal cost & second-order** | "This is the FINAL adversarial pass on a plan already hardened by two prior reviews. Decisions expensive to undo (schema, public API contracts, file formats, dependency choices, naming that leaks into URLs/configs/env vars) with thin justification; second-order effects once it ships — what becomes load-bearing, what gets gamed, what maintenance burden appears in month two. Press tenet T3: does §1.4 carry enough mission + codebase + decision-principles context that an agent can direct unplanned follow-on work without the user? If it cannot, expand it. Then do a holistic final read: do the prior passes' edits hang together, or did they leave seams? Anything P0/P1 you raise here is the last chance to catch it before the gate." |
 
 ### 5.7.2 Dispatch One Pass
@@ -1443,7 +1489,7 @@ You are pass {k} of 3 sequential adversarial reviews. The plan you are reading a
 
 Apply protocol: write the full review artifact first, then incorporate. P0/P1 (confidence ≥0.80) → revise the affected plan section directly, marking any premise fork with `> **Revised {date} (adversarial review):** ...`. P1/P2 (0.60–0.79) → add a row to the plan's existing Risk Register (Section 11), citing the finding id; do NOT create a separate "Risks & Open Questions" section — this plan already has Section 11. Confidence <0.60 → artifact-only. Append one line per incorporated finding to decisions.md. Never touch progress.md or completed-work records.
 
-Plan-execution tenets (T1–T3) are requirements, not judgment calls: enforce them by editing plan.md. If human work is agent-doable or wedged mid-run, revise the plan's Human-Epics (§6) / Prerequisites (§4) to drop or edge-bucket it (T1). If the follow-up-completion contract (§9.5) is missing or vague, add it (T2). If §1.4's mission/codebase/decision-principles context is too thin for an agent to direct unplanned follow-on work, expand it (T3). Park a tenet in the Risk Register only if it genuinely needs an author decision you cannot make — and say so.
+Plan-execution tenets (T1–T4) are requirements, not judgment calls: enforce them by editing plan.md. If human work is agent-doable or wedged mid-run, revise the plan's Human-Epics (§6) / Prerequisites (§4) to drop or edge-bucket it (T1). If the follow-up-completion contract (§9.5) is missing or vague, add it (T2). If §1.4's mission/codebase/decision-principles context is too thin for an agent to direct unplanned follow-on work, expand it (T3). If §8's autonomous E2E suite leaves a testable surface uncovered, is not wired into CI as a blocking merge gate, or (for `--repo`) leaves a touched-area coverage gap unfilled, expand §8 to close it — add the E2E-coverage epics/tasks optimistically (the user wants more coverage) rather than deferring to a question (T4). Park a tenet in the Risk Register only if it genuinely needs an author decision you cannot make — and say so.
 ```
 
 **Anchor propagation (only when `--repo` was given).** Append the same `SOURCE FRESHNESS — repo facts` block used for the Phase 4 review agents (verification anchor `{DEFAULT_REF} @ {ANCHOR}`; read every repo fact from `{WORKTREE}` or `git -C {REPO} show {DEFAULT_REF}:<path>`, never the stale working tree; flag any plan claim that disagrees with the anchor as a finding).
@@ -1644,6 +1690,7 @@ Structure the output in this exact order, as a single message (or a small number
 - Include the Phase 2 naming auto-selection (with the top-5 alternatives inline so the user can swap)
 - Include the Phase 2.6 scope inference
 - Include the Phase 2.7 multi-agent setup inference
+- Include the **Optimistic E2E coverage additions** (decisions.md) — E2E-coverage work added on the assumption the user wants it. List each so the user can veto a specific one; the default is to keep them all.
 - Each row: "I assumed X; correct if wrong."
 
 **8. Open questions**
@@ -1822,7 +1869,8 @@ When all wave agents complete:
 - Verify all PRs are created and passing CI
 - Verify all tests pass, no conflicts between PRs
 - Merge all PRs for the wave
-- **Execute the wave's Bring-Up Runbook (plan.md Section 9.1)**: run migrations in order, install new deps, regenerate types, set new env vars/secrets, restart local dev servers, trigger/verify deploys, invalidate caches, load seed data, run smoke tests. Do not declare the wave done until every step has run and passed.
+- **Execute the wave's Bring-Up Runbook (plan.md Section 9.1)**: run migrations in order, install new deps, regenerate types, set new env vars/secrets, restart local dev servers, trigger/verify deploys, invalidate caches, load seed data. Do not declare the wave done until every step has run and passed.
+- **Run the full autonomous E2E suite (plan.md Section 8) against the reactivated system** — this supersedes a bare smoke test. Every PR in the wave already passed the E2E suite as a blocking CI check before merge; now the full suite must be green against the integrated system. A wave is NOT done while the E2E suite is red.
 
 #### 7.3.5 Checkpoint (MANDATORY after each wave)
 
@@ -1844,7 +1892,7 @@ Write to `progress.md`:
 - CI status: green/red
 - Bring-up runbook executed: yes/no
 - All layers verified live (DB, backend, frontend, workers, deploy): yes/no
-- Smoke test passed: yes/no
+- Autonomous E2E suite (Section 8) green: yes/no
 - Open blockers: none / [list]
 ### Resume context
 [Key decisions, patterns established, and gotchas discovered so far]
@@ -1876,9 +1924,9 @@ After each wave, AFTER the Bring-Up Runbook (7.3.4) has executed:
   - Frontend: loads without console errors, hits the backend successfully
   - Workers/background jobs: running, processing queues, no crash loops
   - Deploy (if production-affecting): new version live at the canonical URL, old version retired
-- **Run the wave's smoke test** against the running system (curl, browser automation, or explicit manual steps) - not just CI
-- If any layer is broken or stale, fix it before proceeding. The next wave does NOT start against a degraded system.
-- Record completion in progress.md: bring-up done, layers verified, smoke test passed
+- **Run the full autonomous E2E suite (plan.md Section 8)** against the running system — not just CI, and not just a smoke test. This is the wave's certainty gate.
+- If any layer is broken or stale, or the E2E suite is red, fix it before proceeding. The next wave does NOT start against a degraded system or a red suite.
+- Record completion in progress.md: bring-up done, layers verified, E2E suite green
 
 ### 7.5 Continue Until Complete
 
@@ -1892,7 +1940,7 @@ After each wave, AFTER the Bring-Up Runbook (7.3.4) has executed:
 - Deployment working
 - **All in-scope follow-up work completed (plan.md Section 9.5)** - do a final follow-up sweep: no open `follow-up` issue remains except genuinely human-blocked ones, and each of those has been surfaced to the user with the exact ask. Execution is NOT complete while an in-scope, non-human-blocked follow-up is open.
 - **Final Bring-Up (plan.md Section 9.4) executed** - all migrations applied, all services running current code, all layers confirmed live
-- **End-to-end smoke test passes** against the running system - the user should be able to open the app and use it immediately
+- **The full autonomous E2E suite (plan.md Section 8) is green** against the running system - every covered surface passes. Green suite ⇒ the user can open the app and use it immediately without any manual testing on their part. Any surface not covered is named in §8.5, not silently left for the user to check.
 
 If blocked by a human-epic or a human-blocked follow-up: create a P0 issue with exact instructions, notify the user, continue non-blocked work. Human-required work is the *only* thing allowed to remain open at completion — reason through everything else yourself using plan §1.4 rather than deferring it to the user.
 
@@ -2056,6 +2104,10 @@ The user should not be a step *inside* an execution run. Minimize required human
 - Every PR passes CI before merge
 - **Every feature is verified to actually work** end-to-end - unit tests passing is the bare minimum, not the finish line. Mocked tests prove internal consistency; they say nothing about whether the real system functions. Use the real API, the real database, the real UI.
 - Security, architecture, and business logic reviews are mandatory unless explicitly skipped
+
+### Autonomous End-to-End Testing — No Manual Testing
+
+Every plan ships a **comprehensive autonomous E2E suite** covering all testable surfaces, wired into CI as a blocking merge gate (plan §8, Phase 3.3.5). The suite is the certainty oracle: green ⇒ clean and ready to merge, red ⇒ broken. **The user's time is not spent on manual testing** — where a flow can't be asserted programmatically, a testing agent drives it; where the surface needs it, the plan provisions third-party infra (RunPod, cloud Mac, real devices). There is no resource constraint on testing. New projects build the suite in from the ground up; existing projects get optimistic gap-fill for every touched area that lacks E2E coverage (the standing assumption is the user always wants more coverage). This is tenet T4 the adversarial review (Phase 5.7) enforces — it expands §8 when coverage is thin rather than deferring to a question.
 
 ### Scope Over Time
 

--- a/modules/xplan/commands/xplana.md
+++ b/modules/xplan/commands/xplana.md
@@ -57,16 +57,17 @@ Autonomous mode affects these xplan phases:
 
 ## Built-In Execution Tenets (matter most here)
 
-Autonomous mode is where these three plan tenets matter most: there is no human in the loop during creation *or* execution, so the plan must stand entirely on its own. They apply in every xplan mode, but `/xplana` leans on them hardest. The Phase 5.7 adversarial reviewer enforces all three (T1–T3), expanding the plan when any is thin:
+Autonomous mode is where these four plan tenets matter most: there is no human in the loop during creation *or* execution, so the plan must stand entirely on its own. They apply in every xplan mode, but `/xplana` leans on them hardest. The Phase 5.7 adversarial reviewer enforces all four (T1–T4), expanding the plan when any is thin:
 
 1. **Human interaction is minimized and bucketed to the edges** (T1). No human step an agent could do via CLI/API; unavoidable human work is front-loaded before Wave 1 or deferred to the end, never wedged mid-run. Once execution starts, it runs to done without pausing for a person.
 2. **Follow-up-completion contract** (T2, plan §9.5). Any follow-on work discovered during execution is tracked, triaged, and — if in-scope — completed before execution is reported complete. Only genuinely human-blocked work may remain open, surfaced with its exact ask.
 3. **Autonomous decision context** (T3, plan §1.4). The plan carries the software's mission, the codebase's governing context, and its decision principles, so an execution agent deduces the direction for unplanned follow-on work *itself* — critical in autonomous mode, where there is no user to ask mid-run. If that context is thin, the adversarial review expands the plan to add it.
+4. **Comprehensive autonomous E2E testing** (T4, plan §8). Every plan ships a full autonomous E2E suite over all testable surfaces, wired into CI as a blocking merge gate — the certainty oracle so the user never tests manually. New projects build it in from the ground up; existing repos get **optimistic gap-fill** for touched areas that lack coverage (added by default on the assumption the user wants more coverage — surfaced in the final walkthrough, not gated behind a mid-flow question, which fits autonomous mode). The plan provisions whatever infra certainty needs (testing agents, RunPod, cloud Mac, real devices); there is no resource constraint on testing. The adversarial review expands §8 when coverage is thin.
 
 ## What This Command Does NOT Do
 
 - It does NOT skip research, naming, the standard reviews, the self-review loop, or the Phase 5.7 adversarial review sequence. Autonomous is the *deep* mode, not the fast one — the finished plan has survived 6 reviews (3 standard + 3 sequential adversarial) before you see it.
-- It does NOT skip the three execution tenets above. The adversarial review enforces minimal edge-bucketed human work (T1), a follow-up-completion contract (T2), and enough decision context to direct unplanned work without a human (T3) — expanding the plan when any is missing.
+- It does NOT skip the four execution tenets above. The adversarial review enforces minimal edge-bucketed human work (T1), a follow-up-completion contract (T2), enough decision context to direct unplanned work without a human (T3), and a comprehensive autonomous E2E suite over all testable surfaces (T4) — expanding the plan when any is missing.
 - It does NOT skip the final execution gate. 6.5 is non-bypassable.
 - It does NOT automatically proceed to execution. The default recommendation at 6.5 in autonomous mode leans toward "save plan, don't execute yet" so the user can review before committing to multi-agent work.
 


### PR DESCRIPTION
Closes #814. **Stacked on #813** (base is the `812-` branch so this diff shows only the T4 work; GitHub auto-retargets to `main` when #813 merges — merge #813 first).

Builds a first-class **autonomous end-to-end testing mandate** into xplan/xplana (and the executor), as tenet **T4** alongside #813's T1–T3. The suite — not the user — is the oracle for broken vs. clean/ready-to-merge, so the user never does manual testing.

## What every plan now guarantees (T4)
- **All testable surfaces covered** by real end-to-end tests against the running system (not mocks): HTTP, UI, CLI, jobs, auth, webhooks, cross-surface journeys.
- **New projects** build the E2E harness in from the ground up — a **Wave-1 foundation epic** — and every feature epic adds its E2E tests from the first wave.
- **Existing projects** (`--repo`): a Phase 0.4.1 coverage-gap audit of touched areas → **optimistic gap-fill** added to the plan by default (assumes the user signs off; surfaced for veto, never a mid-flow question).
- **SDLC integration**: the suite is a **required, blocking CI merge gate**; waves and final bring-up run the full suite; completion gates on green.
- **No resource constraint on testing**: testing agents drive flows that can't be asserted programmatically; third-party infra (RunPod, cloud Mac, real devices) is provisioned as needed.
- **Certainty, not coverage theater**: §8.5 names any surface the suite does *not* certify, so residual manual checks are explicit, never silently assumed.

## Changes by file
- **`agents/adrev-reviewer.md`** — new plan tenet **T4** (comprehensive autonomous E2E coverage), apply-enforced (expands §8 / adds E2E epics optimistically); description + enforcement paragraph updated to T1–T4.
- **`commands/xplan.md`** — Phase 3.3.5 (E2E Test Strategy mandate); 0.4.1 coverage audit; per-epic E2E rule + Wave-1 harness foundation epic; Phase 2.5.2 test-infra options; 3.6 verification/bring-up E2E gate; expanded **Section 8** template (harness, infra, agent-driven testing, CI gate, §8.5 certifies/does-not-certify); Section 9.1/9.4 runbook + Section 13 checklist; 5.6.3 readiness check; 5.7 lens + dispatch enforcement; 6.A optimistic-additions surfacing; new "Autonomous End-to-End Testing — No Manual Testing" principle; execution gates 7.3.4/7.3.5/7.4/7.5.
- **`commands/xplana.md`** — T4 in Built-In Execution Tenets + does-not-do.
- **`commands/etp.md`** — E2E suite as the merge/completion oracle (Phase 4.5, Phase 7), changed-surface coverage as in-scope follow-up, test-infra provisioning guardrail.
- **`adversarial-review/README.md`, `xplan/README.md`, `adrev/SKILL.md`** — doc sync to four tenets.

## Verification
- `tests/test-no-personal-data.sh` — PASS
- `tests/test-modules.sh` — 1556 passed, 0 failed
- Swept for stale "three tenets / T1–T3" phrasing → clean; §8 / T4 cross-refs resolve.