### PR TITLE
#836: composite-eligibility E3 — enabled-mode gate waterfall + apply-time signal gathering + dry-run CLI

### DIFF
--- a/modules/dreaming/bin/dream-daily.sh
+++ b/modules/dreaming/bin/dream-daily.sh
@@ -101,6 +101,25 @@ log() {
     printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >>"${DAILY_LOG}"
 }
 
+# Bound a command's wall-clock (composite-eligibility plan.md §5 E3 / §9.3).
+# The optimistic-integrate step re-verifies transcripts at apply time, so a
+# pathologically large transcript could hang it under launchd; `timeout 600`
+# caps it. The default SIGTERM is caught by run_optimistic_integrate's
+# SIGTERM-safe handler (commit-what-it-has + record a timeout anomaly).
+# POSIX-clean + portable: prefer coreutils `timeout`, then macOS/brew
+# `gtimeout`; if neither exists, run the command directly (no bound rather
+# than a hard failure) so the step is never broken by a missing utility.
+_run_with_timeout() {
+    local secs="$1"; shift
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "${secs}" "$@"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        gtimeout "${secs}" "$@"
+    else
+        "$@"
+    fi
+}
+
 run_step() {
     local label="$1"
     local path="$2"
@@ -258,7 +277,11 @@ run_optimistic_integrate_step() {
 
     log "optimistic-integrate: eval gate passed; running apply_dream_proposal.py optimistic-integrate for ${TODAY}"
     local integrate_out integrate_rc
-    integrate_out="$(python3 "${MODULE_ROOT}/lib/apply_dream_proposal.py" optimistic-integrate --day "${TODAY}" 2>&1)"
+    # timeout 600 bounds the apply-time re-verification cost (plan.md §5 E3);
+    # a fired timeout SIGTERMs the process, which its SIGTERM-safe handler turns
+    # into a clean commit-what-it-has + a recorded timeout anomaly (never a
+    # dirty tree). Exit-tolerance is preserved: this step always returns 0.
+    integrate_out="$(_run_with_timeout 600 python3 "${MODULE_ROOT}/lib/apply_dream_proposal.py" optimistic-integrate --day "${TODAY}" 2>&1)"
     integrate_rc=$?
     printf '%s\n' "${integrate_out}" >>"${DAILY_LOG}"
     if [ "${integrate_rc}" -ne 0 ]; then

--- a/modules/dreaming/lib/apply_dream_proposal.py
+++ b/modules/dreaming/lib/apply_dream_proposal.py
@@ -129,12 +129,16 @@ import contextlib
 import datetime as _dt
 import fcntl
 import json
+import math
 import os
+import re
+import signal
 import subprocess
 import sys
 import time
 import traceback
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
@@ -150,6 +154,16 @@ import dream_analyze as da  # noqa: E402  (sibling module, same lib/ dir)
 # self-improving module's store library").
 learnings_store = da.learnings_store
 GLOBAL_SLUG = learnings_store.GLOBAL_SLUG
+
+# Reuse dream_analyze.py's already-resolved sibling imports (single source of
+# truth for "where does the miner / the pure scoring core live"), exactly as
+# `learnings_store = da.learnings_store` above reuses its store resolution.
+# `eligibility` is Epic E1's frozen pure core (SignalBundle/EligibilityDecision
+# + evaluate_eligibility + the similarity/normalization text helpers this file
+# calls but NEVER duplicates). `tm` is the deterministic transcript miner whose
+# human-origin-filtered correction extractor E3 re-runs at apply time (§3.3).
+eligibility = da.eligibility
+tm = da.tm
 
 dreaming_dir = da.dreaming_dir
 proposals_dir = da.proposals_dir
@@ -1391,10 +1405,523 @@ def record_review_reversal(
     return record
 
 
+# ===========================================================================
+# Composite eligibility gate -- apply-time I/O (composite-eligibility plan.md
+# §3.2-§3.4, §3.7). The PURE scoring lives in eligibility.py (Epic E1); this
+# section is the impure seam that gathers the four signals from the transcripts
+# + live store, re-verifying EVERYTHING at apply time so no model-stamped field
+# is ever trusted (decisions.md #20). It sits beside the other apply-time
+# helpers (`_live_head_count`, `_raw_op_events`); the pure/impure boundary is
+# "already-computed scalars in (SignalBundle), decision out".
+# ===========================================================================
+
+# Anti-coincidence guard (ii) tuning (plan.md §3.4, adrev2-003 / adrev3-002).
+# A tolerant excerpt match takes MAX over many windows, so for a large
+# transcript a short common-token excerpt can coincidentally clear the
+# similarity threshold. Guard (ii) additionally requires that a matched window
+# contain a MINIMUM ABSOLUTE count of the excerpt's distinct content-bearing,
+# non-placeholder tokens. The requirement scales with the excerpt's own
+# content-token count but never drops below the absolute floor -- so a
+# 1-2-content-token excerpt can never be corroborated by coincidence, while a
+# heavily-redacted BUT substantial excerpt (placeholders excluded from the
+# denominator) clears a proportionally lower bar (the two-sided reconciliation
+# of adrev3-002). The constants are pinned by the two-sided test in
+# test_eligibility_gate.py; changing either without re-running both arms is a
+# defect.
+_EXCERPT_GUARD_MIN_ABS_TOKENS = 3
+_EXCERPT_GUARD_FRACTION = 0.5
+
+# Excerpt sliding-window bounds. Guard (i): the comparison window is sized to
+# the excerpt's OWN normalized length (contiguous), so a larger transcript adds
+# candidate windows but never per-window laxity. The step keeps the number of
+# window evaluations bounded; the exact-substring fast path short-circuits the
+# common verbatim case at O(n).
+_EXCERPT_WINDOW_STEP_DIVISOR = 8
+_EXCERPT_MAX_WINDOW_EVALS = 20000
+_EXCERPT_STREAM_BUFFER_MIN = 8192
+
+# Near-duplicate supersede advisory flag (plan.md §3.7, decisions.md #30/#39):
+# a supersede whose content is >= this similar to its target AND changes the
+# fact-token set is flagged for human review. Never blocks; not a score term.
+_NEAR_DUP_SUPERSEDE_SIMILARITY = 0.9
+
+# Session-citation concentration signal (decisions.md #37): a single evidence
+# session cited by this many or more scored proposals in one batch is recorded
+# as an anomaly feeding the SAME windowed circuit breaker as the existing
+# eviction-concentration check -- without touching that (eviction-only) check.
+# Default high enough that a legitimate topically-focused night never trips it.
+_SESSION_CITATION_ANOMALY_MIN = 8
+
+# Miner redaction placeholders ([REDACTED:kind]) are inserted by
+# transcript_miner.make_excerpt() over secrets/PII; the RAW transcript carries
+# the un-redacted text instead, so a placeholder in the cited excerpt must be
+# stripped before any comparison (it can never match its raw source) AND
+# excluded from guard (ii)'s required-token denominator (plan.md §3.3/§3.4).
+_REDACTION_RE = re.compile(r"\[REDACTED:[^\]]*\]", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class SessionVerification:
+    """Per-session apply-time verification, cached once per distinct
+    session_id across a whole batch (plan.md §3.4). Building this is the ONLY
+    expensive I/O (resolve + full read + miner re-run); a session cited by N
+    proposals is built once and reused N times."""
+
+    session_id: str
+    resolved: bool                  # step 1: resolve_session_transcript() found it
+    cwd: str | None
+    slug: str | None                # step 2 input: detect_project_slug(cwd)
+    tier: str                       # "user-corrected" | "inferred" (miner re-run)
+    tier_source: dict | None        # {session_id, line, origin_kind} when user-corrected
+    newest_ts_epoch: float | None   # newest embedded per-line timestamp (recency)
+    oversized: bool                 # > max_transcript_bytes: tier inferred, recency 0
+    path: str | None
+    normalized_text: str | None     # cached normalized transcript text (None if oversized/unresolved)
+
+
+@dataclass(frozen=True)
+class _EligibilityEval:
+    """The full apply-time evaluation of one add/supersede proposal: the pure
+    EligibilityDecision plus the audit-only context (§3.7) that the pure core
+    cannot see (verified/unresolved session ids, tier source, citations, the
+    near-duplicate-supersede flag)."""
+
+    decision: Any                       # eligibility.EligibilityDecision
+    verified_session_ids: list
+    unresolved_session_ids: list
+    evidence_tier: str
+    tier_source: dict | None
+    cited_session_ids: list
+    near_dup_supersede: bool
+
+
+def _prep_excerpt(excerpt: str) -> str:
+    """Normalize a cited excerpt for comparison against raw transcript text
+    (plan.md §3.3/§3.4): strip [REDACTED:...] placeholders (the raw transcript
+    has the un-redacted text there, so the placeholder can only HURT the
+    match), then run eligibility.normalize_content() (which also strips
+    [neutralized] wrappers, lowercases, and collapses whitespace)."""
+    if not excerpt:
+        return ""
+    return eligibility.normalize_content(_REDACTION_RE.sub(" ", excerpt))
+
+
+def _excerpt_content_tokens(excerpt: str) -> set:
+    """Guard (ii)'s denominator: distinct content-bearing, NON-placeholder,
+    non-stop tokens of the excerpt (plan.md §3.4). Placeholders are already
+    removed by `_prep_excerpt`, so a redacted excerpt is scored on a
+    proportionally lower bar rather than penalized for the redacted tokens."""
+    return eligibility._tokens(_prep_excerpt(excerpt))  # noqa: SLF001 -- reuse E1's tokenizer, never duplicate (plan.md §3.3)
+
+
+def _extract_line_text(obj: dict[str, Any]) -> str:
+    """Human/agent-readable text of one transcript line: message text blocks,
+    tool_result content, tool-use input strings, and any top-level `text`. This
+    is the surface a redacted proposal excerpt corroborates against; a superset
+    is deliberate (fail toward MORE corroboration coverage, never less)."""
+    parts: list[str] = []
+    msg = obj.get("message")
+    if isinstance(msg, dict):
+        content = msg.get("content")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if isinstance(block.get("text"), str):
+                    parts.append(block["text"])
+                if isinstance(block.get("content"), str):
+                    parts.append(block["content"])
+                inp = block.get("input")
+                if isinstance(inp, dict):
+                    for v in inp.values():
+                        if isinstance(v, str):
+                            parts.append(v)
+    if isinstance(obj.get("text"), str):
+        parts.append(obj["text"])
+    return " ".join(parts)
+
+
+def _read_transcript_normalized(path: str) -> str:
+    """Read a transcript once and return its normalized readable text
+    (one string). Used for the cached, non-oversized excerpt-match path."""
+    segs: list[str] = []
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                txt = _extract_line_text(obj)
+                if txt:
+                    segs.append(txt)
+    except OSError:
+        return ""
+    return eligibility.normalize_content(" ".join(segs))
+
+
+def _corroborate_in_text(
+    prepped: str, tokens: set, window_len: int, threshold: float, required: int, text: str,
+) -> bool:
+    """Return True iff SOME excerpt-sized window of `text` clears BOTH the
+    similarity threshold (guard i, tolerant match) AND the minimum-distinct-
+    token requirement (guard ii). Fail-closed only after BOTH arms are computed
+    (adrev3-002): the token requirement is never a shortcut that biases against
+    a legitimate redacted excerpt."""
+    if not text or window_len <= 0:
+        return False
+
+    def _window_ok(window: str) -> bool:
+        if eligibility.similarity(prepped, window) < threshold:
+            return False
+        present = len(tokens & eligibility._tokens(window))  # noqa: SLF001 -- reuse E1's tokenizer
+        return present >= required
+
+    # Exact-substring fast path (the common verbatim/redaction-stripped case):
+    # ratio is 1.0, so only guard (ii) can still reject it.
+    idx = text.find(prepped)
+    if idx != -1 and _window_ok(text[idx:idx + window_len]):
+        return True
+
+    n = len(text)
+    if n <= window_len:
+        return _window_ok(text)
+
+    step = max(1, window_len // _EXCERPT_WINDOW_STEP_DIVISOR)
+    last = n - window_len
+    evals = 0
+    pos = 0
+    while pos <= last:
+        if _window_ok(text[pos:pos + window_len]):
+            return True
+        evals += 1
+        if evals >= _EXCERPT_MAX_WINDOW_EVALS:
+            break
+        pos += step
+    return False
+
+
+def _corroborate_streaming(
+    prepped: str, tokens: set, window_len: int, threshold: float, required: int, path: str,
+) -> bool:
+    """Bounded-memory excerpt corroboration for an oversized transcript: stream
+    normalized text into a rolling buffer, scanning excerpt-sized windows and
+    retaining a `window_len - 1` tail so windows spanning an append boundary are
+    still seen (plan.md §3.4: "the excerpt check still streams")."""
+    cap = max(4 * window_len, _EXCERPT_STREAM_BUFFER_MIN)
+    buf = ""
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                seg = eligibility.normalize_content(_extract_line_text(obj))
+                if not seg:
+                    continue
+                buf = (buf + " " + seg) if buf else seg
+                if len(buf) >= cap:
+                    if _corroborate_in_text(prepped, tokens, window_len, threshold, required, buf):
+                        return True
+                    buf = buf[-(window_len - 1):] if window_len > 1 else ""
+    except OSError:
+        return False
+    return _corroborate_in_text(prepped, tokens, window_len, threshold, required, buf)
+
+
+def _excerpt_corroborated(excerpt: str, sv: SessionVerification, elig_cfg: dict[str, Any]) -> bool:
+    """§3.4 check 3: does the cited excerpt verifiably correspond to text in the
+    resolved transcript? Tolerant similarity match (adrev-001) with the
+    anti-coincidence guards (adrev2-003/adrev3-002)."""
+    if not sv.resolved:
+        return False
+    prepped = _prep_excerpt(excerpt)
+    if not prepped:
+        return False
+    tokens = _excerpt_content_tokens(excerpt)
+    # Guard (i) sizes the window to the excerpt's OWN normalized length -- but
+    # sized to the length WITH redaction placeholders KEPT, not the stripped
+    # length. A redacted excerpt is SHORTER than its raw transcript source
+    # (the placeholder replaces a longer secret), so a window sized to the
+    # stripped excerpt would be too small to span the raw source's tokens. The
+    # kept-placeholder length is comparable to the raw span, so the window can
+    # cover it -- while still being excerpt-derived (no "best of all sizes"
+    # laxity that would degrade with transcript size, adrev2-003).
+    window_len = max(len(prepped), len(eligibility.normalize_content(excerpt)))
+    threshold = float(elig_cfg["excerpt_match_min"])
+    required = max(_EXCERPT_GUARD_MIN_ABS_TOKENS, math.ceil(_EXCERPT_GUARD_FRACTION * len(tokens)))
+    if sv.normalized_text is not None:
+        return _corroborate_in_text(prepped, tokens, window_len, threshold, required, sv.normalized_text)
+    if sv.path is not None:
+        return _corroborate_streaming(prepped, tokens, window_len, threshold, required, sv.path)
+    return False
+
+
+def _build_session_verification(session_id: str, elig_cfg: dict[str, Any]) -> SessionVerification:
+    """The per-session I/O (plan.md §3.4). REUSES
+    learnings_store.resolve_session_transcript() (the exact glob
+    promote_to_global's origin binding uses -- never reimplemented) and re-runs
+    the miner's human-origin-filtered correction extractor for the tier. Built
+    at most ONCE per distinct session_id per batch (see `_verify_session`)."""
+    resolved = learnings_store.resolve_session_transcript(session_id)
+    if not resolved:
+        return SessionVerification(
+            session_id=session_id, resolved=False, cwd=None, slug=None,
+            tier="inferred", tier_source=None, newest_ts_epoch=None,
+            oversized=False, path=None, normalized_text=None,
+        )
+    path = str(resolved["path"])
+    cwd = resolved.get("cwd")
+    slug = learnings_store.detect_project_slug(cwd) if cwd else None
+
+    max_bytes = int(elig_cfg["max_transcript_bytes"])
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        size = 0
+    if size > max_bytes:
+        # Oversized: tier forced "inferred", recency 0, no cached text
+        # (the excerpt check still streams on demand) -- fail toward weakest.
+        return SessionVerification(
+            session_id=session_id, resolved=True, cwd=cwd, slug=slug,
+            tier="inferred", tier_source=None, newest_ts_epoch=None,
+            oversized=True, path=path, normalized_text=None,
+        )
+
+    normalized_text = _read_transcript_normalized(path)
+
+    tier = "inferred"
+    tier_source: dict | None = None
+    newest_ts: float | None = None
+    try:
+        mined = tm.mine(path)
+    except Exception:  # noqa: BLE001 -- a malformed transcript must fail toward weakest, never crash the batch
+        mined = None
+    if mined:
+        corrections = mined.get("user_corrections") or []
+        if corrections:
+            tier = "user-corrected"
+            c0 = corrections[0] if isinstance(corrections[0], dict) else {}
+            tier_source = {"session_id": session_id, "line": c0.get("line"), "origin_kind": "human"}
+        newest_iso = mined.get("ended_at") or mined.get("started_at")
+        if newest_iso:
+            parsed = learnings_store._parse_iso(newest_iso)  # noqa: SLF001 -- cross-module ISO parser reuse (mirrors this file's own precedent at _rolling_auto_add_supersede_count)
+            if parsed:
+                newest_ts = parsed
+    return SessionVerification(
+        session_id=session_id, resolved=True, cwd=cwd, slug=slug,
+        tier=tier, tier_source=tier_source, newest_ts_epoch=newest_ts,
+        oversized=False, path=path, normalized_text=normalized_text,
+    )
+
+
+def _verify_session(
+    session_id: str, cache: dict[str, SessionVerification], elig_cfg: dict[str, Any],
+) -> SessionVerification:
+    """Memoized `_build_session_verification` -- the per-batch cache (§3.4)."""
+    sv = cache.get(session_id)
+    if sv is None:
+        sv = _build_session_verification(session_id, elig_cfg)
+        cache[session_id] = sv
+    return sv
+
+
+def _live_head_contents(heads: dict[str, dict[str, Any]]) -> list:
+    """Content strings of a slug's currently-live heads (not deprecated, not
+    superseded) -- novelty's comparison set for `learning_add`."""
+    return [
+        h.get("content") or ""
+        for h in heads.values()
+        if not h.get("deprecated") and not h.get("superseded_by")
+    ]
+
+
+def gather_eligibility_signals(
+    row: dict[str, Any], *, slug: str, cache: dict[str, SessionVerification],
+    heads: dict[str, dict[str, Any]], elig_cfg: dict[str, Any],
+) -> tuple[Any, dict[str, Any]]:
+    """Recompute all four signals deterministically at apply time (plan.md
+    §3.3/§3.4) and return (SignalBundle, audit_context).
+
+    Inputs are the BARE row (evidence session_id/excerpt pairs + row scalars)
+    plus the live-store heads -- NEVER the row's stamped `evidence_tier`/
+    `stamped_signals` (those are digest aids; this signature carries no
+    parameter for them, so a future edit cannot wire trust in by accident,
+    decisions.md #20)."""
+    kind = row.get("kind")
+    conf = _confidence_of(row)
+    content = row.get("content") or ""
+    target_id = row.get("target_id")
+
+    verified: list = []
+    unresolved: list = []
+    cited: list = []
+    seen: set = set()
+    tier = "inferred"
+    tier_source: dict | None = None
+    newest_ts: float | None = None
+
+    for ev in row.get("evidence") or []:
+        if not isinstance(ev, dict):
+            continue
+        sid = ev.get("session_id")
+        if not sid:
+            # Null/empty session_id: excluded from counts AND recency (§3.4,
+            # decisions.md #36).
+            continue
+        cited.append(sid)
+        sv = _verify_session(sid, cache, elig_cfg)
+        if not sv.resolved:
+            if sid not in unresolved:
+                unresolved.append(sid)
+            continue
+        if sv.slug != slug:
+            # Slug mismatch: resolved but not this project -- not counted.
+            continue
+        if not _excerpt_corroborated(ev.get("excerpt") or "", sv, elig_cfg):
+            continue
+        if sid in seen:
+            continue
+        seen.add(sid)
+        verified.append(sid)
+        if sv.tier == "user-corrected" and tier != "user-corrected":
+            tier = "user-corrected"
+            tier_source = sv.tier_source
+        if sv.newest_ts_epoch is not None and (newest_ts is None or sv.newest_ts_epoch > newest_ts):
+            newest_ts = sv.newest_ts_epoch
+
+    age_days = None if newest_ts is None else max(0.0, (time.time() - newest_ts) / 86400.0)
+
+    if kind == "learning_supersede":
+        target = heads.get(target_id)
+        if target is None or target.get("deprecated") or target.get("superseded_by"):
+            # Unresolvable/dead target -> novelty 0 (fail-closed; the row would
+            # fail CAS/liveness at apply anyway, §3.3, decisions.md #39).
+            novelty = 0.0
+        else:
+            novelty = eligibility.novelty_vs(content, [target.get("content") or ""])
+    else:  # learning_add: novelty vs live heads; empty store -> 1.0 (§3.3)
+        novelty = eligibility.novelty_vs(content, _live_head_contents(heads))
+
+    bundle = eligibility.SignalBundle(
+        kind=kind, confidence=conf, verified_sessions=len(verified),
+        evidence_tier=tier, newest_evidence_age_days=age_days, novelty=novelty,
+    )
+    context = {
+        "verified_session_ids": verified,
+        "unresolved_session_ids": unresolved,
+        "cited_session_ids": cited,
+        "evidence_tier": tier,
+        "tier_source": tier_source,
+    }
+    return bundle, context
+
+
+def evaluate_proposal_eligibility(
+    row: dict[str, Any], *, slug: str, cache: dict[str, SessionVerification],
+    heads: dict[str, dict[str, Any]], cfg: dict[str, Any], elig_cfg: dict[str, Any],
+) -> _EligibilityEval:
+    """Full apply-time eligibility evaluation for one add/supersede proposal:
+    the §3.2 static-floor short-circuit (before I/O), signal gathering, the pure
+    `eligibility.evaluate_eligibility` verdict, and the near-duplicate-supersede
+    advisory flag. Writes NOTHING -- the caller writes the audit (real path) or
+    prints the breakdown (dry-run). Any exception propagates to the caller's
+    outer fail-closed handler (never eligible)."""
+    kind = row.get("kind")
+    conf = _confidence_of(row)
+    threshold = float(elig_cfg["threshold"])
+
+    # Step 2 STATIC FLOOR before step 3 GATHER (plan.md §3.2): a sub-floor row
+    # never pays the transcript I/O. eligibility.evaluate_eligibility() re-checks
+    # this internally, so this is purely an I/O-saving short-circuit.
+    if conf < int(elig_cfg["static_floor"]):
+        decision = eligibility.EligibilityDecision(
+            eligible=False, outcome="skipped_floor", decision_basis=None,
+            score=None, threshold=threshold, margin=None, signals={}, weakest_signal=None,
+        )
+        return _EligibilityEval(
+            decision=decision, verified_session_ids=[], unresolved_session_ids=[],
+            evidence_tier="inferred", tier_source=None, cited_session_ids=[], near_dup_supersede=False,
+        )
+
+    bundle, ctx = gather_eligibility_signals(row, slug=slug, cache=cache, heads=heads, elig_cfg=elig_cfg)
+    decision = eligibility.evaluate_eligibility(bundle, cfg)
+
+    near_dup = False
+    if kind == "learning_supersede":
+        target = heads.get(row.get("target_id"))
+        if target is not None:
+            target_content = target.get("content") or ""
+            content = row.get("content") or ""
+            if eligibility.similarity(content, target_content) >= _NEAR_DUP_SUPERSEDE_SIMILARITY:
+                # "changed fact-token set" via the same machinery compact_
+                # preserves_facts uses (plan.md §3.7, decisions.md #30).
+                if learnings_store._extract_fact_tokens(content) != learnings_store._extract_fact_tokens(target_content):  # noqa: SLF001
+                    near_dup = True
+
+    return _EligibilityEval(
+        decision=decision,
+        verified_session_ids=ctx["verified_session_ids"],
+        unresolved_session_ids=ctx["unresolved_session_ids"],
+        evidence_tier=ctx["evidence_tier"],
+        tier_source=ctx["tier_source"],
+        cited_session_ids=ctx["cited_session_ids"],
+        near_dup_supersede=near_dup,
+    )
+
+
+def _eligibility_audit_record(
+    *, batch_id: str, proposal_id: Any, kind: Any, project: Any, row: dict[str, Any], ev: _EligibilityEval,
+) -> dict[str, Any]:
+    """Build the §3.7 audit record for a scored (eligible or skipped) row. No
+    `ok` field -- an eligibility record must never be miscounted as a store
+    application by the scorecard's `ok is True`/`outcome == "applied"` rule."""
+    d = ev.decision
+    record: dict[str, Any] = {
+        "audit_kind": "eligibility",
+        "outcome": d.outcome,
+        "decision_basis": d.decision_basis,
+        "score": d.score,
+        "threshold": d.threshold,
+        "margin": d.margin,
+        "signals": d.signals,
+        "weakest_signal": d.weakest_signal,
+        "verified_sessions": len(ev.verified_session_ids),
+        "evidence_tier": ev.evidence_tier,
+        "unresolved_session_ids": ev.unresolved_session_ids,
+        "type": row.get("type"),
+        "batch_id": batch_id,
+        "proposal_id": proposal_id,
+        "kind": kind,
+        "project": project,
+    }
+    if ev.evidence_tier == "user-corrected" and ev.tier_source:
+        record["evidence_tier_source"] = ev.tier_source
+    if kind == "learning_supersede":
+        record["near_duplicate_supersede"] = ev.near_dup_supersede
+    return record
+
+
 def _process_one_proposal(
     row: dict[str, Any], *, slug: str, cfg: dict[str, Any], live_count: int,
     anomaly_slugs: set[str], add_supersede_counts: dict[str, int],
     eviction_counts: dict[str, int], batch_id: str,
+    heads: dict[str, dict[str, Any]] | None = None,
+    session_cache: dict[str, SessionVerification] | None = None,
+    session_citation_counts: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     """Per-proposal posture/floor/cap/anomaly gate, then apply via the SAME
     `apply_proposal()` human accepts use (so the human-race lock and
@@ -1426,26 +1953,57 @@ def _process_one_proposal(
             })
             return {"outcome": "skipped_gated", "proposal_id": proposal_id}
 
-        floor_key = posture.get("confidence_floor")
-        floor = int(cfg.get(floor_key, 0)) if floor_key else 0
-        conf = _confidence_of(row)
-        if conf < floor:
-            _write_audit({
-                "outcome": "skipped_floor", "batch_id": batch_id, "proposal_id": proposal_id,
-                "kind": kind, "project": project, "detail": f"confidence {conf} < floor {floor}",
-            })
-            return {"outcome": "skipped_floor", "proposal_id": proposal_id}
-
-        if kind == "learning_add":
-            prevalence = row.get("prevalence") or {}
-            sessions = prevalence.get("sessions") if isinstance(prevalence, dict) else None
-            min_sessions = int(cfg.get("add_min_sessions", 2))
-            if not isinstance(sessions, int) or isinstance(sessions, bool) or sessions < min_sessions:
+        # ENABLED-mode composite waterfall (plan.md §3.2), for learning_add /
+        # learning_supersede ONLY. Every other kind (verify/contradict/
+        # deprecate) -- and eligibility disabled OR config-invalid (load_config
+        # resets the block to disabled on any validation failure) -- takes the
+        # legacy path below, bit-for-bit. The eligibility module is not touched
+        # at all on the legacy path (spy-testable, plan.md §5 E3).
+        elig_cfg = cfg.get("eligibility")
+        eligibility_on = isinstance(elig_cfg, dict) and elig_cfg.get("enabled") is True
+        if eligibility_on and kind in ("learning_add", "learning_supersede"):
+            cache = session_cache if session_cache is not None else {}
+            ev = evaluate_proposal_eligibility(
+                row, slug=slug, cache=cache, heads=heads or {}, cfg=cfg, elig_cfg=elig_cfg,
+            )
+            # Session-citation counter -> batch-anomaly input (decisions.md #37):
+            # a cheap per-batch counter keyed on each cited evidence session_id.
+            if session_citation_counts is not None:
+                for sid in ev.cited_session_ids:
+                    session_citation_counts[sid] = session_citation_counts.get(sid, 0) + 1
+            _write_audit(_eligibility_audit_record(
+                batch_id=batch_id, proposal_id=proposal_id, kind=kind, project=project, row=row, ev=ev,
+            ))
+            if not ev.decision.eligible:
+                # skipped_floor / skipped_origin / skipped_composite: the row
+                # stays `pending` (reachable via /dream-apply), never dropped.
+                return {"outcome": ev.decision.outcome, "proposal_id": proposal_id}
+            # ELIGIBLE: fall through to the SHARED downstream (compaction guard,
+            # per-run cap, dwell, apply) -- §3.2 step 7 "downstream unchanged".
+            # The legacy floor + model-claimed prevalence checks are DELIBERATELY
+            # skipped on this path (verified origin gate replaced them,
+            # decisions.md #26).
+        else:
+            floor_key = posture.get("confidence_floor")
+            floor = int(cfg.get(floor_key, 0)) if floor_key else 0
+            conf = _confidence_of(row)
+            if conf < floor:
                 _write_audit({
-                    "outcome": "skipped_prevalence", "batch_id": batch_id, "proposal_id": proposal_id,
-                    "kind": kind, "project": project, "detail": f"sessions={sessions!r} < {min_sessions}",
+                    "outcome": "skipped_floor", "batch_id": batch_id, "proposal_id": proposal_id,
+                    "kind": kind, "project": project, "detail": f"confidence {conf} < floor {floor}",
                 })
-                return {"outcome": "skipped_prevalence", "proposal_id": proposal_id}
+                return {"outcome": "skipped_floor", "proposal_id": proposal_id}
+
+            if kind == "learning_add":
+                prevalence = row.get("prevalence") or {}
+                sessions = prevalence.get("sessions") if isinstance(prevalence, dict) else None
+                min_sessions = int(cfg.get("add_min_sessions", 2))
+                if not isinstance(sessions, int) or isinstance(sessions, bool) or sessions < min_sessions:
+                    _write_audit({
+                        "outcome": "skipped_prevalence", "batch_id": batch_id, "proposal_id": proposal_id,
+                        "kind": kind, "project": project, "detail": f"sessions={sessions!r} < {min_sessions}",
+                    })
+                    return {"outcome": "skipped_prevalence", "proposal_id": proposal_id}
 
         if kind == "learning_supersede" and row.get("compaction_guard_failed"):
             _write_audit({
@@ -1503,6 +2061,66 @@ def _process_one_proposal(
             "outcome": "internal_error", "batch_id": batch_id, "proposal_id": proposal_id, "detail": detail,
         })
         return {"outcome": "internal_error", "proposal_id": proposal_id, "detail": detail}
+
+
+def _learnings_tree_dirty() -> bool:
+    """True iff the learnings-store git tree has uncommitted changes at the
+    start of a run (composite-eligibility plan.md §9.3). A prior batch killed
+    mid-transaction (e.g. by E3's `timeout 600` before a hard SIGKILL, or any
+    crash between the per-row store writes and the single end-of-batch commit)
+    leaves live/dwelling rows written to disk but uncommitted; detecting that
+    here lets a chronic-timeout condition trip the breaker rather than silently
+    repeating. Fail-OPEN (returns False) on any error -- a broken git state
+    must never block or crash the batch. Best-effort: no repo / no git -> not
+    dirty (the common test/fresh-install case)."""
+    root = getattr(learnings_store, "LEARNINGS_ROOT", None)
+    if root is None or not (Path(root) / ".git").exists():
+        return False
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), "status", "--porcelain"],
+            capture_output=True, text=True, check=False, timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0 and bool(proc.stdout.strip())
+
+
+@contextlib.contextmanager
+def _sigterm_soft_stop():
+    """Install a SIGTERM handler that requests a graceful stop instead of an
+    immediate exit (adrev2-002). When `dream-daily.sh`'s `timeout 600` fires,
+    the default SIGTERM would kill `run_optimistic_integrate` between its
+    per-row store writes and its single end-of-batch commit, leaving live but
+    UN-committed dwelling rows (no sha to `revert`) and a dirty learnings tree.
+    Instead, the flag lets the batch loop finish the in-flight row, stop
+    accepting new ones, record a `timeout` anomaly, and run its normal
+    commit-what-it-has path.
+
+    Yields a one-key dict whose `["received"]` the loop polls. Only installable
+    from the main thread (`signal.signal` raises otherwise, e.g. under pytest in
+    a worker thread) -- in that case this is a no-op and the flag simply never
+    fires, which is correct (a threaded test is not the timeout scenario)."""
+    flag = {"received": False}
+
+    def _handler(signum, frame):  # noqa: ARG001
+        flag["received"] = True
+
+    previous = None
+    installed = False
+    try:
+        previous = signal.signal(signal.SIGTERM, _handler)
+        installed = True
+    except (ValueError, OSError, RuntimeError):
+        installed = False
+    try:
+        yield flag
+    finally:
+        if installed:
+            try:
+                signal.signal(signal.SIGTERM, previous)
+            except (ValueError, OSError, RuntimeError):
+                pass
 
 
 def run_optimistic_integrate(day: str) -> dict[str, Any]:
@@ -1601,16 +2219,44 @@ def run_optimistic_integrate(day: str) -> dict[str, Any]:
                 "project": slug, "detail": f"{len(eviction_rows)} eviction proposal(s) concentrated",
             })
 
+    # Dirty-tree anomaly (plan.md §9.3, adrev2-002): a prior batch killed
+    # mid-transaction (e.g. a fired timeout) leaves uncommitted rows; record it
+    # so chronic timeouts trip the breaker rather than silently repeating.
+    if _learnings_tree_dirty():
+        run_anomaly_timestamps.append(_utc_now_iso())
+        summary["anomalies"].append({"kind": "dirty_learnings_tree"})
+        _write_audit({
+            "outcome": "dirty_learnings_tree", "batch_id": batch_id,
+            "detail": "uncommitted learnings-store changes at run start (possible prior timeout kill)",
+        })
+
     add_supersede_counts: dict[str, int] = {slug: 0 for slug in by_slug}
     eviction_counts: dict[str, int] = {slug: 0 for slug in by_slug}
 
-    with _suppressed_autocommit():  # adrev-opt-013: one commit for the whole batch, not one per write
+    # Per-batch session-verification cache (§3.4) + citation counter
+    # (decisions.md #37), shared across every proposal so a session cited by N
+    # proposals is resolved/read/mined exactly ONCE.
+    session_cache: dict[str, SessionVerification] = {}
+    session_citation_counts: dict[str, int] = {}
+
+    timed_out = False
+    with _sigterm_soft_stop() as sigterm, _suppressed_autocommit():  # adrev-opt-013: one commit for the whole batch
         for slug, slug_rows in by_slug.items():
+            if sigterm["received"]:
+                break
             for row in slug_rows:
+                if sigterm["received"]:
+                    # adrev2-002: stop accepting NEW proposals on SIGTERM; the
+                    # in-flight row (if any) already completed atomically. Fall
+                    # through to the normal commit-what-it-has path below.
+                    timed_out = True
+                    break
                 outcome = _process_one_proposal(
                     row, slug=slug, cfg=cfg, live_count=live_counts[slug],
                     anomaly_slugs=anomaly_slugs, add_supersede_counts=add_supersede_counts,
                     eviction_counts=eviction_counts, batch_id=batch_id,
+                    heads=heads_by_slug[slug], session_cache=session_cache,
+                    session_citation_counts=session_citation_counts,
                 )
                 summary["results"].append(outcome)
                 if outcome.get("applied"):
@@ -1619,6 +2265,34 @@ def run_optimistic_integrate(day: str) -> dict[str, Any]:
                     summary["failed"] += 1
                 else:
                     summary["skipped"] += 1
+            if sigterm["received"]:
+                timed_out = True
+                break
+
+    if timed_out:
+        # Record a `timeout` breaker anomaly BEFORE the commit so a fired
+        # timeout is durably attributed and chronic timeouts trip the breaker.
+        run_anomaly_timestamps.append(_utc_now_iso())
+        summary["anomalies"].append({"kind": "timeout"})
+        summary["timed_out"] = True
+        _write_audit({
+            "outcome": "timeout", "batch_id": batch_id,
+            "detail": "SIGTERM received mid-batch; committing rows already applied",
+        })
+
+    # Session-citation concentration signal (decisions.md #37): a single
+    # session cited by many scored proposals in one batch is anomalous. Feeds
+    # the SAME windowed breaker as eviction concentration, without touching the
+    # (eviction-only) `_batch_anomaly_fires` check.
+    if session_citation_counts:
+        top_sid, top_count = max(session_citation_counts.items(), key=lambda kv: kv[1])
+        if top_count >= _SESSION_CITATION_ANOMALY_MIN:
+            run_anomaly_timestamps.append(_utc_now_iso())
+            summary["anomalies"].append({"kind": "session_citation_concentration", "count": top_count})
+            _write_audit({
+                "outcome": "session_citation_concentration", "batch_id": batch_id,
+                "detail": f"session cited {top_count} times in one batch",
+            })
 
     # Cross-night accumulation signal (§3.8) -- derived AFTER applying, so
     # it reflects tonight's own contribution too. Feeds the breaker for
@@ -1663,6 +2337,89 @@ def run_optimistic_integrate(day: str) -> dict[str, Any]:
         summary["commit"] = commit_result
 
     return summary
+
+
+# ---------------------------------------------------------------------------
+# eligibility-dry-run CLI: score a day's pending add/supersede proposals and
+# print the §3.7 per-signal breakdown, applying NOTHING and writing NO audit
+# (composite-eligibility plan.md §5 E3). This is the H1 what-if inspector --
+# it force-scores the composite even when eligibility is DISABLED in config, so
+# the operator can preview a day's proposals before opting in.
+# ---------------------------------------------------------------------------
+
+
+def run_eligibility_dry_run(day: str) -> dict[str, Any]:
+    """Read-only: score every pending add/supersede proposal for `day` and
+    return their per-signal breakdowns. Writes nothing (no audit, no status
+    change, no store write). Non-scored kinds and gated postures are reported
+    with a note rather than a composite score."""
+    result: dict[str, Any] = {"day": day, "proposals": []}
+    path = proposals_dir() / f"{day}.jsonl"
+    if not path.is_file():
+        return result
+
+    rows = _read_jsonl(path)
+    pending = [r for r in rows if r.get("status") == "pending"]
+    cfg = da.load_config().get("optimistic_integration") or {}
+    elig_cfg = cfg.get("eligibility") or {}
+
+    slugs = {r.get("project") for r in pending if isinstance(r.get("project"), str) and r.get("project")}
+    heads_by_slug: dict[str, dict[str, dict[str, Any]]] = {
+        s: {h["id"]: h for h in learnings_store.load_all(s)} for s in slugs
+    }
+    cache: dict[str, SessionVerification] = {}
+
+    for row in pending:
+        pid = row.get("id")
+        kind = row.get("kind")
+        project = row.get("project")
+        entry: dict[str, Any] = {
+            "proposal_id": pid, "kind": kind, "project": project,
+            "confidence": _confidence_of(row), "type": row.get("type"),
+        }
+        posture = da.resolve_posture(kind, project)
+        if posture["posture"] == "gated":
+            entry["outcome"] = "skipped_gated"
+            entry["note"] = "gated posture (e.g. _global) -- never composite-scored"
+            result["proposals"].append(entry)
+            continue
+        if kind not in ("learning_add", "learning_supersede"):
+            entry["outcome"] = "legacy_path"
+            entry["note"] = f"kind {kind!r} is not composite-scored (legacy floor applies)"
+            result["proposals"].append(entry)
+            continue
+        try:
+            ev = evaluate_proposal_eligibility(
+                row, slug=project, cache=cache,
+                heads=heads_by_slug.get(project) or {}, cfg=cfg, elig_cfg=elig_cfg,
+            )
+        except Exception:  # noqa: BLE001 -- dry-run must never crash on one bad row
+            entry["outcome"] = "internal_error"
+            entry["note"] = traceback.format_exc()
+            result["proposals"].append(entry)
+            continue
+        d = ev.decision
+        entry.update({
+            "outcome": d.outcome,
+            "decision_basis": d.decision_basis,
+            "score": d.score,
+            "threshold": d.threshold,
+            "margin": d.margin,
+            "signals": d.signals,
+            "weakest_signal": d.weakest_signal,
+            "verified_sessions": len(ev.verified_session_ids),
+            "evidence_tier": ev.evidence_tier,
+            "unresolved_session_ids": ev.unresolved_session_ids,
+        })
+        if not elig_cfg.get("enabled"):
+            entry["note"] = "eligibility disabled in config -- this is a what-if preview only"
+        if ev.evidence_tier == "user-corrected" and ev.tier_source:
+            entry["evidence_tier_source"] = ev.tier_source
+        if kind == "learning_supersede":
+            entry["near_duplicate_supersede"] = ev.near_dup_supersede
+        result["proposals"].append(entry)
+
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -1892,6 +2649,13 @@ def _cmd_eval_refresh(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_eligibility_dry_run(args: argparse.Namespace) -> int:
+    day = args.date or today_iso()
+    result = run_eligibility_dry_run(day)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
 def build_arg_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="CCGM dreaming: human-gated apply path (Epic 6).")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -1962,6 +2726,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     refresh_p.add_argument("--day", help="defaults to today (UTC, or CCGM_DREAMING_TODAY)")
     refresh_p.set_defaults(func=_cmd_eval_refresh)
+
+    dry_p = sub.add_parser(
+        "eligibility-dry-run",
+        help="score a day's pending learning_add/learning_supersede proposals through the composite "
+             "eligibility gate and print the per-signal breakdown, applying NOTHING (composite-"
+             "eligibility plan.md §5 E3; the H1 what-if inspector -- scores even when eligibility is "
+             "disabled in config)",
+    )
+    dry_p.add_argument("--date", help="proposals/{date}.jsonl; defaults to today (UTC, or CCGM_DREAMING_TODAY)")
+    dry_p.set_defaults(func=_cmd_eligibility_dry_run)
 
     return p
 

--- a/modules/dreaming/tests/test_eligibility_gate.py
+++ b/modules/dreaming/tests/test_eligibility_gate.py
@@ -713,6 +713,147 @@ class NoveltyTests(GateTestBase):
 
 
 # ---------------------------------------------------------------------------
+# Session-citation concentration anomaly (decisions.md #37).
+#
+# Pinned semantics: the counter increments once per evidence CITATION (per
+# non-null session_id entry on a scored add/supersede row) in ENABLED mode
+# only; rows short-circuited below the static floor never reach the counter.
+# When one session accumulates >= adp._SESSION_CITATION_ANOMALY_MIN citations
+# in a batch, exactly ONE anomaly is recorded via the SAME windowed-breaker
+# anomaly-timestamp path the eviction-concentration check uses (observable in
+# summary["anomalies"], the apply-audit log, and state/optimistic.json's
+# anomaly_log). The anomaly NEVER changes any per-row outcome in the firing
+# run -- it only accumulates toward a future breaker trip.
+# ---------------------------------------------------------------------------
+
+
+class SessionCitationAnomalyTests(GateTestBase):
+    def _state_anomaly_log(self) -> list:
+        path = adp.optimistic_state_path()
+        if not path.is_file():
+            return []
+        return json.loads(path.read_text(encoding="utf-8")).get("anomaly_log", [])
+
+    def _citation_batch(self, *, n_rows: int, slug: str, sid: str, confidence: int = 6) -> list:
+        # One citation per proposal; content varies so store keys never collide.
+        return [
+            self._add_row(pid=self._pid(f"cit{i}"), slug=slug, session_id=sid,
+                          excerpt=_LONG_SENTENCE, content=f"{_LONG_SENTENCE} variant {i}",
+                          confidence=confidence)
+            for i in range(n_rows)
+        ]
+
+    def _citation_anomalies(self, summary: dict) -> list:
+        return [a for a in summary["anomalies"] if a.get("kind") == "session_citation_concentration"]
+
+    def test_at_threshold_fires_and_feeds_breaker_path(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        # Session deliberately UNRESOLVABLE: citations count regardless of
+        # whether verification succeeds (padding to fake sessions is exactly
+        # the shape the signal watches).
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        self._write_day(day, self._citation_batch(
+            n_rows=adp._SESSION_CITATION_ANOMALY_MIN, slug=slug, sid=sid))
+        log_before = len(self._state_anomaly_log())
+
+        summary = adp.run_optimistic_integrate(day)
+
+        fired = self._citation_anomalies(summary)
+        self.assertEqual(len(fired), 1, summary)
+        self.assertEqual(fired[0]["count"], adp._SESSION_CITATION_ANOMALY_MIN)
+        # Breaker anomaly-timestamp path received it: state anomaly_log grew.
+        self.assertEqual(len(self._state_anomaly_log()), log_before + 1)
+        # And the audit trail carries the record.
+        self.assertTrue(any(
+            rec.get("outcome") == "session_citation_concentration" and rec.get("batch_id") == summary["batch_id"]
+            for rec in self._audit()
+        ))
+
+    def test_below_threshold_does_not_fire(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        self._write_day(day, self._citation_batch(
+            n_rows=adp._SESSION_CITATION_ANOMALY_MIN - 1, slug=slug, sid=sid))
+        log_before = len(self._state_anomaly_log())
+
+        summary = adp.run_optimistic_integrate(day)
+
+        self.assertEqual(self._citation_anomalies(summary), [], summary)
+        self.assertEqual(len(self._state_anomaly_log()), log_before)
+        self.assertFalse(any(
+            rec.get("outcome") == "session_citation_concentration" and rec.get("batch_id") == summary["batch_id"]
+            for rec in self._audit()
+        ))
+
+    def test_disabled_mode_never_counts_citations(self):
+        # Strongest form: conf-9/sessions-5 rows that fully APPLY on the legacy
+        # path -- even a fully-applying disabled-mode batch citing one session
+        # >= threshold times records NO citation anomaly (the counter is only
+        # fed on the enabled composite path, which disabled mode never enters).
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_config({"eligibility": {"enabled": False}})
+        day = self._day()
+        self._write_day(day, self._citation_batch(
+            n_rows=adp._SESSION_CITATION_ANOMALY_MIN, slug=slug, sid=sid, confidence=9))
+        log_before = len(self._state_anomaly_log())
+
+        summary = adp.run_optimistic_integrate(day)
+
+        self.assertEqual(summary["applied"], adp._SESSION_CITATION_ANOMALY_MIN, summary)
+        self.assertEqual(self._citation_anomalies(summary), [], summary)
+        self.assertEqual(len(self._state_anomaly_log()), log_before)
+        self.assertFalse(any(
+            rec.get("outcome") == "session_citation_concentration" and rec.get("batch_id") == summary["batch_id"]
+            for rec in self._audit()
+        ))
+
+    def test_firing_anomaly_does_not_change_per_row_outcomes(self):
+        # A RESOLVABLE, user-corrected session cited by >= threshold eligible
+        # rows: every row still scores/applies normally in the SAME run the
+        # anomaly fires in -- the anomaly only accumulates toward the breaker
+        # (one anomaly < circuit_breaker_max_anomalies=2, so no trip either).
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=True), days_ago=1)
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        rows = self._citation_batch(n_rows=adp._SESSION_CITATION_ANOMALY_MIN, slug=slug, sid=sid)
+        self._write_day(day, rows)
+
+        summary = adp.run_optimistic_integrate(day)
+
+        self.assertEqual(len(self._citation_anomalies(summary)), 1, summary)
+        # Every row applied normally despite the anomaly firing in this run.
+        self.assertEqual(summary["applied"], adp._SESSION_CITATION_ANOMALY_MIN, summary)
+        for row in rows:
+            self.assertEqual(self._status(day, row["id"]), "auto_applied")
+            rec = self._elig_audit_for(row["id"])
+            self.assertEqual(rec["outcome"], "eligible")
+        # Breaker not tripped/suspended by a single anomaly.
+        self.assertNotIn(summary.get("circuit_breaker"), ("tripped", "suspended"))
+        state = json.loads(adp.optimistic_state_path().read_text(encoding="utf-8"))
+        self.assertFalse(state.get("suspended"), state)
+
+    def test_static_floor_rows_do_not_feed_counter(self):
+        # Rows short-circuited at the static floor never gather signals, so
+        # their citations are NOT counted: threshold-many sub-floor rows citing
+        # one session record no anomaly.
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        self._write_day(day, self._citation_batch(
+            n_rows=adp._SESSION_CITATION_ANOMALY_MIN, slug=slug, sid=sid, confidence=4))
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(self._citation_anomalies(summary), [], summary)
+
+
+# ---------------------------------------------------------------------------
 # eligibility-dry-run CLI: scores, prints, mutates nothing.
 # ---------------------------------------------------------------------------
 

--- a/modules/dreaming/tests/test_eligibility_gate.py
+++ b/modules/dreaming/tests/test_eligibility_gate.py
@@ -366,6 +366,77 @@ class GuardIITwoSidedTests(GateTestBase):
         self.assertEqual(red_ev.verified_session_ids, [red_sid],
                          "heavily-redacted legitimate excerpt must be accepted (adrev-001 preserved)")
 
+    def test_proportional_arm_binds_beyond_absolute_floor(self):
+        """Regression-lock for _EXCERPT_GUARD_FRACTION's DOWNWARD direction.
+
+        The two-sided test above only exercises the _EXCERPT_GUARD_MIN_ABS_TOKENS
+        floor (short excerpts), so it would still pass if the fraction were
+        silently gutted to 0.0. This test constructs a pair where ONLY the
+        proportional arm can reject: a 12-content-token excerpt (required =
+        max(3, ceil(0.5*12)) = 6 > the absolute floor of 3) against a
+        same-length transcript sentence sharing high character similarity
+        (~0.89 >= 0.85) but only 4 intact tokens.
+
+          * 4 >= 3  -> the absolute floor alone would ACCEPT it;
+          * 4 <  6  -> the shipped proportional arm REJECTS it.
+
+        Self-validation: with _EXCERPT_GUARD_FRACTION patched to 0.0 the SAME
+        pair is accepted, proving the rejection came from the proportional arm
+        (not similarity or the floor). Mirror positive: 10 intact tokens >= 6
+        -> accepted under the shipped constants, all else equal.
+        """
+        excerpt = "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima"
+        # 8 of 12 tokens mutated by one SAME-POSITION character (length
+        # preserved so the excerpt-sized window covers the sentence exactly):
+        # token intersection = {india, juliet, kilo, lima} = 4.
+        low_overlap = "alphq bravp charlif deltq echp foxtrob golg hotep india juliet kilo lima"
+        # Only 2 mutated: intersection = 10.
+        high_overlap = "alphq bravp charlie delta echo foxtrot golf hotel india juliet kilo lima"
+
+        # Preconditions of the construction (fail loudly if fixtures drift).
+        tokens = adp._excerpt_content_tokens(excerpt)
+        self.assertEqual(len(tokens), 12)
+        required = max(adp._EXCERPT_GUARD_MIN_ABS_TOKENS,
+                       math.ceil(adp._EXCERPT_GUARD_FRACTION * len(tokens)))
+        self.assertGreater(required, adp._EXCERPT_GUARD_MIN_ABS_TOKENS,
+                           "construction must make the proportional arm the binding one")
+
+        slug = self._slug()
+        low_sid = f"sess-low-{uuid.uuid4().hex[:6]}"
+        high_sid = f"sess-high-{uuid.uuid4().hex[:6]}"
+        self._write_session(low_sid, slug=slug, turns=[tf.user_turn(low_overlap, human=True)])
+        self._write_session(high_sid, slug=slug, turns=[tf.user_turn(high_overlap, human=True)])
+
+        low_row = self._add_row(pid=self._pid("low"), slug=slug, session_id=low_sid,
+                                content=excerpt, excerpt=excerpt)
+        high_row = self._add_row(pid=self._pid("high"), slug=slug, session_id=high_sid,
+                                 content=excerpt, excerpt=excerpt)
+
+        low_ev = self._eval(low_row, slug=slug)
+        self.assertEqual(low_ev.verified_session_ids, [],
+                         "4 intact tokens < ceil(0.5*12)=6: the proportional arm must reject")
+
+        high_ev = self._eval(high_row, slug=slug)
+        self.assertEqual(high_ev.verified_session_ids, [high_sid],
+                         "10 intact tokens >= 6: accepted under the shipped constants")
+
+        # Self-validation: the SAME low-overlap pair is accepted once the
+        # fraction is gutted to 0.0 -- so the rejection above is attributable
+        # to the proportional arm alone (similarity and the absolute floor
+        # both pass). This is exactly the silent-downgrade this test locks out.
+        with mock.patch.object(adp, "_EXCERPT_GUARD_FRACTION", 0.0):
+            gutted_ev = self._eval(low_row, slug=slug)
+        self.assertEqual(gutted_ev.verified_session_ids, [low_sid],
+                         "with fraction=0.0 the pair must be accepted -- if this fails, the "
+                         "construction no longer isolates the proportional arm")
+
+        # Constant pin: 3/0.5 are the values the two-sided calibration
+        # (adrev3-002: short-common-token rejected AND redacted-legit accepted)
+        # and this proportional-arm lock were computed against. Changing either
+        # requires re-running BOTH arms of both tests.
+        self.assertEqual(adp._EXCERPT_GUARD_MIN_ABS_TOKENS, 3)
+        self.assertEqual(adp._EXCERPT_GUARD_FRACTION, 0.5)
+
 
 # ---------------------------------------------------------------------------
 # Tier re-mining (both directions) + spoofing.

--- a/modules/dreaming/tests/test_eligibility_gate.py
+++ b/modules/dreaming/tests/test_eligibility_gate.py
@@ -1,0 +1,759 @@
+#!/usr/bin/env python3
+"""
+Tests for the composite-eligibility gate integration (composite-eligibility
+plan.md Epic E3): apply_dream_proposal.py's enabled-mode waterfall inside
+_process_one_proposal(), gather_eligibility_signals() + the per-batch
+SessionVerification cache (§3.4), the audit breakdown (§3.7), the near-
+duplicate-supersede flag, and the eligibility-dry-run CLI.
+
+Runs in isolation: CCGM_LEARNINGS_DIR + CCGM_DREAMING_DIR + CCGM_CLAUDE_PROJECTS_DIR
++ HOME are redirected to tempdirs BEFORE import (module-level constants freeze
+at import time -- learnings_store.LEARNINGS_ROOT and CLAUDE_PROJECTS_ROOT; #793).
+No network, no ANTHROPIC_API_KEY, never the real store/dreaming dir/transcripts.
+Every transcript is synthetic (transcript_fixtures.py; no real path/username).
+
+Run with: python3 -m pytest modules/dreaming/tests/test_eligibility_gate.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sys
+import tempfile
+import unittest
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import mock
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(HERE.parent / "lib"))
+
+sys.modules.pop("learnings_store", None)
+sys.modules.pop("dream_analyze", None)
+sys.modules.pop("apply_dream_proposal", None)
+sys.modules.pop("transcript_miner", None)
+
+_TMP_LEARNINGS = tempfile.mkdtemp(prefix="ccgm-elig-gate-learnings-")
+_TMP_DREAMING = tempfile.mkdtemp(prefix="ccgm-elig-gate-dreaming-")
+_TMP_PROJECTS = tempfile.mkdtemp(prefix="ccgm-elig-gate-projects-")
+_TMP_HOME = tempfile.mkdtemp(prefix="ccgm-elig-gate-home-")
+_ORIG = {
+    "CCGM_LEARNINGS_DIR": os.environ.get("CCGM_LEARNINGS_DIR"),
+    "CCGM_DREAMING_DIR": os.environ.get("CCGM_DREAMING_DIR"),
+    "CCGM_CLAUDE_PROJECTS_DIR": os.environ.get("CCGM_CLAUDE_PROJECTS_DIR"),
+    "HOME": os.environ.get("HOME"),
+}
+os.environ["CCGM_LEARNINGS_DIR"] = _TMP_LEARNINGS
+os.environ["CCGM_DREAMING_DIR"] = _TMP_DREAMING
+os.environ["CCGM_CLAUDE_PROJECTS_DIR"] = _TMP_PROJECTS
+os.environ["HOME"] = _TMP_HOME
+
+import apply_dream_proposal as adp  # noqa: E402
+import dream_analyze as da  # noqa: E402
+import eligibility as elig  # noqa: E402
+import learnings_store as ls  # noqa: E402
+import transcript_fixtures as tf  # noqa: E402
+
+
+def tearDownModule() -> None:
+    for key, orig in _ORIG.items():
+        if orig is not None:
+            os.environ[key] = orig
+        else:
+            os.environ.pop(key, None)
+
+
+_LONG_SENTENCE = (
+    "The Edit tool does not follow symlinks so read the workspace path first "
+    "before editing the file"
+)
+
+
+def _iso(dt: datetime) -> str:
+    return tf.iso(dt)
+
+
+class GateTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._pin("CCGM_LEARNINGS_DIR", str(ls.LEARNINGS_ROOT))
+        self._pin("CCGM_DREAMING_DIR", _TMP_DREAMING)
+        self._pin("CCGM_CLAUDE_PROJECTS_DIR", str(ls.CLAUDE_PROJECTS_ROOT))
+        self._pin("HOME", _TMP_HOME)
+        adp.proposals_dir().mkdir(parents=True, exist_ok=True)
+        adp._write_optimistic_state_atomic(adp._default_optimistic_state())
+
+    def _pin(self, key: str, value: str) -> None:
+        had = key in os.environ
+        prior = os.environ.get(key)
+        os.environ[key] = value
+        self.addCleanup(lambda: os.environ.__setitem__(key, prior) if had else os.environ.pop(key, None))
+
+    # ---- fixtures -------------------------------------------------------
+
+    def _slug(self, label: str = "elig") -> str:
+        return f"{label}-{uuid.uuid4().hex[:8]}"
+
+    def _cwd_for(self, slug: str) -> str:
+        # A guaranteed-nonexistent absolute path whose basename IS the slug, so
+        # detect_project_slug() falls through git resolution to basename==slug.
+        return f"/synthetic-nonexistent/code/{slug}"
+
+    def _write_session(
+        self, session_id: str, *, slug: str, turns: list, days_ago: float = 1.0,
+    ) -> str:
+        base = datetime.now(timezone.utc) - timedelta(days=days_ago)
+        path = ls.CLAUDE_PROJECTS_ROOT / f"proj-{uuid.uuid4().hex[:6]}" / f"{session_id}.jsonl"
+        tf.write_transcript(
+            path, turns, session_id=session_id, cwd=self._cwd_for(slug),
+            base_ts=_iso(base),
+        )
+        return str(path)
+
+    def _corroborating_turns(self, *, correction: bool, sentence: str = _LONG_SENTENCE) -> list:
+        turns: list = []
+        if correction:
+            turns.extend(tf.correction_sequence(
+                request="Please reformat the config file.",
+                correction="No, that's wrong, revert that change to the config entirely.",
+            ))
+        turns.append(tf.user_turn(sentence, human=True))
+        return turns
+
+    def _elig_cfg(self, **overrides) -> dict:
+        cfg = elig.default_eligibility()
+        cfg["enabled"] = True
+        cfg.update(overrides)
+        return cfg
+
+    def _optimistic(self, elig_cfg: dict | None = None, **top) -> dict:
+        cfg = {"confidence_floor_content": 8, "add_min_sessions": 2}
+        cfg.update(top)
+        cfg["eligibility"] = elig_cfg if elig_cfg is not None else self._elig_cfg()
+        return cfg
+
+    def _add_row(self, *, pid: str, slug: str, session_id: str, excerpt: str,
+                 content: str = _LONG_SENTENCE, confidence: int = 6, type_: str = "pitfall",
+                 extra_evidence: list | None = None, **extra) -> dict:
+        evidence = [{"session_id": session_id, "excerpt": excerpt}]
+        if extra_evidence:
+            evidence.extend(extra_evidence)
+        row = {
+            "id": pid, "kind": "learning_add", "project": slug, "target_id": None,
+            "content": content, "type": type_, "confidence": confidence,
+            "prevalence": {"sessions": 2, "agents": 1}, "evidence": evidence,
+            "justification": "test", "fingerprint": f"fp-{pid}",
+            "generated_at": "2026-01-01T00:00:00.000Z", "status": "pending",
+        }
+        row.update(extra)
+        return row
+
+    def _write_config(self, optimistic: dict) -> None:
+        p = da.dreaming_dir() / "config.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"optimistic_integration": optimistic}), encoding="utf-8")
+
+    def _write_day(self, day: str, rows: list) -> None:
+        path = adp.proposals_dir() / f"{day}.jsonl"
+        with path.open("w", encoding="utf-8") as fh:
+            for r in rows:
+                fh.write(json.dumps(r, sort_keys=True) + "\n")
+
+    def _day(self) -> str:
+        return f"2026-test-{uuid.uuid4().hex[:8]}"
+
+    def _pid(self, label: str = "p") -> str:
+        # Globally unique: find_proposal() scans EVERY proposals/*.jsonl file, so
+        # a pid reused across tests would resolve to an earlier test's already-
+        # applied row and be refused. Real proposal ids are uuids; mirror that.
+        return f"{label}-{uuid.uuid4().hex[:10]}"
+
+    def _read_day(self, day: str) -> list:
+        return adp._read_jsonl(adp.proposals_dir() / f"{day}.jsonl")
+
+    def _status(self, day: str, pid: str) -> str | None:
+        for r in self._read_day(day):
+            if r.get("id") == pid:
+                return r.get("status")
+        return None
+
+    def _audit(self) -> list:
+        path = adp.apply_audit_path()
+        if not path.is_file():
+            return []
+        return [json.loads(ln) for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+    def _elig_audit_for(self, pid: str) -> dict | None:
+        # LAST match: the shared apply-audit.jsonl accumulates across tests, so
+        # a pid reused by an earlier test would otherwise shadow this test's
+        # record. Reading immediately after this test's run, the last-written
+        # eligibility record for `pid` is ours.
+        found = None
+        for rec in self._audit():
+            if rec.get("audit_kind") == "eligibility" and rec.get("proposal_id") == pid:
+                found = rec
+        return found
+
+    def _eval(self, row: dict, *, slug: str, heads: dict | None = None,
+              elig_cfg: dict | None = None, optimistic: dict | None = None):
+        ec = elig_cfg if elig_cfg is not None else self._elig_cfg()
+        opt = optimistic if optimistic is not None else self._optimistic(ec)
+        return adp.evaluate_proposal_eligibility(
+            row, slug=slug, cache={}, heads=heads or {}, cfg=opt, elig_cfg=ec,
+        )
+
+
+# ---------------------------------------------------------------------------
+# §3.4 three-part session verification matrix.
+# ---------------------------------------------------------------------------
+
+
+class SessionVerificationMatrixTests(GateTestBase):
+    def test_resolvable_corroborated_counts(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=False))
+        row = self._add_row(pid="a1", slug=slug, session_id=sid, excerpt=_LONG_SENTENCE)
+        ev = self._eval(row, slug=slug)
+        self.assertEqual(ev.verified_session_ids, [sid])
+
+    def test_unresolvable_session_not_counted(self):
+        slug = self._slug()
+        row = self._add_row(pid="a1", slug=slug, session_id="sess-does-not-exist", excerpt=_LONG_SENTENCE)
+        ev = self._eval(row, slug=slug)
+        self.assertEqual(ev.verified_session_ids, [])
+        self.assertIn("sess-does-not-exist", ev.unresolved_session_ids)
+
+    def test_slug_mismatch_not_counted(self):
+        slug = self._slug()
+        other = self._slug("other")
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        # transcript cwd basename == `other`, but row.project == slug -> mismatch
+        self._write_session(sid, slug=other, turns=self._corroborating_turns(correction=False))
+        row = self._add_row(pid="a1", slug=slug, session_id=sid, excerpt=_LONG_SENTENCE)
+        ev = self._eval(row, slug=slug)
+        self.assertEqual(ev.verified_session_ids, [])
+
+    def test_garbage_excerpt_not_counted(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=False))
+        row = self._add_row(pid="a1", slug=slug, session_id=sid,
+                            excerpt="completely unrelated zzzqqq wubwub content nowhere present")
+        ev = self._eval(row, slug=slug)
+        self.assertEqual(ev.verified_session_ids, [])
+
+    def test_paraphrased_excerpt_counted(self):
+        # adrev-001: a paraphrased excerpt above excerpt_match_min still counts.
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=False))
+        row = self._add_row(
+            pid="a1", slug=slug, session_id=sid,
+            excerpt="The Edit tool doesn't follow symlinks, so read the workspace path first before editing the file",
+        )
+        ev = self._eval(row, slug=slug)
+        self.assertEqual(ev.verified_session_ids, [sid])
+
+    def test_neutralized_wrapper_excerpt_matches_raw(self):
+        # adrev-001: normalization strips [neutralized] wrappers before compare.
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=False))
+        row = self._add_row(
+            pid="a1", slug=slug, session_id=sid,
+            excerpt="[neutralized]The Edit tool[/neutralized] does not follow symlinks so read the "
+                    "workspace path first before editing the file",
+        )
+        ev = self._eval(row, slug=slug)
+        self.assertEqual(ev.verified_session_ids, [sid])
+
+    def test_redaction_placeholder_excerpt_still_counts(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        raw = ("the deploy key ghp_ABCD1234SECRET must be set in the settings file before running "
+               "the migration script now")
+        self._write_session(sid, slug=slug, turns=[tf.user_turn(raw, human=True)])
+        row = self._add_row(
+            pid="a1", slug=slug, session_id=sid, content=raw,
+            excerpt="the deploy key [REDACTED:github_token] must be set in the settings file before "
+                    "running the migration script now",
+        )
+        ev = self._eval(row, slug=slug)
+        self.assertEqual(ev.verified_session_ids, [sid])
+
+    def test_duplicate_citation_counts_once(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=False))
+        row = self._add_row(
+            pid="a1", slug=slug, session_id=sid, excerpt=_LONG_SENTENCE,
+            extra_evidence=[{"session_id": sid, "excerpt": _LONG_SENTENCE}],
+        )
+        ev = self._eval(row, slug=slug)
+        self.assertEqual(ev.verified_session_ids, [sid])
+        self.assertEqual(len(ev.verified_session_ids), 1)
+
+    def test_null_session_excluded(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=False))
+        row = self._add_row(
+            pid="a1", slug=slug, session_id=sid, excerpt=_LONG_SENTENCE,
+            extra_evidence=[{"session_id": None, "excerpt": _LONG_SENTENCE},
+                            {"session_id": "", "excerpt": _LONG_SENTENCE}],
+        )
+        ev = self._eval(row, slug=slug)
+        self.assertEqual(ev.verified_session_ids, [sid])
+        self.assertNotIn(None, ev.cited_session_ids)
+        self.assertNotIn("", ev.cited_session_ids)
+
+    def test_oversized_transcript_counts_but_tier_inferred_recency_zero(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        # A human correction WOULD mint user-corrected, but the tiny byte cap
+        # forces tier inferred + recency 0 while the excerpt check still streams.
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=True))
+        ec = self._elig_cfg(max_transcript_bytes=1_000_000)  # config floor
+        # Force "oversized" by reporting a file size far above the cap (config
+        # validation forbids <1MB caps, so we cannot shrink the cap itself).
+        row = self._add_row(pid="a1", slug=slug, session_id=sid, excerpt=_LONG_SENTENCE)
+        with mock.patch.object(adp.os.path, "getsize", return_value=10 ** 9):
+            bundle, _ = adp.gather_eligibility_signals(row, slug=slug, cache={}, heads={}, elig_cfg=ec)
+        # Excerpt-verified session STILL counts (the check streams), but tier is
+        # forced inferred and recency 0 (no timestamp read) -- fail toward weakest.
+        self.assertEqual(bundle.verified_sessions, 1)
+        self.assertEqual(bundle.evidence_tier, "inferred")
+        self.assertIsNone(bundle.newest_evidence_age_days)
+
+
+# ---------------------------------------------------------------------------
+# Guard-(ii) two-sided reconciliation (adrev3-002): one test, both arms.
+# ---------------------------------------------------------------------------
+
+
+class GuardIITwoSidedTests(GateTestBase):
+    def test_short_common_rejected_and_redacted_legit_accepted(self):
+        slug = self._slug()
+        # Arm (a): a short common-token excerpt (2 content tokens) that the LARGE
+        # transcript literally CONTAINS -> similarity would clear, but guard (ii)
+        # requires >= 3 distinct content tokens, so it is rejected (coincidence
+        # prevented, size-independent).
+        big_sid = f"sess-big-{uuid.uuid4().hex[:6]}"
+        big_line = ("the file was changed here today and then again after that " * 200) + "the file was changed"
+        self._write_session(big_sid, slug=slug, turns=[tf.user_turn(big_line, human=True)])
+        short_row = self._add_row(pid="short", slug=slug, session_id=big_sid,
+                                  content="the file was changed", excerpt="the file was changed")
+        short_ev = self._eval(short_row, slug=slug)
+        self.assertEqual(short_ev.verified_session_ids, [],
+                         "short common-token excerpt must be rejected by guard (ii)")
+
+        # Arm (b): a heavily-redacted BUT substantial legitimate excerpt is
+        # accepted -- placeholders are excluded from guard (ii)'s denominator.
+        red_sid = f"sess-red-{uuid.uuid4().hex[:6]}"
+        raw = ("the production deploy key ghp_TOPSECRET7788 must be exported into the settings file "
+               "and the migration script before the nightly build can run")
+        self._write_session(red_sid, slug=slug, turns=[tf.user_turn(raw, human=True)])
+        red_row = self._add_row(
+            pid="red", slug=slug, session_id=red_sid, content=raw,
+            excerpt="the production deploy key [REDACTED:github_token] must be exported into the "
+                    "settings file and the migration script before the nightly build can run",
+        )
+        red_ev = self._eval(red_row, slug=slug)
+        self.assertEqual(red_ev.verified_session_ids, [red_sid],
+                         "heavily-redacted legitimate excerpt must be accepted (adrev-001 preserved)")
+
+
+# ---------------------------------------------------------------------------
+# Tier re-mining (both directions) + spoofing.
+# ---------------------------------------------------------------------------
+
+
+class TierTests(GateTestBase):
+    def test_human_origin_correction_mints_user_corrected(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=True))
+        ev = self._eval(self._add_row(pid="a1", slug=slug, session_id=sid, excerpt=_LONG_SENTENCE), slug=slug)
+        self.assertEqual(ev.evidence_tier, "user-corrected")
+        self.assertIsNotNone(ev.tier_source)
+        self.assertEqual(ev.tier_source.get("origin_kind"), "human")
+
+    def test_tool_result_only_correction_stays_inferred(self):
+        # sec-C1: a negation phrase in a NON-human (tool_result) turn is not a
+        # correction (E2's human-origin filter), so tier stays inferred.
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        turns = [
+            tf.user_turn("Please reformat the config file.", human=True),
+            tf.assistant_turn("Working.", tool_uses=[{"id": "t1", "name": "Bash", "input": {"command": "x"}}]),
+            tf.friction_turn(tool_use_id="t1", content="that's wrong, revert that entirely", exit_code=1),
+            tf.user_turn(_LONG_SENTENCE, human=True),
+        ]
+        self._write_session(sid, slug=slug, turns=turns)
+        ev = self._eval(self._add_row(pid="a1", slug=slug, session_id=sid, excerpt=_LONG_SENTENCE), slug=slug)
+        self.assertEqual(ev.evidence_tier, "inferred")
+
+    def test_forged_stamped_fields_ignored_skipped_origin(self):
+        # arch-C3: a row carrying a forged evidence_tier + stamped_signals but a
+        # CORRECTION-FREE transcript is scored on the freshly-computed tier
+        # (inferred); a single inferred session < add_min_sessions -> skipped_origin.
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=False))
+        row = self._add_row(
+            pid="a1", slug=slug, session_id=sid, excerpt=_LONG_SENTENCE, confidence=6,
+            evidence_tier="user-corrected",
+            stamped_signals={"prevalence": 9, "recency": 1.0},
+        )
+        ev = self._eval(row, slug=slug)
+        self.assertEqual(ev.evidence_tier, "inferred")
+        self.assertEqual(ev.decision.outcome, "skipped_origin")
+        self.assertFalse(ev.decision.eligible)
+
+
+# ---------------------------------------------------------------------------
+# Waterfall routing + the disabled-mode spy (eligibility never called).
+# ---------------------------------------------------------------------------
+
+
+class WaterfallRoutingTests(GateTestBase):
+    def test_disabled_mode_never_calls_eligibility(self):
+        slug = self._slug()
+        self._write_config({"eligibility": {"enabled": False}})
+        day = self._day()
+        self._write_day(day, [self._add_row(pid="a1", slug=slug, session_id="sess-x",
+                                            excerpt=_LONG_SENTENCE, confidence=8)])
+        with mock.patch.object(adp.eligibility, "evaluate_eligibility",
+                               wraps=adp.eligibility.evaluate_eligibility) as spy:
+            adp.run_optimistic_integrate(day)
+        self.assertEqual(spy.call_count, 0, "eligibility must not be called on the disabled/legacy path")
+
+    def test_enabled_non_content_kind_takes_legacy_path(self):
+        slug = self._slug()
+        # seed a target to verify
+        e = ls.build_entry(type_="pattern", content="verify target", confidence=5)
+        e["project"] = slug
+        ls.append_entry(e, slug=slug)
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        self._write_day(day, [{
+            "id": "v1", "kind": "learning_verify", "project": slug, "target_id": e["id"],
+            "content": None, "type": None, "confidence": 8,
+            "prevalence": {"sessions": 2, "agents": 1},
+            "evidence": [{"session_id": "sess-x", "excerpt": "x"}],
+            "justification": "t", "fingerprint": "fp-v1",
+            "generated_at": "2026-01-01T00:00:00.000Z", "status": "pending",
+        }])
+        with mock.patch.object(adp.eligibility, "evaluate_eligibility",
+                               wraps=adp.eligibility.evaluate_eligibility) as spy:
+            summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(spy.call_count, 0, "verify must not route through the composite")
+        self.assertEqual(summary["applied"], 1)
+
+    def test_enabled_add_routes_through_composite(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=True))
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        pid = self._pid("add")
+        self._write_day(day, [self._add_row(pid=pid, slug=slug, session_id=sid,
+                                            excerpt=_LONG_SENTENCE, confidence=6)])
+        with mock.patch.object(adp.eligibility, "evaluate_eligibility",
+                               wraps=adp.eligibility.evaluate_eligibility) as spy:
+            summary = adp.run_optimistic_integrate(day)
+        self.assertGreaterEqual(spy.call_count, 1)
+        self.assertEqual(summary["applied"], 1)
+        self.assertEqual(self._status(day, pid), "auto_applied")
+
+
+# ---------------------------------------------------------------------------
+# Origin gate + composite outcomes end-to-end (through run_optimistic_integrate).
+# ---------------------------------------------------------------------------
+
+
+class OutcomeTests(GateTestBase):
+    def test_inferred_single_session_skipped_origin_stays_pending(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=False))
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        self._write_day(day, [self._add_row(pid="a1", slug=slug, session_id=sid,
+                                            excerpt=_LONG_SENTENCE, confidence=6)])
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 0)
+        self.assertEqual(self._status(day, "a1"), "pending")
+        rec = self._elig_audit_for("a1")
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec["outcome"], "skipped_origin")
+
+    def test_user_corrected_conf6_eligible_composite(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=True), days_ago=1)
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        pid = self._pid("add")
+        self._write_day(day, [self._add_row(pid=pid, slug=slug, session_id=sid,
+                                            excerpt=_LONG_SENTENCE, confidence=6)])
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 1, summary)
+        rec = self._elig_audit_for(pid)
+        self.assertEqual(rec["outcome"], "eligible")
+        self.assertEqual(rec["decision_basis"], "composite")
+
+    def test_static_floor_below_min_skipped_floor_no_io(self):
+        slug = self._slug()
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        # conf 4 < static_floor 5 -> skipped_floor without any gather I/O.
+        self._write_day(day, [self._add_row(pid="a1", slug=slug, session_id="sess-none",
+                                            excerpt=_LONG_SENTENCE, confidence=4)])
+        with mock.patch.object(adp, "gather_eligibility_signals",
+                               side_effect=AssertionError("gather must not run below static floor")):
+            summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 0)
+        rec = self._elig_audit_for("a1")
+        self.assertEqual(rec["outcome"], "skipped_floor")
+
+    def test_conf8_multi_session_legacy_escape(self):
+        slug = self._slug()
+        s1, s2 = f"sess-{uuid.uuid4().hex[:6]}", f"sess-{uuid.uuid4().hex[:6]}"
+        for s in (s1, s2):
+            self._write_session(s, slug=slug, turns=self._corroborating_turns(correction=False))
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        pid = self._pid("add")
+        row = self._add_row(pid=pid, slug=slug, session_id=s1, excerpt=_LONG_SENTENCE, confidence=8,
+                            extra_evidence=[{"session_id": s2, "excerpt": _LONG_SENTENCE}])
+        self._write_day(day, [row])
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 1, summary)
+        rec = self._elig_audit_for(pid)
+        self.assertEqual(rec["decision_basis"], "legacy_floor")
+
+
+# ---------------------------------------------------------------------------
+# Audit completeness + pending readback (§3.7).
+# ---------------------------------------------------------------------------
+
+
+class AuditTests(GateTestBase):
+    def test_every_outcome_carries_full_breakdown(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=True), days_ago=1)
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        self._write_day(day, [self._add_row(pid="a1", slug=slug, session_id=sid,
+                                            excerpt=_LONG_SENTENCE, confidence=6, type_="pitfall")])
+        adp.run_optimistic_integrate(day)
+        rec = self._elig_audit_for("a1")
+        for field in ("outcome", "decision_basis", "score", "threshold", "margin",
+                      "signals", "weakest_signal", "verified_sessions", "evidence_tier",
+                      "unresolved_session_ids", "type"):
+            self.assertIn(field, rec, field)
+        self.assertEqual(set(rec["signals"].keys()), {"confidence", "prevalence", "recency", "novelty"})
+        self.assertEqual(rec["type"], "pitfall")
+        self.assertNotIn("ok", rec, "eligibility audit must not carry an ok field")
+
+    def test_skipped_composite_records_margin_and_weakest(self):
+        # A conf-5, 2-session, stale-evidence inferred add fails the composite.
+        slug = self._slug()
+        s1, s2 = f"sess-{uuid.uuid4().hex[:6]}", f"sess-{uuid.uuid4().hex[:6]}"
+        for s in (s1, s2):
+            self._write_session(s, slug=slug, turns=self._corroborating_turns(correction=False), days_ago=120)
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        row = self._add_row(pid="a1", slug=slug, session_id=s1, excerpt=_LONG_SENTENCE, confidence=5,
+                            extra_evidence=[{"session_id": s2, "excerpt": _LONG_SENTENCE}])
+        self._write_day(day, [row])
+        summary = adp.run_optimistic_integrate(day)
+        self.assertEqual(summary["applied"], 0)
+        self.assertEqual(self._status(day, "a1"), "pending")
+        rec = self._elig_audit_for("a1")
+        self.assertEqual(rec["outcome"], "skipped_composite")
+        self.assertIsNotNone(rec["margin"])
+        self.assertIn(rec["weakest_signal"], {"confidence", "prevalence", "recency", "novelty"})
+
+
+# ---------------------------------------------------------------------------
+# Per-batch cache: one session cited by many proposals is built once.
+# ---------------------------------------------------------------------------
+
+
+class CacheTests(GateTestBase):
+    def test_shared_session_built_once(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=True))
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        rows = [self._add_row(pid=f"a{i}", slug=slug, session_id=sid, excerpt=_LONG_SENTENCE,
+                              content=f"{_LONG_SENTENCE} variant {i}", confidence=6)
+                for i in range(5)]
+        self._write_day(day, rows)
+        calls: list[str] = []
+        real = adp._build_session_verification
+
+        def _counting(session_id, elig_cfg):
+            calls.append(session_id)
+            return real(session_id, elig_cfg)
+
+        with mock.patch.object(adp, "_build_session_verification", side_effect=_counting):
+            adp.run_optimistic_integrate(day)
+        self.assertEqual(calls.count(sid), 1, f"session built {calls.count(sid)} times, expected 1")
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: an exception in gathering -> internal_error, batch continues.
+# ---------------------------------------------------------------------------
+
+
+class FailClosedTests(GateTestBase):
+    def test_gatherer_exception_is_internal_error_batch_continues(self):
+        slug = self._slug()
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        rows = [self._add_row(pid="a1", slug=slug, session_id="sess-1", excerpt=_LONG_SENTENCE, confidence=6),
+                self._add_row(pid="a2", slug=slug, session_id="sess-2", excerpt=_LONG_SENTENCE, confidence=6)]
+        self._write_day(day, rows)
+        with mock.patch.object(adp, "gather_eligibility_signals",
+                               side_effect=RuntimeError("unreadable store")):
+            summary = adp.run_optimistic_integrate(day)
+        outcomes = [r["outcome"] for r in summary["results"]]
+        self.assertEqual(outcomes.count("internal_error"), 2, summary)
+        self.assertEqual(summary["applied"], 0)
+        # both rows remain pending
+        self.assertEqual(self._status(day, "a1"), "pending")
+        self.assertEqual(self._status(day, "a2"), "pending")
+
+
+# ---------------------------------------------------------------------------
+# Near-duplicate supersede advisory flag (both directions).
+# ---------------------------------------------------------------------------
+
+
+class NearDupSupersedeTests(GateTestBase):
+    def _supersede_setup(self, *, new_content: str, target_content: str):
+        slug = self._slug()
+        e = ls.build_entry(type_="pattern", content=target_content, confidence=8)
+        e["project"] = slug
+        ls.append_entry(e, slug=slug)
+        heads = {h["id"]: h for h in ls.load_all(slug)}
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=[tf.user_turn(new_content, human=True)])
+        row = {
+            "id": "s1", "kind": "learning_supersede", "project": slug, "target_id": e["id"],
+            "content": new_content, "type": "pattern", "confidence": 6,
+            "prevalence": {"sessions": 2, "agents": 1},
+            "evidence": [{"session_id": sid, "excerpt": new_content}],
+            "justification": "t", "fingerprint": "fp-s1",
+            "generated_at": "2026-01-01T00:00:00.000Z", "status": "pending",
+        }
+        return slug, heads, row
+
+    def test_near_dup_fact_flip_flagged(self):
+        target = "Deploy to production on port 8080 using the blue pipeline after the nightly build."
+        new = "Deploy to production on port 9090 using the blue pipeline after the nightly build."
+        slug, heads, row = self._supersede_setup(new_content=new, target_content=target)
+        ev = self._eval(row, slug=slug, heads=heads)
+        self.assertTrue(ev.near_dup_supersede)
+        # near-dup vs target also drives a low novelty (pays twice, #39). Novelty
+        # lands in the bundle regardless of which waterfall step the decision
+        # short-circuits at, so read it from the bundle directly.
+        bundle, _ = adp.gather_eligibility_signals(
+            row, slug=slug, cache={}, heads=heads, elig_cfg=self._elig_cfg())
+        self.assertLessEqual(bundle.novelty, 0.15)
+
+    def test_substantive_update_not_flagged(self):
+        target = "Deploy to production on port 8080 using the blue pipeline after the nightly build."
+        new = ("Roll back the deployment entirely and switch every service to the green pipeline; "
+               "the blue pipeline is deprecated and must never be used for production traffic again.")
+        slug, heads, row = self._supersede_setup(new_content=new, target_content=target)
+        ev = self._eval(row, slug=slug, heads=heads)
+        self.assertFalse(ev.near_dup_supersede)
+
+
+# ---------------------------------------------------------------------------
+# Novelty semantics.
+# ---------------------------------------------------------------------------
+
+
+class NoveltyTests(GateTestBase):
+    def test_add_empty_store_novelty_one(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=True))
+        bundle, _ = adp.gather_eligibility_signals(
+            self._add_row(pid="a1", slug=slug, session_id=sid, excerpt=_LONG_SENTENCE),
+            slug=slug, cache={}, heads={}, elig_cfg=self._elig_cfg())
+        self.assertEqual(bundle.novelty, 1.0)
+
+    def test_supersede_unresolvable_target_novelty_zero(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=[tf.user_turn(_LONG_SENTENCE, human=True)])
+        row = {
+            "id": "s1", "kind": "learning_supersede", "project": slug, "target_id": "does-not-exist",
+            "content": _LONG_SENTENCE, "type": "pattern", "confidence": 8,
+            "prevalence": {"sessions": 2, "agents": 1},
+            "evidence": [{"session_id": sid, "excerpt": _LONG_SENTENCE}],
+            "justification": "t", "fingerprint": "fp-s1",
+            "generated_at": "2026-01-01T00:00:00.000Z", "status": "pending",
+        }
+        bundle, _ = adp.gather_eligibility_signals(
+            row, slug=slug, cache={}, heads={}, elig_cfg=self._elig_cfg())
+        self.assertEqual(bundle.novelty, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# eligibility-dry-run CLI: scores, prints, mutates nothing.
+# ---------------------------------------------------------------------------
+
+
+class DryRunTests(GateTestBase):
+    def test_dry_run_scores_without_mutating(self):
+        import hashlib
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=True))
+        # Note: eligibility DISABLED in config -- dry-run is a what-if preview.
+        self._write_config({"eligibility": {"enabled": False}})
+        day = self._day()
+        self._write_day(day, [self._add_row(pid="a1", slug=slug, session_id=sid,
+                                            excerpt=_LONG_SENTENCE, confidence=6)])
+        path = adp.proposals_dir() / f"{day}.jsonl"
+        before = hashlib.sha256(path.read_bytes()).hexdigest()
+        audit_before = len(self._audit())
+
+        result = adp.run_eligibility_dry_run(day)
+
+        after = hashlib.sha256(path.read_bytes()).hexdigest()
+        self.assertEqual(before, after, "dry-run must not mutate the proposals file")
+        self.assertEqual(len(self._audit()), audit_before, "dry-run must write no audit records")
+        self.assertEqual(len(result["proposals"]), 1)
+        entry = result["proposals"][0]
+        self.assertIn("score", entry)
+        self.assertIn("signals", entry)
+        self.assertIn("note", entry)  # "what-if preview" note when disabled
+
+    def test_dry_run_cli_exit_zero(self):
+        slug = self._slug()
+        sid = f"sess-{uuid.uuid4().hex[:8]}"
+        self._write_session(sid, slug=slug, turns=self._corroborating_turns(correction=True))
+        self._write_config({"eligibility": {"enabled": True}})
+        day = self._day()
+        self._write_day(day, [self._add_row(pid="a1", slug=slug, session_id=sid,
+                                            excerpt=_LONG_SENTENCE, confidence=6)])
+        rc = adp.main(["eligibility-dry-run", "--date", day])
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/dreaming/tests/test_optimistic_engine.py
+++ b/modules/dreaming/tests/test_optimistic_engine.py
@@ -38,6 +38,7 @@ import tempfile
 import threading
 import time
 import unittest
+import unittest.mock
 import uuid
 from pathlib import Path
 
@@ -54,12 +55,15 @@ sys.modules.pop("apply_dream_proposal", None)
 
 _TMP_LEARNINGS = tempfile.mkdtemp(prefix="ccgm-dreaming-test-optengine-learnings-")
 _TMP_DREAMING = tempfile.mkdtemp(prefix="ccgm-dreaming-test-optengine-dreaming-")
+_TMP_PROJECTS = tempfile.mkdtemp(prefix="ccgm-dreaming-test-optengine-projects-")
 _TMP_HOME = tempfile.mkdtemp(prefix="ccgm-dreaming-test-optengine-home-")
 _ORIG_LEARNINGS_DIR = os.environ.get("CCGM_LEARNINGS_DIR")
 _ORIG_DREAMING_DIR = os.environ.get("CCGM_DREAMING_DIR")
+_ORIG_PROJECTS_DIR = os.environ.get("CCGM_CLAUDE_PROJECTS_DIR")
 _ORIG_HOME = os.environ.get("HOME")
 os.environ["CCGM_LEARNINGS_DIR"] = _TMP_LEARNINGS
 os.environ["CCGM_DREAMING_DIR"] = _TMP_DREAMING
+os.environ["CCGM_CLAUDE_PROJECTS_DIR"] = _TMP_PROJECTS
 os.environ["HOME"] = _TMP_HOME
 
 import apply_dream_proposal as adp  # noqa: E402
@@ -74,6 +78,7 @@ def tearDownModule() -> None:
     for key, orig in (
         ("CCGM_LEARNINGS_DIR", _ORIG_LEARNINGS_DIR),
         ("CCGM_DREAMING_DIR", _ORIG_DREAMING_DIR),
+        ("CCGM_CLAUDE_PROJECTS_DIR", _ORIG_PROJECTS_DIR),
         ("HOME", _ORIG_HOME),
     ):
         if orig is not None:
@@ -124,6 +129,7 @@ class OptimisticEngineTestBase(unittest.TestCase):
         # (mirrors test_apply_dream_proposal.py's own rationale).
         self._pin_env("CCGM_LEARNINGS_DIR", str(ls.LEARNINGS_ROOT))
         self._pin_env("CCGM_DREAMING_DIR", _TMP_DREAMING)
+        self._pin_env("CCGM_CLAUDE_PROJECTS_DIR", str(ls.CLAUDE_PROJECTS_ROOT))
         self._pin_env("HOME", _TMP_HOME)
         adp.proposals_dir().mkdir(parents=True, exist_ok=True)
         # Clean, non-suspended breaker state before EVERY test (see module
@@ -1300,6 +1306,138 @@ class GatingTests(OptimisticEngineTestBase):
         self.assertTrue(any(
             a.get("outcome") == "anomaly_recorded" and a.get("reason") == "red_eval_gate" for a in audit
         ), audit)
+
+
+# ---------------------------------------------------------------------------
+# Composite-eligibility E3: eviction ops are UNTOUCHED by the gate.
+# ---------------------------------------------------------------------------
+
+
+class EvictionBitForBitTests(OptimisticEngineTestBase):
+    """learning_contradict / learning_deprecate must behave identically with
+    eligibility enabled=true and enabled=false: the composite is scoped to
+    add/supersede ONLY (plan.md §1.3, decisions.md #11)."""
+
+    def _run_eviction(self, *, eligibility_enabled: bool, kind: str) -> tuple[dict, str | None]:
+        slug = _unique_slug("evict")
+        target = self._seed_learning(slug, content="to be evicted", confidence=8)
+        self._write_config({"dwell_hours": 12, "eligibility": {"enabled": eligibility_enabled}})
+        day = _unique_day()
+        pid = f"e-{uuid.uuid4().hex[:8]}"
+        self._write_day(day, [_proposal_row(pid=pid, kind=kind, project=slug,
+                                            target_id=target, confidence=8)])
+        summary = adp.run_optimistic_integrate(day)
+        return summary, self._status_of(day, pid)
+
+    def test_contradict_identical_enabled_vs_disabled(self):
+        off_summary, off_status = self._run_eviction(eligibility_enabled=False, kind="learning_contradict")
+        on_summary, on_status = self._run_eviction(eligibility_enabled=True, kind="learning_contradict")
+        self.assertEqual(off_summary["applied"], 1)
+        self.assertEqual(on_summary["applied"], off_summary["applied"])
+        self.assertEqual(on_status, off_status)
+        self.assertEqual(on_status, "auto_applied")
+
+    def test_deprecate_identical_enabled_vs_disabled(self):
+        off_summary, off_status = self._run_eviction(eligibility_enabled=False, kind="learning_deprecate")
+        on_summary, on_status = self._run_eviction(eligibility_enabled=True, kind="learning_deprecate")
+        self.assertEqual(off_summary["applied"], 1)
+        self.assertEqual(on_summary["applied"], off_summary["applied"])
+        self.assertEqual(on_status, off_status)
+
+    def test_eviction_never_calls_eligibility(self):
+        slug = _unique_slug("evict-nocall")
+        target = self._seed_learning(slug, content="to be evicted", confidence=8)
+        self._write_config({"eligibility": {"enabled": True}})
+        day = _unique_day()
+        self._write_day(day, [_proposal_row(pid=f"e-{uuid.uuid4().hex[:8]}", kind="learning_contradict",
+                                            project=slug, target_id=target, confidence=8)])
+        with unittest.mock.patch.object(adp.eligibility, "evaluate_eligibility",
+                                        wraps=adp.eligibility.evaluate_eligibility) as spy:
+            adp.run_optimistic_integrate(day)
+        self.assertEqual(spy.call_count, 0)
+
+
+# ---------------------------------------------------------------------------
+# Composite-eligibility E3: SIGTERM-safe batch (adrev2-002) + dirty-tree
+# anomaly (§9.3).
+# ---------------------------------------------------------------------------
+
+
+class SigtermSafeTests(OptimisticEngineTestBase):
+    def test_soft_stop_breaks_batch_and_records_timeout(self):
+        import contextlib
+        slug = _unique_slug("sigterm")
+        self._write_config()
+        day = _unique_day()
+        rows = [_proposal_row(pid=f"s{i}", kind="learning_add", project=slug,
+                              content=f"c{i}", type_="pattern", confidence=9, sessions=5)
+                for i in range(3)]
+        self._write_day(day, rows)
+
+        control = {"received": False}
+
+        @contextlib.contextmanager
+        def _fake_soft_stop():
+            yield control
+
+        processed: list = []
+        real = adp._process_one_proposal
+
+        def _wrapper(row, **kw):
+            processed.append(row.get("id"))
+            # Simulate a SIGTERM arriving after the first row is handled.
+            control["received"] = True
+            return {"outcome": "applied", "proposal_id": row.get("id"), "applied": True}
+
+        with unittest.mock.patch.object(adp, "_sigterm_soft_stop", _fake_soft_stop), \
+                unittest.mock.patch.object(adp, "_process_one_proposal", _wrapper):
+            summary = adp.run_optimistic_integrate(day)
+
+        self.assertEqual(len(processed), 1, "batch must stop accepting new rows after SIGTERM")
+        self.assertTrue(summary.get("timed_out"))
+        self.assertTrue(any(a.get("kind") == "timeout" for a in summary["anomalies"]), summary)
+        # The one applied row still got its single batch commit path.
+        self.assertEqual(summary["applied"], 1)
+
+    def test_sigterm_handler_installed_and_restored(self):
+        import signal as _signal
+        import threading
+        if threading.current_thread() is not threading.main_thread():
+            self.skipTest("SIGTERM handler is only installable from the main thread")
+        before = _signal.getsignal(_signal.SIGTERM)
+        with adp._sigterm_soft_stop() as flag:
+            self.assertFalse(flag["received"])
+            handler = _signal.getsignal(_signal.SIGTERM)
+            self.assertTrue(callable(handler))
+            handler(_signal.SIGTERM, None)  # fire directly -- no real signal delivered
+            self.assertTrue(flag["received"])
+        self.assertEqual(_signal.getsignal(_signal.SIGTERM), before, "handler must be restored")
+
+
+class DirtyTreeTests(OptimisticEngineTestBase):
+    def test_dirty_tree_records_anomaly(self):
+        slug = _unique_slug("dirty")
+        self._write_config({"eligibility": {"enabled": True}})
+        day = _unique_day()
+        self._write_day(day, [_proposal_row(pid=f"d-{uuid.uuid4().hex[:8]}", kind="learning_add",
+                                            project=slug, content="x", type_="pattern",
+                                            confidence=9, sessions=5)])
+        with unittest.mock.patch.object(adp, "_learnings_tree_dirty", return_value=True):
+            summary = adp.run_optimistic_integrate(day)
+        self.assertTrue(any(a.get("kind") == "dirty_learnings_tree" for a in summary["anomalies"]), summary)
+
+    def test_learnings_tree_dirty_detects_real_git_state(self):
+        repo = Path(tempfile.mkdtemp(prefix="ccgm-dirty-tree-"))
+        subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+        subprocess.run(["git", "-C", str(repo), "config", "user.email", "t@t"], check=True)
+        subprocess.run(["git", "-C", str(repo), "config", "user.name", "t"], check=True)
+        (repo / "a.txt").write_text("one\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo), "add", "a.txt"], check=True)
+        subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "init"], check=True)
+        with unittest.mock.patch.object(adp.learnings_store, "LEARNINGS_ROOT", repo):
+            self.assertFalse(adp._learnings_tree_dirty())  # clean
+            (repo / "a.txt").write_text("two\n", encoding="utf-8")
+            self.assertTrue(adp._learnings_tree_dirty())   # dirty
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #836

Epic **E3** of the composite-eligibility plan (builds on merged E1 #841 and E2 #842). Implements the enabled-mode gate waterfall inside the optimistic-integration apply path, apply-time signal gathering with per-batch caching, the audit breakdown, the dry-run CLI, and the SIGTERM-safe timeout wrapper.

## What changed

- **`apply_dream_proposal.py`** (the mechanism):
  - **Waterfall (§3.2)** inside `_process_one_proposal`, enabled mode, `learning_add`/`learning_supersede` only. Config-invalid/`enabled:false` and every other kind (verify/contradict/deprecate/gated/unknown) take today's legacy path **bit-for-bit** — the eligibility module is not called at all (spy-tested). Static floor short-circuits before I/O; eligible rows fall through to the shared downstream (compaction guard, per-run cap, dwell, apply); every skip writes an audit record and leaves the row `pending`. Any exception in steps 3–6 propagates to the existing outer handler → `internal_error` (no inner catch-and-default).
  - **`gather_eligibility_signals()`** (§3.3/§3.4): signature takes bare row evidence (`session_id`/`excerpt`) + row scalars + live-store heads — **no parameter for stamped `evidence_tier`/`stamped_signals`**, so forged fields can't be trusted (decisions #20). Three-part session verification: `resolve_session_transcript()` (reused, not reimplemented) → `detect_project_slug(transcript cwd)` slug match → tolerant excerpt corroboration with §3.3 normalization and the anti-coincidence guards (excerpt-sized contiguous window sized to accommodate redaction; minimum absolute distinct content-token count with placeholders excluded from the denominator, adrev2-003/adrev3-002). Tier re-mined via `transcript_miner.mine`'s human-origin correction extractor; recency from embedded per-line timestamps; per-kind novelty via E1's `novelty_vs`/`similarity` (add → live heads, empty store → 1.0; supersede → target's old content, unresolvable → 0).
  - **Per-batch `SessionVerification` cache** built once per distinct `session_id` (test asserts a session cited by 5 proposals is built once), plus a citation counter → new batch-anomaly input (decisions #37). Reuses the existing `heads_by_slug`/`live_counts` precompute.
  - **Audit (§3.7)**: outcome, decision_basis, score, threshold, margin, 4 normalized signals, weakest_signal, verified_sessions, evidence_tier (+ source when user-corrected), unresolved_session_ids, type; near-duplicate-supersede advisory flag (`similarity ≥ 0.9` AND fact-token set changed via `compact_preserves_facts` machinery). No `ok` field (never miscounted as an apply).
  - **CLI**: `eligibility-dry-run [--date YYYY-MM-DD]` — the H1 what-if inspector; scores pending add/supersede proposals, applies nothing, writes no audit.
  - **SIGTERM-safe batch (adrev2-002)**: `run_optimistic_integrate` installs a soft-stop SIGTERM handler (main-thread-only, restored on exit) that finishes the in-flight row, stops accepting new ones, records a `timeout` breaker anomaly, and runs the normal single-commit path. A dirty learnings tree at run start is recorded as a breaker anomaly (§9.3).
- **`dream-daily.sh`**: wraps the optimistic-integrate step in a portable `timeout 600` (`timeout`→`gtimeout`→direct fallback; no GNU/BSD tool drift), preserving exit-tolerance.

## Not touched (per spec)
`eligibility.py`, `transcript_miner.py`, `dream_analyze.py`, `module.json`, docs, `_confidence_of`, fingerprint logic, every eviction branch. **`learnings_store.py` needed no seam** — `CCGM_CLAUDE_PROJECTS_DIR` already backs `resolve_session_transcript` via `CLAUDE_PROJECTS_ROOT` (frozen at import), so the plan's before-import test convention works as-is.

## Verification (fresh)

```
$ python3 -m pytest modules/dreaming/tests/ modules/self-improving/tests/ -q
776 passed, 13 subtests passed in 19.18s        # was 738 pre-E3 (+38: new test_eligibility_gate.py 31, extended test_optimistic_engine.py)

$ CCGM_DREAMING_DIR=$(mktemp -d) CCGM_LEARNINGS_DIR=$(mktemp -d) \
    bash modules/dreaming/bin/dream-daily.sh --offline modules/dreaming/tests/fixtures/offline-responses --force-day 2026-01-02
smoke exit=0        # default config: optimistic-integrate skipped by the outer flag → 0 apply-audit records, identical to pre-E3 (golden parity)

$ python3 modules/dreaming/lib/apply_dream_proposal.py eligibility-dry-run --date 2026-01-02   # against a fixture CCGM_DREAMING_DIR
proposals scored: 1 | first outcome: skipped_origin ; exit=0

$ bash tests/test-no-personal-data.sh   → PASS: No personal data or secret/PII shapes found
$ bash tests/test-modules.sh            → Results: 1557 passed, 0 failed
$ bash modules/dreaming/bin/dream-eval.sh --offline modules/dreaming/tests/fixtures/offline-responses   → exit 0
```

Disabled-mode parity is proven by the full pre-existing suite (all 738 legacy-path tests unchanged) plus an explicit spy test that `eligibility.evaluate_eligibility` is never called when disabled. Eviction ops are asserted bit-for-bit identical with `eligibility.enabled` true vs false.
