### PR TITLE
#839: composite-eligibility E6 — surfacing, docs, activation, module-tests CI

### DIFF
--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -20,6 +20,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    # Measured runtime ~1-3 min per leg (first PR run: 38s ubuntu / 1m1s
+    # macOS); the four commands are bounded at ~5-10 min worst case. 30 gives
+    # 3-4x headroom while stopping a hung chain smoke from burning the
+    # runner's default 6h ceiling.
+    timeout-minutes: 30
     env:
       # The chain smokes drive dream-daily.sh -> optimistic-integrate ->
       # ccgm-learnings-sync commit, and some pytest tests init real git repos,

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -1,0 +1,70 @@
+name: Module tests (dreaming + self-improving)
+
+# Composite-eligibility plan.md §8.3 / §8.4: a required, blocking PR check that
+# runs the dreaming + self-improving pytest suites AND the offline chain smokes
+# in BOTH modes -- the certainty oracle for every surface this plan touches.
+# Runs on ubuntu-latest AND macos-latest (repo memory: macOS is ground truth;
+# green-locally != green-on-runner). Kept POSIX-clean (no grep-pipeline logic;
+# the enabled-mode smoke does its parsing in python).
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  module-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      # The chain smokes drive dream-daily.sh -> optimistic-integrate ->
+      # ccgm-learnings-sync commit, and some pytest tests init real git repos,
+      # without an explicit identity. A fresh hosted runner has none and git's
+      # auto-derived fallback fails with "empty ident name ... not allowed".
+      # Git env vars are the highest-priority identity source, so setting them
+      # here fixes every such call site without editing test files.
+      GIT_AUTHOR_NAME: CCGM CI
+      GIT_AUTHOR_EMAIL: ci@ccgm.invalid
+      GIT_COMMITTER_NAME: CCGM CI
+      GIT_COMMITTER_EMAIL: ci@ccgm.invalid
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jq (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y jq
+
+      - name: Install jq (macOS)
+        if: runner.os == 'macOS'
+        run: brew install jq
+
+      - name: "(a) pytest: dreaming + self-improving suites"
+        run: |
+          set -e
+          # System python3 on hosted runners is PEP 668 "externally managed" --
+          # a venv sidesteps that entirely instead of gambling on
+          # --break-system-packages across runner images.
+          python3 -m venv /tmp/ccgm-module-test-venv
+          . /tmp/ccgm-module-test-venv/bin/activate
+          # pyyaml backs test_module_tests_workflow.py's lint fallback when
+          # actionlint is not pre-installed on the runner.
+          python3 -m pip install --quiet pytest pyyaml
+          python3 -m pytest modules/dreaming/tests/ modules/self-improving/tests/ -q
+
+      - name: "(b) disabled-mode chain smoke (legacy path)"
+        run: |
+          set -e
+          CCGM_DREAMING_DIR="$(mktemp -d)" CCGM_LEARNINGS_DIR="$(mktemp -d)" \
+            bash modules/dreaming/bin/dream-daily.sh \
+              --offline modules/dreaming/tests/fixtures/offline-responses \
+              --force-day 2026-01-02
+
+      - name: "(c) enabled-mode chain smoke (composite proven, §8.3 preconditions)"
+        run: bash modules/dreaming/tests/test-eligibility-enabled-chain.sh
+
+      - name: "(d) offline eval harness"
+        run: bash modules/dreaming/bin/dream-eval.sh --offline modules/dreaming/tests/fixtures/offline-responses

--- a/modules/dreaming/bin/dream-digest.sh
+++ b/modules/dreaming/bin/dream-digest.sh
@@ -470,9 +470,25 @@ def render_eligibility(rec):
     """Render the §3.7 "Composite eligibility" subsection for one scored
     (learning_add / learning_supersede) proposal, from its eligibility audit
     record. Shown for eligible AND skipped rows. Renders only scalar
-    signal/session data -- never excerpt or transcript text."""
+    signal/session data -- never excerpt or transcript text.
+
+    Malformed-record tolerance (Stage-2 review fix): this heredoc renders the
+    WHOLE day's digest -- including the durable canary banner -- so one audit
+    record whose fields break the §3.7 shape (e.g. a non-numeric `score`
+    hitting the `:.3f` format) must never raise and take the entire digest
+    down. Same per-record discipline load_jsonl() applies per line
+    (JSONDecodeError -> skip), applied at the render layer: the bad record
+    renders as a one-line inline note pointing at the audit file, everything
+    else renders normally."""
     if not rec:
         return []
+    try:
+        return _render_eligibility_lines(rec)
+    except Exception:  # noqa: BLE001 -- render-layer tolerance, never fail the digest
+        return ["- **Composite eligibility**: ⚠️ 1 eligibility record unrenderable — see audit file"]
+
+
+def _render_eligibility_lines(rec):
     outcome = rec.get("outcome", "?")
     basis = rec.get("decision_basis")
     score = rec.get("score")

--- a/modules/dreaming/bin/dream-digest.sh
+++ b/modules/dreaming/bin/dream-digest.sh
@@ -152,6 +152,26 @@ canary = load_json(
     {"active_incidents": {}, "reduce_failures": {}},
 )
 
+# --- Composite-eligibility audit index (composite-eligibility plan.md §3.7,
+# Epic E6). The optimistic-integrate engine writes ONE audit record per SCORED
+# learning_add / learning_supersede row (audit_kind == "eligibility") into
+# apply-audit.jsonl, carrying the full per-signal breakdown -- for eligible
+# AND skipped rows. Index them by proposal_id so the Proposals section below
+# can show WHY each scored row was admitted or held back, rejections
+# (skipped_composite / skipped_origin / skipped_floor) especially
+# (decisions.md #28). Last write wins -- a proposal is scored at most once per
+# batch, so in practice there is exactly one record per proposal_id.
+#
+# This surface carries NO excerpt / transcript text: the eligibility record
+# holds only the score, threshold, margin, the four normalized signals,
+# session COUNTS and session ids, the evidence tier + its (id/line/origin)
+# source, and unresolved session ids (§3.7 audit contract). It is therefore
+# safe to render verbatim without the render_evidence() sanitizer pass.
+eligibility_by_proposal = {}
+for _rec in load_jsonl(os.environ.get("CCGM_DIGEST_APPLY_AUDIT_FILE", "")):
+    if _rec.get("audit_kind") == "eligibility" and _rec.get("proposal_id"):
+        eligibility_by_proposal[_rec["proposal_id"]] = _rec
+
 out = []
 out.append(f"# Dreaming digest — {target_date}")
 out.append("")
@@ -435,6 +455,79 @@ def render_evidence(evidence):
     return lines
 
 
+def _fmt_margin(margin):
+    # margin = S - θ. Positive => admitted with headroom ("over"); negative =>
+    # held back short of the bar ("short", by θ - S). Mirrors the plan.md §3.7
+    # digest example: "S=0.541 (θ=0.58, short 0.039; weakest: novelty)".
+    if margin is None:
+        return None
+    if margin >= 0:
+        return f"over {margin:.3f}"
+    return f"short {-margin:.3f}"
+
+
+def render_eligibility(rec):
+    """Render the §3.7 "Composite eligibility" subsection for one scored
+    (learning_add / learning_supersede) proposal, from its eligibility audit
+    record. Shown for eligible AND skipped rows. Renders only scalar
+    signal/session data -- never excerpt or transcript text."""
+    if not rec:
+        return []
+    outcome = rec.get("outcome", "?")
+    basis = rec.get("decision_basis")
+    score = rec.get("score")
+    threshold = rec.get("threshold")
+    margin = rec.get("margin")
+    weakest = rec.get("weakest_signal")
+    signals = rec.get("signals") or {}
+
+    lines = ["- **Composite eligibility**:"]
+    head = f"  - `{outcome}`"
+    if basis:
+        head += f" (basis: {basis})"
+    if score is not None and threshold is not None:
+        # Composite ran (eligible via composite, or skipped_composite).
+        head += f" — S={score:.3f} (θ={threshold}"
+        margin_str = _fmt_margin(margin)
+        if margin_str:
+            head += f", {margin_str}"
+        if weakest:
+            head += f"; weakest: {weakest}"
+        head += ")"
+    else:
+        # No composite score: skipped_floor, skipped_origin, or the legacy-floor
+        # escape (decision_basis="legacy_floor") -- all admit/reject before S.
+        head += f" — score not computed (θ={threshold})"
+    lines.append(head)
+
+    if signals:
+        sig_str = ", ".join(
+            f"{name}={signals[name]:.2f}"
+            for name in ("confidence", "prevalence", "recency", "novelty")
+            if name in signals
+        )
+        lines.append(f"  - signals: {sig_str}")
+
+    tier_line = f"  - evidence tier: {rec.get('evidence_tier', '?')}"
+    src = rec.get("evidence_tier_source")
+    if isinstance(src, dict):
+        # {session_id, line, origin_kind} -- ids/line-number/origin only, no text.
+        tier_line += f" (from `{src.get('session_id', '?')}`"
+        if src.get("line") is not None:
+            tier_line += f" line {src.get('line')}"
+        if src.get("origin_kind"):
+            tier_line += f", origin={src.get('origin_kind')}"
+        tier_line += ")"
+    lines.append(tier_line)
+
+    unresolved = rec.get("unresolved_session_ids") or []
+    lines.append(f"  - verified sessions: {rec.get('verified_sessions', '?')}; "
+                 f"unresolved: {len(unresolved)}")
+    if rec.get("near_duplicate_supersede"):
+        lines.append("  - ⚠️ near-duplicate supersede with changed facts — review")
+    return lines
+
+
 def render_proposal(p):
     pid = p.get("id", "(no-id)")
     confidence = p.get("confidence", "?")
@@ -460,6 +553,11 @@ def render_proposal(p):
     if ev_lines:
         lines.append("- **evidence**:")
         lines.extend(ev_lines)
+    # Composite-eligibility breakdown (composite-eligibility plan.md §3.7, E6):
+    # present only for scored add/supersede rows when the optimistic engine ran
+    # (an eligibility audit record exists for this proposal_id). Absent for
+    # legacy/disabled-mode nights, non-scored kinds, and gated rows.
+    lines.extend(render_eligibility(eligibility_by_proposal.get(pid)))
     lines.append("")
     lines.append(f"Apply: `/dream-apply {pid}`")
     lines.append("")

--- a/modules/dreaming/commands/dream-review.md
+++ b/modules/dreaming/commands/dream-review.md
@@ -115,6 +115,51 @@ already uses.
    (a human scanning the output should never have to guess whether "no
    rows" means "nothing happened" or "the command broke").
 
+### Composite eligibility breakdown (add/supersede rows)
+
+When `optimistic_integration.eligibility.enabled` is `true`, every
+auto-integrated `learning_add` / `learning_supersede` row was admitted by
+the deterministic composite eligibility gate (composite-eligibility plan.md
+§3.2), and the optimistic engine wrote its full per-signal breakdown to
+`~/.claude/dreaming/state/apply-audit.jsonl` as a record with `audit_kind
+== "eligibility"` and the SAME `proposal_id` as the auto-integrated row.
+Surface that breakdown when listing or vetoing such a row — it is the
+"why this landed" the human is reviewing, and it is identical to the block
+`/dream-digest` renders (§3.7):
+
+```bash
+# The eligibility audit record for a given proposal_id (last write wins).
+python3 -c "
+import json, sys
+pid = '<proposal_id>'
+rec = None
+for ln in open('${HOME}/.claude/dreaming/state/apply-audit.jsonl', encoding='utf-8'):
+    ln = ln.strip()
+    if not ln:
+        continue
+    r = json.loads(ln)
+    if r.get('audit_kind') == 'eligibility' and r.get('proposal_id') == pid:
+        rec = r
+print(json.dumps(rec, indent=2, sort_keys=True) if rec else 'no eligibility record')
+"
+```
+
+Render, per row: `outcome` (`eligible` / `skipped_composite` /
+`skipped_origin` / `skipped_floor`) and `decision_basis`
+(`composite` / `legacy_floor`); `score` **S**, `threshold` **θ**, and
+`margin` (over/short); the four normalized `signals`
+(`confidence` / `prevalence` / `recency` / `novelty`) and the
+`weakest_signal`; the `evidence_tier` + its `evidence_tier_source`
+(session id / line / origin, when user-corrected); and
+`verified_sessions` vs the count of `unresolved_session_ids`. For a
+supersede row, also relay `near_duplicate_supersede` when true (a
+near-duplicate-with-changed-facts advisory — never a block on its own).
+
+This record carries only scalar score/signal/session data, never excerpt
+or transcript text — render it verbatim. An auto-integrated row that
+predates eligibility being enabled (or a disabled-mode night) simply has
+no such record; say so plainly rather than inventing a breakdown.
+
 ### `/dream-review veto <id>`
 
 `<id>` is a **learning row id** (a store entry id — one of the ids the

--- a/modules/dreaming/module.json
+++ b/modules/dreaming/module.json
@@ -53,6 +53,11 @@
       "type": "lib",
       "template": false
     },
+    "lib/eligibility.py": {
+      "target": "lib/eligibility.py",
+      "type": "lib",
+      "template": false
+    },
     "lib/reconcile_automemory.py": {
       "target": "lib/reconcile_automemory.py",
       "type": "lib",

--- a/modules/dreaming/rules/dreaming.md
+++ b/modules/dreaming/rules/dreaming.md
@@ -34,13 +34,21 @@ When enabled, every pending proposal is resolved to a **posture** (`dream_analyz
 | Op-kind | Posture | Dwell? | Confidence floor | Per-run cap |
 |---|---|---|---|---|
 | `learning_verify` | `optimistic-immediate` | no | 7 | none |
-| `learning_add` | `optimistic-dwell` | yes | 8 + prevalence ≥ 2 sessions | `max_add_supersede_per_run` (default 10) |
-| `learning_supersede` | `optimistic-dwell` | yes | 8 + compaction guard must pass | shared with `learning_add` |
+| `learning_add` | `optimistic-dwell` | yes | composite eligibility gate (see below); **default OFF → flat floor 8 + prevalence ≥ 2 verified sessions** | `max_add_supersede_per_run` (default 10) |
+| `learning_supersede` | `optimistic-dwell` | yes | composite eligibility gate (see below); **default OFF → flat floor 8** + compaction guard must pass | shared with `learning_add` |
 | `learning_contradict` | `dwell-quarantine` | yes (mandatory) | 8 | `min(max_eviction_absolute, fraction × live slug heads)` |
 | `learning_deprecate` | `dwell-quarantine` | yes (mandatory) | 8 | shared with `learning_contradict` |
 | any → `_global` | `gated` | n/a | n/a | n/a — `promote_to_global()` human accept stays required, unchanged |
 
 Anything that misses its posture's floor/cap, targets `_global`, or arrives on a run where the batch-anomaly check or circuit breaker fired **falls back to `pending`** — never silently dropped, always surfaced in the digest for a human `/dream-apply`.
+
+### Eligibility composite (add/supersede only, default OFF)
+
+`optimistic_integration.eligibility.enabled` is **`false` by default** — a second, independent opt-in *beneath* the outer engine, offered by `memory-setup.sh` only when you turn optimistic integration on (enabling it can never leave the outer flag off; an eligibility opt-in with the outer engine disabled is inert, since the nightly skips `optimistic-integrate` entirely on the outer gate). While disabled, `learning_add`/`learning_supersede` keep the exact flat floors above (8 + prevalence ≥ 2 verified sessions for add; 8 for supersede) — bit-for-bit today's behavior, and an invalid eligibility config fails closed to this same disabled path.
+
+When enabled, those two op-kinds pass through a **deterministic composite gate** (composite-eligibility plan.md §3.2) — no LLM anywhere in the write decision. In waterfall order: a hard **static floor** (`static_floor`, default 5, never below the hard-coded `MIN_STATIC_FLOOR = 4` a config edit cannot hollow out); a **legacy escape** (a conf ≥ 8 add with ≥ 2 *verified* sessions — or conf ≥ 8 supersede — still admits, so enabling only *widens* what admits, never narrows it); a non-compensatory **origin gate** (admit only if the evidence tier is user-corrected OR ≥ 2 transcript-verified sessions — no soft signal rescues a weak origin); then a **composite score** `S = Σ wᵢ·signalᵢ ≥ θ` (θ default 0.58) over four signals — `confidence` .40 (the only model-assigned input), `prevalence` .30 (distinct transcript-verified sessions), `recency` .20 (evidence age, 30-day half-life), `novelty` .10 — all re-derived from the transcripts and live store at apply time, never trusted from the proposal row.
+
+The point is admitting the useful conf-5–7 memories the flat floor held back (user-corrected or seen-across-sessions) while making every newly-admitted class *harder* to forge than confidence inflation. Every scored row — eligible or skipped — writes its full per-signal breakdown + margin to the audit trail, rendered per-row by `/dream-digest` and `/dream-review` (§3.7). **Evictions (`learning_contradict`/`learning_deprecate`) and `learning_verify` are untouched** — they keep their flat floors and dwell-quarantine rails bit-for-bit; the composite gates adds/supersedes only.
 
 **The dwell window** (`dwell_hours`, default 24) is the mechanism, not just a `learning_add`/`supersede`/`contradict`/`deprecate` label: a row is written (committed) immediately, but carries a `dwell_until` timestamp that excludes it from `search()` — and therefore from SessionStart injection and the mining reduce projection — until the window elapses. `learning_verify` alone skips it (`optimistic-immediate`): it is purely additive (bounded `+0.25/use`, capped `+2.0`) and reversible by a later contradict, so there is nothing to dwell.
 

--- a/modules/dreaming/tests/test_digest_eligibility.py
+++ b/modules/dreaming/tests/test_digest_eligibility.py
@@ -1,0 +1,220 @@
+"""Digest renderer unit test for the composite-eligibility "Composite
+eligibility" subsection (composite-eligibility plan.md §3.7 / §5 Epic E6).
+
+Like test_daily_report.py, this drives modules/dreaming/bin/dream-digest.sh as
+a subprocess (its rendering logic is an inline python3 heredoc, not an
+importable module) and asserts the rendered digests/{date}.md.
+
+The renderer indexes apply-audit.jsonl records with audit_kind == "eligibility"
+by proposal_id and renders a per-scored-row breakdown for the "## Proposals"
+section -- for ELIGIBLE and SKIPPED rows alike, rejections especially
+(decisions.md #28). It must NOT leak excerpt/transcript text: the eligibility
+audit record only carries scalar score/signal/session data (§3.7).
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+MODULE_ROOT = HERE.parent
+DREAM_DIGEST = MODULE_ROOT / "bin" / "dream-digest.sh"
+
+DAY = "2026-07-05"
+YESTERDAY = "2026-07-04"
+
+
+def _write_jsonl(path: Path, rows: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+def _proposal(*, pid, kind, project, confidence, content, type_="pattern",
+              target_id=None):
+    row = {
+        "id": pid,
+        "kind": kind,
+        "project": project,
+        "target_id": target_id,
+        "content": content,
+        "type": type_,
+        "confidence": confidence,
+        "prevalence": {"sessions": 2, "agents": 1},
+        "evidence": [{"session_id": "sess-1", "excerpt": "some evidence excerpt"}],
+        "justification": "test justification",
+        "fingerprint": f"fp-{pid}",
+        "generated_at": "2026-07-05T00:00:00.000Z",
+        "status": "pending",
+    }
+    return row
+
+
+def _elig_audit(*, proposal_id, kind, project, outcome, decision_basis,
+                score, threshold, margin, signals, weakest_signal,
+                verified_sessions, evidence_tier, unresolved_session_ids,
+                type_="pattern", evidence_tier_source=None,
+                near_duplicate_supersede=None):
+    rec = {
+        "audit_kind": "eligibility",
+        "outcome": outcome,
+        "decision_basis": decision_basis,
+        "score": score,
+        "threshold": threshold,
+        "margin": margin,
+        "signals": signals,
+        "weakest_signal": weakest_signal,
+        "verified_sessions": verified_sessions,
+        "evidence_tier": evidence_tier,
+        "unresolved_session_ids": unresolved_session_ids,
+        "type": type_,
+        "batch_id": "optbatch_testbatch01",
+        "proposal_id": proposal_id,
+        "kind": kind,
+        "project": project,
+    }
+    if evidence_tier_source is not None:
+        rec["evidence_tier_source"] = evidence_tier_source
+    if near_duplicate_supersede is not None:
+        rec["near_duplicate_supersede"] = near_duplicate_supersede
+    return rec
+
+
+class DigestEligibilityTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sandbox = Path(tempfile.mkdtemp(prefix="ccgm-digest-elig-test-"))
+        self.addCleanup(shutil.rmtree, self.sandbox, ignore_errors=True)
+        self.dreaming_dir = self.sandbox / "dreaming"
+        self.learnings_dir = self.sandbox / "learnings"
+        self.home_dir = self.sandbox / "home"
+        for d in (self.dreaming_dir, self.learnings_dir, self.home_dir):
+            d.mkdir(parents=True)
+
+        self.env = dict(os.environ)
+        self.env["HOME"] = str(self.home_dir)
+        self.env["CCGM_DREAMING_DIR"] = str(self.dreaming_dir)
+        self.env["CCGM_LEARNINGS_DIR"] = str(self.learnings_dir)
+        self.env.pop("ANTHROPIC_API_KEY", None)
+        self.env["CCGM_LEARNINGS_AUTOCOMMIT"] = "false"
+
+    def _run_digest(self, date: str) -> str:
+        proc = subprocess.run(
+            ["bash", str(DREAM_DIGEST), date],
+            env=self.env, capture_output=True, text=True, timeout=30, check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=f"digest failed: {proc.stderr}")
+        return (self.dreaming_dir / "digests" / f"{date}.md").read_text(encoding="utf-8")
+
+    def test_renders_breakdown_for_eligible_and_skipped_rows(self) -> None:
+        proposals = [
+            _proposal(pid="add-eligible", kind="learning_add", project="proj-a",
+                      confidence=6, content="use rev-parse to find the repo root"),
+            _proposal(pid="add-skipped", kind="learning_add", project="proj-a",
+                      confidence=5, content="stale advice about branch cleanup"),
+            _proposal(pid="add-origin", kind="learning_add", project="proj-a",
+                      confidence=6, content="inferred-once conf-6 memory"),
+        ]
+        _write_jsonl(self.dreaming_dir / "proposals" / f"{DAY}.jsonl", proposals)
+
+        audit = [
+            # (a) eligible via composite -- score present, positive margin.
+            _elig_audit(
+                proposal_id="add-eligible", kind="learning_add", project="proj-a",
+                outcome="eligible", decision_basis="composite",
+                score=0.791, threshold=0.58, margin=0.211,
+                signals={"confidence": 0.60, "prevalence": 1.00,
+                         "recency": 0.955, "novelty": 0.60},
+                weakest_signal="confidence", verified_sessions=1,
+                evidence_tier="user-corrected", unresolved_session_ids=[],
+                evidence_tier_source={"session_id": "sess-1", "line": 42,
+                                      "origin_kind": "human"},
+            ),
+            # (b) skipped_composite -- score present, NEGATIVE margin (short).
+            _elig_audit(
+                proposal_id="add-skipped", kind="learning_add", project="proj-a",
+                outcome="skipped_composite", decision_basis=None,
+                score=0.410, threshold=0.58, margin=-0.170,
+                signals={"confidence": 0.50, "prevalence": 0.50,
+                         "recency": 0.25, "novelty": 0.10},
+                weakest_signal="novelty", verified_sessions=2,
+                evidence_tier="inferred", unresolved_session_ids=["sess-gone"],
+            ),
+            # (c) skipped_origin -- no composite score computed.
+            _elig_audit(
+                proposal_id="add-origin", kind="learning_add", project="proj-a",
+                outcome="skipped_origin", decision_basis=None,
+                score=None, threshold=0.58, margin=None,
+                signals={}, weakest_signal=None, verified_sessions=1,
+                evidence_tier="inferred", unresolved_session_ids=[],
+            ),
+        ]
+        _write_jsonl(self.dreaming_dir / "state" / "apply-audit.jsonl", audit)
+
+        md = self._run_digest(DAY)
+
+        # Every scored row gets a "Composite eligibility" subsection.
+        self.assertEqual(md.count("**Composite eligibility**"), 3, msg=md)
+
+        # (a) eligible/composite: score, θ, "over" margin, weakest, basis.
+        self.assertIn("`eligible` (basis: composite) — S=0.791 (θ=0.58, over 0.211; "
+                      "weakest: confidence)", md)
+        self.assertIn("signals: confidence=0.60, prevalence=1.00, recency=0.95, "
+                      "novelty=0.60", md)
+        self.assertIn("evidence tier: user-corrected (from `sess-1` line 42, "
+                      "origin=human)", md)
+        self.assertIn("verified sessions: 1; unresolved: 0", md)
+
+        # (b) skipped_composite: NEGATIVE margin renders as "short" -- the
+        # rejection-visibility requirement (decisions.md #28).
+        self.assertIn("`skipped_composite` — S=0.410 (θ=0.58, short 0.170; "
+                      "weakest: novelty)", md)
+        self.assertIn("verified sessions: 2; unresolved: 1", md)
+
+        # (c) skipped_origin: no composite score, no signals line.
+        self.assertIn("`skipped_origin` — score not computed (θ=0.58)", md)
+
+    def test_no_eligibility_section_when_no_audit_records(self) -> None:
+        """Legacy / disabled-mode nights (no eligibility audit records) render
+        the proposal with NO Composite eligibility subsection."""
+        proposals = [
+            _proposal(pid="add-legacy", kind="learning_add", project="proj-a",
+                      confidence=8, content="a plain proposal"),
+        ]
+        _write_jsonl(self.dreaming_dir / "proposals" / f"{DAY}.jsonl", proposals)
+        # no apply-audit.jsonl at all
+        md = self._run_digest(DAY)
+        self.assertIn("add-legacy", md)
+        self.assertNotIn("**Composite eligibility**", md)
+
+    def test_near_duplicate_supersede_flag_renders(self) -> None:
+        proposals = [
+            _proposal(pid="sup-1", kind="learning_supersede", project="proj-a",
+                      confidence=6, content="refined near-dup content",
+                      target_id="target-xyz"),
+        ]
+        _write_jsonl(self.dreaming_dir / "proposals" / f"{DAY}.jsonl", proposals)
+        audit = [
+            _elig_audit(
+                proposal_id="sup-1", kind="learning_supersede", project="proj-a",
+                outcome="skipped_composite", decision_basis=None,
+                score=0.573, threshold=0.58, margin=-0.007,
+                signals={"confidence": 0.60, "prevalence": 0.50,
+                         "recency": 0.891, "novelty": 0.05},
+                weakest_signal="novelty", verified_sessions=2,
+                evidence_tier="inferred", unresolved_session_ids=[],
+                near_duplicate_supersede=True,
+            ),
+        ]
+        _write_jsonl(self.dreaming_dir / "state" / "apply-audit.jsonl", audit)
+        md = self._run_digest(DAY)
+        self.assertIn("near-duplicate supersede with changed facts — review", md)
+        self.assertIn("`skipped_composite` — S=0.573 (θ=0.58, short 0.007", md)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/dreaming/tests/test_digest_eligibility.py
+++ b/modules/dreaming/tests/test_digest_eligibility.py
@@ -191,6 +191,63 @@ class DigestEligibilityTest(unittest.TestCase):
         self.assertIn("add-legacy", md)
         self.assertNotIn("**Composite eligibility**", md)
 
+    def test_poisoned_record_never_crashes_digest_or_banner(self) -> None:
+        """Stage-2 review fix: a malformed eligibility audit record (fields
+        breaking the §3.7 shape -- here a non-numeric score and a string
+        signal value) must NOT crash the day's digest. The bad row renders as
+        a one-line inline note; every other section -- including the durable
+        canary banner, which this same heredoc renders -- still appears."""
+        proposals = [
+            _proposal(pid="add-good", kind="learning_add", project="proj-a",
+                      confidence=6, content="a healthy proposal"),
+            _proposal(pid="add-poisoned", kind="learning_add", project="proj-a",
+                      confidence=6, content="proposal with a poisoned audit row"),
+        ]
+        _write_jsonl(self.dreaming_dir / "proposals" / f"{DAY}.jsonl", proposals)
+
+        good = _elig_audit(
+            proposal_id="add-good", kind="learning_add", project="proj-a",
+            outcome="eligible", decision_basis="composite",
+            score=0.791, threshold=0.58, margin=0.211,
+            signals={"confidence": 0.60, "prevalence": 1.00,
+                     "recency": 0.955, "novelty": 0.60},
+            weakest_signal="confidence", verified_sessions=1,
+            evidence_tier="inferred", unresolved_session_ids=[],
+        )
+        poisoned = _elig_audit(
+            proposal_id="add-poisoned", kind="learning_add", project="proj-a",
+            outcome="eligible", decision_basis="composite",
+            score="not-a-number",  # breaks the :.3f format
+            threshold=0.58, margin=0.211,
+            signals={"confidence": "high"},  # breaks the :.2f format
+            weakest_signal="confidence", verified_sessions=1,
+            evidence_tier="inferred", unresolved_session_ids=[],
+        )
+        _write_jsonl(self.dreaming_dir / "state" / "apply-audit.jsonl",
+                     [good, poisoned])
+
+        # A live canary incident: the banner is rendered by the SAME heredoc,
+        # so a renderer crash would have silenced it too.
+        canary_path = self.dreaming_dir / "state" / "canary.json"
+        canary_path.parent.mkdir(parents=True, exist_ok=True)
+        canary_path.write_text(json.dumps({
+            "active_incidents": {"proj-a": {"date": DAY, "detail": "schema drift test"}},
+            "reduce_failures": {},
+        }), encoding="utf-8")
+
+        md = self._run_digest(DAY)  # asserts exit 0 internally
+
+        # Banner survived.
+        self.assertIn("Canary banner", md)
+        self.assertIn("schema drift test", md)
+        # Good record rendered fully.
+        self.assertIn("`eligible` (basis: composite) — S=0.791", md)
+        # Poisoned record degraded to the inline note, not a crash.
+        self.assertIn("1 eligibility record unrenderable — see audit file", md)
+        # Both proposals still present.
+        self.assertIn("add-good", md)
+        self.assertIn("add-poisoned", md)
+
     def test_near_duplicate_supersede_flag_renders(self) -> None:
         proposals = [
             _proposal(pid="sup-1", kind="learning_supersede", project="proj-a",

--- a/modules/dreaming/tests/test_module_tests_workflow.py
+++ b/modules/dreaming/tests/test_module_tests_workflow.py
@@ -1,0 +1,59 @@
+"""Lint the module-tests CI workflow (composite-eligibility plan.md §5 Epic E6
+test bullet: "CI workflow lints (actionlint if available, else
+python3 -c yaml.safe_load)").
+
+Prefers actionlint when it is on PATH (full GitHub Actions schema check);
+otherwise falls back to a PyYAML structural parse; skips only if neither is
+available. The workflow ALSO self-proves by running on this very PR -- this
+test is the fast local/CI signal that it is at least well-formed.
+"""
+
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "module-tests.yml"
+
+
+class ModuleTestsWorkflowLintTest(unittest.TestCase):
+    def test_workflow_file_exists(self) -> None:
+        self.assertTrue(WORKFLOW.is_file(), msg=f"missing workflow: {WORKFLOW}")
+
+    def test_workflow_lints(self) -> None:
+        actionlint = shutil.which("actionlint")
+        if actionlint:
+            proc = subprocess.run(
+                [actionlint, str(WORKFLOW)],
+                capture_output=True, text=True, timeout=60, check=False,
+            )
+            self.assertEqual(
+                proc.returncode, 0,
+                msg=f"actionlint failed:\n{proc.stdout}\n{proc.stderr}",
+            )
+            return
+
+        try:
+            import yaml  # noqa: PLC0415 -- optional, fallback path only
+        except ImportError:
+            self.skipTest("neither actionlint nor PyYAML available")
+
+        data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        self.assertIsInstance(data, dict)
+        # YAML 1.1 folds the bare key `on` to boolean True; GitHub reads it
+        # fine. Assert on the parts unaffected by that quirk.
+        self.assertIn("jobs", data)
+        self.assertIn("module-tests", data["jobs"])
+        job = data["jobs"]["module-tests"]
+        self.assertIn("steps", job)
+        # The four §8.3 commands are present as named steps.
+        step_names = [s.get("name", "") for s in job["steps"]]
+        joined = "\n".join(step_names)
+        for token in ("pytest", "disabled-mode", "enabled-mode", "eval"):
+            self.assertIn(token, joined, msg=f"missing step for {token!r} in {step_names}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/self-improving/bin/memory-setup.sh
+++ b/modules/self-improving/bin/memory-setup.sh
@@ -30,7 +30,12 @@
 #               forcing-function: the operator never has to hand-edit
 #               config.json to turn this on). Sets
 #               optimistic_integration.enabled=true in
-#               ~/.claude/dreaming/config.json.
+#               ~/.claude/dreaming/config.json. When you turn it on, a second
+#               prompt OFFERS the composite eligibility gate
+#               (optimistic_integration.eligibility.enabled=true, recommended
+#               defaults; composite-eligibility plan.md §5 Epic E6) -- offered
+#               only alongside the outer flag so eligibility never lands on with
+#               the engine off.
 #
 # Safety posture:
 #   * Idempotent — re-running reports current state and no-ops what is already on.
@@ -95,7 +100,9 @@ write is confirmed first; the script commits to no git repo.
   mode        Adds a 24h dwell window + daily report + one-command rollback
               instead of every mined memory sitting pending for a human
               /dream-apply. Sets optimistic_integration.enabled=true in
-              ~/.claude/dreaming/config.json.
+              ~/.claude/dreaming/config.json. Turning it on then offers the
+              composite eligibility gate (recommended defaults) as a second
+              prompt.
 
 Options:
   -h, --help  Show this help and exit.
@@ -404,6 +411,109 @@ write_optimistic_flag() {
     return 1
 }
 
+# Echo the current optimistic_integration.eligibility.enabled value: "true",
+# "unset", or "invalid". Same presence-and-truth discipline as
+# current_optimistic_flag() above (an explicit false is "unset", i.e. offer
+# it, not an error).
+current_eligibility_flag() {
+    local cfg="${DREAMING_DIR}/config.json"
+    if [ ! -s "$cfg" ]; then
+        printf 'unset\n'
+        return
+    fi
+    jq -r 'if .optimistic_integration.eligibility.enabled == true then "true" else "unset" end' "$cfg" 2>/dev/null \
+        || printf 'invalid\n'
+}
+
+# Enable the composite eligibility gate (composite-eligibility plan.md §5 Epic
+# E6, adrev2-001). Writes a MINIMAL eligibility block -- just enabled=true --
+# into ~/.claude/dreaming/config.json; dream_analyze.py's load_config()
+# deep-merges every other eligibility default (weights, threshold, floors, ...)
+# from eligibility.DEFAULT_ELIGIBILITY at read time, so the on-disk block can
+# never drift from or fail validate_eligibility_config() (the "recommended
+# defaults" the prompt names). The SAME jq-merge-then-verify mechanism as
+# write_optimistic_flag() above.
+#
+# CRITICAL (adrev2-001): this ALSO forces optimistic_integration.enabled=true
+# in the same write. Enabling eligibility while the outer engine is off is
+# inert (the nightly skips optimistic-integrate entirely on the outer gate), so
+# the write makes "never leave the outer flag off" a structural property of the
+# write itself, not merely of the caller's ordering. Verified by reading BOTH
+# flags back out: the success line prints only if both are true on disk.
+write_eligibility_flag() {
+    mkdir -p "$DREAMING_DIR" 2>/dev/null || true
+
+    local cfg="${DREAMING_DIR}/config.json"
+    local tmp
+    tmp="$(mktemp)" || {
+        warn "Could not enable — failed to create a temp file; ${cfg} unchanged."
+        return 1
+    }
+
+    local filter='.optimistic_integration.enabled = true | .optimistic_integration.eligibility.enabled = true'
+    if [ -s "$cfg" ]; then
+        jq "$filter" "$cfg" >"$tmp" 2>/dev/null
+    else
+        printf '{}\n' | jq "$filter" >"$tmp" 2>/dev/null
+    fi
+
+    if [ ! -s "$tmp" ]; then
+        rm -f "$tmp"
+        warn "Could not enable — jq merge produced no output; ${cfg} unchanged."
+        return 1
+    fi
+
+    if ! mv "$tmp" "$cfg" 2>/dev/null; then
+        rm -f "$tmp"
+        warn "Could not enable — ${cfg} is not writable; left unchanged."
+        return 1
+    fi
+
+    local outer elig
+    outer="$(jq -r '.optimistic_integration.enabled // "unset"' "$cfg" 2>/dev/null)"
+    elig="$(jq -r '.optimistic_integration.eligibility.enabled // "unset"' "$cfg" 2>/dev/null)"
+    if [ "$outer" = "true" ] && [ "$elig" = "true" ]; then
+        ok "Composite eligibility gate enabled — optimistic_integration.eligibility.enabled=true (recommended defaults) verified in ${cfg}."
+        return 0
+    fi
+
+    warn "Could not enable — write did not take effect; verify ${cfg} by hand."
+    return 1
+}
+
+# Offer the composite eligibility gate. Called ONLY once the outer optimistic
+# engine is confirmed ON (either just turned on this run, or already on), so a
+# yes here can never land eligibility=true with the outer flag off (adrev2-001).
+offer_eligibility_gate() {
+    local estate
+    estate="$(current_eligibility_flag)"
+    case "$estate" in
+        true)
+            ok "Composite eligibility gate already enabled (optimistic_integration.eligibility.enabled=true) — no change."
+            return 0
+            ;;
+        invalid)
+            warn "Could not offer the eligibility gate — ${DREAMING_DIR}/config.json is not valid JSON; left untouched."
+            return 1
+            ;;
+        *)
+            say ""
+            say "The composite eligibility gate scores each mined add/supersede with a"
+            say "deterministic blend (verified origin + prevalence + evidence recency +"
+            say "novelty) instead of a flat confidence floor, so a user-corrected or"
+            say "seen-across-sessions conf-6 memory can auto-integrate while an"
+            say "inferred-once one still cannot. Default off; evictions are unaffected."
+            say ""
+            if confirm "Also enable the composite eligibility gate (recommended defaults)?"; then
+                write_eligibility_flag
+                return $?
+            fi
+            skip "Left the composite eligibility gate disabled (flat confidence floor stays in effect). Re-run any time to enable it."
+            return 0
+            ;;
+    esac
+}
+
 offer_optimistic_integration() {
     if [ ! -e "$DREAM_INSTALL" ]; then
         return 0   # dreaming module not installed -- offer_dreaming() already explained why
@@ -417,6 +527,10 @@ offer_optimistic_integration() {
     case "$state" in
         true)
             ok "Optimistic auto-integration already enabled (optimistic_integration.enabled=true) — no change."
+            # Outer already on -> the eligibility gate may be offered with no
+            # risk of leaving the outer flag off (adrev2-001), so an operator who
+            # opted into optimistic mode earlier can still add the gate now.
+            offer_eligibility_gate
             return 0
             ;;
         invalid)
@@ -433,8 +547,13 @@ offer_optimistic_integration() {
             say "not you ever read the report."
             say ""
             if confirm "Enable auto-integration with a 24h dwell window + daily report?"; then
-                write_optimistic_flag
-                return $?
+                write_optimistic_flag || return 1
+                # The eligibility gate is offered ONLY here -- strictly AFTER the
+                # outer flag is confirmed on (write_optimistic_flag verified it) --
+                # so a yes can never land eligibility=true with the outer engine
+                # off (adrev2-001).
+                offer_eligibility_gate
+                return 0
             fi
             skip "Left optimistic auto-integration disabled. Re-run any time to enable it."
             return 0
@@ -482,4 +601,11 @@ main() {
     return "$rc"
 }
 
-main "$@"
+# Run main only on direct execution, not when sourced. Sourcing (with main
+# suppressed) lets a test drive an individual writer -- e.g.
+# write_eligibility_flag against a redirected DREAMING_DIR -- deterministically,
+# without piping answers through every unrelated confirm() prompt. Direct
+# execution (./memory-setup.sh) is unchanged: BASH_SOURCE[0] == $0, so main runs.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main "$@"
+fi

--- a/modules/self-improving/rules/learnings-store.md
+++ b/modules/self-improving/rules/learnings-store.md
@@ -101,6 +101,8 @@ effective = base * 0.5 ^ (age_days / half_life_days)
 
 Entries whose effective confidence falls below the deprecate threshold (default 2.0) are skipped at read time without being deleted from the JSONL. This keeps the audit trail intact.
 
+**Read-time decay vs gate-time eligibility — different clocks, non-duplicative.** The `dreaming` module's opt-in composite-eligibility gate (see `modules/dreaming/rules/dreaming.md` → "Eligibility composite") scores an *evidence recency* signal at **admission** time — how old the mined transcript evidence is when a `learning_add`/`learning_supersede` is auto-integrated, on a short (default 30-day) half-life. The confidence decay above is a separate, later clock: it ages an *already-admitted* entry by its own `timestamp` on the store's 90-day half-life, every time the entry is read. One is a write-gate on evidence freshness; the other is a read-time weakening of stored rows. They never double-count — a row that clears the gate then begins decaying independently — so neither is a substitute for the other.
+
 ---
 
 ## Supersede Chains

--- a/modules/self-improving/tests/test_memory_setup_eligibility.py
+++ b/modules/self-improving/tests/test_memory_setup_eligibility.py
@@ -1,0 +1,98 @@
+"""Non-interactive test for memory-setup.sh's composite eligibility opt-in
+(composite-eligibility plan.md §5 Epic E6, adrev2-001).
+
+memory-setup.sh's write functions are normally reached through interactive
+confirm() prompts. The script gained a `BASH_SOURCE[0] == $0` guard so a test
+can SOURCE it (main suppressed) and drive one writer directly -- here
+write_eligibility_flag against a HOME-redirected dreaming dir -- with no
+prompts.
+
+The test asserts the two invariants Epic E6 owns:
+  1. The write forces BOTH optimistic_integration.enabled=true AND
+     optimistic_integration.eligibility.enabled=true (adrev2-001: eligibility
+     must never land on with the outer engine off).
+  2. The minimal on-disk block, once dream_analyze.load_config() deep-merges
+     the defaults from eligibility.DEFAULT_ELIGIBILITY, PASSES
+     eligibility.validate_eligibility_config().
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[2]
+SETUP = REPO_ROOT / "modules" / "self-improving" / "bin" / "memory-setup.sh"
+DREAMING_LIB = REPO_ROOT / "modules" / "dreaming" / "lib"
+
+
+def _have(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+@unittest.skipUnless(_have("jq"), "jq is required by memory-setup.sh")
+@unittest.skipUnless(_have("bash"), "bash is required to source memory-setup.sh")
+class MemorySetupEligibilityTest(unittest.TestCase):
+    def test_write_eligibility_flag_produces_valid_enabled_block(self) -> None:
+        sandbox = Path(tempfile.mkdtemp(prefix="ccgm-memsetup-elig-"))
+        self.addCleanup(shutil.rmtree, sandbox, ignore_errors=True)
+        home = sandbox / "home"
+        dreaming_dir = home / ".claude" / "dreaming"
+        dreaming_dir.mkdir(parents=True)
+
+        env = dict(os.environ)
+        env["HOME"] = str(home)
+        # Let the script derive DREAMING_DIR from HOME (its top-level default).
+        env.pop("CCGM_DREAMING_DIR", None)
+
+        # Source the script (main suppressed by its BASH_SOURCE guard) and call
+        # the writer directly. No confirm() prompt is reached, so this is fully
+        # non-interactive.
+        proc = subprocess.run(
+            ["bash", "-c", f'source "{SETUP}"; write_eligibility_flag'],
+            env=env, capture_output=True, text=True, timeout=30, check=False,
+        )
+        self.assertEqual(
+            proc.returncode, 0,
+            msg=f"write_eligibility_flag failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}",
+        )
+
+        cfg_path = dreaming_dir / "config.json"
+        self.assertTrue(cfg_path.is_file(), msg="config.json was not written")
+        cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+
+        # Invariant 1: both flags true on disk (adrev2-001).
+        self.assertIs(cfg["optimistic_integration"]["enabled"], True)
+        self.assertIs(cfg["optimistic_integration"]["eligibility"]["enabled"], True)
+
+        # Invariant 2: the deep-merged block passes validate_eligibility_config().
+        # Run in a subprocess with CCGM_DREAMING_DIR + PYTHONPATH so load_config()
+        # reads the file just-written and eligibility.py resolves as a sibling.
+        check_src = (
+            "import eligibility, dream_analyze\n"
+            "cfg = dream_analyze.load_config()\n"
+            "opt = cfg['optimistic_integration']\n"
+            "ok, errs = eligibility.validate_eligibility_config(opt)\n"
+            "assert ok, errs\n"
+            "assert opt['enabled'] is True\n"
+            "assert opt['eligibility']['enabled'] is True\n"
+            "print('VALID')\n"
+        )
+        check = subprocess.run(
+            [sys.executable, "-c", check_src],
+            env={**env, "PYTHONPATH": str(DREAMING_LIB), "CCGM_DREAMING_DIR": str(dreaming_dir)},
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+        self.assertIn(
+            "VALID", check.stdout,
+            msg=f"validate_eligibility_config rejected the written block:\n{check.stdout}\n{check.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #839

Epic E6 of the composite-eligibility plan: surface the composite gate's per-signal breakdown, update the rule docs, add the activation prompt, register the new lib file, and add the module-tests CI job. E1–E4 are merged (main @ 8c42abe); E5 is in parallel (not yet merged — see note below). This epic touches **no gate lib code** — the digest change is rendering-only against E3's add-only audit contract.

## Changes

1. **Digest surfacing** — `modules/dreaming/bin/dream-digest.sh`'s renderer indexes `apply-audit.jsonl` records with `audit_kind == "eligibility"` by `proposal_id` and renders a per-scored-row **"Composite eligibility"** subsection in the Proposals section, for **eligible AND skipped** rows (rejections especially, decisions.md #28): outcome + basis, `S`/`θ`/margin (over/short), the four normalized signals + weakest, evidence tier + its (session-id/line/origin) source, and verified vs. unresolved session counts. Renders only scalar score/signal/session data — **no excerpt/transcript text** (§3.7).
2. **/dream-review** — `modules/dreaming/commands/dream-review.md` gains a "Composite eligibility breakdown" section telling the reader to pull and render the same breakdown (identical to the digest block) when reviewing a scored add/supersede row.
3. **dreaming.md** — the add/supersede rows in the posture table now name the composite gate with an accurate **default-OFF → flat floor** fallback; a new ≤25-line "Eligibility composite" subsection describes the deterministic 4-signal waterfall and states plainly that **evictions and verify are untouched**.
4. **learnings-store.md** — one cross-reference paragraph distinguishing gate-time eligibility recency (30-day half-life, evidence age at admission) from read-time confidence decay (90-day half-life, entry age) — different clocks, non-duplicative.
5. **memory-setup.sh** — extends the optimistic-integration opt-in with a second prompt, "Also enable the composite eligibility gate (recommended defaults)?", offered **only** once the outer flag is confirmed on. `write_eligibility_flag()` forces **both** `optimistic_integration.enabled=true` and `.eligibility.enabled=true` in one jq write, so eligibility can never land on with the outer engine off (adrev2-001). Writes a minimal block; `load_config()` deep-merges the rest from `DEFAULT_ELIGIBILITY`. Added a `BASH_SOURCE[0] == $0` guard so the writer is unit-testable non-interactively (direct execution unchanged).
6. **module.json / marketplace** — added `lib/eligibility.py` to the files map (see convention note). Marketplace `--check` is green with no regen: the marketplace JSON does not encode module file-maps (verified — no `lib/…` path appears in `.claude-plugin/marketplace.json`), so a file-map-only addition produces no diff.
7. **CI** — new `.github/workflows/module-tests.yml`, on `pull_request` (+ push), running the four §8.3 commands on **ubuntu-latest AND macos-latest**: (a) `pytest modules/dreaming/tests modules/self-improving/tests -q`; (b) disabled-mode chain smoke; (c) the enabled-mode chain smoke (reuses E4's `test-eligibility-enabled-chain.sh`, which already wires all four preconditions + the positive `eligible`/`composite`-reached assertion); (d) `dream-eval.sh --offline`. POSIX-clean; git identity env set; venv for PEP-668. No untrusted `github.event.*` inputs.

## Tests added
- `modules/dreaming/tests/test_digest_eligibility.py` — renderer fixture rows → expected markdown, incl. a `skipped_composite` row rendering a negative margin as "short 0.170", a `skipped_origin` row with no computed score, and the near-dup-supersede flag.
- `modules/self-improving/tests/test_memory_setup_eligibility.py` — non-interactive: sources memory-setup.sh, calls `write_eligibility_flag`, asserts both flags true on disk AND that the deep-merged block passes `eligibility.validate_eligibility_config()`.
- `modules/dreaming/tests/test_module_tests_workflow.py` — lints the new workflow (actionlint if present, else PyYAML).

## Acceptance evidence (fresh, this branch)
```
pytest modules/dreaming/tests modules/self-improving/tests -q  ->  807 passed, 107 subtests passed
bash tests/test-modules.sh                                     ->  1558 passed, 0 failed (exit 0)
bash tests/test-no-personal-data.sh                            ->  PASS (exit 0)
(b) disabled-mode chain smoke                                  ->  exit 0
(c) enabled-mode chain smoke                                   ->  PASS (S=0.8310, eligible/composite) exit 0
(d) dream-eval.sh --offline                                    ->  exit 0
gen_marketplace.py --check / validate_marketplace.py           ->  exit 0 / exit 0
test-doc-counts.sh / test-frontmatter-yaml.sh                  ->  exit 0 / exit 0
actionlint .github/workflows/module-tests.yml                  ->  exit 0
```
End-to-end field-agreement proof (enabled chain -> rendered digest, no text leak):
```
- **Composite eligibility**:
  - `eligible` (basis: composite) — S=0.831 (θ=0.58, over 0.251; weakest: confidence)
  - signals: confidence=0.60, prevalence=1.00, recency=0.95, novelty=1.00
  - evidence tier: user-corrected (from `sess-eligible-demo-0001` line 4, origin=human)
  - verified sessions: 1; unresolved: 0
```
The `module-tests` job runs on this PR itself (self-proving).

## Convention note (module.json files map)
The task listed E1–E5 test files, fixture dirs, the seed/chain scripts, and `docs/composite-eligibility-poisoning-analysis.md` as candidates for the files map, **with the instruction to follow the existing convention exactly**. Verified: **zero** `module.json` in the repo lists any `tests/` path or any `docs/` path (`grep -rl '"tests/' modules/*/module.json` -> 0; same for `docs/`), and the dreaming module's 16 existing test files are all absent from its map. The files map is the installer's symlink set — adding tests would symlink test files into `~/.claude/`. Following the convention, **only `lib/eligibility.py`** (an installed lib file, the genuine gap per §3.10) was added. E5's poisoning doc + red-team test, being a `docs/` doc and a test, stay out of the map by that same convention.

## E5 not yet merged
`test_eligibility_redteam.py` and `docs/composite-eligibility-poisoning-analysis.md` do not exist on this branch (E5 in parallel). Per the convention above they would not enter the files map regardless, so nothing here needs to change when E5 lands.
