### PR TITLE
#856: docupdate statusline docs for ctx-vs-auto-compact-budget behavior

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -931,7 +931,7 @@ A compact, dependency-free single-line Claude Code statusline.
 
 **Installs**: `statusline.sh` (script), `settings.partial.json` (wires the `statusLine` setting)
 
-**What it does**: Consumes the statusline JSON Claude Code pipes on stdin and renders, separated by ` | `: model + effort (`🧠 O-4.8 Max`), multi-clone identity (`⛓ agent-2`, read from `.env.clone`), directory + git branch, context-used percentage (`ctx:42%`), a `⚠ COMPACT SOON` warning when ≤15% context remains, session cost (`$1.23`, from `.cost.total_cost_usd`), and 5h/7d rate-limit bars with reset countdowns. Every field is optional — a missing JSON key drops its section, so the bar degrades gracefully on older Claude Code versions.
+**What it does**: Consumes the statusline JSON Claude Code pipes on stdin and renders, separated by ` | `: model + effort (`🧠 O-4.8 Max`), multi-clone identity (`⛓ agent-2`, read from `.env.clone`), directory + git branch, context-used percentage measured against the auto-compact budget (`ctx:42%`), a `⚠ COMPACT SOON` warning when nearing that budget, session cost (`$1.23`, from `.cost.total_cost_usd`), and 5h/7d rate-limit bars with reset countdowns. Every field is optional — a missing JSON key drops its section, so the bar degrades gracefully on older Claude Code versions.
 
 Unlike the statusline script bundled in `commands-utility` (which is never wired to the `statusLine` setting), this module ships the script *and* a settings partial, so `--add statusline` produces a working statusline with no manual `settings.json` editing. It is a superset of that script — it adds clone identity, session cost, and the compaction warning. Depends only on `jq`.
 

--- a/modules/statusline/README.md
+++ b/modules/statusline/README.md
@@ -11,8 +11,8 @@ Consumes the statusline JSON Claude Code pipes to the script on stdin and render
 | **Model + effort** | `.model.display_name`, `.effort.level` | `🧠 O-4.8 Max`, `🐢 S-4.6`, `⚠️ H-4.5`. Family/version parsed generically — new model versions need no edits. |
 | **Clone identity** | `.env.clone` in cwd | `⛓ agent-2` when the working dir is a multi-clone checkout (reads `AGENT_ID`). Omitted otherwise. |
 | **Dir + branch** | `.cwd`, git | Immediate directory name plus the current git branch. |
-| **Context used** | `.context_window.remaining_percentage` | `ctx:42%` (green/yellow/red by usage). |
-| **Compaction warning** | derived | `⚠ COMPACT SOON` appears when ≤15% context remains, so you can `/compact` before an auto-compaction truncates the session. |
+| **Context used** | `.context_window.total_input_tokens` ÷ auto-compact budget | `ctx:42%` (green/yellow/red by usage), measured against the compaction budget — `min(context_window_size, 500000)` — not the full window, so it reaches 100% as auto-compaction fires. Falls back to `.context_window.remaining_percentage` on older Claude Code. |
+| **Compaction warning** | derived | `⚠ COMPACT SOON` appears at ≥90% of the auto-compact budget, so you can `/compact` before an auto-compaction truncates the session. Override the budget via `CCGM_CTX_COMPACT_BUDGET` if you changed it with `/autocompact`. |
 | **Session cost** | `.cost.total_cost_usd` | `$1.23` for the current session. Omitted when Claude Code does not supply it. |
 | **Rate limits** | `.rate_limits.five_hour`, `.rate_limits.seven_day` | `5h:30% █░░░░ 2h14m` and `7d:…` bars with reset countdowns. |
 


### PR DESCRIPTION
## Summary

Follow-up to #854. Updates statusline docs that still described the pre-#854 behavior (context % vs full window; `⚠ COMPACT SOON` at ≤15% remaining).

## Changes

- `modules/statusline/README.md` — Context-used source is now `total_input_tokens ÷ min(context_window_size, 500000)`; warning fires at ≥90% of the auto-compact budget; notes the `CCGM_CTX_COMPACT_BUDGET` override and the `remaining_percentage` fallback.
- `docs/modules.md` — context-used % is against the auto-compact budget; warning fires when nearing that budget.

`module.json` / `plugin.json` descriptions were already generic ("context-used % with a compaction warning") and remain accurate — no marketplace regen.

## Test Plan

- `grep` confirms no `≤15%` / "15% context remains" prose references remain (the sole `remaining_percentage` mention is the intended fallback note).
- Docs-only change; statusline unit suite unaffected (22/22 from #854).

Closes #856