### PR TITLE
#854: statusline ctx:% vs auto-compact budget + fix dead COMPACT SOON warning

### DIFF
--- a/modules/statusline/statusline.sh
+++ b/modules/statusline/statusline.sh
@@ -3,7 +3,8 @@
 #
 # Consumes the statusline JSON on stdin and renders, separated by " | ":
 #   model (+effort)  |  clone identity (if .env.clone)  |  dir + git branch
-#   |  context used %  |  ⚠ COMPACT SOON warning when context is low
+#   |  context used % (vs auto-compact budget)  |  ⚠ COMPACT SOON warning
+#      when nearing that budget
 #   |  session cost ($)  |  5h & 7d rate-limit bars
 #
 # Dependency-free beyond jq (already required by every CCGM tool). Portable to
@@ -81,7 +82,14 @@ if [ -d "$cwd/.git" ] || git -C "$cwd" rev-parse --git-dir >/dev/null 2>&1; then
     || git -C "$cwd" -c core.fsmonitor=false rev-parse --short HEAD 2>/dev/null)
 fi
 
-# --- Context remaining (inverted to "used" for display)
+# --- Context. Prefer raw token counts so "used %" can be measured against the
+# auto-compact budget rather than the full window. Claude Code's statusline JSON
+# exposes total_input_tokens (input + cache_creation + cache_read, i.e. what is
+# in context now) and context_window_size (200k, or 1M for extended-context
+# models) — but NOT the auto-compact threshold itself. remaining_percentage is a
+# full-window figure, kept only as a fallback for older Claude Code builds.
+ctx_used_tokens=$(echo "$input" | jq -r '.context_window.total_input_tokens // empty')
+ctx_window_size=$(echo "$input" | jq -r '.context_window.context_window_size // empty')
 remaining=$(echo "$input" | jq -r '.context_window.remaining_percentage // empty')
 
 # --- Session cost (USD). Claude Code exposes this under .cost.total_cost_usd.
@@ -155,10 +163,30 @@ if [ -n "$git_branch" ]; then
 fi
 sections+=("$dir_part")
 
-# Context used (100 - remaining) + compaction warning when low.
-if [ -n "$remaining" ]; then
+# Context used %, measured against the AUTO-COMPACT budget — the point where
+# Claude Code auto-compacts — not the full window. For extended-context (1M)
+# models that budget is capped far below capacity (500k "auto window" by
+# default), so a full-window % reads ~half of true pressure and the compaction
+# warning never fires before the surprise compaction. We model the budget as
+# min(context_window_size, CAP): for a 200k model min() is the full window (it
+# compacts near the top, so nothing changes); for a 1M model it becomes 500k, so
+# the bar hits 100% exactly when compaction fires. CAP is overridable for anyone
+# who changes it via /autocompact, since the JSON does not expose the threshold.
+COMPACT_BUDGET_CAP=${CCGM_CTX_COMPACT_BUDGET:-500000}
+used_int=""
+if [ -n "$ctx_used_tokens" ] && [ -n "$ctx_window_size" ] && [ "$ctx_window_size" -gt 0 ] 2>/dev/null; then
+  used_tokens=$(printf '%.0f' "$ctx_used_tokens")
+  budget=$ctx_window_size
+  [ "$budget" -gt "$COMPACT_BUDGET_CAP" ] && budget=$COMPACT_BUDGET_CAP
+  used_int=$(( used_tokens * 100 / budget ))
+  [ "$used_int" -gt 100 ] && used_int=100
+elif [ -n "$remaining" ]; then
+  # Fallback: older Claude Code without raw token fields — full-window %.
   remaining_int=$(printf '%.0f' "$remaining")
   used_int=$((100 - remaining_int))
+fi
+
+if [ -n "$used_int" ]; then
   if [ "$used_int" -lt 60 ]; then
     ctx_color="$GREEN"
   elif [ "$used_int" -lt 85 ]; then
@@ -167,9 +195,9 @@ if [ -n "$remaining" ]; then
     ctx_color="$RED"
   fi
   sections+=("$(printf "${ctx_color}ctx:${used_int}%%${RESET}")")
-  # Compaction warning: when little context remains, flag it loudly so the user
-  # can /compact or wrap up before an auto-compaction truncates the session.
-  if [ "$remaining_int" -le 15 ]; then
+  # Compaction warning: flag loudly as we near the auto-compact budget so the
+  # user can /compact or wrap up deliberately before an auto-compaction fires.
+  if [ "$used_int" -ge 90 ]; then
     sections+=("$(printf "${RED}⚠ COMPACT SOON${RESET}")")
   fi
 fi

--- a/modules/statusline/tests/test_statusline.sh
+++ b/modules/statusline/tests/test_statusline.sh
@@ -76,8 +76,33 @@ contains "cost rendered" "$OUT" '$1.50'
 absent "no cost when field absent" "$(render "$(printf '{"model":{"display_name":"Opus 4.8"},"cwd":"%s"}' "$TMPHOME")" "$TMPHOME")" '$'
 
 echo ""
-echo "=== statusline: compaction warning ==="
-# 10% remaining -> warning fires.
+echo "=== statusline: context vs auto-compact budget ==="
+# 1M-context model: budget is capped at 500k, so 460k used = 92% (NOT 46% of 1M),
+# which is the whole point — the bar reflects true pressure to auto-compaction.
+OUT="$(render "$(printf '{"model":{"display_name":"Opus 4.8"},"cwd":"%s","context_window":{"total_input_tokens":460000,"context_window_size":1000000}}' "$TMPHOME")" "$TMPHOME")"
+contains "1M model 460k -> 92%% of 500k budget" "$OUT" "ctx:92%"
+contains "1M model 460k -> compact warning" "$OUT" "COMPACT SOON"
+# 1M-context model at 250k -> 50% of budget, no warning.
+OUT="$(render "$(printf '{"model":{"display_name":"Opus 4.8"},"cwd":"%s","context_window":{"total_input_tokens":250000,"context_window_size":1000000}}' "$TMPHOME")" "$TMPHOME")"
+contains "1M model 250k -> 50%%" "$OUT" "ctx:50%"
+absent "1M model 250k -> no warning" "$OUT" "COMPACT SOON"
+# 200k model: budget == full window (min(200k,500k)); 180k = 90% -> warning.
+OUT="$(render "$(printf '{"model":{"display_name":"Sonnet 4.6"},"cwd":"%s","context_window":{"total_input_tokens":180000,"context_window_size":200000}}' "$TMPHOME")" "$TMPHOME")"
+contains "200k model 180k -> 90%%" "$OUT" "ctx:90%"
+contains "200k model 180k -> compact warning" "$OUT" "COMPACT SOON"
+# 200k model at 100k -> 50%, no warning.
+absent "200k model 100k -> no warning" "$(render "$(printf '{"model":{"display_name":"Sonnet 4.6"},"cwd":"%s","context_window":{"total_input_tokens":100000,"context_window_size":200000}}' "$TMPHOME")" "$TMPHOME")" "COMPACT SOON"
+# Over-budget clamps to 100%.
+OUT="$(render "$(printf '{"model":{"display_name":"Opus 4.8"},"cwd":"%s","context_window":{"total_input_tokens":540000,"context_window_size":1000000}}' "$TMPHOME")" "$TMPHOME")"
+contains "over-budget clamps to 100%%" "$OUT" "ctx:100%"
+# Raw tokens take precedence over remaining_percentage (budget path, not fallback).
+OUT="$(render "$(printf '{"model":{"display_name":"Opus 4.8"},"cwd":"%s","context_window":{"total_input_tokens":460000,"context_window_size":1000000,"remaining_percentage":54}}' "$TMPHOME")" "$TMPHOME")"
+contains "raw tokens beat remaining_percentage" "$OUT" "ctx:92%"
+absent "does not fall back to full-window 46%%" "$OUT" "ctx:46%"
+
+echo ""
+echo "=== statusline: compaction warning (fallback: remaining_percentage only) ==="
+# Older Claude Code without raw token fields -> full-window %. 10% remaining fires.
 OUT="$(render "$(printf '{"model":{"display_name":"Opus 4.8"},"cwd":"%s","context_window":{"remaining_percentage":10}}' "$TMPHOME")" "$TMPHOME")"
 contains "compact warning at 10%% remaining" "$OUT" "COMPACT SOON"
 contains "ctx shown at 90%% used" "$OUT" "ctx:90%"


### PR DESCRIPTION
## Summary

Fixes the statusline showing `ctx:46%` moments before an auto-compaction on a 1M-context model, with no `⚠ COMPACT SOON` warning.

The bar read `context_window.remaining_percentage`, which is `used%` against the **full window** (1M). But auto-compaction fires at the **500k "auto window"** — a threshold the statusline JSON does not expose. So `46%` of 1M (≈460k) was really **~92%** of the way to compaction, and the warning (fired at `remaining ≤ 15%` = 850k) was dead code on 1M models since compaction hits at 50% remaining.

## Changes

- `used% = total_input_tokens / min(context_window_size, 500000)` — 200k models unchanged (min() = full window); 1M models now hit 100% exactly at compaction.
- `⚠ COMPACT SOON` recalibrated to `≥ 90%` of the budget (~50k headroom on 500k).
- Budget overridable via `CCGM_CTX_COMPACT_BUDGET` (real threshold isn't in the JSON; configurable via `/autocompact`).
- Graceful fallback to the old full-window `%` when raw token fields are absent (older Claude Code).

## Test Plan

- `bash modules/statusline/tests/test_statusline.sh` → **22/22 pass**, incl. new budget-relative cases (1M @ 460k → `ctx:92%` + warning; 1M @ 250k → `ctx:50%` no warning; 200k @ 180k → `ctx:90%` + warning; over-budget clamps to 100%; raw tokens beat `remaining_percentage`) and retained fallback-path cases.
- `bash -n` clean under macOS system bash 3.2.57; full suite passes under 3.2.
- Live render of the reported state (460k / 1M) → `ctx:92% | ⚠ COMPACT SOON`.

Closes #854