### PR TITLE
#831: propagate structural-canary shape through analyzer, digest, and CI gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,22 @@ jobs:
             bash "$t"
           done
 
+      - name: Dreaming module tests (pytest + self-check + offline chain)
+        run: |
+          set -e
+          # System python3 on hosted runners is PEP 668 "externally
+          # managed" -- a venv sidesteps that entirely instead of gambling
+          # on --break-system-packages support across runner images.
+          python3 -m venv /tmp/ccgm-dreaming-test-venv
+          source /tmp/ccgm-dreaming-test-venv/bin/activate
+          python3 -m pip install --quiet pytest
+          python3 -m pytest modules/dreaming/tests/ -q
+          python3 modules/dreaming/lib/transcript_miner.py --self-check
+          CCGM_DREAMING_DIR=$(mktemp -d) CCGM_LEARNINGS_DIR=$(mktemp -d) \
+            bash modules/dreaming/bin/dream-daily.sh \
+              --offline modules/dreaming/tests/fixtures/offline-responses \
+              --force-day 2026-01-02
+
   test-macos:
     runs-on: macos-latest
     steps:
@@ -114,3 +130,19 @@ jobs:
             echo "=== Running $t ==="
             bash "$t"
           done
+
+      - name: Dreaming module tests (pytest + self-check + offline chain)
+        run: |
+          set -e
+          # System python3 on hosted runners is PEP 668 "externally
+          # managed" -- a venv sidesteps that entirely instead of gambling
+          # on --break-system-packages support across runner images.
+          python3 -m venv /tmp/ccgm-dreaming-test-venv
+          source /tmp/ccgm-dreaming-test-venv/bin/activate
+          python3 -m pip install --quiet pytest
+          python3 -m pytest modules/dreaming/tests/ -q
+          python3 modules/dreaming/lib/transcript_miner.py --self-check
+          CCGM_DREAMING_DIR=$(mktemp -d) CCGM_LEARNINGS_DIR=$(mktemp -d) \
+            bash modules/dreaming/bin/dream-daily.sh \
+              --offline modules/dreaming/tests/fixtures/offline-responses \
+              --force-day 2026-01-02

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,22 @@ jobs:
           done
 
       - name: Dreaming module tests (pytest + self-check + offline chain)
+        env:
+          # Some dreaming tests exercise real git repos via subprocess
+          # (ccgm-learnings-sync init, ad-hoc `git commit`) without an
+          # explicit env= override, so they inherit whatever identity is
+          # ambient. Every dev machine has a global git identity already
+          # configured; a fresh hosted runner has none, and its service
+          # account's blank GECOS name makes git's own auto-derived
+          # fallback fail with "empty ident name ... not allowed". Git
+          # env vars are the highest-priority identity source (override
+          # config files and any HOME redirection a test performs), so
+          # setting them here fixes every such call site without editing
+          # the test files themselves.
+          GIT_AUTHOR_NAME: CCGM CI
+          GIT_AUTHOR_EMAIL: ci@ccgm.invalid
+          GIT_COMMITTER_NAME: CCGM CI
+          GIT_COMMITTER_EMAIL: ci@ccgm.invalid
         run: |
           set -e
           # System python3 on hosted runners is PEP 668 "externally
@@ -132,6 +148,22 @@ jobs:
           done
 
       - name: Dreaming module tests (pytest + self-check + offline chain)
+        env:
+          # Some dreaming tests exercise real git repos via subprocess
+          # (ccgm-learnings-sync init, ad-hoc `git commit`) without an
+          # explicit env= override, so they inherit whatever identity is
+          # ambient. Every dev machine has a global git identity already
+          # configured; a fresh hosted runner has none, and its service
+          # account's blank GECOS name makes git's own auto-derived
+          # fallback fail with "empty ident name ... not allowed". Git
+          # env vars are the highest-priority identity source (override
+          # config files and any HOME redirection a test performs), so
+          # setting them here fixes every such call site without editing
+          # the test files themselves.
+          GIT_AUTHOR_NAME: CCGM CI
+          GIT_AUTHOR_EMAIL: ci@ccgm.invalid
+          GIT_COMMITTER_NAME: CCGM CI
+          GIT_COMMITTER_EMAIL: ci@ccgm.invalid
         run: |
           set -e
           # System python3 on hosted runners is PEP 668 "externally

--- a/modules/dreaming/bin/dream-digest.sh
+++ b/modules/dreaming/bin/dream-digest.sh
@@ -29,11 +29,11 @@
 #   - the DURABLE canary state (~/.claude/dreaming/state/canary.json),
 #     read unconditionally regardless of which date is being rendered: a
 #     loud banner when any schema_canary incident is still active, or when
-#     any untested transcript-schema version has been observed
-#     (adrev-014 + the #753 handoff note -- both signals must stay visible
-#     even if a human misses the exact day they first appeared, since
-#     Epic 6's dream-daily.sh chain is exit-tolerant and can swallow a
-#     non-zero exit silently).
+#     a reduce-phase parse failure is unresolved (adrev-014 + the #753
+#     handoff note -- both signals must stay visible even if a human
+#     misses the exact day they first appeared, since Epic 6's
+#     dream-daily.sh chain is exit-tolerant and can swallow a non-zero
+#     exit silently).
 #   - yesterday's proposals, tallied by status (accepted/auto_applied vs
 #     rejected) -- forward-compatible with Epic 6's /dream-apply, which is
 #     the only future writer of any status other than "pending".
@@ -149,7 +149,7 @@ yesterday_proposals = load_jsonl(os.environ["CCGM_DIGEST_YESTERDAY_PROPOSALS_FIL
 run_summary = load_json(os.environ["CCGM_DIGEST_RUN_SUMMARY_FILE"], None)
 canary = load_json(
     os.environ["CCGM_DIGEST_CANARY_FILE"],
-    {"active_incidents": {}, "untested_versions_observed": {}, "reduce_failures": {}},
+    {"active_incidents": {}, "reduce_failures": {}},
 )
 
 out = []
@@ -158,7 +158,6 @@ out.append("")
 
 # --- Durable canary banner (adrev-014 + #753 handoff) ----------------------
 active_incidents = canary.get("active_incidents") or {}
-untested_versions = canary.get("untested_versions_observed") or {}
 # Reduce-phase parse failures (#769 Stage-2 P1 #1): main() aborts without
 # writing proposals or advancing watermarks when the reduce model never
 # returns parseable JSON, even after the retry nudge. That abort is
@@ -167,7 +166,7 @@ untested_versions = canary.get("untested_versions_observed") or {}
 # durable file so it gets the same loud, persists-until-acknowledged
 # banner as a schema_canary incident.
 reduce_failures = canary.get("reduce_failures") or {}
-if active_incidents or untested_versions or reduce_failures:
+if active_incidents or reduce_failures:
     out.append("## ⚠️ Canary banner (durable — shown until acknowledged)")
     out.append("")
     if active_incidents:
@@ -175,12 +174,6 @@ if active_incidents or untested_versions or reduce_failures:
         out.append("")
         for slug, info in sorted(active_incidents.items()):
             out.append(f"- `{slug}` (first seen {info.get('date', '?')}): {info.get('detail', '')}")
-        out.append("")
-    if untested_versions:
-        out.append("**Untested transcript-schema versions observed:**")
-        out.append("")
-        for version, count in sorted(untested_versions.items()):
-            out.append(f"- `{version}` — {count} session(s)")
         out.append("")
     if reduce_failures:
         out.append("**Reduce-phase parse failures (mined evidence NOT consumed, watermark NOT advanced):**")

--- a/modules/dreaming/bin/dream-digest.sh
+++ b/modules/dreaming/bin/dream-digest.sh
@@ -104,7 +104,7 @@ from pathlib import Path
 
 # Render-time defense-in-depth for evidence excerpts (#769 Stage-2 P1 #2):
 # reuse the SAME sanitizer the write path already applies, via the
-# module's established cross-module import helper, rather than
+# established cross-module import helper, rather than
 # re-deriving the injection patterns here. See finalize_proposal() in
 # lib/dream_analyze.py for the write-path sanitization this backstops.
 sys.path.insert(0, os.path.join(os.environ["CCGM_DIGEST_MODULE_ROOT"], "lib"))
@@ -211,20 +211,20 @@ else:
 
 # --- Applied this run (auto) -- optimistic-memory plan.md Section 5 Epic 5.
 #
-# Epic 3's optimistic-integration engine writes status: "auto_applied" +
+# The Epic 3 optimistic-integration engine writes status: "auto_applied" +
 # batch_id + posture + (for dwell postures) dwell_until directly onto a
-# proposal row (apply_dream_proposal.py's apply_proposal()). The nightly
+# proposal row (apply_proposal() in apply_dream_proposal.py). The nightly
 # chain runs optimistic-integrate BEFORE this digest (dream-daily.sh), so
-# TODAY's own proposals file always carries the batch this section
+# the proposals file for TODAY always carries the batch this section
 # reports, with its dwell window still entirely ahead of it.
 #
 # "Already surfaced" dedup (plan.md: "the report shows a batch once, in
 # the report for its own day"): a marker file per batch_id
 # (state/surfaced/<batch_id>.json) is checked before rendering and written
 # after. This is the ONLY dedup mechanism -- there is no separate
-# same-day-vs-later-day special case: re-rendering the SAME day's digest a
-# second time (nothing new happened) and a batch_id that (defensively)
-# resurfaces in a LATER day's file are handled identically -- once a batch
+# same-day-vs-later-day special case: re-rendering the digest for the SAME
+# day a second time (nothing new happened) and a batch_id that (defensively)
+# resurfaces in the file for a LATER day are handled identically -- once a batch
 # has been shown, it is never shown again.
 #
 # Silent when nothing (new) was auto-applied (research: a digest that
@@ -266,7 +266,7 @@ applied_rows = [p for p in applied_all if p.get("batch_id") in new_batch_ids]
 if applied_rows:
     audit_records = load_jsonl(os.environ.get("CCGM_DIGEST_APPLY_AUDIT_FILE", ""))
     # Last write wins -- apply-audit.jsonl is append-only/chronological and
-    # (per apply_proposal()'s adrev-013 "refuse non-pending" rule) a given
+    # (per the adrev-013 "refuse non-pending" rule in apply_proposal()) a given
     # proposal_id is applied at most once, so in practice there is exactly
     # one matching record; this is a defensive tie-break, not a correctness
     # requirement.
@@ -296,7 +296,7 @@ if applied_rows:
         # The learnings-store id "its" undo command below actually names --
         # for add/supersede this is the NEW entry the proposal created
         # (never recorded on the proposal row itself, only in the audit
-        # trail); for contradict/deprecate it is the row's own target_id.
+        # trail); for contradict/deprecate it is the target_id already on that row.
         if p.get("kind") in ("learning_add", "learning_supersede"):
             return resolve_new_entry_id(p.get("id"))
         return p.get("target_id")
@@ -349,7 +349,7 @@ if applied_rows:
             lines.append(f"#### {project} — {kind}")
             lines.append("")
             for p in sorted(grouped[(project, kind)], key=lambda p: p.get("id", "")):
-                lines.append(f"##### `{p.get('id')}`")
+                lines.append(f'##### `{p.get("id")}`')
                 lines.append("")
                 lines.append(f"- **target**: `{row_target_id(p) or '(unknown)'}`")
                 lines.append(f"- **posture**: {p.get('posture', '?')}")
@@ -496,8 +496,8 @@ else:
             for p in rows:
                 out.append(render_proposal(p))
 
-# --- Yesterday's applied/rejected tally --------------------------------------
-out.append("## Yesterday's tally")
+# --- Prior-day applied/rejected tally ------------------------------------
+out.append("## Prior-day tally")
 out.append("")
 if not yesterday_proposals:
     out.append(f"_No proposals recorded for {yesterday}._")

--- a/modules/dreaming/lib/dream_analyze.py
+++ b/modules/dreaming/lib/dream_analyze.py
@@ -514,7 +514,7 @@ def _write_json_atomic(path: Path, obj: Any) -> None:
 
 
 def _default_canary_state() -> dict[str, Any]:
-    return {"active_incidents": {}, "untested_versions_observed": {}, "reduce_failures": {}}
+    return {"active_incidents": {}, "reduce_failures": {}}
 
 
 def record_canary_incident(slug: str, date: str, detail: str) -> None:
@@ -526,17 +526,6 @@ def record_canary_incident(slug: str, date: str, detail: str) -> None:
     state = _read_json(canary_state_path(), _default_canary_state())
     state.setdefault("active_incidents", {})
     state["active_incidents"][slug] = {"date": date, "detail": detail}
-    state["last_updated"] = _utc_now_iso()
-    _write_json_atomic(canary_state_path(), state)
-
-
-def record_untested_versions(untested_versions: list[str]) -> None:
-    if not untested_versions:
-        return
-    state = _read_json(canary_state_path(), _default_canary_state())
-    state.setdefault("untested_versions_observed", {})
-    for v in untested_versions:
-        state["untested_versions_observed"][v] = int(state["untested_versions_observed"].get(v, 0)) + 1
     state["last_updated"] = _utc_now_iso()
     _write_json_atomic(canary_state_path(), state)
 
@@ -631,7 +620,6 @@ def mine_due_slugs(
             skipped[slug] = "evidence bundle schema validation failed"
             continue
 
-        record_untested_versions(bundle.get("canary", {}).get("untested_versions", []))
         bundles[slug] = bundle
 
     return bundles, skipped
@@ -1471,7 +1459,6 @@ def main(argv: list[str] | None = None) -> int:
             "cost_breakdown": cost_breakdown,
             "actual_input_tokens": total_input_tokens,
             "actual_output_tokens": total_output_tokens,
-            "untested_versions": [],
         }
         runs_dir().mkdir(parents=True, exist_ok=True)
         _write_json_atomic(runs_dir() / f"{today}.json", run_summary)
@@ -1510,10 +1497,6 @@ def main(argv: list[str] | None = None) -> int:
         if timestamps:
             tm.write_watermark(slug, max(timestamps))
 
-    untested_versions = sorted({
-        v for slug in planned_slugs for v in bundles[slug].get("canary", {}).get("untested_versions", [])
-    })
-
     run_summary = {
         "date": today,
         "generated_at": _utc_now_iso(),
@@ -1530,7 +1513,6 @@ def main(argv: list[str] | None = None) -> int:
         "cost_breakdown": cost_breakdown,
         "actual_input_tokens": total_input_tokens,
         "actual_output_tokens": total_output_tokens,
-        "untested_versions": untested_versions,
     }
     runs_dir().mkdir(parents=True, exist_ok=True)
     _write_json_atomic(runs_dir() / f"{today}.json", run_summary)

--- a/modules/dreaming/lib/dreaming-prompt-map.md
+++ b/modules/dreaming/lib/dreaming-prompt-map.md
@@ -38,8 +38,9 @@ exact contract):
   exemplars), then routine clusters (bare counts, no exemplars -- these are
   NOT proposal-worthy on their own; a routine cluster's `count` being large
   is normal noise, not a signal).
-- `canary` -- observed/untested transcript-schema versions. Informational;
-  never propose anything about this field itself.
+- `canary` -- observed transcript-schema versions (informational only;
+  drift is a hard failure that never reaches this prompt). Never propose
+  anything about this field itself.
 
 Weight friction clusters heavily. A cluster that recurs across multiple
 distinct `sample_session_ids` is a much stronger signal than a single

--- a/modules/dreaming/lib/evidence-bundle-schema.json
+++ b/modules/dreaming/lib/evidence-bundle-schema.json
@@ -99,6 +99,26 @@
             "type": "integer",
             "minimum": 0,
             "description": "Count of times a recognized friction-bearing field (is_error/hookErrors/preventedContinuation/toolUseResult) was structurally present, regardless of value. Distinguishes a genuinely quiet session (fields present, no problems) from schema drift (fields absent) -- see schema_canary()."
+          },
+          "turn_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Count of parsed turns (user + assistant) in this session. Feeds the turn_structure invariant in validate_structure()/schema_canary()."
+          },
+          "assistant_turn_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Count of assistant turns in this session. Gates the token_economics invariant in validate_structure()/schema_canary(): message.usage is read on every assistant line regardless of tool_use, so this gate is a strict superset of tool_use_count."
+          },
+          "usage_field_presence": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Count of times a recognized token/cache usage field (message.usage.{input,output,cache_creation,cache_read}_tokens) was structurally present, regardless of value. Feeds the token_economics invariant in validate_structure()/schema_canary()."
+          },
+          "parsed_line_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Count of successfully parsed JSON lines in this session's transcript. Gates the turn_structure invariant in validate_structure()/schema_canary(): a rename of the top-level `type` envelope field would otherwise zero tool_use_count too, so this invariant is gated on parsed lines instead."
           }
         }
       }

--- a/modules/dreaming/tests/test_daily_report.py
+++ b/modules/dreaming/tests/test_daily_report.py
@@ -426,5 +426,78 @@ class IdempotentAndSurfacedDedupTest(DailyReportTestBase):
         self.assertNotIn("## Applied this run (auto)", day2_body)
 
 
+class CanaryBannerTests(DailyReportTestBase):
+    """Structural-canary plan.md Epic 2 (adrev-003): grep-cleanliness of
+    dream-digest.sh alone proves the removed code path is gone, not the
+    rendered behavior -- the healthy offline chain never trips the
+    drift->record_canary_incident->banner path, and a stray leftover branch
+    could keep rendering the removed "untested transcript-schema versions"
+    block. Both halves are asserted here against real rendered digest text.
+    """
+
+    def _write_canary(self, state: dict) -> None:
+        canary_path = self.dreaming_dir / "state" / "canary.json"
+        canary_path.parent.mkdir(parents=True, exist_ok=True)
+        canary_path.write_text(json.dumps(state), encoding="utf-8")
+
+    def test_active_incident_renders_loud_banner_with_named_detail(self) -> None:
+        date = "2026-04-01"
+        detail = (
+            "schema_canary: structural drift detected -- friction_events "
+            "(is_error/toolUseResult/hookErrors/preventedContinuation): 4 "
+            "tool_use block(s) observed across 1 session(s) but zero "
+            "recognized friction-bearing fields were found anywhere in the "
+            "window."
+        )
+        self._write_canary({
+            "active_incidents": {"futureversion-app": {"date": date, "detail": detail}},
+            "reduce_failures": {},
+        })
+
+        proc = self._run_digest(date)
+        self.assertEqual(proc.returncode, 0, msg=f"stdout={proc.stdout}\nstderr={proc.stderr}")
+
+        body = self._digest_path(date).read_text(encoding="utf-8")
+        self.assertIn("## ⚠️ Canary banner (durable — shown until acknowledged)", body)
+        self.assertIn("**schema_canary fired for:**", body)
+        self.assertIn("`futureversion-app`", body)
+        self.assertIn(detail, body, "the loud banner must render the incident's full named-extraction detail")
+
+    def test_no_untested_version_banner_ever_renders(self) -> None:
+        # (a) the post-Epic-2 shape (no untested_versions_observed key at
+        # all) must never produce an untested-version block.
+        date_a = "2026-04-03"
+        self._write_canary({"active_incidents": {}, "reduce_failures": {}})
+
+        proc_a = self._run_digest(date_a)
+        self.assertEqual(proc_a.returncode, 0, msg=f"stdout={proc_a.stdout}\nstderr={proc_a.stderr}")
+        body_a = self._digest_path(date_a).read_text(encoding="utf-8")
+        self.assertNotIn("Untested transcript-schema versions observed", body_a)
+        self.assertNotIn("untested_versions_observed", body_a)
+        self.assertNotIn("## ⚠️ Canary banner", body_a, "no incidents at all must render no banner")
+
+        # (b) defensive: a STALE canary.json left over from a pre-Epic-2
+        # install that still carries a populated legacy
+        # untested_versions_observed key must ALSO never render the block --
+        # the digest no longer reads that key at all, so leftover on-disk
+        # state from before this upgrade cannot resurrect the toil banner.
+        date_b = "2026-04-04"
+        self._write_canary({
+            "active_incidents": {},
+            "untested_versions_observed": {"2.1.153": 4, "2.1.201": 2},
+            "reduce_failures": {},
+        })
+
+        proc_b = self._run_digest(date_b)
+        self.assertEqual(proc_b.returncode, 0, msg=f"stdout={proc_b.stdout}\nstderr={proc_b.stderr}")
+        body_b = self._digest_path(date_b).read_text(encoding="utf-8")
+        self.assertNotIn("Untested transcript-schema versions observed", body_b)
+        self.assertNotIn("2.1.153", body_b)
+        self.assertNotIn(
+            "## ⚠️ Canary banner", body_b,
+            "an empty active_incidents + reduce_failures alongside a legacy-only key must render no banner at all",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/modules/dreaming/tests/test_dream_analyze.py
+++ b/modules/dreaming/tests/test_dream_analyze.py
@@ -38,6 +38,7 @@ import dream_analyze as da  # noqa: E402
 OFFLINE_FIXTURES = HERE / "fixtures" / "offline-responses"
 BROKEN_REDUCE_FIXTURES = HERE / "fixtures" / "offline-responses-broken-reduce"
 FRICTION_FIXTURE = HERE / "fixtures" / "friction.jsonl"
+DRIFT_FIXTURE = HERE / "fixtures" / "drift.jsonl"
 
 
 def _isolate_env(test: unittest.TestCase) -> Path:
@@ -75,15 +76,15 @@ def _isolate_env(test: unittest.TestCase) -> Path:
     return Path(tmp)
 
 
-def _make_projects_root(tag: str) -> Path:
-    """Copy friction.jsonl into a fresh temp projects_root under a
-    subdirectory (discover() requires transcripts inside a subdir of the
-    root). Fresh cp -> fresh mtime, independent of the fixture's own
-    2026-01-01 content timestamps (mirrors test-dream-pipeline.sh)."""
+def _make_projects_root(tag: str, fixture: Path = FRICTION_FIXTURE) -> Path:
+    """Copy `fixture` into a fresh temp projects_root under a subdirectory
+    (discover() requires transcripts inside a subdir of the root). Fresh cp
+    -> fresh mtime, independent of the fixture's own 2026-01-01 content
+    timestamps (mirrors test-dream-pipeline.sh)."""
     root = Path(tempfile.mkdtemp(prefix=f"ccgm-dreaming-test-projects-{tag}-"))
     session_dir = root / "session-a"
     session_dir.mkdir(parents=True, exist_ok=True)
-    (session_dir / "friction.jsonl").write_text(FRICTION_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    (session_dir / fixture.name).write_text(fixture.read_text(encoding="utf-8"), encoding="utf-8")
     return root
 
 
@@ -776,6 +777,44 @@ class MainIntegrationTests(unittest.TestCase):
             store_projection_token_estimate_fn=lambda scopes: 0,
         )
         self.assertEqual(planned, ["tidy-app"], "the never-dreamed slug (no watermark) must be planned before the recently-dreamed one, and the budget affords only one")
+
+
+# ---------------------------------------------------------------------------
+# Canary state: _default_canary_state() shape + SchemaDriftError ->
+# active_incidents recording (structural-canary plan.md Epic 2).
+# ---------------------------------------------------------------------------
+
+class CanaryStateTests(unittest.TestCase):
+    def test_default_canary_state_has_no_untested_versions_key(self):
+        # Epic 2: the version-allowlist toil signal (untested_versions_
+        # observed) is gone from the durable canary state -- only the two
+        # incident families remain.
+        self.assertEqual(da._default_canary_state(), {"active_incidents": {}, "reduce_failures": {}})
+
+    def test_schema_drift_error_records_active_incident_with_named_detail(self):
+        # drift.jsonl (Epic 1) renames every friction field while keeping
+        # type/usage/tool_use intact, so mining it trips validate_structure's
+        # friction_events invariant. mine_due_slugs() must catch the raised
+        # SchemaDriftError, durably record it via record_canary_incident()
+        # rather than crashing the whole run, and exclude the drifted slug
+        # from the bundles it returns for mining.
+        dreaming_dir = _isolate_env(self)
+        cwd_line = json.loads(DRIFT_FIXTURE.read_text(encoding="utf-8").splitlines()[0])
+        slug = da.tm.detect_project_slug(cwd_line["cwd"])
+
+        projects_root = _make_projects_root("driftcanary", fixture=DRIFT_FIXTURE)
+        self.addCleanup(lambda: __import__("shutil").rmtree(projects_root, ignore_errors=True))
+
+        bundles, skipped = da.mine_due_slugs(
+            [slug], cfg=dict(da.DEFAULT_CONFIG), projects_root=str(projects_root), today="2026-01-01",
+        )
+        self.assertEqual(bundles, {}, "the drifted slug must be excluded from the bundles returned for mining")
+        self.assertEqual(skipped.get(slug), "schema_canary fired")
+
+        canary = json.loads((dreaming_dir / "state" / "canary.json").read_text(encoding="utf-8"))
+        self.assertIn(slug, canary.get("active_incidents", {}))
+        detail = canary["active_incidents"][slug]["detail"]
+        self.assertIn("friction_events", detail, "the recorded detail must name the broken extraction")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Epic 2 of the dreaming structural-canary plan (Epic 1: #830, merged). Propagates the field-level structural-canary shape change through every remaining consumer, adds the digest-banner and canary-state behavioral tests the prior review round (adrev-003) flagged as missing, and wires the dreaming module's own test suite into CI as a required blocking gate (adrev-002) — previously `.github/workflows/test.yml` ran zero pytest, so this whole surface had no merge gate.

- `lib/evidence-bundle-schema.json`: documents the four new `mine()` presence counters (`turn_count`, `assistant_turn_count`, `usage_field_presence`, `parsed_line_count`) on `sessions[].properties`. The `canary.required` relaxation already shipped in Epic 1 — verified unchanged, not re-edited.
- `lib/dream_analyze.py`: deletes `record_untested_versions()`, its call site, the `untested_versions_observed` key from `_default_canary_state()`, the reduce-phase aggregation, and both `run_summary["untested_versions"]` writes. `record_canary_incident()` / `SchemaDriftError` handling / `reduce_failures` are untouched.
- `bin/dream-digest.sh`: removes the "Untested transcript-schema versions observed" banner block entirely; the banner condition is now `if active_incidents or reduce_failures:`.
- `lib/dreaming-prompt-map.md`: updates the `canary` field description for the map-phase analyzer prompt.
- `tests/test_dream_analyze.py`: new `CanaryStateTests` — asserts `_default_canary_state()` has no `untested_versions_observed` key, and that mining a real drift fixture through `mine_due_slugs()` catches `SchemaDriftError` and durably records a named-detail `active_incidents` entry (not just that the code compiles).
- `tests/test_daily_report.py`: new `CanaryBannerTests` — drives `dream-digest.sh` as a real subprocess against a seeded `state/canary.json` and asserts on the *rendered digest text*: a loud banner names the incident's detail, and no untested-version block ever renders again (including against a stale legacy-shaped `canary.json` carrying a populated `untested_versions_observed` key, defending against a partial-removal regression).
- `.github/workflows/test.yml`: adds a required, blocking "Dreaming module tests" step to both the `test` (ubuntu) and `test-macos` jobs — `pytest modules/dreaming/tests/ -q`, `transcript_miner.py --self-check`, and the offline analyze→digest chain smoke.

## Two pre-existing bugs surfaced by wiring in the CI gate

Both were latent because CI ran zero pytest for this module before this PR — exactly the gap adrev-002 exists to close. Neither is related to the `untested_versions` removal; both reproduce identically against `origin/main` pre-this-branch and are fixed here because a permanently-red required check defeats the entire point of the gate.

1. **`dream-digest.sh` bash-3.2 parse failure (macOS job).** Bash <4.0 has a well-known lexer bug: a straight apostrophe inside a `#`-led comment — even inside a quoted `<<'PYEOF'` heredoc nested in `$(...)` — desyncs its quote-tracking, eventually erroring "unexpected EOF while looking for matching `)'". Confirmed via bisection against `origin/main`'s copy. Fixed by removing the apostrophe from the 11 affected lines (9 pure comment rewordings, 2 zero-semantic quote-style swaps in live code) — verified with `/bin/bash -n`, a real end-to-end execution under `/bin/bash`, and the full pytest suite green throughout. The only rendered-text change is "Yesterday's tally" → "Prior-day tally" (grepped: nothing asserts on the old string).
2. **Missing git identity (ubuntu job).** `test_optimistic_engine.py::_init_learnings_git()` and `test_dream_review.py::SyncRevertTests._git()` both call `subprocess.run()` with no `env=` override, so they inherit whatever identity is ambient. Every dev machine's OS account has a real name git can auto-derive an identity from; GitHub's hosted-runner service account does not, so git refuses with "empty ident name ... not allowed". Fixed by setting `GIT_AUTHOR_NAME`/`EMAIL` + `GIT_COMMITTER_NAME`/`EMAIL` at the CI step level (git's highest-priority identity source, unaffected by the `HOME` redirection some of these tests perform) — zero changes to either test file.

## Test plan

- [x] `python3 -m pytest modules/dreaming/tests/ -q` — 394 passed, 5 subtests passed (local and in CI)
- [x] `python3 modules/dreaming/lib/transcript_miner.py --self-check` — `ok: true`, `drift_fixture_raises_canary: true`
- [x] `_default_canary_state()` returns exactly `{"active_incidents": {}, "reduce_failures": {}}`
- [x] Offline chain (`dream-daily.sh --offline ... --force-day 2026-01-02`) exits 0, produces a digest with no "untested" text anywhere
- [x] `grep -rn "untested" modules/dreaming/lib modules/dreaming/bin` — zero matches (production code fully clean)
- [x] `bash tests/test-no-personal-data.sh` — PASS
- [x] Both CI jobs (`test`, `test-macos`) green end-to-end on GitHub Actions, including the new "Dreaming module tests" step — https://github.com/lucasmccomb/ccgm/actions/runs/28909442547

## Note

`bash tests/test-modules.sh` reports one pre-existing, unrelated failure (`orphan-reaper is missing module.json`) that predates this branch and is untouched by this diff.

---
Closes #831
Addresses #773 (dreaming portion only — see comment on #773; the remaining modules/ suites stay tracked there)