### PR TITLE
#805: weekly scorecard extension -- optimistic-era metrics (Epic 7)

### DIFF
--- a/modules/dreaming/commands/dream-scorecard.md
+++ b/modules/dreaming/commands/dream-scorecard.md
@@ -31,6 +31,21 @@ signals — the honest answer to "how do I know the memory system is working?"
   a reuse means a stored learning paid off across sessions.
 - **Applied** — proposals applied to the store in the window (apply-audit +
   proposals-dir funnel), by kind.
+- **Optimistic integration** — the optimistic-memory model's own safety
+  signals, so "is it working AND is it safe" is answerable at a glance:
+  - **auto-integrated** — proposals the optimistic engine itself applied this
+    window (apply-audit `method: "auto_apply"`), grouped by posture
+    (`optimistic-immediate` / `optimistic-dwell` / `dwell-quarantine`).
+  - **mid-dwell** — learnings currently inside their dwell window (written,
+    but not yet read-eligible) — a live snapshot as of report generation, not
+    window-scoped, mirroring Store health's own always-current framing.
+  - **reverted after review** — rows vetoed or batch-reverted this window
+    (apply-audit `outcome: "reverted"`). This is a convention `/dream-review`
+    (#804) is expected to write when it ships; until then this reads 0.
+  - **circuit-breaker trips** — how many times the windowed anomaly breaker
+    tripped this window (apply-audit `outcome: "circuit_breaker_tripped"`),
+    plus whether the breaker is currently suspended
+    (`state/optimistic.json`).
 - **Store health** — total active learnings, effective-confidence bands, and
   deprecated/superseded counts.
 
@@ -51,8 +66,11 @@ signals — the honest answer to "how do I know the memory system is working?"
 
 ## How it interacts with state
 
-Strictly **read-only** over the learnings store, proposals, apply-audit, and
-injection-log. The one write is the rendered markdown at
+Strictly **read-only** over the learnings store, proposals, apply-audit,
+injection-log, and `state/optimistic.json` (the circuit-breaker state file —
+read for the "currently suspended" line; a sibling of apply-audit.jsonl under
+`state/`, so no new path is threaded through the `.sh` wrapper). The one
+write is the rendered markdown at
 `~/.claude/dreaming/scorecards/{week-ending}.md`. All counting lives in
 `lib/scorecard.py` (deterministic, unit-tested); the `.sh` only resolves the
 window + wall clock. The library never reads the wall clock itself.

--- a/modules/dreaming/lib/scorecard.py
+++ b/modules/dreaming/lib/scorecard.py
@@ -39,9 +39,32 @@ Data sources (all read-only):
     which carries the authoritative applied-at `ts`) cross-referenced with the
     proposals dir (~/.claude/dreaming/proposals/*.jsonl) for the
     generated->applied funnel.
+  - Optimistic integration (optimistic-memory plan.md Epic 7): auto-integrated
+    counts and circuit-breaker trips are read from the SAME apply-audit rows
+    Applied already loads (`method == "auto_apply"` and `outcome ==
+    "circuit_breaker_tripped"` respectively -- both already written today by
+    Epic 3's run_optimistic_integrate()/record_anomaly()). Mid-dwell is read
+    from the SAME projected heads Store health already computes
+    (`store_api.is_dwelling(head, now=...)`). "Currently suspended" is read
+    from ~/.claude/dreaming/state/optimistic.json -- a SIBLING of
+    apply-audit.jsonl under the same `state/` dir in every real deployment, so
+    its path is derived from `apply_audit_path` rather than threaded through
+    as a new `render()` parameter (keeps the `.sh` wrapper's call site
+    unchanged). "reverted-after-review" reads an `outcome == "reverted"`
+    apply-audit record -- a convention this Epic establishes for Epic 6
+    (`/dream-review` veto/revert, #804, not yet built as of this Epic) to
+    write, mirroring every other state-changing action in
+    apply_dream_proposal.py (exactly one `_write_audit()` call per action)
+    rather than inferring a revert after the fact from op-event archaeology.
+    Until Epic 6 ships that write, this legitimately reads 0 -- an accurate
+    "nothing reverted yet" answer, not a broken counter.
 
 Every section degrades gracefully: a missing/empty source prints
-"_no data this window._" and never raises.
+"_no data this window._" and never raises. The optimistic-integration
+section is the one exception to the "_no data_" fallback (matching Store
+health's own convention): it always renders concrete counts, including 0,
+since a missing apply-audit/state file is a fully-determined "zero activity"
+answer here, not an "unknown" one.
 """
 from __future__ import annotations
 
@@ -172,6 +195,21 @@ def _load_jsonl_dir(directory: Path) -> list[dict[str, Any]]:
     except OSError:
         return rows
     return rows
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    """Parse one JSON-object file (e.g. state/optimistic.json -- a single
+    object, NOT one-per-line JSONL). Missing file, unreadable file, or
+    non-object JSON -> {} (never raises), mirroring the JSONL loaders'
+    defensive philosophy above. Read-only: never creates or touches the
+    file when it is missing."""
+    try:
+        if not path.is_file():
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 def _dedupe_by_id(lines: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -337,6 +375,60 @@ def _aggregate_applied(
     }
 
 
+def _aggregate_optimistic(
+    audit_rows: list[dict[str, Any]],
+    start: float,
+    end: float,
+) -> dict[str, Any]:
+    """Window-scoped optimistic-integration signals (optimistic-memory
+    plan.md Epic 7) -- read from the SAME apply-audit rows
+    `_aggregate_applied` already loads; no new data source.
+
+    auto-integrated: records the optimistic engine itself wrote
+    (`method == "auto_apply"`, `outcome == "applied"` --
+    `run_optimistic_integrate()`/`_process_one_proposal()` in
+    apply_dream_proposal.py), grouped by the `posture` string already
+    recorded on the same record (`resolve_posture()`'s
+    optimistic-immediate/optimistic-dwell/dwell-quarantine/gated).
+
+    reverted-after-review ("rows vetoed / reverts in the window"): see the
+    module docstring's "Optimistic integration" paragraph for why this counts
+    `outcome == "reverted"` -- a convention this Epic establishes for Epic 6
+    (#804, not yet built) to write, rather than inferring a revert from
+    op-event archaeology. Reads 0 until Epic 6 ships that write.
+
+    circuit-breaker trips: `outcome == "circuit_breaker_tripped"` records
+    already written today by `_evaluate_breaker_trip()`, from BOTH the
+    end-of-batch check in `run_optimistic_integrate()` and the standalone
+    `record_anomaly()` path (a red eval-gate night that never reaches
+    `run_optimistic_integrate()` at all) -- counting this outcome value
+    catches both sources of a trip.
+    """
+    auto_integrated_total = 0
+    auto_integrated_by_posture: Counter[str] = Counter()
+    reverted_total = 0
+    breaker_trips = 0
+
+    for r in audit_rows:
+        if not _in_window(_parse_ts(r.get("ts", "")), start, end):
+            continue
+        outcome = r.get("outcome")
+        if outcome == "applied" and r.get("method") == "auto_apply":
+            auto_integrated_total += 1
+            auto_integrated_by_posture[str(r.get("posture") or "unknown")] += 1
+        elif outcome == "reverted":
+            reverted_total += 1
+        elif outcome == "circuit_breaker_tripped":
+            breaker_trips += 1
+
+    return {
+        "auto_integrated_total": auto_integrated_total,
+        "auto_integrated_by_posture": dict(auto_integrated_by_posture),
+        "reverted_total": reverted_total,
+        "breaker_trips": breaker_trips,
+    }
+
+
 def _aggregate_health(
     slug_lines: dict[str, list[dict[str, Any]]],
     store_api: Any,
@@ -348,7 +440,7 @@ def _aggregate_health(
     (_project_lines + effective_confidence) -- no disk writes, no snapshot
     cache, no global-path coupling."""
     high = medium = low = 0
-    active = deprecated = superseded = 0
+    active = deprecated = superseded = dwelling = 0
     for lines in slug_lines.values():
         try:
             heads = store_api._project_lines(lines).get("heads", [])
@@ -373,6 +465,15 @@ def _aggregate_health(
                 medium += 1
             else:
                 low += 1
+            # optimistic-memory plan.md Epic 7: a still-dwelling row is real,
+            # active store content (only deprecated/superseded rows are
+            # excluded from "active" above) -- it is additionally flagged
+            # here as not-yet-read-eligible so the scorecard can surface it.
+            try:
+                if store_api.is_dwelling(head, now=now_epoch):
+                    dwelling += 1
+            except Exception:
+                pass
     return {
         "active": active,
         "high": high,
@@ -380,6 +481,7 @@ def _aggregate_health(
         "low": low,
         "deprecated": deprecated,
         "superseded": superseded,
+        "dwelling": dwelling,
     }
 
 
@@ -429,8 +531,8 @@ def render(
         proposals_dir: ~/.claude/dreaming/proposals.
         apply_audit_path: ~/.claude/dreaming/state/apply-audit.jsonl.
         store_api: the learnings_store module (used only for the pure
-            functions _project_lines + effective_confidence + optional
-            sanitize_content).
+            functions _project_lines + effective_confidence + is_dwelling +
+            optional sanitize_content).
         generated_at: report generation time, PASSED IN (no Date.now here).
         now: decay anchor for effective_confidence; defaults to window_end.
 
@@ -440,6 +542,11 @@ def render(
     injection_log_dir = Path(injection_log_dir)
     proposals_dir = Path(proposals_dir)
     apply_audit_path = Path(apply_audit_path)
+    # state/optimistic.json is a SIBLING of apply-audit.jsonl under state/ in
+    # every real deployment (both dream_analyze.state_dir()-rooted) -- derived
+    # here rather than threaded as a new render() parameter so the .sh
+    # wrapper's call site needs no change (plan.md Epic 7).
+    optimistic_state_path = apply_audit_path.parent / "optimistic.json"
 
     start = _to_epoch(window_start)
     end = _to_epoch(window_end)
@@ -452,11 +559,13 @@ def render(
     injection_rows = _load_jsonl_dir(injection_log_dir)
     proposal_rows = _load_jsonl_dir(proposals_dir)
     audit_rows = _load_jsonl(apply_audit_path)
+    optimistic_state = _load_json_object(optimistic_state_path)
 
     # --- Aggregate ---------------------------------------------------------
     cap = _aggregate_captured_reused(slug_lines, start, end)
     inj = _aggregate_injected(injection_rows, start, end)
     app = _aggregate_applied(audit_rows, proposal_rows, start, end)
+    opt = _aggregate_optimistic(audit_rows, start, end)
     health = _aggregate_health(slug_lines, store_api, now_epoch)
 
     # Build an id -> content map only from the reused targets, so the reused
@@ -569,6 +678,33 @@ def render(
         if app["applied_by_kind"]:
             for kind, n in sorted(app["applied_by_kind"].items(), key=lambda kv: (-kv[1], kv[0])):
                 out.append(f"  - {kind}: {n}")
+    out.append("")
+
+    # --- 4b. Optimistic integration (plan.md Epic 7) ------------------------
+    # Unlike every section above, this one never falls back to _NO_DATA: a
+    # missing apply-audit/state file is a fully-determined "zero activity"
+    # answer here (matching Store health's own always-numeric convention),
+    # not an "unknown" one.
+    out.append(
+        f"## Optimistic integration — {opt['auto_integrated_total']} auto-integrated · "
+        f"{health['dwelling']} mid-dwell · {opt['reverted_total']} reverted · "
+        f"{opt['breaker_trips']} breaker trips"
+    )
+    out.append("")
+    out.append(f"- auto-integrated this window: {opt['auto_integrated_total']}")
+    if opt["auto_integrated_by_posture"]:
+        for posture, n in sorted(
+            opt["auto_integrated_by_posture"].items(), key=lambda kv: (-kv[1], kv[0])
+        ):
+            out.append(f"  - {posture}: {n}")
+    out.append(f"- mid-dwell (currently, all projects): {health['dwelling']}")
+    out.append(f"- reverted after review (veto/batch-revert) this window: {opt['reverted_total']}")
+    out.append(f"- circuit-breaker trips this window: {opt['breaker_trips']}")
+    if optimistic_state.get("suspended"):
+        since = optimistic_state.get("suspended_at") or "unknown time"
+        out.append(f"- currently suspended: yes (since {since})")
+    else:
+        out.append("- currently suspended: no")
     out.append("")
 
     # --- 5. Store health ---------------------------------------------------

--- a/modules/dreaming/tests/test_scorecard.py
+++ b/modules/dreaming/tests/test_scorecard.py
@@ -65,6 +65,13 @@ def _write_jsonl(path: Path, rows: list[dict]) -> None:
             fh.write(json.dumps(r) + "\n")
 
 
+def _write_json(path: Path, obj: dict) -> None:
+    """Write ONE JSON object (not JSONL) -- for state/optimistic.json
+    fixtures, which are a single object, never one-per-line."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
 class ScorecardRenderTest(unittest.TestCase):
     # Week ending 2026-06-30 -> window [2026-06-24 00:00Z, 2026-07-01 00:00Z).
     WINDOW_START = datetime(2026, 6, 24, tzinfo=UTC)
@@ -338,6 +345,207 @@ class ScorecardWrapperSmokeTest(unittest.TestCase):
         body = out_file.read_text(encoding="utf-8")
         self.assertIn("# Dreaming scorecard — week ending 2026-06-30", body)
         self.assertIn("## Store health — 1 active learnings", body)
+
+
+class ScorecardOptimisticTest(unittest.TestCase):
+    """Epic 7 (optimistic-memory plan.md, #805): auto-integrated (by
+    posture), mid-dwell, reverted-after-review, circuit-breaker-trips.
+
+    Independent fixtures/tmpdir from ScorecardRenderTest (own apply-audit
+    file, own learnings dir): ScorecardRenderTest's `_audit()` builder always
+    stamps `method: "human_accept"`, so adding `method: "auto_apply"` rows to
+    that SHARED fixture file would inflate `_aggregate_applied`'s existing
+    "Applied" counts too (that aggregator counts ANY ok/outcome=="applied"
+    row regardless of method) -- pinned by `test_applied_exact` above, which
+    this class must not perturb.
+
+    Primary scenario matches plan.md Epic 7's test spec: 3 auto-applied
+    adds, 1 dwelling row, 1 revert, 1 breaker trip.
+    """
+
+    WINDOW_START = datetime(2026, 6, 24, tzinfo=UTC)
+    WINDOW_END = datetime(2026, 7, 1, tzinfo=UTC)
+    GENERATED_AT = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="ccgm-scorecard-opt-test-"))
+        self.learnings_dir = self.root / "learnings"
+        self.injection_dir = self.root / "dreaming" / "injection-log"
+        self.proposals_dir = self.root / "dreaming" / "proposals"
+        self.audit_path = self.root / "dreaming" / "state" / "apply-audit.jsonl"
+        # optimistic.json is a SIBLING of apply-audit.jsonl under state/ --
+        # render() derives this path itself; no new render() kwarg needed.
+        self.state_path = self.audit_path.parent / "optimistic.json"
+
+        # One head with a future dwell_until (mid-dwell as of window_end, the
+        # `now` anchor render() defaults to) + one whose dwell already
+        # elapsed (must NOT count as dwelling).
+        _write_jsonl(self.learnings_dir / "acme_widget" / "agents" / "agent-a.jsonl", [
+            self._add("OA1", _ts(25), "auto-integrated add, still dwelling",
+                       "2026-07-05T00:00:00.000Z"),
+            self._add("OA2", _ts(26), "auto-integrated add, dwell already elapsed",
+                       "2026-06-25T00:00:00.000Z"),
+        ])
+
+        # 3 auto-applied adds (posture optimistic-dwell) + 1 reverted-after-
+        # review + 1 circuit-breaker trip, all in-window; 1 auto-applied add
+        # BEFORE the window (must not inflate the count). The "reverted" and
+        # "circuit_breaker_tripped" rows deliberately carry NO `ok` field
+        # (matching the on-disk shape of every other non-apply audit outcome,
+        # e.g. circuit_breaker_tripped/anomaly_recorded in
+        # apply_dream_proposal.py) -- `_aggregate_applied`'s existing
+        # predicate (`ok is True or outcome == "applied"`) would otherwise
+        # double-count a "reverted" row into the Applied section too.
+        _write_jsonl(self.audit_path, [
+            self._auto_applied(_ts(25, 10), "opt1"),
+            self._auto_applied(_ts(26, 10), "opt1"),
+            self._auto_applied(_ts(27, 10), "opt1"),
+            {"id": "audit_revert_1", "ts": _ts(28, 9), "outcome": "reverted",
+             "target_id": "OA2", "method": "human_veto"},
+            {"id": "audit_trip_1", "ts": _ts(28, 11), "outcome": "circuit_breaker_tripped",
+             "batch_id": "opt1", "detail": "2 anomalies within 7 night window (threshold 2)"},
+            self._auto_applied(_ts(20, 10), "opt0"),  # before window -> excluded
+        ])
+
+    @staticmethod
+    def _add(id_, ts, content, dwell_until):
+        return {"id": id_, "op": "add", "target_id": None, "timestamp": ts, "type": "pattern",
+                "content": content, "confidence": 8, "project": "acme_widget",
+                "dwell_until": dwell_until}
+
+    @staticmethod
+    def _auto_applied(ts, batch_id):
+        return {"id": f"audit_add_{ts}", "ts": ts, "kind": "learning_add", "outcome": "applied",
+                "ok": True, "method": "auto_apply", "posture": "optimistic-dwell",
+                "batch_id": batch_id, "proposal_id": f"prop-{ts}"}
+
+    def _render(self) -> str:
+        return scorecard.render(
+            self.WINDOW_START,
+            self.WINDOW_END,
+            learnings_dir=self.learnings_dir,
+            injection_log_dir=self.injection_dir,
+            proposals_dir=self.proposals_dir,
+            apply_audit_path=self.audit_path,
+            store_api=learnings_store,
+            generated_at=self.GENERATED_AT,
+        )
+
+    def test_auto_integrated_exact(self):
+        md = self._render()
+        self.assertIn("auto-integrated this window: 3", md)
+        self.assertIn("optimistic-dwell: 3", md)
+        # Out-of-window auto-applied row (opt0) must not inflate the count.
+        self.assertNotIn("4 auto-integrated", md)
+        self.assertNotIn("auto-integrated this window: 4", md)
+
+    def test_dwell_pending_exact(self):
+        md = self._render()
+        self.assertIn("mid-dwell (currently, all projects): 1", md)
+
+    def test_reverted_exact(self):
+        md = self._render()
+        self.assertIn("reverted after review (veto/batch-revert) this window: 1", md)
+
+    def test_breaker_trips_exact(self):
+        md = self._render()
+        self.assertIn("circuit-breaker trips this window: 1", md)
+
+    def test_reverted_and_trip_not_double_counted_as_applied(self):
+        # The pre-existing Applied-section predicate is `ok is True or
+        # outcome == "applied"`. The "reverted"/"circuit_breaker_tripped"
+        # rows carry no `ok` field and neither outcome is "applied", so only
+        # the 3 genuine auto-applied adds should land in "Applied".
+        md = self._render()
+        self.assertIn("## Applied — 3 proposals applied this window", md)
+        self.assertIn("applied this window: 3", md)
+
+    def test_header_line_exact(self):
+        md = self._render()
+        self.assertIn(
+            "## Optimistic integration — 3 auto-integrated · 1 mid-dwell · "
+            "1 reverted · 1 breaker trips",
+            md,
+        )
+
+    def test_deterministic_same_fixtures_same_window(self):
+        self.assertEqual(self._render(), self._render())
+
+    def test_currently_suspended_reads_state_file(self):
+        _write_json(self.state_path, {
+            "suspended": True, "suspended_at": "2026-06-28T11:05:00.000Z",
+            "anomaly_log": [], "last_run": "2026-06-28T11:05:00.000Z",
+        })
+        md = self._render()
+        self.assertIn("currently suspended: yes (since 2026-06-28T11:05:00.000Z)", md)
+
+    def test_currently_suspended_false_when_state_file_missing(self):
+        md = self._render()
+        self.assertNotIn("currently suspended: yes", md)
+        self.assertIn("currently suspended: no", md)
+
+    def test_read_only_no_writes(self):
+        audit_before = self.audit_path.read_bytes()
+        state_existed_before = self.state_path.is_file()
+        self._render()
+        self.assertEqual(self.audit_path.read_bytes(), audit_before)
+        # _load_json_object must never CREATE optimistic.json as a side
+        # effect of reading a missing one.
+        self.assertEqual(self.state_path.is_file(), state_existed_before)
+
+    def test_returns_str_no_traceback(self):
+        md = self._render()
+        self.assertIsInstance(md, str)
+        self.assertNotIn("Traceback", md)
+
+
+class ScorecardOptimisticPostureMixTest(unittest.TestCase):
+    """Separate, minimal fixture proving auto-integrated actually GROUPS by
+    posture (Epic 7 Outputs: "by posture") rather than summing everything
+    into one bucket -- ScorecardOptimisticTest's single-posture scenario
+    cannot distinguish correct grouping from no grouping at all."""
+
+    WINDOW_START = datetime(2026, 6, 24, tzinfo=UTC)
+    WINDOW_END = datetime(2026, 7, 1, tzinfo=UTC)
+
+    def test_groups_by_posture(self):
+        root = Path(tempfile.mkdtemp(prefix="ccgm-scorecard-opt-posture-"))
+        audit_path = root / "dreaming" / "state" / "apply-audit.jsonl"
+        empty = root / "empty"
+        _write_jsonl(audit_path, [
+            {"id": "a1", "ts": _ts(25, 10), "kind": "learning_add", "outcome": "applied",
+             "ok": True, "method": "auto_apply", "posture": "optimistic-dwell", "batch_id": "b1"},
+            {"id": "a2", "ts": _ts(26, 10), "kind": "learning_verify", "outcome": "applied",
+             "ok": True, "method": "auto_apply", "posture": "optimistic-immediate", "batch_id": "b1"},
+            {"id": "a3", "ts": _ts(27, 10), "kind": "learning_verify", "outcome": "applied",
+             "ok": True, "method": "auto_apply", "posture": "optimistic-immediate", "batch_id": "b1"},
+            {"id": "a4", "ts": _ts(28, 10), "kind": "learning_contradict", "outcome": "applied",
+             "ok": True, "method": "auto_apply", "posture": "dwell-quarantine", "batch_id": "b1"},
+            # A human-accepted (non-auto) apply must NOT be counted here.
+            {"id": "a5", "ts": _ts(28, 11), "kind": "learning_add", "outcome": "applied",
+             "ok": True, "method": "human_accept", "proposal_id": "p-human"},
+        ])
+        md = scorecard.render(
+            self.WINDOW_START, self.WINDOW_END,
+            learnings_dir=empty / "learnings",
+            injection_log_dir=empty / "inj",
+            proposals_dir=empty / "prop",
+            apply_audit_path=audit_path,
+            store_api=learnings_store,
+            generated_at=self.WINDOW_END,
+        )
+        self.assertIn("auto-integrated this window: 4", md)
+        self.assertIn("optimistic-immediate: 2", md)
+        self.assertIn("optimistic-dwell: 1", md)
+        self.assertIn("dwell-quarantine: 1", md)
+        # Sorted by -count then posture name ASC: immediate(2) first, then
+        # the count=1 tie broken alphabetically ("dwell-quarantine" <
+        # "optimistic-dwell").
+        idx_immediate = md.index("optimistic-immediate: 2")
+        idx_quarantine = md.index("dwell-quarantine: 1")
+        idx_dwell = md.index("optimistic-dwell: 1")
+        self.assertLess(idx_immediate, idx_quarantine)
+        self.assertLess(idx_quarantine, idx_dwell)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #805

## Summary

- Adds four optimistic-memory metrics to the deterministic weekly scorecard (`modules/dreaming/lib/scorecard.py`): **auto-integrated** (count of `auto_applied` this window, grouped by posture), **mid-dwell** (rows currently mid-dwell, as of report generation), **reverted-after-review** (vetoes/batch-reverts), and **circuit-breaker trips** this window, plus a "currently suspended" status line.
- All new signals are read from data sources that already exist on disk today (the same apply-audit rows `Applied` already loads, the same projected heads `Store health` already computes, and `state/optimistic.json` -- a sibling of `apply-audit.jsonl` under `state/`, so no new `render()` parameter or `.sh` wrapper change was needed). The scorecard remains strictly read-only and deterministic (no wall-clock reads in the library).
- `reverted-after-review` establishes a documented convention (`outcome: "reverted"` in apply-audit) for Epic 6 (`/dream-review`, #804 -- not yet built) to write when it ships; until then it legitimately reads 0.
- Updates `modules/dreaming/commands/dream-scorecard.md` to document the new section.
- Extends `modules/dreaming/tests/test_scorecard.py` with the plan's exact scenario (3 auto-applied adds, 1 dwelling row, 1 revert, 1 breaker trip) plus a posture-mix test, determinism test, and a read-only-no-writes test.

## Test plan

- [x] `python3 -m pytest modules/dreaming/tests/test_scorecard.py -q` -- 23 passed
- [x] `python3 -m pytest modules/dreaming/tests/ modules/self-improving/tests/ -q` -- 540 passed, 13 subtests passed (no regressions)
- [x] `bash tests/test-no-personal-data.sh` -- pass
- [x] Only `scorecard.py`, `dream-scorecard.md`, `test_scorecard.py` touched (no `dream-scorecard.sh` change needed)