### PR TITLE
#811: fix test-dream-apply.sh monkeypatch signature drift

### DIFF
--- a/modules/dreaming/tests/test-dream-apply.sh
+++ b/modules/dreaming/tests/test-dream-apply.sh
@@ -896,7 +896,7 @@ invocations = {"n": 0}
 counter_lock = threading.Lock()
 
 
-def slow_apply_counter_op(row, op):
+def slow_apply_counter_op(row, op, *, auto=False, dwell_hours=None):
     with counter_lock:
         invocations["n"] += 1
     time.sleep(0.4)  # simulate real subprocess latency, widen the race window


### PR DESCRIPTION
## Summary

- `test-dream-apply.sh`'s `slow_apply_counter_op` monkeypatch stub had signature `(row, op)`, but the real `_apply_counter_op` in `apply_dream_proposal.py` gained keyword-only `auto` and `dwell_hours` params in #777 and the optimistic-memory epics.
- `apply_proposal()` calls the (now patched) function with `auto=` and `dwell_hours=` kwargs via `_apply_learning_verify`, so the stub raised `TypeError: slow_apply_counter_op() got an unexpected keyword argument 'auto'`, failing the concurrent-apply race test.
- Fix: updated the stub's signature to `(row, op, *, auto=False, dwell_hours=None)`, matching the real function's contract (and matching the already-correct stub of the same name in `test_optimistic_engine.py`).

Closes #811

## Test plan

- [x] Confirmed baseline failure before the fix: `95 passed, 2 failed` (both failures on "concurrent apply of the same id")
- [x] Applied the one-line signature fix
- [x] Fresh run after fix: `97 passed, 0 failed`