### PR TITLE
#821: catch UnicodeDecodeError alongside JSONDecodeError in JSON loaders

### DIFF
--- a/modules/dreaming/lib/apply_dream_proposal.py
+++ b/modules/dreaming/lib/apply_dream_proposal.py
@@ -1020,7 +1020,7 @@ def _read_optimistic_state() -> dict[str, Any]:
         return _default_optimistic_state()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return {**_default_optimistic_state(), "suspended": True, "suspended_at": _utc_now_iso()}
     if not isinstance(data, dict):
         return {**_default_optimistic_state(), "suspended": True, "suspended_at": _utc_now_iso()}

--- a/modules/dreaming/lib/dream_analyze.py
+++ b/modules/dreaming/lib/dream_analyze.py
@@ -418,7 +418,7 @@ def _load_env_file(path: Path) -> None:
         return
     try:
         text = path.read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return
     for line in text.splitlines():
         line = line.strip()

--- a/modules/dreaming/lib/scorecard.py
+++ b/modules/dreaming/lib/scorecard.py
@@ -178,7 +178,7 @@ def _load_jsonl(path: Path) -> list[dict[str, Any]]:
                     continue
                 if isinstance(obj, dict):
                     rows.append(obj)
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return rows
     return rows
 
@@ -207,7 +207,7 @@ def _load_json_object(path: Path) -> dict[str, Any]:
         if not path.is_file():
             return {}
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return {}
     return data if isinstance(data, dict) else {}
 

--- a/modules/dreaming/tests/test_apply_dream_proposal.py
+++ b/modules/dreaming/tests/test_apply_dream_proposal.py
@@ -358,5 +358,40 @@ class RejectProposalTests(unittest.TestCase):
         self.assertEqual(agg["applied_total"], 0)
 
 
+class ReadOptimisticStateUnicodeDecodeErrorTests(unittest.TestCase):
+    """#821: a state/optimistic.json containing invalid UTF-8 bytes must be
+    handled with the SAME fail-CLOSED behavior as a malformed-JSON file
+    (adrev-opt-014), not escape as an uncaught UnicodeDecodeError."""
+
+    def setUp(self):
+        self._dreaming = tempfile.mkdtemp(prefix="ccgm-dreaming-badutf8-optstate-")
+        self.addCleanup(shutil.rmtree, self._dreaming, ignore_errors=True)
+        self._pin_env("CCGM_DREAMING_DIR", self._dreaming)
+
+    def _pin_env(self, key: str, value: str) -> None:
+        had = key in os.environ
+        prior = os.environ.get(key)
+        os.environ[key] = value
+
+        def _restore():
+            if had:
+                os.environ[key] = prior
+            else:
+                os.environ.pop(key, None)
+
+        self.addCleanup(_restore)
+
+    def test_invalid_utf8_state_file_fails_closed_not_raises(self):
+        path = adp.optimistic_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\xff\xfe not json\n")
+
+        state = adp._read_optimistic_state()  # noqa: SLF001
+
+        self.assertTrue(state["suspended"])
+        self.assertIsNotNone(state["suspended_at"])
+        self.assertEqual(state["anomaly_log"], [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/modules/dreaming/tests/test_dream_analyze.py
+++ b/modules/dreaming/tests/test_dream_analyze.py
@@ -535,6 +535,14 @@ class EnvLoadingTests(unittest.TestCase):
         da._load_env_file(self.tmp / "does-not-exist.env")  # noqa: SLF001
         self.assertNotIn("ANTHROPIC_API_KEY", os.environ)
 
+    def test_load_env_file_invalid_utf8_is_a_noop(self):
+        # #821: invalid UTF-8 bytes must be handled the same graceful way as
+        # a missing file, not escape as an uncaught UnicodeDecodeError.
+        env_path = self.tmp / "bad.env"
+        env_path.write_bytes(b"\xff\xfe not env\n")
+        da._load_env_file(env_path)  # noqa: SLF001
+        self.assertNotIn("ANTHROPIC_API_KEY", os.environ)
+
 
 # ---------------------------------------------------------------------------
 # existing_fingerprints() + write_proposals(): dedup bookkeeping.

--- a/modules/dreaming/tests/test_scorecard.py
+++ b/modules/dreaming/tests/test_scorecard.py
@@ -276,6 +276,47 @@ class ScorecardDegradeTest(unittest.TestCase):
         self.assertNotIn("Traceback", md)
 
 
+class ScorecardUnicodeDecodeErrorTest(unittest.TestCase):
+    """#821: a file with invalid UTF-8 bytes must be skipped like a malformed
+    JSON line, not crash the loader with an uncaught UnicodeDecodeError."""
+
+    INVALID_UTF8 = b"\xff\xfe not json\n"
+
+    def test_load_jsonl_skips_invalid_utf8_file(self):
+        root = Path(tempfile.mkdtemp(prefix="ccgm-scorecard-badutf8-"))
+        path = root / "bad.jsonl"
+        path.write_bytes(self.INVALID_UTF8)
+        self.assertEqual(scorecard._load_jsonl(path), [])  # noqa: SLF001
+
+    def test_load_json_object_returns_empty_on_invalid_utf8(self):
+        root = Path(tempfile.mkdtemp(prefix="ccgm-scorecard-badutf8-"))
+        path = root / "bad.json"
+        path.write_bytes(self.INVALID_UTF8)
+        self.assertEqual(scorecard._load_json_object(path), {})  # noqa: SLF001
+
+    def test_render_survives_corrupt_optimistic_state_file(self):
+        # Mirrors the issue's own severity note: a corrupt state/optimistic.json
+        # must not crash the whole scorecard render.
+        root = Path(tempfile.mkdtemp(prefix="ccgm-scorecard-badutf8-render-"))
+        audit_path = root / "dreaming" / "state" / "apply-audit.jsonl"
+        state_path = audit_path.parent / "optimistic.json"
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_bytes(self.INVALID_UTF8)
+        md = scorecard.render(
+            datetime(2026, 6, 24, tzinfo=UTC),
+            datetime(2026, 7, 1, tzinfo=UTC),
+            learnings_dir=root / "nope-learnings",
+            injection_log_dir=root / "nope-injection",
+            proposals_dir=root / "nope-proposals",
+            apply_audit_path=audit_path,
+            store_api=learnings_store,
+            generated_at=datetime(2026, 7, 1, tzinfo=UTC),
+        )
+        self.assertIsInstance(md, str)
+        self.assertNotIn("Traceback", md)
+        self.assertIn("currently suspended: no", md)
+
+
 class ScorecardWindowBoundaryTest(unittest.TestCase):
     """Pin the half-open [start, end) convention at BOTH edges: a timestamp
     exactly at window_start is included; exactly at window_end is excluded."""


### PR DESCRIPTION
Closes #821

## Summary

Four loaders in the dreaming module catch `json.JSONDecodeError` (or `OSError`) around a `Path.read_text(encoding="utf-8")` / text-mode file read, but not `UnicodeDecodeError` — a file containing an invalid UTF-8 byte therefore escapes as an uncaught exception and crashes the caller instead of degrading gracefully like a malformed-JSON file already does.

Widened each site's existing `except` clause to also catch `UnicodeDecodeError`, mirroring the exact graceful fallback each loader already uses for its sibling error type. No behavior change beyond catching the new error type — no refactors, no renames.

## Loaders changed

- `modules/dreaming/lib/scorecard.py:181` — `_load_jsonl`: `except OSError:` → `except (OSError, UnicodeDecodeError):`
- `modules/dreaming/lib/scorecard.py:210` — `_load_json_object`: `except (OSError, json.JSONDecodeError):` → `except (OSError, json.JSONDecodeError, UnicodeDecodeError):`
- `modules/dreaming/lib/apply_dream_proposal.py:1011` — `_read_optimistic_state`: `except (OSError, json.JSONDecodeError):` → `except (OSError, json.JSONDecodeError, UnicodeDecodeError):` (preserves the documented fail-CLOSED contract — a corrupt state file now suspends rather than crashing)
- `modules/dreaming/lib/dream_analyze.py:421` — `_load_env_file`: `except OSError:` → `except (OSError, UnicodeDecodeError):`

## Test plan

- Reproduced each bug pre-fix (confirmed `UnicodeDecodeError` escaping all four call sites) before applying the fix.
- Added a regression test per site (writes a file containing `b"\xff\xfe not json\n"`, asserts graceful skip/fallback instead of a raised exception), plus one end-to-end `scorecard.render()` test for a corrupt `state/optimistic.json`.
- `python3 -m pytest modules/dreaming/tests/ -q` → 381 passed, 5 subtests passed
- `python3 -m pytest modules/self-improving/tests/ -q` → 204 passed, 8 subtests passed
- `bash modules/dreaming/tests/test-dream-apply.sh` → 97 passed, 0 failed
- `bash modules/dreaming/tests/test-dream-pipeline.sh` → 40 passed, 0 failed
- `bash modules/dreaming/tests/test-dream-reconcile.sh` → 18 passed, 0 failed
- `bash modules/dreaming/tests/smoke-live-analyzer.sh` → PASS
- `bash tests/test-no-personal-data.sh` → PASS