### PR TITLE
#822: don't count rejected proposals as applied in digest/scorecard aggregation

### DIFF
--- a/modules/dreaming/lib/apply_dream_proposal.py
+++ b/modules/dreaming/lib/apply_dream_proposal.py
@@ -880,7 +880,19 @@ def apply_proposal(
 
 def reject_proposal(proposal_id: str, *, method: str = "human_reject") -> dict[str, Any]:
     """Mark a pending proposal 'rejected'. No store write of any kind --
-    a rejection is purely a bookkeeping decision."""
+    a rejection is purely a bookkeeping decision.
+
+    The success record deliberately carries NO `ok` field (#822) -- matching
+    the no-`ok` on-disk shape of `circuit_breaker_tripped`/`anomaly_recorded`/
+    `record_review_reversal`'s "reverted" record. This previously wrote
+    `ok: True`, and `scorecard.py`'s `_aggregate_applied()` treated ANY
+    `ok is True` row as an apply (in addition to `outcome == "applied"`), so
+    every rejection silently inflated the scorecard's "Applied" total by one.
+    That aggregator now keys on `outcome == "applied"` only (see its own
+    docstring) -- this omission is the paired half of the fix, keeping `ok`
+    meaning one thing everywhere it appears in this audit log: "an
+    apply_proposal() handler actually mutated the store."
+    """
     path, row = find_proposal(proposal_id)
     if row is None or path is None:
         record = {"proposal_id": proposal_id, "method": method, "outcome": "not_found", "ok": False}
@@ -897,7 +909,7 @@ def reject_proposal(proposal_id: str, *, method: str = "human_reject") -> dict[s
     _rewrite_status(path, proposal_id, "rejected")
     record = {
         "proposal_id": proposal_id, "kind": row.get("kind"), "project": row.get("project"),
-        "target_id": row.get("target_id"), "method": method, "outcome": "rejected", "ok": True,
+        "target_id": row.get("target_id"), "method": method, "outcome": "rejected",
     }
     _write_audit(record)
     return record

--- a/modules/dreaming/lib/scorecard.py
+++ b/modules/dreaming/lib/scorecard.py
@@ -347,11 +347,22 @@ def _aggregate_applied(
     """Applied = apply-audit records whose outcome is a successful apply and
     whose `ts` is in-window (the audit carries the authoritative applied-at
     time). Cross-referenced with proposals generated in-window for the
-    generated->applied funnel."""
+    generated->applied funnel.
+
+    Keys strictly on `outcome == "applied"` (#822), never on an `ok` field.
+    `apply_proposal()` always writes `ok` in lockstep with
+    `outcome == "applied"` for its own records, so the two were equivalent
+    for that writer alone -- but other apply-audit writers use `ok: True`
+    to mean "this bookkeeping action succeeded" for outcomes that are NOT
+    an apply (e.g. `reject_proposal()`'s "rejected" record), and the old
+    `ok is True or outcome == "applied"` predicate silently counted those
+    as applies too. `outcome` is the one field every audit record can be
+    trusted to name honestly.
+    """
     applied_by_kind: Counter[str] = Counter()
     applied_total = 0
     for r in audit_rows:
-        if not (r.get("ok") is True or r.get("outcome") == "applied"):
+        if r.get("outcome") != "applied":
             continue
         if not _in_window(_parse_ts(r.get("ts", "")), start, end):
             continue

--- a/modules/dreaming/tests/test_apply_dream_proposal.py
+++ b/modules/dreaming/tests/test_apply_dream_proposal.py
@@ -278,5 +278,85 @@ class RecordReviewReversalTests(unittest.TestCase):
         self.assertEqual(opt["auto_integrated_total"], 0)
 
 
+class RejectProposalTests(unittest.TestCase):
+    """#822: reject_proposal()'s success record previously carried
+    `outcome: "rejected", ok: True`. scorecard.py's _aggregate_applied()
+    counted ANY `ok is True` row as an apply (in addition to
+    `outcome == "applied"`), so every manually-rejected proposal silently
+    inflated the scorecard's "Applied" total by one. Pins BOTH halves of
+    the fix: the on-disk record shape (no `ok` field, matching
+    `record_review_reversal()`'s "reverted" record), and that
+    scorecard._aggregate_applied() does not count the exact record
+    reject_proposal() writes."""
+
+    def setUp(self):
+        # Fresh CCGM_DREAMING_DIR per test so proposals_dir()/apply_audit_path()
+        # (both derived from it) are clean and isolated -- mirrors
+        # RecordReviewReversalTests; reject_proposal() never touches the
+        # learnings store or spawns a subprocess either.
+        self._dreaming = tempfile.mkdtemp(prefix="ccgm-dreaming-reject-")
+        self.addCleanup(shutil.rmtree, self._dreaming, ignore_errors=True)
+        self._pin_env("CCGM_DREAMING_DIR", self._dreaming)
+        adp.proposals_dir().mkdir(parents=True, exist_ok=True)
+
+    def _pin_env(self, key: str, value: str) -> None:
+        had = key in os.environ
+        prior = os.environ.get(key)
+        os.environ[key] = value
+
+        def _restore():
+            if had:
+                os.environ[key] = prior
+            else:
+                os.environ.pop(key, None)
+
+        self.addCleanup(_restore)
+
+    def _write_day(self, day: str, row: dict) -> None:
+        (adp.proposals_dir() / f"{day}.jsonl").write_text(
+            json.dumps(row, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    def _audit_rows(self) -> list[dict]:
+        path = adp.apply_audit_path()
+        if not path.is_file():
+            return []
+        return [json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()]
+
+    def test_reject_record_shape_has_no_ok_field(self):
+        self._write_day("2026-03-01", _proposal_row(
+            pid="rejectme01", slug="reject-fixture-slug", target_id="L-target", confidence=5,
+        ))
+
+        rec = adp.reject_proposal("rejectme01")
+        self.assertEqual(rec["outcome"], "rejected")
+        # No `ok` field: _aggregate_applied() counted any `ok is True` row as
+        # an apply, so a rejection carrying `ok: True` was silently
+        # double-counted as an "Applied" proposal (#822).
+        self.assertNotIn("ok", rec)
+
+        _, row = adp.find_proposal("rejectme01")
+        self.assertEqual(row["status"], "rejected")
+
+        rows = self._audit_rows()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0], rec, "the on-disk record must be exactly what the function returned")
+
+    def test_rejected_proposal_not_counted_as_applied_by_scorecard(self):
+        # The load-bearing #822 assertion: the EXACT record reject_proposal()
+        # writes must not be counted by scorecard._aggregate_applied() as an
+        # apply.
+        import scorecard  # same lib dir as apply_dream_proposal (sys.path set above)
+
+        self._write_day("2026-03-02", _proposal_row(
+            pid="rejectme02", slug="reject-fixture-slug", target_id="L-target", confidence=5,
+        ))
+        rec = adp.reject_proposal("rejectme02")
+
+        now = time.time()
+        agg = scorecard._aggregate_applied([rec], [], now - 3600, now + 3600)  # noqa: SLF001
+        self.assertEqual(agg["applied_total"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/modules/dreaming/tests/test_scorecard.py
+++ b/modules/dreaming/tests/test_scorecard.py
@@ -548,5 +548,58 @@ class ScorecardOptimisticPostureMixTest(unittest.TestCase):
         self.assertLess(idx_quarantine, idx_dwell)
 
 
+class ScorecardRejectedNotAppliedTest(unittest.TestCase):
+    """#822: a rejected proposal's apply-audit record must never be counted
+    as an "Applied" proposal -- neither the pre-fix `ok: True` shape (a real
+    on-disk record written before this fix, which a scorecard run may still
+    read for some time) nor a future regression that reintroduces it.
+    `_aggregate_applied()` now keys strictly on `outcome == "applied"`."""
+
+    WINDOW_START = datetime(2026, 6, 24, tzinfo=UTC)
+    WINDOW_END = datetime(2026, 7, 1, tzinfo=UTC)
+
+    def test_aggregate_applied_excludes_rejected_rows(self):
+        rows = [
+            # One genuine apply.
+            {"id": "a1", "ts": _ts(25, 10), "kind": "learning_add", "outcome": "applied",
+             "ok": True, "method": "human_accept", "proposal_id": "p-applied"},
+            # Pre-#822 on-disk shape: a rejection that still carries
+            # `ok: True`. Must NOT be counted even though `ok is True`.
+            {"id": "a2", "ts": _ts(26, 10), "kind": "learning_verify", "outcome": "rejected",
+             "ok": True, "method": "human_reject", "proposal_id": "p-rejected"},
+            # Current (post-#822) shape: no `ok` field at all.
+            {"id": "a3", "ts": _ts(27, 10), "kind": "learning_verify", "outcome": "rejected",
+             "method": "human_reject", "proposal_id": "p-rejected-2"},
+        ]
+        start = scorecard._to_epoch(self.WINDOW_START)  # noqa: SLF001
+        end = scorecard._to_epoch(self.WINDOW_END)  # noqa: SLF001
+        agg = scorecard._aggregate_applied(rows, [], start, end)  # noqa: SLF001
+        self.assertEqual(agg["applied_total"], 1)
+        self.assertEqual(agg["applied_by_kind"], {"learning_add": 1})
+
+    def test_rendered_applied_section_excludes_rejected_rows(self):
+        root = Path(tempfile.mkdtemp(prefix="ccgm-scorecard-reject-"))
+        audit_path = root / "dreaming" / "state" / "apply-audit.jsonl"
+        empty = root / "empty"
+        _write_jsonl(audit_path, [
+            {"id": "a1", "ts": _ts(25, 10), "kind": "learning_add", "outcome": "applied",
+             "ok": True, "method": "human_accept", "proposal_id": "p-applied"},
+            {"id": "a2", "ts": _ts(26, 10), "kind": "learning_verify", "outcome": "rejected",
+             "ok": True, "method": "human_reject", "proposal_id": "p-rejected"},
+        ])
+        md = scorecard.render(
+            self.WINDOW_START, self.WINDOW_END,
+            learnings_dir=empty / "learnings",
+            injection_log_dir=empty / "inj",
+            proposals_dir=empty / "prop",
+            apply_audit_path=audit_path,
+            store_api=learnings_store,
+            generated_at=self.WINDOW_END,
+        )
+        self.assertIn("## Applied — 1 proposals applied this window", md)
+        self.assertIn("applied this window: 1", md)
+        self.assertNotIn("applied this window: 2", md)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #822

## Summary

`scorecard.py`'s weekly observability scorecard was counting manually-rejected proposals into the "Applied" total, inflating the metric by the number of rejections in the window.

## Root cause

`apply_dream_proposal.py`'s `reject_proposal()` wrote a success audit record shaped `{"outcome": "rejected", "ok": True, ...}`. `scorecard.py`'s `_aggregate_applied()` predicate was `r.get("ok") is True or r.get("outcome") == "applied"` — so any row with `ok: True`, regardless of its actual outcome, was counted as an apply. A rejection is never an apply, so this silently miscounted rejections as applied proposals.

## Fix

Two paired changes, per the issue's preferred/load-bearing fix plus the invited secondary correction:

1. **`scorecard.py`** — `_aggregate_applied()` now keys strictly on `outcome == "applied"`, never on an `ok` field. This is the load-bearing fix: it stops the miscount regardless of what any writer puts in `ok`, including any pre-existing on-disk record from before this fix.
2. **`apply_dream_proposal.py`** — `reject_proposal()`'s success record no longer carries `ok: True` at all, matching the established no-`ok` shape already used by `circuit_breaker_tripped`/`anomaly_recorded`/`record_review_reversal`'s "reverted" record elsewhere in this same audit log. This keeps `ok`'s meaning consistent everywhere it appears: "an `apply_proposal()` handler actually mutated the store."

The `ok: False` failure-path records in `reject_proposal()` (`not_found`, `refused_not_pending`) are untouched — they never contributed to the miscount and are out of scope.

## Test plan

- Added `RejectProposalTests` in `modules/dreaming/tests/test_apply_dream_proposal.py`: pins the on-disk record shape (no `ok` field) and proves the exact record `reject_proposal()` writes is not counted by `scorecard._aggregate_applied()`.
- Added `ScorecardRejectedNotAppliedTest` in `modules/dreaming/tests/test_scorecard.py`: unit-tests `_aggregate_applied()` directly against both the pre-fix (`ok: True`) and post-fix (no `ok`) rejection-record shapes, plus an end-to-end `render()` assertion that the rendered "Applied" section excludes a rejected row.
- Full fresh verification:
  - `python3 -m pytest modules/dreaming/tests/ -q` → 376 passed, 5 subtests passed
  - `bash modules/dreaming/tests/test-dream-apply.sh` → 97 passed, 0 failed
  - `bash modules/dreaming/tests/test-dream-pipeline.sh` → 40 passed, 0 failed
  - `bash tests/test-no-personal-data.sh` → PASS