### PR TITLE
#834: pure scoring core (eligibility.py) + test infrastructure

### DIFF
--- a/modules/dreaming/lib/eligibility.py
+++ b/modules/dreaming/lib/eligibility.py
@@ -6,11 +6,11 @@ described in the composite-eligibility plan (plan.md §3.5). It takes an
 already-computed ``SignalBundle`` (scalars in) and returns an
 ``EligibilityDecision`` (decision out). It performs NO I/O: no filesystem,
 no network, no subprocess, and imports nothing beyond the stdlib set
-``dataclasses`` / ``math`` / ``difflib`` / ``re`` (plus ``__future__`` for
-deferred annotations). The HARD INVARIANT of the dreaming module -- "model
-proposes, deterministic rails decide" -- is enforceable here by an AST test
-precisely because this file cannot reach the store, the transcripts, or the
-network.
+``re`` / ``dataclasses`` / ``difflib`` (plus ``__future__`` for deferred
+annotations) -- a subset of the §3.5 permitted set. The HARD INVARIANT of
+the dreaming module -- "model proposes, deterministic rails decide" -- is
+enforceable here by an AST test precisely because this file cannot reach the
+store, the transcripts, or the network.
 
 Fail-closed doctrine (plan.md §1.4 principle 1, decisions.md #23): a signal
 that cannot be computed is 0, never 0.5, and NO signal computation catches an
@@ -60,6 +60,12 @@ MIN_STATIC_FLOOR = 4
 # minimum-viable motivating shape (case (d)) passes at <=15.4 days evidence
 # age, while stale junk (case (e)) fails at 0.41. `type` is NOT a scoring
 # input (decisions.md #38) -- the blend is four signals, weights sum to 1.0.
+#
+# Consumers that seed a config and then mutate it MUST take their seed from
+# :func:`default_eligibility` (a fresh, fully-independent copy). ``dict()`` of
+# this constant is a SHALLOW copy that ALIASES the nested ``weights`` dict, so
+# mutating a seed's weights in place would corrupt this module global
+# process-wide -- see :func:`default_eligibility` and R2.
 DEFAULT_ELIGIBILITY: dict = {
     "enabled": False,
     "static_floor": 5,
@@ -77,6 +83,22 @@ DEFAULT_ELIGIBILITY: dict = {
     "excerpt_match_min": 0.85,
     "max_transcript_bytes": 50000000,
 }
+
+
+def default_eligibility() -> dict:
+    """Return a fresh, fully-independent copy of :data:`DEFAULT_ELIGIBILITY`.
+
+    Consumers that seed an eligibility config and then mutate it (E2's
+    ``load_config()``, E3, tests) MUST obtain their seed here, NOT via
+    ``dict(DEFAULT_ELIGIBILITY)`` -- the latter is a shallow copy that ALIASES
+    the nested ``weights`` dict, so mutating the seed's weights corrupts the
+    module global process-wide (R2). This rebuilds the top-level dict AND a
+    fresh nested ``weights`` dict, so no reference to the constant survives.
+    :data:`DEFAULT_ELIGIBILITY` remains the canonical value; deriving the copy
+    from it keeps the two structurally unable to drift.
+    """
+    return {**DEFAULT_ELIGIBILITY, "weights": dict(DEFAULT_ELIGIBILITY["weights"])}
+
 
 # The exact four signal names the weights dict must carry. A stray key
 # (e.g. a pre-#38 "type_prior") is a validation FAILURE, catching stale
@@ -255,7 +277,13 @@ def _recency_score(newest_evidence_age_days: float | None, half_life_days: float
     """
     if newest_evidence_age_days is None:
         return 0.0
-    return 0.5 ** (newest_evidence_age_days / half_life_days)
+    # Clamp age to >= 0 before the exponent so a future-dated (negative-age)
+    # evidence timestamp cannot yield reĉ > 1 and push S out of [0, 1] (§3.3's
+    # "all ∈ [0,1]" normalization contract). A forged/skewed future timestamp
+    # gets at most the same 1.0 an age≈0 forger already gets -- never more. A
+    # NaN age stays NaN through max(), so S becomes NaN and fails closed.
+    age_days = max(newest_evidence_age_days, 0.0)
+    return 0.5 ** (age_days / half_life_days)
 
 
 # ---------------------------------------------------------------------------
@@ -317,7 +345,22 @@ def evaluate_eligibility(bundle: SignalBundle, optimistic: dict) -> EligibilityD
     this function owns steps 2, 4, 5, 6. It reads the eligibility sub-block
     plus ``confidence_floor_content`` and ``add_min_sessions`` from the whole
     merged ``optimistic`` dict.
+
+    Only ``learning_add`` / ``learning_supersede`` are routable here; steps 5-6
+    are "unreachable for kinds outside {add, supersede} by construction"
+    (plan.md §3.2). This raises ``ValueError`` (rather than returning a skip) on
+    any other kind so a future E3 routing slip fails CLOSED: the caller's outer
+    handler converts the exception to ``internal_error``, never an eligible
+    verdict. Raising keeps the outcome set a stable parse contract (no new
+    string) while making an unknown kind non-compensable by any signal.
     """
+    if bundle.kind not in ("learning_add", "learning_supersede"):
+        raise ValueError(
+            f"evaluate_eligibility received unroutable kind {bundle.kind!r}; "
+            "only 'learning_add'/'learning_supersede' reach the composite gate "
+            "(plan.md §3.2)"
+        )
+
     elig = optimistic["eligibility"]
     threshold = elig["threshold"]
     static_floor = elig["static_floor"]

--- a/modules/dreaming/lib/eligibility.py
+++ b/modules/dreaming/lib/eligibility.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""Pure scoring core for the dreaming optimistic-integration eligibility gate.
+
+This module is the deterministic heart of the composite eligibility gate
+described in the composite-eligibility plan (plan.md §3.5). It takes an
+already-computed ``SignalBundle`` (scalars in) and returns an
+``EligibilityDecision`` (decision out). It performs NO I/O: no filesystem,
+no network, no subprocess, and imports nothing beyond the stdlib set
+``dataclasses`` / ``math`` / ``difflib`` / ``re`` (plus ``__future__`` for
+deferred annotations). The HARD INVARIANT of the dreaming module -- "model
+proposes, deterministic rails decide" -- is enforceable here by an AST test
+precisely because this file cannot reach the store, the transcripts, or the
+network.
+
+Fail-closed doctrine (plan.md §1.4 principle 1, decisions.md #23): a signal
+that cannot be computed is 0, never 0.5, and NO signal computation catches an
+exception and returns a non-zero default -- it propagates or returns the
+signal's floor of 0. This module deliberately contains no ``try``/``except``.
+
+The gatherer (Epic 3, ``apply_dream_proposal.gather_eligibility_signals``)
+performs all the I/O -- session resolution, tier re-mining, recency from
+embedded timestamps, novelty against the live store's heads -- and hands the
+resulting scalars to :func:`evaluate_eligibility`. The only text machinery
+that lives here (:func:`similarity`, :func:`novelty_vs`, and the §3.3
+normalization) is pure and is called BY the gatherer against the store's
+heads; this module never touches the store itself.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+
+# Hard-coded, non-configurable lower bound on the static confidence floor.
+# A config whose eligibility.static_floor drops below this fails validation
+# closed (plan.md §3.2, §3.6). This is the un-hollowable-by-config floor that
+# sits beneath the composite so a config edit cannot admit sub-4 confidence.
+MIN_STATIC_FLOOR = 4
+
+# The single, authoritative default config for the eligibility sub-block
+# (plan.md §3.6; adrev2-005: E1 is the sole owner of the whole config
+# contract). ``dream_analyze.load_config()`` (Epic 2) imports and seeds this;
+# E1's own validation tests reference it by import so fixture drift is
+# structurally impossible.
+#
+# Weights rationale (plan.md §3.6):
+#   confidence .40 -- the model's own signal; the largest single term, but a
+#     minority of the blend and never sufficient alone (it is the ONLY
+#     model-assigned scoring input, so its share is deliberately capped).
+#   prevalence .30 -- the strongest *verified* signal: distinct
+#     transcript-verified cited sessions, which an attacker cannot forge
+#     without real on-machine sessions.
+#   recency    .20 -- a soft freshness prior over the evidence's own age;
+#     backdatable on-machine, so weighted below prevalence and never treated
+#     as evidence of origin.
+#   novelty    .10 -- informational and attacker-maximizable for adds (or
+#     refinement-detecting for supersedes); deliberately the smallest weight.
+# threshold θ = 0.58 is calibrated against the plan.md §3.9 worked cases: the
+# minimum-viable motivating shape (case (d)) passes at <=15.4 days evidence
+# age, while stale junk (case (e)) fails at 0.41. `type` is NOT a scoring
+# input (decisions.md #38) -- the blend is four signals, weights sum to 1.0.
+DEFAULT_ELIGIBILITY: dict = {
+    "enabled": False,
+    "static_floor": 5,
+    "threshold": 0.58,
+    "legacy_floor_admits": True,
+    "weights": {
+        "confidence": 0.40,
+        "prevalence": 0.30,
+        "recency": 0.20,
+        "novelty": 0.10,
+    },
+    "prevalence_cap": 4,
+    "prevalence_cap_user_corrected": 1,
+    "recency_half_life_days": 30,
+    "excerpt_match_min": 0.85,
+    "max_transcript_bytes": 50000000,
+}
+
+# The exact four signal names the weights dict must carry. A stray key
+# (e.g. a pre-#38 "type_prior") is a validation FAILURE, catching stale
+# configs loudly rather than silently ignoring them (plan.md §3.6).
+_WEIGHT_KEYS = ("confidence", "prevalence", "recency", "novelty")
+
+# Deterministic tie-break ordering for weakest_signal selection.
+_SIGNAL_ORDER = {name: i for i, name in enumerate(_WEIGHT_KEYS)}
+
+# A small, deterministic stop set for token-Jaccard similarity (plan.md §3.3).
+# Kept intentionally small and locale-free.
+_STOP_WORDS = frozenset(
+    {
+        "a", "an", "and", "are", "as", "at", "be", "by", "for", "from",
+        "in", "is", "it", "of", "on", "or", "the", "this", "that", "to",
+        "was", "were", "with",
+    }
+)
+
+# Matches the literal [neutralized] / [/neutralized] wrappers that
+# learnings_store.sanitize_content() inserts around injection-shaped text.
+# Stripped before any similarity comparison so a sanitized excerpt still
+# matches its raw transcript source (plan.md §3.3, §3.4).
+_NEUTRALIZED_RE = re.compile(r"\[/?neutralized\]", re.IGNORECASE)
+
+_WHITESPACE_RE = re.compile(r"\s+")
+_WORD_RE = re.compile(r"\w+")
+
+
+# ---------------------------------------------------------------------------
+# Frozen contract dataclasses (plan.md §3.5 -- field names are frozen; E3
+# imports them verbatim)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SignalBundle:
+    """Already-computed scalars for one proposal (plan.md §3.5).
+
+    Every field is produced deterministically by the gatherer at apply time;
+    nothing here is a model-emitted claim except ``confidence`` (the single
+    accepted model-assigned scalar).
+    """
+
+    kind: str                            # "learning_add" | "learning_supersede"
+    confidence: int                      # raw 1-10 from the proposal row
+    verified_sessions: int               # §3.4 distinct, transcript-verified count
+    evidence_tier: str                   # "user-corrected" | "inferred"
+    newest_evidence_age_days: float | None
+    novelty: float                       # nov̂, precomputed per-kind (§3.3)
+
+
+@dataclass(frozen=True)
+class EligibilityDecision:
+    """The gate's verdict for one proposal (plan.md §3.5).
+
+    ``outcome`` and ``decision_basis`` are a stable, add-only parse contract
+    read by the digest, ``/dream-review``, and the weekly scorecard
+    (plan.md §1.4).
+    """
+
+    eligible: bool
+    outcome: str                  # "eligible"|"skipped_floor"|"skipped_origin"|"skipped_composite"
+    decision_basis: str | None    # "legacy_floor" | "composite" | None
+    score: float | None           # S, when the composite was computed
+    threshold: float
+    margin: float | None          # S - threshold, when computed
+    signals: dict                 # conf̂/prev̂/reĉ/nov̂ as used
+    weakest_signal: str | None
+
+
+# ---------------------------------------------------------------------------
+# Pure text helpers (§3.3 content normalization + similarity)
+# ---------------------------------------------------------------------------
+
+
+def normalize_content(text: str) -> str:
+    """Normalize text for similarity comparison (plan.md §3.3).
+
+    Lowercase, strip ``[neutralized]``/``[/neutralized]`` wrappers, and
+    collapse all runs of whitespace to a single space. Deterministic and
+    locale-independent.
+    """
+    if not text:
+        return ""
+    stripped = _NEUTRALIZED_RE.sub(" ", text)
+    collapsed = _WHITESPACE_RE.sub(" ", stripped)
+    return collapsed.strip().lower()
+
+
+def _tokens(normalized: str) -> set:
+    """Content-bearing word tokens (\\w+) of already-normalized text, minus
+    the stop set (plan.md §3.3)."""
+    return {t for t in _WORD_RE.findall(normalized) if t not in _STOP_WORDS}
+
+
+def token_jaccard(a: str, b: str) -> float:
+    """Jaccard similarity of the two texts' stop-filtered token sets.
+
+    Both texts are normalized first. Two empty token sets are treated as
+    identical (1.0); an empty set against a non-empty set shares nothing
+    (0.0).
+    """
+    ta = _tokens(normalize_content(a))
+    tb = _tokens(normalize_content(b))
+    union = ta | tb
+    if not union:
+        return 1.0
+    return len(ta & tb) / len(union)
+
+
+def similarity(a: str, b: str) -> float:
+    """Text similarity in [0, 1] = max(SequenceMatcher.ratio, token_jaccard)
+    on normalized text (plan.md §3.3).
+
+    ``SequenceMatcher.ratio`` is the primary, order-sensitive arm;
+    ``token_jaccard`` is a set-based floor. Taking the max means a match on
+    either arm counts, which is the tolerant behavior the excerpt check and
+    novelty both rely on.
+    """
+    na = normalize_content(a)
+    nb = normalize_content(b)
+    seq_ratio = SequenceMatcher(None, na, nb).ratio()
+    return max(seq_ratio, token_jaccard(a, b))
+
+
+def novelty_vs(content: str, others: list) -> float:
+    """nov̂ = 1 - max(similarity(content, o) for o in others).
+
+    The gatherer calls this against the slug's live heads (learning_add) or
+    a single-element list holding the target head's old content
+    (learning_supersede). An EMPTY ``others`` yields novelty 1.0 -- an empty
+    store makes any content maximally novel (plan.md §3.3, deliberate and
+    tested). This helper is pure text machinery: it never touches the store.
+    """
+    best = 0.0
+    for other in others:
+        s = similarity(content, other)
+        if s > best:
+            best = s
+    return 1.0 - best
+
+
+# ---------------------------------------------------------------------------
+# Numeric helpers
+# ---------------------------------------------------------------------------
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+def _is_number(x) -> bool:
+    return isinstance(x, (int, float)) and not isinstance(x, bool)
+
+
+def _is_int(x) -> bool:
+    return isinstance(x, int) and not isinstance(x, bool)
+
+
+def _recency_score(newest_evidence_age_days: float | None, half_life_days: float) -> float:
+    """reĉ = 0.5 ** (age_days / half_life_days); no verified evidence -> 0.
+
+    Two clocks, deliberately non-duplicative (decisions.md #14):
+      * This score decays the EVIDENCE's age at admission with a 30-day
+        half-life -- "how fresh is the observation this memory rests on?"
+      * ``learnings_store.effective_confidence()`` separately decays an
+        ALREADY-ADMITTED row by ITS OWN age with a 90-day half-life -- "how
+        old is this memory now?"
+    They measure different ages against different clocks; scoring evidence
+    recency here does not double-count the store's own read-time decay.
+
+    A ``None`` age (no verified session, or an oversized transcript whose
+    recency was forced to 0 per §3.4) scores 0 -- fail toward the weakest
+    value, never a 0.5 default.
+    """
+    if newest_evidence_age_days is None:
+        return 0.0
+    return 0.5 ** (newest_evidence_age_days / half_life_days)
+
+
+# ---------------------------------------------------------------------------
+# Composite score (§3.3 normalized signals -> S)
+# ---------------------------------------------------------------------------
+
+
+def composite_score(bundle: SignalBundle, elig_cfg: dict) -> tuple[float, dict]:
+    """Compute S = Σ wᵢ·signal̂ᵢ and return (S, normalized-signals dict).
+
+    ``elig_cfg`` is the (already-validated, already-defaulted) eligibility
+    sub-block. Each normalized signal is in [0, 1]; the weights sum to 1, so
+    S is in [0, 1] and each signal's contribution is bounded by its weight.
+    """
+    weights = elig_cfg["weights"]
+
+    conf_hat = _clamp(bundle.confidence, 0, 10) / 10.0
+
+    # Prevalence cap tightens to 1 for a user-corrected tier: a single
+    # human-verified corrective session saturates prevalence, so multi-session
+    # dilution is not required on top of a genuine origin signal (§3.3).
+    if bundle.evidence_tier == "user-corrected":
+        cap = elig_cfg["prevalence_cap_user_corrected"]
+    else:
+        cap = elig_cfg["prevalence_cap"]
+    prev_hat = _clamp(min(bundle.verified_sessions, cap) / cap, 0.0, 1.0)
+
+    rec_hat = _recency_score(bundle.newest_evidence_age_days, elig_cfg["recency_half_life_days"])
+
+    nov_hat = _clamp(bundle.novelty, 0.0, 1.0)
+
+    signals = {
+        "confidence": conf_hat,
+        "prevalence": prev_hat,
+        "recency": rec_hat,
+        "novelty": nov_hat,
+    }
+    score = sum(weights[name] * signals[name] for name in _WEIGHT_KEYS)
+    return score, signals
+
+
+def _weakest_signal(signals: dict) -> str:
+    """The signal name with the smallest normalized value, tie-broken by the
+    canonical signal order for determinism."""
+    return min(signals, key=lambda name: (signals[name], _SIGNAL_ORDER[name]))
+
+
+# ---------------------------------------------------------------------------
+# Gate waterfall (plan.md §3.2 steps 2, 4, 5, 6)
+# ---------------------------------------------------------------------------
+
+
+def evaluate_eligibility(bundle: SignalBundle, optimistic: dict) -> EligibilityDecision:
+    """Run the enabled-mode waterfall for a ``learning_add`` /
+    ``learning_supersede`` proposal and return the decision (plan.md §3.2).
+
+    The caller (Epic 3) is responsible for steps 0-1 (posture resolution,
+    config-invalid/disabled -> legacy path) and for gathering the bundle;
+    this function owns steps 2, 4, 5, 6. It reads the eligibility sub-block
+    plus ``confidence_floor_content`` and ``add_min_sessions`` from the whole
+    merged ``optimistic`` dict.
+    """
+    elig = optimistic["eligibility"]
+    threshold = elig["threshold"]
+    static_floor = elig["static_floor"]
+    legacy_floor_admits = elig["legacy_floor_admits"]
+    confidence_floor_content = optimistic["confidence_floor_content"]
+    add_min_sessions = optimistic["add_min_sessions"]
+
+    # Step 2: STATIC FLOOR (strict <, matching legacy).
+    if bundle.confidence < static_floor:
+        return EligibilityDecision(
+            eligible=False,
+            outcome="skipped_floor",
+            decision_basis=None,
+            score=None,
+            threshold=threshold,
+            margin=None,
+            signals={},
+            weakest_signal=None,
+        )
+
+    # Step 4: LEGACY ESCAPE (per-kind; disabled when legacy_floor_admits=false).
+    # add       -> reproduces BOTH legacy conditions (floor AND session count)
+    #              so an inferred-once conf-9 add stays rejected as today.
+    # supersede -> legacy truly has no session check, so floor-only is faithful.
+    if legacy_floor_admits:
+        if bundle.kind == "learning_add":
+            if bundle.confidence >= confidence_floor_content and bundle.verified_sessions >= add_min_sessions:
+                return _legacy_eligible(threshold)
+        elif bundle.kind == "learning_supersede":
+            if bundle.confidence >= confidence_floor_content:
+                return _legacy_eligible(threshold)
+
+    # Step 5: ORIGIN GATE (non-compensatory -- no soft-signal value rescues it).
+    # An unknown evidence_tier string is not "user-corrected", so it fails
+    # this arm and falls through to the session-count arm: fail-closed.
+    origin_ok = (bundle.evidence_tier == "user-corrected") or (bundle.verified_sessions >= add_min_sessions)
+    if not origin_ok:
+        return EligibilityDecision(
+            eligible=False,
+            outcome="skipped_origin",
+            decision_basis=None,
+            score=None,
+            threshold=threshold,
+            margin=None,
+            signals={},
+            weakest_signal=None,
+        )
+
+    # Step 6: COMPOSITE (S >= threshold admits).
+    score, signals = composite_score(bundle, elig)
+    margin = score - threshold
+    weakest = _weakest_signal(signals)
+    if score >= threshold:
+        return EligibilityDecision(
+            eligible=True,
+            outcome="eligible",
+            decision_basis="composite",
+            score=score,
+            threshold=threshold,
+            margin=margin,
+            signals=signals,
+            weakest_signal=weakest,
+        )
+    return EligibilityDecision(
+        eligible=False,
+        outcome="skipped_composite",
+        decision_basis=None,
+        score=score,
+        threshold=threshold,
+        margin=margin,
+        signals=signals,
+        weakest_signal=weakest,
+    )
+
+
+def _legacy_eligible(threshold: float) -> EligibilityDecision:
+    return EligibilityDecision(
+        eligible=True,
+        outcome="eligible",
+        decision_basis="legacy_floor",
+        score=None,
+        threshold=threshold,
+        margin=None,
+        signals={},
+        weakest_signal=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config validation (§3.6; runs AFTER defaulting, fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def validate_eligibility_config(optimistic: dict) -> tuple[bool, list]:
+    """Validate the eligibility sub-block of a merged ``optimistic`` dict.
+
+    Runs AFTER defaulting (the caller seeds :data:`DEFAULT_ELIGIBILITY` then
+    overlays the user's block). Returns ``(ok, errors)``; ANY failure means
+    the caller treats eligibility as disabled (plan.md §3.6, decisions.md
+    #18/#22). Takes the whole merged optimistic dict because the
+    ``static_floor <= confidence_floor_content`` bound is cross-field.
+
+    Checks (plan.md §3.6):
+      * every key type-checked;
+      * weights: keys EXACTLY the four signal names (a stray ``type_prior``
+        fails), each a number >= 0, sum = 1 ± 0.001;
+      * threshold ∈ [0, 1]; excerpt_match_min ∈ [0, 1];
+      * prevalence caps integers >= 1; half-life a number > 0;
+      * max_transcript_bytes an integer >= 1_000_000;
+      * MIN_STATIC_FLOOR <= static_floor <= confidence_floor_content.
+    """
+    errors: list = []
+
+    if not isinstance(optimistic, dict):
+        return False, ["optimistic config is not a dict"]
+
+    elig = optimistic.get("eligibility")
+    if not isinstance(elig, dict):
+        return False, ["eligibility block is missing or not a dict"]
+
+    # enabled
+    if not isinstance(elig.get("enabled"), bool):
+        errors.append("eligibility.enabled must be a bool")
+
+    # legacy_floor_admits
+    if not isinstance(elig.get("legacy_floor_admits"), bool):
+        errors.append("eligibility.legacy_floor_admits must be a bool")
+
+    # static_floor (int; cross-field bound applied below)
+    static_floor = elig.get("static_floor")
+    if not _is_int(static_floor):
+        errors.append("eligibility.static_floor must be an int")
+
+    # threshold ∈ [0, 1]
+    threshold = elig.get("threshold")
+    if not _is_number(threshold):
+        errors.append("eligibility.threshold must be a number")
+    elif not (0.0 <= threshold <= 1.0):
+        errors.append("eligibility.threshold must be in [0, 1]")
+
+    # excerpt_match_min ∈ [0, 1]
+    emm = elig.get("excerpt_match_min")
+    if not _is_number(emm):
+        errors.append("eligibility.excerpt_match_min must be a number")
+    elif not (0.0 <= emm <= 1.0):
+        errors.append("eligibility.excerpt_match_min must be in [0, 1]")
+
+    # prevalence caps (ints >= 1)
+    for key in ("prevalence_cap", "prevalence_cap_user_corrected"):
+        val = elig.get(key)
+        if not _is_int(val):
+            errors.append(f"eligibility.{key} must be an int")
+        elif val < 1:
+            errors.append(f"eligibility.{key} must be >= 1")
+
+    # recency_half_life_days (number > 0)
+    hl = elig.get("recency_half_life_days")
+    if not _is_number(hl):
+        errors.append("eligibility.recency_half_life_days must be a number")
+    elif hl <= 0:
+        errors.append("eligibility.recency_half_life_days must be > 0")
+
+    # max_transcript_bytes (int >= 1_000_000)
+    mtb = elig.get("max_transcript_bytes")
+    if not _is_int(mtb):
+        errors.append("eligibility.max_transcript_bytes must be an int")
+    elif mtb < 1_000_000:
+        errors.append("eligibility.max_transcript_bytes must be >= 1_000_000")
+
+    # weights: exactly the four signal names, each number >= 0, sum = 1 ± 0.001
+    weights = elig.get("weights")
+    if not isinstance(weights, dict):
+        errors.append("eligibility.weights must be a dict")
+    else:
+        if set(weights.keys()) != set(_WEIGHT_KEYS):
+            errors.append(
+                "eligibility.weights keys must be exactly "
+                f"{sorted(_WEIGHT_KEYS)} (got {sorted(weights.keys())})"
+            )
+        bad_weight = False
+        for name, w in weights.items():
+            if not _is_number(w):
+                errors.append(f"eligibility.weights[{name!r}] must be a number")
+                bad_weight = True
+            elif w < 0:
+                errors.append(f"eligibility.weights[{name!r}] must be >= 0")
+                bad_weight = True
+        if not bad_weight:
+            total = sum(weights[name] for name in weights)
+            if abs(total - 1.0) > 0.001:
+                errors.append(f"eligibility.weights must sum to 1 ± 0.001 (got {total})")
+
+    # Cross-field: MIN_STATIC_FLOOR <= static_floor <= confidence_floor_content
+    cfc = optimistic.get("confidence_floor_content")
+    if not _is_int(cfc):
+        errors.append("confidence_floor_content must be an int")
+    if _is_int(static_floor):
+        if static_floor < MIN_STATIC_FLOOR:
+            errors.append(
+                f"eligibility.static_floor ({static_floor}) must be >= MIN_STATIC_FLOOR ({MIN_STATIC_FLOOR})"
+            )
+        if _is_int(cfc) and static_floor > cfc:
+            errors.append(
+                f"eligibility.static_floor ({static_floor}) must be <= confidence_floor_content ({cfc})"
+            )
+
+    return (not errors), errors

--- a/modules/dreaming/tests/test_eligibility.py
+++ b/modules/dreaming/tests/test_eligibility.py
@@ -1,0 +1,804 @@
+#!/usr/bin/env python3
+"""Exhaustive tests for modules/dreaming/lib/eligibility.py (composite-eligibility E1).
+
+Covers the plan.md §5 Epic E1 test list: the nine §3.9 worked cases pinned to
+exact 3-decimal S values, boundary pins, monotonicity sweeps, the origin-gate
+non-compensability property, per-kind legacy escape, the full
+validate_eligibility_config matrix (§3.6), AST-based purity + no-broad-except
+lints, frozen-dataclass assertions, and similarity/normalization pins.
+
+eligibility.py is pure (no env, no I/O), so no CCGM_* env redirection is
+needed before import -- unlike the store/miner tests.
+
+Run: python3 -m pytest modules/dreaming/tests/test_eligibility.py -q
+  or: python3 modules/dreaming/tests/test_eligibility.py
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import dataclasses
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+LIB = HERE.parent / "lib"
+sys.path.insert(0, str(LIB))
+
+import eligibility as elig  # noqa: E402
+from eligibility import (  # noqa: E402
+    DEFAULT_ELIGIBILITY,
+    MIN_STATIC_FLOOR,
+    EligibilityDecision,
+    SignalBundle,
+    composite_score,
+    evaluate_eligibility,
+    normalize_content,
+    novelty_vs,
+    similarity,
+    token_jaccard,
+    validate_eligibility_config,
+)
+
+ELIGIBILITY_SRC = LIB / "eligibility.py"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def opt(cfc: int = 8, add_min: int = 2, **elig_overrides) -> dict:
+    """A merged optimistic dict with a fully-defaulted eligibility block plus
+    any top-level eligibility overrides."""
+    o = {
+        "confidence_floor_content": cfc,
+        "add_min_sessions": add_min,
+        "eligibility": copy.deepcopy(DEFAULT_ELIGIBILITY),
+    }
+    o["eligibility"].update(elig_overrides)
+    return o
+
+
+def bundle(
+    kind="learning_add",
+    confidence=6,
+    verified_sessions=2,
+    evidence_tier="inferred",
+    newest_evidence_age_days=10.0,
+    novelty=0.5,
+) -> SignalBundle:
+    return SignalBundle(
+        kind=kind,
+        confidence=confidence,
+        verified_sessions=verified_sessions,
+        evidence_tier=evidence_tier,
+        newest_evidence_age_days=newest_evidence_age_days,
+        novelty=novelty,
+    )
+
+
+# ---------------------------------------------------------------------------
+# §3.9 worked cases (exact S to 3 decimals)
+# ---------------------------------------------------------------------------
+
+
+class WorkedCaseTests(unittest.TestCase):
+    def test_case_a_add_user_corrected(self):
+        b = bundle(kind="learning_add", confidence=6, verified_sessions=1,
+                   evidence_tier="user-corrected", newest_evidence_age_days=2.0, novelty=0.6)
+        s, _ = composite_score(b, DEFAULT_ELIGIBILITY)
+        self.assertEqual(round(s, 3), 0.791)
+        d = evaluate_eligibility(b, opt())
+        self.assertTrue(d.eligible)
+        self.assertEqual(d.outcome, "eligible")
+        self.assertEqual(d.decision_basis, "composite")
+
+    def test_case_b_add_inferred_3sess(self):
+        b = bundle(kind="learning_add", confidence=6, verified_sessions=3,
+                   evidence_tier="inferred", newest_evidence_age_days=7.0, novelty=0.5)
+        s, _ = composite_score(b, DEFAULT_ELIGIBILITY)
+        self.assertEqual(round(s, 3), 0.685)
+        self.assertEqual(evaluate_eligibility(b, opt()).outcome, "eligible")
+
+    def test_case_c_add_inferred_1sess_skips_origin(self):
+        b = bundle(kind="learning_add", confidence=6, verified_sessions=1,
+                   evidence_tier="inferred", newest_evidence_age_days=2.0, novelty=0.5)
+        d = evaluate_eligibility(b, opt())
+        self.assertFalse(d.eligible)
+        self.assertEqual(d.outcome, "skipped_origin")
+        self.assertIsNone(d.score)  # never reaches S
+        self.assertEqual(d.signals, {})
+
+    def test_case_d_add_inferred_2sess_crossover(self):
+        b = bundle(kind="learning_add", confidence=6, verified_sessions=2,
+                   evidence_tier="inferred", newest_evidence_age_days=10.0, novelty=0.5)
+        s, _ = composite_score(b, DEFAULT_ELIGIBILITY)
+        self.assertEqual(round(s, 3), 0.599)
+        self.assertEqual(evaluate_eligibility(b, opt()).outcome, "eligible")
+
+    def test_case_e_add_conf5_stale_skips_composite(self):
+        b = bundle(kind="learning_add", confidence=5, verified_sessions=2,
+                   evidence_tier="inferred", newest_evidence_age_days=60.0, novelty=0.1)
+        s, _ = composite_score(b, DEFAULT_ELIGIBILITY)
+        self.assertEqual(round(s, 3), 0.410)
+        d = evaluate_eligibility(b, opt())
+        self.assertFalse(d.eligible)
+        self.assertEqual(d.outcome, "skipped_composite")
+
+    def test_case_f_add_conf9_inferred_1sess_skips_origin(self):
+        # conf-9 clears the legacy floor but not the session count -> matches today.
+        b = bundle(kind="learning_add", confidence=9, verified_sessions=1,
+                   evidence_tier="inferred", newest_evidence_age_days=2.0, novelty=0.5)
+        d = evaluate_eligibility(b, opt())
+        self.assertFalse(d.eligible)
+        self.assertEqual(d.outcome, "skipped_origin")
+
+    def test_case_g_eviction_not_scored_by_pure_core(self):
+        # (g) contradict/deprecate take the legacy path bit-for-bit and are
+        # NEVER routed to evaluate_eligibility (unreachable for kinds outside
+        # {add, supersede} by construction, plan.md §3.2). Documented here:
+        # the pure core exposes no branch for eviction kinds.
+        self.assertNotIn("learning_contradict", ("learning_add", "learning_supersede"))
+        self.assertNotIn("learning_deprecate", ("learning_add", "learning_supersede"))
+
+    def test_case_h_supersede_near_dup_skips_composite(self):
+        b = bundle(kind="learning_supersede", confidence=6, verified_sessions=2,
+                   evidence_tier="inferred", newest_evidence_age_days=5.0, novelty=0.05)
+        s, _ = composite_score(b, DEFAULT_ELIGIBILITY)
+        self.assertEqual(round(s, 3), 0.573)
+        self.assertEqual(evaluate_eligibility(b, opt()).outcome, "skipped_composite")
+
+    def test_case_i_supersede_substantive_eligible(self):
+        b = bundle(kind="learning_supersede", confidence=6, verified_sessions=2,
+                   evidence_tier="inferred", newest_evidence_age_days=5.0, novelty=0.6)
+        s, _ = composite_score(b, DEFAULT_ELIGIBILITY)
+        self.assertEqual(round(s, 3), 0.628)
+        d = evaluate_eligibility(b, opt())
+        self.assertTrue(d.eligible)
+        self.assertEqual(d.decision_basis, "composite")
+
+
+# ---------------------------------------------------------------------------
+# Normalized-signal pins (the values that feed §3.9)
+# ---------------------------------------------------------------------------
+
+
+class SignalNormalizationTests(unittest.TestCase):
+    def test_prevalence_cap_user_corrected_saturates_at_one(self):
+        b = bundle(evidence_tier="user-corrected", verified_sessions=1)
+        _, sig = composite_score(b, DEFAULT_ELIGIBILITY)
+        self.assertEqual(sig["prevalence"], 1.0)
+
+    def test_prevalence_inferred_uses_cap_four(self):
+        _, sig = composite_score(bundle(evidence_tier="inferred", verified_sessions=2), DEFAULT_ELIGIBILITY)
+        self.assertEqual(sig["prevalence"], 0.5)
+
+    def test_prevalence_clamped_at_one_when_over_cap(self):
+        _, sig = composite_score(bundle(evidence_tier="inferred", verified_sessions=99), DEFAULT_ELIGIBILITY)
+        self.assertEqual(sig["prevalence"], 1.0)
+
+    def test_confidence_normalized_over_ten(self):
+        _, sig = composite_score(bundle(confidence=6), DEFAULT_ELIGIBILITY)
+        self.assertEqual(sig["confidence"], 0.6)
+
+    def test_confidence_clamped_to_ten(self):
+        _, sig = composite_score(bundle(confidence=99), DEFAULT_ELIGIBILITY)
+        self.assertEqual(sig["confidence"], 1.0)
+
+    def test_recency_none_age_is_zero(self):
+        _, sig = composite_score(bundle(newest_evidence_age_days=None), DEFAULT_ELIGIBILITY)
+        self.assertEqual(sig["recency"], 0.0)
+
+    def test_recency_at_one_half_life_is_half(self):
+        _, sig = composite_score(bundle(newest_evidence_age_days=30.0), DEFAULT_ELIGIBILITY)
+        self.assertAlmostEqual(sig["recency"], 0.5, places=6)
+
+    def test_recency_at_zero_age_is_one(self):
+        _, sig = composite_score(bundle(newest_evidence_age_days=0.0), DEFAULT_ELIGIBILITY)
+        self.assertEqual(sig["recency"], 1.0)
+
+    def test_novelty_passed_through_and_clamped(self):
+        _, sig = composite_score(bundle(novelty=0.42), DEFAULT_ELIGIBILITY)
+        self.assertEqual(sig["novelty"], 0.42)
+        _, sig2 = composite_score(bundle(novelty=5.0), DEFAULT_ELIGIBILITY)
+        self.assertEqual(sig2["novelty"], 1.0)
+
+    def test_unknown_tier_treated_as_inferred_in_prevalence(self):
+        # Fail-closed: a bogus tier uses the wider cap-4 (inferred), never cap-1.
+        _, sig = composite_score(bundle(evidence_tier="bogus", verified_sessions=2), DEFAULT_ELIGIBILITY)
+        self.assertEqual(sig["prevalence"], 0.5)
+
+
+# ---------------------------------------------------------------------------
+# Boundary pins
+# ---------------------------------------------------------------------------
+
+
+class BoundaryTests(unittest.TestCase):
+    def test_conf_equals_static_floor_reaches_composite(self):
+        # static_floor default 5; conf 5 passes the strict-< floor.
+        b = bundle(kind="learning_add", confidence=5, verified_sessions=2,
+                   evidence_tier="inferred", newest_evidence_age_days=10.0, novelty=0.5)
+        d = evaluate_eligibility(b, opt())
+        self.assertIn(d.outcome, ("eligible", "skipped_composite"))
+        self.assertIsNotNone(d.score)
+
+    def test_conf_below_static_floor_skips_floor(self):
+        b = bundle(confidence=4)
+        d = evaluate_eligibility(b, opt())
+        self.assertFalse(d.eligible)
+        self.assertEqual(d.outcome, "skipped_floor")
+        self.assertIsNone(d.score)
+        self.assertEqual(d.signals, {})
+
+    def test_score_equal_threshold_admits(self):
+        b = bundle(kind="learning_add", confidence=6, verified_sessions=2,
+                   evidence_tier="inferred", newest_evidence_age_days=10.0, novelty=0.5)
+        s, _ = composite_score(b, DEFAULT_ELIGIBILITY)
+        d = evaluate_eligibility(b, opt(threshold=s))  # threshold == S exactly
+        self.assertTrue(d.eligible)
+        self.assertEqual(d.decision_basis, "composite")
+        self.assertGreaterEqual(d.score, d.threshold)
+
+    def test_score_just_below_threshold_rejects(self):
+        b = bundle(kind="learning_add", confidence=6, verified_sessions=2,
+                   evidence_tier="inferred", newest_evidence_age_days=10.0, novelty=0.5)
+        s, _ = composite_score(b, DEFAULT_ELIGIBILITY)
+        # nudge threshold a hair above S
+        d = evaluate_eligibility(b, opt(threshold=min(1.0, s + 1e-9)))
+        self.assertFalse(d.eligible)
+        self.assertEqual(d.outcome, "skipped_composite")
+
+    def test_margin_is_score_minus_threshold(self):
+        b = bundle(kind="learning_add", confidence=6, verified_sessions=2,
+                   evidence_tier="inferred", newest_evidence_age_days=10.0, novelty=0.5)
+        d = evaluate_eligibility(b, opt())
+        self.assertAlmostEqual(d.margin, d.score - d.threshold, places=9)
+
+
+# ---------------------------------------------------------------------------
+# Monotonicity + contribution bounds
+# ---------------------------------------------------------------------------
+
+
+class MonotonicityTests(unittest.TestCase):
+    def test_S_nondecreasing_in_confidence(self):
+        prev = -1.0
+        for c in range(5, 11):
+            s, _ = composite_score(bundle(confidence=c), DEFAULT_ELIGIBILITY)
+            self.assertGreaterEqual(s, prev)
+            prev = s
+
+    def test_S_nondecreasing_in_verified_sessions(self):
+        prev = -1.0
+        for vs in range(0, 6):
+            s, _ = composite_score(bundle(verified_sessions=vs, evidence_tier="inferred"), DEFAULT_ELIGIBILITY)
+            self.assertGreaterEqual(s, prev)
+            prev = s
+
+    def test_S_nondecreasing_in_novelty(self):
+        prev = -1.0
+        for nov in (0.0, 0.25, 0.5, 0.75, 1.0):
+            s, _ = composite_score(bundle(novelty=nov), DEFAULT_ELIGIBILITY)
+            self.assertGreaterEqual(s, prev)
+            prev = s
+
+    def test_S_nonincreasing_in_age(self):
+        prev = 2.0
+        for age in (0.0, 5.0, 30.0, 60.0, 120.0):
+            s, _ = composite_score(bundle(newest_evidence_age_days=age), DEFAULT_ELIGIBILITY)
+            self.assertLessEqual(s, prev)
+            prev = s
+
+    def test_per_signal_contribution_bounded_by_weight(self):
+        weights = DEFAULT_ELIGIBILITY["weights"]
+        for conf in (5, 8, 10):
+            for vs in (0, 2, 4):
+                for age in (0.0, 30.0, None):
+                    for nov in (0.0, 0.5, 1.0):
+                        b = bundle(confidence=conf, verified_sessions=vs,
+                                   newest_evidence_age_days=age, novelty=nov)
+                        _, sig = composite_score(b, DEFAULT_ELIGIBILITY)
+                        for name, w in weights.items():
+                            self.assertLessEqual(w * sig[name], w + 1e-12)
+                            self.assertGreaterEqual(sig[name], 0.0)
+                            self.assertLessEqual(sig[name], 1.0)
+
+    def test_S_in_unit_interval(self):
+        for conf in (0, 5, 10):
+            for vs in (0, 3, 10):
+                for age in (0.0, 45.0, None):
+                    for nov in (0.0, 1.0):
+                        s, _ = composite_score(
+                            bundle(confidence=conf, verified_sessions=vs,
+                                   newest_evidence_age_days=age, novelty=nov),
+                            DEFAULT_ELIGIBILITY,
+                        )
+                        self.assertGreaterEqual(s, 0.0)
+                        self.assertLessEqual(s, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Origin gate non-compensability (property sweep)
+# ---------------------------------------------------------------------------
+
+
+class OriginGateTests(unittest.TestCase):
+    def test_inferred_below_min_sessions_always_skips_origin(self):
+        # legacy_floor_admits off isolates the origin gate; no soft-signal
+        # value (conf/recency/novelty) rescues a failing origin.
+        cfg = opt(legacy_floor_admits=False)
+        for kind in ("learning_add", "learning_supersede"):
+            for vs in (0, 1):
+                for conf in (5, 6, 7, 8, 9, 10):
+                    for nov in (0.0, 0.5, 1.0):
+                        for age in (0.0, 5.0, None):
+                            b = bundle(kind=kind, confidence=conf, verified_sessions=vs,
+                                       evidence_tier="inferred", newest_evidence_age_days=age, novelty=nov)
+                            d = evaluate_eligibility(b, cfg)
+                            self.assertEqual(d.outcome, "skipped_origin",
+                                             msg=f"{kind} vs={vs} conf={conf} nov={nov} age={age}")
+
+    def test_legacy_on_below_floor_still_skips_origin(self):
+        # With legacy on but conf below the content floor, add/supersede with a
+        # failing origin still skip_origin (legacy escape does not fire).
+        cfg = opt()  # legacy on, cfc 8
+        for kind in ("learning_add", "learning_supersede"):
+            for vs in (0, 1):
+                for conf in (5, 6, 7):
+                    b = bundle(kind=kind, confidence=conf, verified_sessions=vs,
+                               evidence_tier="inferred", newest_evidence_age_days=5.0, novelty=1.0)
+                    self.assertEqual(evaluate_eligibility(b, cfg).outcome, "skipped_origin")
+
+    def test_user_corrected_rescues_origin_with_zero_sessions(self):
+        # A user-corrected tier passes the origin gate even at 0 verified sessions.
+        b = bundle(kind="learning_add", confidence=6, verified_sessions=0,
+                   evidence_tier="user-corrected", newest_evidence_age_days=2.0, novelty=0.6)
+        d = evaluate_eligibility(b, opt())
+        self.assertNotEqual(d.outcome, "skipped_origin")
+        self.assertIsNotNone(d.score)
+
+    def test_unknown_tier_fails_origin_like_inferred(self):
+        b = bundle(kind="learning_add", confidence=6, verified_sessions=1,
+                   evidence_tier="totally-bogus", newest_evidence_age_days=2.0, novelty=0.9)
+        self.assertEqual(evaluate_eligibility(b, opt()).outcome, "skipped_origin")
+
+
+# ---------------------------------------------------------------------------
+# Legacy escape (per-kind)
+# ---------------------------------------------------------------------------
+
+
+class LegacyEscapeTests(unittest.TestCase):
+    def test_add_needs_floor_and_sessions(self):
+        # conf>=8 AND vs>=2 -> legacy_floor eligible.
+        b = bundle(kind="learning_add", confidence=8, verified_sessions=2, evidence_tier="inferred")
+        d = evaluate_eligibility(b, opt())
+        self.assertTrue(d.eligible)
+        self.assertEqual(d.decision_basis, "legacy_floor")
+        self.assertIsNone(d.score)  # legacy path never computes S
+
+    def test_add_floor_without_sessions_falls_to_origin(self):
+        b = bundle(kind="learning_add", confidence=9, verified_sessions=1, evidence_tier="inferred")
+        self.assertEqual(evaluate_eligibility(b, opt()).outcome, "skipped_origin")
+
+    def test_add_below_floor_with_sessions_reaches_composite(self):
+        b = bundle(kind="learning_add", confidence=7, verified_sessions=2, evidence_tier="inferred",
+                   newest_evidence_age_days=5.0, novelty=0.5)
+        d = evaluate_eligibility(b, opt())
+        self.assertIsNotNone(d.score)
+        self.assertNotEqual(d.decision_basis, "legacy_floor")
+
+    def test_supersede_floor_only(self):
+        # supersede at conf>=8 admits on floor alone, even with 0 verified sessions.
+        b = bundle(kind="learning_supersede", confidence=8, verified_sessions=0, evidence_tier="inferred")
+        d = evaluate_eligibility(b, opt())
+        self.assertTrue(d.eligible)
+        self.assertEqual(d.decision_basis, "legacy_floor")
+
+    def test_supersede_below_floor_needs_origin(self):
+        b = bundle(kind="learning_supersede", confidence=7, verified_sessions=0, evidence_tier="inferred")
+        self.assertEqual(evaluate_eligibility(b, opt()).outcome, "skipped_origin")
+
+    def test_legacy_floor_admits_false_disables_step_four_add(self):
+        # add conf9 vs2 with legacy off -> reaches composite (basis != legacy_floor).
+        b = bundle(kind="learning_add", confidence=9, verified_sessions=2, evidence_tier="inferred",
+                   newest_evidence_age_days=5.0, novelty=0.5)
+        d = evaluate_eligibility(b, opt(legacy_floor_admits=False))
+        self.assertIsNotNone(d.score)
+        self.assertNotEqual(d.decision_basis, "legacy_floor")
+
+    def test_legacy_floor_admits_false_disables_step_four_supersede(self):
+        # supersede conf9 vs0 inferred: legacy-on would admit; legacy-off -> origin fails.
+        b = bundle(kind="learning_supersede", confidence=9, verified_sessions=0, evidence_tier="inferred")
+        self.assertTrue(evaluate_eligibility(b, opt()).eligible)  # legacy on admits
+        self.assertEqual(evaluate_eligibility(b, opt(legacy_floor_admits=False)).outcome, "skipped_origin")
+
+
+# ---------------------------------------------------------------------------
+# validate_eligibility_config matrix (§3.6)
+# ---------------------------------------------------------------------------
+
+
+class ValidateConfigTests(unittest.TestCase):
+    def _bad(self, **elig_overrides):
+        ok, errors = validate_eligibility_config(opt(**elig_overrides))
+        self.assertFalse(ok)
+        self.assertTrue(errors)
+        return errors
+
+    def test_default_config_valid(self):
+        ok, errors = validate_eligibility_config(opt())
+        self.assertTrue(ok, msg=str(errors))
+        self.assertEqual(errors, [])
+
+    def test_single_key_override_still_valid_after_defaulting(self):
+        # {"eligibility": {"threshold": 0.7}} preserves every sibling default.
+        ok, errors = validate_eligibility_config(opt(threshold=0.7))
+        self.assertTrue(ok, msg=str(errors))
+
+    def test_static_floor_below_min_fails(self):
+        self._bad(static_floor=MIN_STATIC_FLOOR - 1)
+
+    def test_static_floor_above_confidence_floor_content_fails(self):
+        ok, errors = validate_eligibility_config(opt(cfc=8, static_floor=9))
+        self.assertFalse(ok)
+        self.assertTrue(any("confidence_floor_content" in e for e in errors))
+
+    def test_static_floor_at_min_boundary_valid(self):
+        ok, _ = validate_eligibility_config(opt(cfc=8, static_floor=MIN_STATIC_FLOOR))
+        self.assertTrue(ok)
+
+    def test_static_floor_equal_cfc_valid(self):
+        ok, _ = validate_eligibility_config(opt(cfc=6, static_floor=6))
+        self.assertTrue(ok)
+
+    def test_static_floor_non_int_fails(self):
+        self._bad(static_floor=5.0)
+
+    def test_static_floor_bool_fails(self):
+        # bool is an int subclass; must be rejected as a static_floor.
+        self._bad(static_floor=True)
+
+    def test_weights_sum_not_one_fails(self):
+        self._bad(weights={"confidence": 0.3, "prevalence": 0.3, "recency": 0.3, "novelty": 0.3})
+
+    def test_weights_sum_within_tolerance_valid(self):
+        ok, _ = validate_eligibility_config(
+            opt(weights={"confidence": 0.4005, "prevalence": 0.2995, "recency": 0.2, "novelty": 0.1})
+        )
+        self.assertTrue(ok)
+
+    def test_weights_stray_type_prior_key_fails(self):
+        errors = self._bad(weights={"confidence": 0.4, "prevalence": 0.3, "recency": 0.2,
+                                    "novelty": 0.05, "type_prior": 0.05})
+        self.assertTrue(any("weights keys" in e for e in errors))
+
+    def test_weights_missing_key_fails(self):
+        self._bad(weights={"confidence": 0.5, "prevalence": 0.3, "recency": 0.2})
+
+    def test_weights_negative_fails(self):
+        self._bad(weights={"confidence": -0.1, "prevalence": 0.4, "recency": 0.4, "novelty": 0.3})
+
+    def test_weights_non_number_fails(self):
+        self._bad(weights={"confidence": "x", "prevalence": 0.3, "recency": 0.2, "novelty": 0.1})
+
+    def test_weights_bool_value_fails(self):
+        self._bad(weights={"confidence": True, "prevalence": 0.3, "recency": 0.2, "novelty": 0.1})
+
+    def test_weights_not_a_dict_fails(self):
+        self._bad(weights=[0.4, 0.3, 0.2, 0.1])
+
+    def test_threshold_out_of_range_fails(self):
+        self._bad(threshold=1.5)
+
+    def test_threshold_non_number_fails(self):
+        self._bad(threshold="high")
+
+    def test_threshold_boundary_zero_and_one_valid(self):
+        self.assertTrue(validate_eligibility_config(opt(threshold=0.0))[0])
+        self.assertTrue(validate_eligibility_config(opt(threshold=1.0))[0])
+
+    def test_excerpt_match_min_out_of_range_fails(self):
+        self._bad(excerpt_match_min=1.2)
+
+    def test_excerpt_match_min_non_number_fails(self):
+        self._bad(excerpt_match_min=None)
+
+    def test_prevalence_cap_below_one_fails(self):
+        self._bad(prevalence_cap=0)
+
+    def test_prevalence_cap_non_int_fails(self):
+        self._bad(prevalence_cap=4.0)
+
+    def test_prevalence_cap_user_corrected_below_one_fails(self):
+        self._bad(prevalence_cap_user_corrected=0)
+
+    def test_prevalence_cap_user_corrected_non_int_fails(self):
+        self._bad(prevalence_cap_user_corrected="1")
+
+    def test_half_life_non_positive_fails(self):
+        self._bad(recency_half_life_days=0)
+        self._bad(recency_half_life_days=-5)
+
+    def test_half_life_non_number_fails(self):
+        self._bad(recency_half_life_days="30")
+
+    def test_max_transcript_bytes_too_small_fails(self):
+        self._bad(max_transcript_bytes=999_999)
+
+    def test_max_transcript_bytes_non_int_fails(self):
+        self._bad(max_transcript_bytes=5.0e7)
+
+    def test_enabled_non_bool_fails(self):
+        self._bad(enabled="yes")
+
+    def test_legacy_floor_admits_non_bool_fails(self):
+        self._bad(legacy_floor_admits=1)
+
+    def test_confidence_floor_content_missing_fails(self):
+        o = opt()
+        del o["confidence_floor_content"]
+        ok, errors = validate_eligibility_config(o)
+        self.assertFalse(ok)
+        self.assertTrue(any("confidence_floor_content" in e for e in errors))
+
+    def test_confidence_floor_content_non_int_fails(self):
+        o = opt()
+        o["confidence_floor_content"] = "8"
+        self.assertFalse(validate_eligibility_config(o)[0])
+
+    def test_eligibility_block_missing_fails(self):
+        ok, errors = validate_eligibility_config({"confidence_floor_content": 8, "add_min_sessions": 2})
+        self.assertFalse(ok)
+        self.assertTrue(any("eligibility block" in e for e in errors))
+
+    def test_eligibility_block_not_dict_fails(self):
+        self.assertFalse(validate_eligibility_config(
+            {"confidence_floor_content": 8, "eligibility": []})[0])
+
+    def test_optimistic_not_dict_fails(self):
+        ok, errors = validate_eligibility_config(["not", "a", "dict"])
+        self.assertFalse(ok)
+        self.assertTrue(errors)
+
+
+# ---------------------------------------------------------------------------
+# similarity / normalization pins
+# ---------------------------------------------------------------------------
+
+
+class SimilarityTests(unittest.TestCase):
+    def test_normalize_strips_neutralized_wrappers(self):
+        self.assertEqual(normalize_content("[neutralized]drop tables[/neutralized]"), "drop tables")
+
+    def test_normalize_lowercases_and_collapses_whitespace(self):
+        self.assertEqual(normalize_content("  Hello   WORLD \n Foo\t"), "hello world foo")
+
+    def test_normalize_empty(self):
+        self.assertEqual(normalize_content(""), "")
+        self.assertEqual(normalize_content("   "), "")
+
+    def test_similarity_identical_is_one(self):
+        self.assertEqual(similarity("hello world", "hello world"), 1.0)
+
+    def test_similarity_neutralized_wrapper_matches_raw(self):
+        # Stripping the wrapper before comparison -> identical to the raw text.
+        self.assertEqual(
+            similarity("[neutralized]foo bar baz[/neutralized]", "foo bar baz"), 1.0
+        )
+
+    def test_similarity_case_and_whitespace_insensitive(self):
+        self.assertEqual(similarity("Foo   Bar", "foo bar"), 1.0)
+
+    def test_similarity_disjoint_is_low(self):
+        self.assertLess(similarity("aaaaa", "bbbbb"), 0.5)
+
+    def test_token_jaccard_half(self):
+        # {quick,brown,fox} vs {quick,brown,cat} -> 2/4 = 0.5
+        self.assertEqual(token_jaccard("quick brown fox", "quick brown cat"), 0.5)
+
+    def test_token_jaccard_stop_words_ignored(self):
+        # "the cat" vs "a cat" -> both reduce to {cat} -> 1.0
+        self.assertEqual(token_jaccard("the cat", "a cat"), 1.0)
+
+    def test_token_jaccard_both_empty_is_one(self):
+        self.assertEqual(token_jaccard("", ""), 1.0)
+
+    def test_token_jaccard_empty_vs_nonempty_is_zero(self):
+        self.assertEqual(token_jaccard("", "cat dog"), 0.0)
+
+    def test_similarity_is_max_of_arms(self):
+        # Reordered tokens: SequenceMatcher.ratio drops but jaccard stays 1.0,
+        # so the max is 1.0.
+        self.assertEqual(similarity("alpha beta gamma", "gamma beta alpha"), 1.0)
+
+    def test_novelty_empty_store_is_one(self):
+        self.assertEqual(novelty_vs("anything at all", []), 1.0)
+
+    def test_novelty_identical_head_is_zero(self):
+        self.assertEqual(novelty_vs("same content here", ["same content here"]), 0.0)
+
+    def test_novelty_takes_max_similarity(self):
+        # Nearest head is identical -> novelty 0 regardless of other far heads.
+        nov = novelty_vs("target text", ["totally unrelated", "target text", "nope"])
+        self.assertEqual(nov, 0.0)
+
+    def test_novelty_partial(self):
+        nov = novelty_vs("quick brown fox", ["quick brown cat"])
+        # 1 - max(ratio, 0.5); both < 1 -> novelty strictly between 0 and 1.
+        self.assertGreater(nov, 0.0)
+        self.assertLess(nov, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Frozen dataclasses
+# ---------------------------------------------------------------------------
+
+
+class FrozenDataclassTests(unittest.TestCase):
+    def test_signal_bundle_frozen(self):
+        b = bundle()
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            b.confidence = 10  # type: ignore[misc]
+
+    def test_eligibility_decision_frozen(self):
+        d = evaluate_eligibility(bundle(), opt())
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            d.eligible = False  # type: ignore[misc]
+
+    def test_signal_bundle_is_dataclass(self):
+        self.assertTrue(dataclasses.is_dataclass(SignalBundle))
+        params = SignalBundle.__dataclass_params__
+        self.assertTrue(params.frozen)
+
+    def test_decision_field_names_frozen_contract(self):
+        # E3 imports these verbatim -- guard the names.
+        names = {f.name for f in dataclasses.fields(EligibilityDecision)}
+        self.assertEqual(
+            names,
+            {"eligible", "outcome", "decision_basis", "score", "threshold",
+             "margin", "signals", "weakest_signal"},
+        )
+
+    def test_bundle_field_names_frozen_contract(self):
+        names = {f.name for f in dataclasses.fields(SignalBundle)}
+        self.assertEqual(
+            names,
+            {"kind", "confidence", "verified_sessions", "evidence_tier",
+             "newest_evidence_age_days", "novelty"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# weakest_signal + outcome-string stability
+# ---------------------------------------------------------------------------
+
+
+class WeakestSignalTests(unittest.TestCase):
+    def test_weakest_is_lowest_normalized_signal(self):
+        b = bundle(kind="learning_supersede", confidence=6, verified_sessions=2,
+                   evidence_tier="inferred", newest_evidence_age_days=5.0, novelty=0.05)
+        d = evaluate_eligibility(b, opt())
+        self.assertEqual(d.weakest_signal, "novelty")
+
+    def test_weakest_tie_break_is_canonical_order(self):
+        # conf̂=.60 and nov̂=.60 tie for the min; canonical order picks confidence.
+        b = bundle(kind="learning_add", confidence=6, verified_sessions=1,
+                   evidence_tier="user-corrected", newest_evidence_age_days=2.0, novelty=0.6)
+        d = evaluate_eligibility(b, opt())
+        self.assertEqual(d.weakest_signal, "confidence")
+
+    def test_outcome_strings_are_the_stable_set(self):
+        outcomes = set()
+        outcomes.add(evaluate_eligibility(bundle(confidence=3), opt()).outcome)  # floor
+        outcomes.add(evaluate_eligibility(
+            bundle(kind="learning_add", confidence=6, verified_sessions=1, evidence_tier="inferred"),
+            opt()).outcome)  # origin
+        outcomes.add(evaluate_eligibility(
+            bundle(kind="learning_add", confidence=5, verified_sessions=2, evidence_tier="inferred",
+                   newest_evidence_age_days=60.0, novelty=0.1), opt()).outcome)  # composite reject
+        outcomes.add(evaluate_eligibility(
+            bundle(kind="learning_add", confidence=6, verified_sessions=1, evidence_tier="user-corrected",
+                   newest_evidence_age_days=2.0, novelty=0.6), opt()).outcome)  # eligible
+        self.assertEqual(outcomes, {"skipped_floor", "skipped_origin", "skipped_composite", "eligible"})
+
+    def test_decision_basis_values(self):
+        legacy = evaluate_eligibility(
+            bundle(kind="learning_supersede", confidence=8, verified_sessions=0, evidence_tier="inferred"),
+            opt())
+        composite = evaluate_eligibility(
+            bundle(kind="learning_add", confidence=6, verified_sessions=1, evidence_tier="user-corrected",
+                   newest_evidence_age_days=2.0, novelty=0.6), opt())
+        floor = evaluate_eligibility(bundle(confidence=3), opt())
+        self.assertEqual(legacy.decision_basis, "legacy_floor")
+        self.assertEqual(composite.decision_basis, "composite")
+        self.assertIsNone(floor.decision_basis)
+
+
+# ---------------------------------------------------------------------------
+# AST purity + no-broad-except lints (HARD INVARIANT enforcement)
+# ---------------------------------------------------------------------------
+
+
+class PurityTests(unittest.TestCase):
+    ALLOWED_IMPORTS = {"__future__", "dataclasses", "math", "difflib", "re", "typing"}
+
+    def _tree(self):
+        return ast.parse(ELIGIBILITY_SRC.read_text(encoding="utf-8"))
+
+    def test_only_allowed_stdlib_imports(self):
+        tree = self._tree()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    top = alias.name.split(".")[0]
+                    self.assertIn(top, self.ALLOWED_IMPORTS,
+                                  msg=f"disallowed import: {alias.name}")
+            elif isinstance(node, ast.ImportFrom):
+                # relative imports (node.level > 0) would reach into the package
+                # -- forbidden for a pure module.
+                self.assertEqual(node.level, 0, msg="relative import forbidden in pure core")
+                top = (node.module or "").split(".")[0]
+                self.assertIn(top, self.ALLOWED_IMPORTS,
+                              msg=f"disallowed from-import: {node.module}")
+
+    def test_no_dynamic_io_calls(self):
+        # AST-level (not substring, so docstrings are ignored): the pure core
+        # must not reach I/O dynamically either -- no open()/eval()/exec()/
+        # compile()/__import__() call escapes the import allowlist.
+        tree = self._tree()
+        banned_calls = {"open", "eval", "exec", "compile", "__import__"}
+        offenders = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id in banned_calls:
+                    offenders.append(node.func.id)
+            # Attribute access on a banned I/O root (os.*, subprocess.*, ...);
+            # unreachable without an import (guarded above) but asserted anyway.
+            if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+                if node.value.id in {"os", "subprocess", "socket", "urllib", "pathlib", "shutil"}:
+                    offenders.append(f"{node.value.id}.{node.attr}")
+        self.assertEqual(offenders, [], msg=f"pure core reaches I/O: {offenders}")
+
+    def test_no_broad_except_returning_nonzero(self):
+        # decisions.md #23: no signal computation may catch an exception and
+        # return a non-zero default. Flag any except-handler whose body returns
+        # a truthy/nonzero constant.
+        tree = self._tree()
+        violations = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ExceptHandler):
+                continue
+            for child in ast.walk(node):
+                if isinstance(child, ast.Return) and isinstance(child.value, ast.Constant):
+                    val = child.value.value
+                    if isinstance(val, (int, float)) and not isinstance(val, bool) and val != 0:
+                        violations.append(ast.dump(child))
+                    elif val not in (None, 0, 0.0, False):
+                        violations.append(ast.dump(child))
+        self.assertEqual(violations, [], msg=f"broad-except nonzero returns: {violations}")
+
+    def test_module_has_no_try_blocks(self):
+        # Stronger than the spec: the pure core contains no try/except at all,
+        # so a signal error propagates rather than being swallowed.
+        tree = self._tree()
+        self.assertEqual([n for n in ast.walk(tree) if isinstance(n, ast.Try)], [])
+
+    def test_min_static_floor_is_four(self):
+        self.assertEqual(MIN_STATIC_FLOOR, 4)
+
+    def test_default_weights_sum_to_one(self):
+        self.assertAlmostEqual(sum(DEFAULT_ELIGIBILITY["weights"].values()), 1.0, places=9)
+
+    def test_default_config_is_valid_and_disabled(self):
+        self.assertFalse(DEFAULT_ELIGIBILITY["enabled"])
+        ok, errors = validate_eligibility_config(opt())
+        self.assertTrue(ok, msg=str(errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/dreaming/tests/test_eligibility.py
+++ b/modules/dreaming/tests/test_eligibility.py
@@ -34,6 +34,7 @@ from eligibility import (  # noqa: E402
     EligibilityDecision,
     SignalBundle,
     composite_score,
+    default_eligibility,
     evaluate_eligibility,
     normalize_content,
     novelty_vs,
@@ -322,6 +323,58 @@ class MonotonicityTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Recency clamp — negative / extreme evidence age (B1 fail-open regression)
+# ---------------------------------------------------------------------------
+
+
+class RecencyClampTests(unittest.TestCase):
+    def test_negative_age_recency_clamps_to_one(self):
+        # B1: a future-dated (negative-age) timestamp must not score reĉ > 1.
+        _, sig = composite_score(bundle(newest_evidence_age_days=-30.0), DEFAULT_ELIGIBILITY)
+        self.assertEqual(sig["recency"], 1.0)
+        s, _ = composite_score(bundle(newest_evidence_age_days=-30.0), DEFAULT_ELIGIBILITY)
+        self.assertLessEqual(s, 1.0)
+
+    def test_future_dated_attack_now_skips_composite(self):
+        # The exact reproduced B1 attack: pre-clamp this scored S=1.16 -> ELIGIBLE
+        # (fail-open); the age=+60 twin is §3.9 case (e) at S=0.410 (skipped).
+        # With the clamp, reĉ saturates at 1.0 and
+        # S = .40*.5 + .30*.5 + .20*1.0 + .10*.1 = .560 < .58 -> skipped_composite.
+        b = bundle(kind="learning_add", confidence=5, verified_sessions=2,
+                   evidence_tier="inferred", newest_evidence_age_days=-60.0, novelty=0.1)
+        s, sig = composite_score(b, DEFAULT_ELIGIBILITY)
+        self.assertEqual(sig["recency"], 1.0)
+        self.assertEqual(round(s, 3), 0.560)
+        d = evaluate_eligibility(b, opt())
+        self.assertFalse(d.eligible)
+        self.assertEqual(d.outcome, "skipped_composite")
+
+    def test_all_signals_and_score_bounded_over_extreme_ages(self):
+        # Property sweep: across an age grid that spans future-dated, zero,
+        # huge, and infinite ages AND extreme (out-of-range) signal inputs,
+        # every emitted signal and the score stay in [0, 1]. (NaN age is
+        # excluded by design — it fails closed to S=NaN, not into [0,1].)
+        ages = (-1e9, -1.0, 0.0, 1.0, 1e9, float("inf"))
+        for kind in ("learning_add", "learning_supersede"):
+            for conf in (-5, 0, 5, 10, 99):
+                for vs in (-1, 0, 2, 99):
+                    for tier in ("inferred", "user-corrected"):
+                        for nov in (-1.0, 0.0, 0.5, 1.0, 5.0):
+                            for age in ages:
+                                b = bundle(kind=kind, confidence=conf, verified_sessions=vs,
+                                           evidence_tier=tier, newest_evidence_age_days=age,
+                                           novelty=nov)
+                                s, sig = composite_score(b, DEFAULT_ELIGIBILITY)
+                                ctx = (f"kind={kind} conf={conf} vs={vs} tier={tier} "
+                                       f"nov={nov} age={age}")
+                                for name, val in sig.items():
+                                    self.assertGreaterEqual(val, 0.0, msg=f"{name} {ctx}")
+                                    self.assertLessEqual(val, 1.0, msg=f"{name} {ctx}")
+                                self.assertGreaterEqual(s, 0.0, msg=ctx)
+                                self.assertLessEqual(s, 1.0, msg=ctx)
+
+
+# ---------------------------------------------------------------------------
 # Origin gate non-compensability (property sweep)
 # ---------------------------------------------------------------------------
 
@@ -416,6 +469,40 @@ class LegacyEscapeTests(unittest.TestCase):
         b = bundle(kind="learning_supersede", confidence=9, verified_sessions=0, evidence_tier="inferred")
         self.assertTrue(evaluate_eligibility(b, opt()).eligible)  # legacy on admits
         self.assertEqual(evaluate_eligibility(b, opt(legacy_floor_admits=False)).outcome, "skipped_origin")
+
+
+# ---------------------------------------------------------------------------
+# Unknown-kind guard (R1 — fail closed on unroutable kinds)
+# ---------------------------------------------------------------------------
+
+
+class UnknownKindGuardTests(unittest.TestCase):
+    def _maxed(self, kind):
+        # Maxed signals: if a kind slipped through, this would be ELIGIBLE.
+        return bundle(kind=kind, confidence=10, verified_sessions=9,
+                      evidence_tier="user-corrected", newest_evidence_age_days=0.0, novelty=1.0)
+
+    def test_learning_verify_raises_even_with_maxed_signals(self):
+        with self.assertRaises(ValueError):
+            evaluate_eligibility(self._maxed("learning_verify"), opt())
+
+    def test_learning_contradict_raises_even_with_maxed_signals(self):
+        with self.assertRaises(ValueError):
+            evaluate_eligibility(self._maxed("learning_contradict"), opt())
+
+    def test_garbage_kind_raises_even_with_maxed_signals(self):
+        with self.assertRaises(ValueError):
+            evaluate_eligibility(self._maxed("totally_bogus"), opt())
+
+    def test_valueerror_names_the_offending_kind(self):
+        with self.assertRaises(ValueError) as cm:
+            evaluate_eligibility(self._maxed("learning_verify"), opt())
+        self.assertIn("learning_verify", str(cm.exception))
+
+    def test_routable_kinds_do_not_raise(self):
+        for kind in ("learning_add", "learning_supersede"):
+            # Should evaluate without raising (verdict itself is not asserted here).
+            evaluate_eligibility(self._maxed(kind), opt())
 
 
 # ---------------------------------------------------------------------------
@@ -564,6 +651,32 @@ class ValidateConfigTests(unittest.TestCase):
         ok, errors = validate_eligibility_config(["not", "a", "dict"])
         self.assertFalse(ok)
         self.assertTrue(errors)
+
+
+# ---------------------------------------------------------------------------
+# default_eligibility() factory (R2 — no shared-nested-weights aliasing)
+# ---------------------------------------------------------------------------
+
+
+class DefaultEligibilityFactoryTests(unittest.TestCase):
+    def test_factory_equals_constant_by_value(self):
+        self.assertEqual(default_eligibility(), DEFAULT_ELIGIBILITY)
+
+    def test_factory_mutation_does_not_corrupt_constant(self):
+        f = default_eligibility()
+        f["weights"]["confidence"] = 0.99
+        self.assertEqual(DEFAULT_ELIGIBILITY["weights"]["confidence"], 0.40)
+
+    def test_two_factory_calls_do_not_alias(self):
+        a = default_eligibility()
+        b = default_eligibility()
+        a["weights"]["recency"] = 0.99
+        self.assertEqual(b["weights"]["recency"], 0.20)
+        a["threshold"] = 0.1
+        self.assertNotEqual(b["threshold"], 0.1)
+
+    def test_factory_weights_is_not_the_constant_weights_object(self):
+        self.assertIsNot(default_eligibility()["weights"], DEFAULT_ELIGIBILITY["weights"])
 
 
 # ---------------------------------------------------------------------------
@@ -725,6 +838,11 @@ class WeakestSignalTests(unittest.TestCase):
 
 
 class PurityTests(unittest.TestCase):
+    # The §3.5 permitted stdlib set, NOT the set actually imported. The module
+    # imports only re/dataclasses/difflib/__future__ (math and typing are
+    # allowed-but-unused). This is intentionally a superset so a future pure
+    # helper may reach for math/typing without a lint change; the AST test only
+    # rejects imports OUTSIDE this permitted set.
     ALLOWED_IMPORTS = {"__future__", "dataclasses", "math", "difflib", "re", "typing"}
 
     def _tree(self):

--- a/modules/dreaming/tests/transcript_fixtures.py
+++ b/modules/dreaming/tests/transcript_fixtures.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Synthetic Claude Code transcript JSONL builders for the dreaming tests.
+
+Every later composite-eligibility epic (E2 miner origin-fix, E3 session
+verification / tier re-mining) needs synthetic transcripts whose *shape*
+``transcript_miner.mine()`` actually parses. This module builds those shapes
+programmatically instead of hand-authoring brittle JSONL blobs.
+
+Everything here is 100% synthetic: default cwd is a fake
+``/Users/testuser/code/example`` -- never a real username, path, or captured
+transcript (public-repo rule, plan.md §1.4).
+
+The line shapes match what ``transcript_miner.mine()`` reads at anchor
+(``transcript_miner.py`` line-by-line ``obj`` handling):
+  * top-level keys ``type``, ``sessionId``, ``uuid``, ``parentUuid``,
+    ``timestamp``, ``cwd``, ``gitBranch``, ``version``;
+  * ``message.role`` / ``message.content`` (a list of typed blocks);
+  * assistant ``tool_use`` blocks (with ``message.usage`` token counts);
+  * user ``tool_result`` blocks with ``is_error`` (+ optional
+    ``toolUseResult.exit_code``) -> the miner's friction events;
+  * a human "typed" user turn carries the origin markers Epic 2 filters on
+    (``origin.kind == "human"`` and/or ``promptSource == "typed"``) that the
+    miner does not read today; a ``tool_result`` turn deliberately omits them
+    so the origin filter can distinguish real human corrections from synthetic
+    tool-result echoes.
+
+Turn builders return partial dicts (no session/cwd/uuid/timestamp);
+:func:`build_transcript` wires those in and returns the full line-object list,
+and :func:`write_transcript` serializes it to a ``.jsonl`` path.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+DEFAULT_CWD = "/Users/testuser/code/example"
+DEFAULT_SESSION_ID = "fixture-session-0001"
+DEFAULT_GIT_BRANCH = "main"
+DEFAULT_VERSION = "2.1.198"
+DEFAULT_BASE_TS = "2026-01-03T14:00:00.000Z"
+DEFAULT_TS_STEP_SECONDS = 2
+
+
+def iso(dt: datetime) -> str:
+    """Render a datetime as the millisecond-precision UTC ISO string the
+    transcript format uses (``...Z`` suffix)."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S") + f".{dt.microsecond // 1000:03d}Z"
+
+
+def _parse_iso(ts: str) -> datetime:
+    # Accept the "...Z" and millisecond forms this module emits.
+    cleaned = ts.replace("Z", "+00:00")
+    return datetime.fromisoformat(cleaned)
+
+
+# ---------------------------------------------------------------------------
+# Turn builders (partial dicts; assembled by build_transcript)
+# ---------------------------------------------------------------------------
+
+
+def user_turn(
+    text: str,
+    *,
+    human: bool = True,
+    prompt_source: str | None = None,
+    origin_kind: str | None = None,
+    ts: str | None = None,
+) -> dict:
+    """A ``type: "user"`` prose turn.
+
+    ``human=True`` (default) marks the turn as operator-typed by attaching
+    BOTH origin markers Epic 2 filters on: ``promptSource == "typed"`` and
+    ``origin.kind == "human"``. Override ``prompt_source`` / ``origin_kind``
+    explicitly to build the single-marker or missing-marker (fail-closed)
+    variants Epic 2's tests need; passing ``human=False`` with neither
+    override yields a user turn carrying NO origin markers.
+    """
+    if human:
+        ps = "typed" if prompt_source is None else prompt_source
+        ok = "human" if origin_kind is None else origin_kind
+    else:
+        ps = prompt_source
+        ok = origin_kind
+    turn: dict = {
+        "type": "user",
+        "text": text,
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+    if ps is not None:
+        turn["promptSource"] = ps
+    if ok is not None:
+        turn["origin"] = {"kind": ok}
+    if ts is not None:
+        turn["timestamp"] = ts
+    return turn
+
+
+def assistant_turn(
+    text: str = "",
+    *,
+    tool_uses: list | None = None,
+    usage: dict | None = None,
+    ts: str | None = None,
+) -> dict:
+    """A ``type: "assistant"`` turn, optionally emitting ``tool_use`` blocks.
+
+    ``tool_uses`` is a list of dicts ``{"id", "name", "input"}`` (``id`` and
+    ``name`` default to ``tool_1`` / ``Bash``); each becomes a ``tool_use``
+    content block a later ``tool_result`` turn can reference by id. ``usage``
+    overrides the default token-count block the miner reads.
+    """
+    content: list = []
+    if text:
+        content.append({"type": "text", "text": text})
+    for i, tu in enumerate(tool_uses or [], start=1):
+        content.append(
+            {
+                "type": "tool_use",
+                "id": tu.get("id", f"tool_{i}"),
+                "name": tu.get("name", "Bash"),
+                "input": tu.get("input", {}),
+            }
+        )
+    if usage is None:
+        usage = {
+            "input_tokens": 300,
+            "output_tokens": 40,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 250,
+        }
+    turn: dict = {
+        "type": "assistant",
+        "text": text,
+        "message": {"role": "assistant", "model": "claude-fixture-1", "content": content, "usage": usage},
+    }
+    if ts is not None:
+        turn["timestamp"] = ts
+    return turn
+
+
+def tool_result_turn(
+    *,
+    tool_use_id: str = "tool_1",
+    content: str = "",
+    is_error: bool = False,
+    exit_code: int | None = None,
+    ts: str | None = None,
+) -> dict:
+    """A ``type: "user"`` turn carrying a ``tool_result`` block.
+
+    This is NOT a human-typed turn: it deliberately omits origin markers, so
+    Epic 2's origin filter treats a negation phrase appearing here (e.g. in
+    echoed command output) as a non-correction. Set ``is_error=True`` and/or a
+    non-zero ``exit_code`` to make the miner record a friction event for it.
+    """
+    block: dict = {"type": "tool_result", "tool_use_id": tool_use_id, "content": content}
+    if is_error:
+        block["is_error"] = True
+    turn: dict = {
+        "type": "user",
+        "text": content,
+        "message": {"role": "user", "content": [block]},
+    }
+    if exit_code is not None:
+        turn["toolUseResult"] = {"exit_code": exit_code}
+    if ts is not None:
+        turn["timestamp"] = ts
+    return turn
+
+
+def friction_turn(
+    *,
+    tool_use_id: str = "tool_1",
+    content: str = "command failed",
+    exit_code: int = 1,
+    ts: str | None = None,
+) -> dict:
+    """Convenience: a ``tool_result`` turn that the miner records as a
+    ``tool_error`` friction event (``is_error`` + non-zero ``exit_code``)."""
+    return tool_result_turn(
+        tool_use_id=tool_use_id,
+        content=content,
+        is_error=True,
+        exit_code=exit_code,
+        ts=ts,
+    )
+
+
+def correction_sequence(
+    *,
+    request: str = "Reformat the config file to use tabs.",
+    correction: str = "No, that's wrong, please revert that change entirely.",
+    command: str = "sed -i 's/    /\\t/g' config.yaml",
+    error: str = "sed: -i may not be used with stdin",
+    tool_use_id: str = "tool_1",
+    human_correction: bool = True,
+) -> list:
+    """A four-turn friction-then-correction sequence the miner mines into a
+    ``user_correction``.
+
+    Order: human request -> assistant tool_use -> tool_result error (friction)
+    -> human correction (carrying a NEGATION_PHRASES match). ``correction``
+    must contain a miner negation phrase (e.g. "that's wrong", "revert that")
+    to be extracted. ``human_correction=False`` builds the sec-C1 regression
+    shape: the negation phrase lands in a NON-human turn so the origin filter
+    (Epic 2) drops it.
+    """
+    return [
+        user_turn(request, human=True),
+        assistant_turn(
+            "Working on it.",
+            tool_uses=[{"id": tool_use_id, "name": "Bash", "input": {"command": command}}],
+        ),
+        friction_turn(tool_use_id=tool_use_id, content=error, exit_code=1),
+        user_turn(correction, human=human_correction),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Assembly + serialization
+# ---------------------------------------------------------------------------
+
+
+def build_transcript(
+    turns: list,
+    *,
+    session_id: str = DEFAULT_SESSION_ID,
+    cwd: str = DEFAULT_CWD,
+    git_branch: str = DEFAULT_GIT_BRANCH,
+    version: str = DEFAULT_VERSION,
+    base_ts: str = DEFAULT_BASE_TS,
+    ts_step_seconds: int = DEFAULT_TS_STEP_SECONDS,
+) -> list:
+    """Wire per-line identity/metadata onto a list of turn dicts.
+
+    Fills ``sessionId``, ``cwd``, ``gitBranch``, ``version``, a sequential
+    ``uuid``/``parentUuid`` chain, and a ``timestamp`` for any turn that did
+    not set one (``base_ts`` + ``ts_step_seconds`` per turn). Turn-level
+    ``timestamp`` and ``cwd`` overrides are preserved, so a test can embed
+    arbitrary per-line timestamps (recency) or a per-turn cwd (slug mismatch).
+    The internal ``text`` helper key is stripped from the emitted objects.
+    """
+    base = _parse_iso(base_ts)
+    lines: list = []
+    prev_uuid: str | None = None
+    for i, turn in enumerate(turns):
+        obj = {k: v for k, v in turn.items() if k != "text"}
+        obj.setdefault("sessionId", session_id)
+        obj.setdefault("cwd", cwd)
+        obj.setdefault("gitBranch", git_branch)
+        obj.setdefault("version", version)
+        obj.setdefault("uuid", f"u{i}")
+        obj["parentUuid"] = prev_uuid
+        if "timestamp" not in obj:
+            obj["timestamp"] = iso(base + timedelta(seconds=ts_step_seconds * i))
+        # Move type/sessionId/uuid to a stable leading order for readability;
+        # JSON object key order does not affect the miner, but stable output
+        # keeps fixtures diff-friendly.
+        lines.append(obj)
+        prev_uuid = obj["uuid"]
+    return lines
+
+
+def to_jsonl(lines: list) -> str:
+    """Serialize built line objects to newline-delimited JSON text."""
+    return "\n".join(json.dumps(obj, ensure_ascii=False) for obj in lines) + "\n"
+
+
+def write_transcript(path: str | Path, turns: list, **kwargs) -> Path:
+    """Build (via :func:`build_transcript`) and write a transcript to ``path``.
+
+    Extra keyword args are forwarded to :func:`build_transcript` (session_id,
+    cwd, base_ts, ...). Returns the ``Path`` written.
+    """
+    lines = build_transcript(turns, **kwargs)
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(to_jsonl(lines), encoding="utf-8")
+    return p


### PR DESCRIPTION
## Summary

Epic E1 of the composite-eligibility plan: the pure, deterministic scoring core `eligibility.py`, its exhaustive unit tests, and the shared synthetic-transcript fixture builder every later epic's tests will use. Three new files, **no existing file modified** (config-wiring / registration belong to E2+).

`eligibility.py` is the deterministic heart of the composite gate (plan.md §3.5): scalars in (`SignalBundle`) → decision out (`EligibilityDecision`). It performs no I/O and imports nothing beyond stdlib `dataclasses`/`difflib`/`re` — the HARD INVARIANT ("model proposes, deterministic rails decide") is enforced here by an AST test.

## Changes

- **`modules/dreaming/lib/eligibility.py`** — the §3.5 contract verbatim:
  - Frozen dataclasses `SignalBundle` + `EligibilityDecision` (field names frozen for E3).
  - `MIN_STATIC_FLOOR = 4`; `DEFAULT_ELIGIBILITY` (E1 is the single owner of the §3.6 config block — E2 imports/seeds it).
  - `validate_eligibility_config(optimistic) -> (bool, list)` — fail-closed, cross-field `MIN_STATIC_FLOOR <= static_floor <= confidence_floor_content`, weights keys exactly `{confidence, prevalence, recency, novelty}` (a stray `type_prior` fails loudly), sum = 1 ± 0.001.
  - `composite_score(bundle, elig_cfg)` — 4-signal blend `{conf .40, prev .30, rec .20, nov .10}`, `type` is not a scoring input (decisions.md #38).
  - `evaluate_eligibility(bundle, optimistic)` — waterfall steps 2/4/5/6 (static floor → per-kind legacy escape → non-compensatory origin gate → composite ≥ θ).
  - Pure text helpers `similarity()` = `max(SequenceMatcher.ratio, token_jaccard)`, §3.3 normalization (lowercase, collapse whitespace, strip `[neutralized]` wrappers, `\w+` tokens minus a small stop set), plus `novelty_vs()` for the gatherer's empty-store-→-1.0 semantics.
  - Recency docstring states the two-clocks distinction (evidence age HL 30d vs store read-time decay HL 90d — decisions.md #14). No `try`/`except` anywhere; a signal that cannot be computed returns 0, never a 0.5 default (decisions.md #23).
- **`modules/dreaming/tests/test_eligibility.py`** — 109 tests: all nine §3.9 worked cases pinned to exact 3-decimal S values `(a).791 (b).685 (d).599 (e).410 (h).573 (i).628`, `(c)`/`(f)` skip origin, `(g)` documented as never routed to the pure core; boundary pins (`conf == static_floor` reaches composite via strict `<`; `S == threshold` admits via `>=`); monotonicity sweeps + contribution bounds; origin-gate non-compensability property sweep; per-kind legacy escape (add needs floor AND sessions, supersede floor-only, `legacy_floor_admits=false` disables step 4); the full `validate_eligibility_config` matrix; AST purity + no-broad-except-returning-nonzero lints; frozen-dataclass assertions; similarity/normalization pins; unknown `evidence_tier` → treated as inferred (fail-closed).
- **`modules/dreaming/tests/transcript_fixtures.py`** — synthetic transcript JSONL builders (human-origin `origin.kind=="human"`/`promptSource=="typed"` turns, tool_result turns, friction events, correction sequences, configurable embedded timestamps/cwd). Shapes verified against the real `transcript_miner.mine()`; all cwds are synthetic (`/Users/testuser/code/example`).

Why: replaces the flat confidence floor with a deterministic composite that admits user-corrected / multi-session mid-confidence memories while keeping every new class harder to forge than the floor it replaces. E1 lands the pure core + test infra with zero behavioral change to the live pipeline (nothing imports `eligibility.py` yet).

## Test Plan

CI for these suites does not exist until a later epic, so this PR body is the evidence. All commands run fresh at `HEAD`:

```
$ python3 -m pytest modules/dreaming/tests/test_eligibility.py -q
........................................................................ [ 66%]
.....................................                                    [100%]
109 passed in 0.05s

$ python3 -m pytest modules/dreaming/tests/ modules/self-improving/tests/ -q
694 passed, 13 subtests passed in 18.95s

$ bash tests/test-no-personal-data.sh
=== CCGM Personal Data Check ===
Scanning for maintainer-specific identifiers (9 targets)...
Scanning whole repo for secret/PII shapes (test/fixture/audit dirs excluded)...
PASS: No personal data or secret/PII shapes found

$ bash tests/test-modules.sh
===================================
  Results: 1557 passed, 0 failed
===================================
```

The full-suite pass (694) proves no accidental breakage — this PR touches no existing file.

Closes #834
