### PR TITLE
#860: comprehensive technical memory-system doc + concise README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,15 +256,22 @@ The installer sets up SearXNG, Ollama, the Python environment, and copies the co
 
 ## Memory System
 
-CCGM has a durable, cross-session memory system in two halves: a **read path** (the `self-improving` learnings store, which surfaces what you've learned at the start of each new session) and an opt-in **write path** (the `dreaming` module, which mines your session transcripts nightly and proposes new learnings). The read path is local and free; `dreaming` is opt-in and spends Anthropic API tokens. Every proposal is human-reviewed via `/dream-apply` by default; an opt-in `optimistic_integration` mode (default off) auto-integrates instead, behind a 24h dwell window, per-slug blast caps, and a circuit breaker, with post-hoc review and rollback via `/dream-review`.
+CCGM has a durable, cross-session memory: a store that learns from your work and surfaces what it knows at the start of each new session. It comes in two halves that share one store:
 
-Activate it with:
+| Half | Module | What it does | Cost |
+|------|--------|--------------|------|
+| **Read path** | `self-improving` | Stores learnings and injects the project's top-ranked ones into each fresh session, ranked by confidence with time-decay and staleness. | Local, free, no network |
+| **Write path** | `dreaming` | A nightly analyzer mines your session transcripts into evidence-tagged *proposals* for new learnings, behind a human gate. | Opt-in; spends Anthropic API tokens |
+
+The read path is the valuable, always-safe half and works on its own — you never need the write path to benefit from memory. A learning is captured (via `/reflect` or the CLI), stored as an append-only op-event, injected at the *next* fresh session start, and reinforced when it pays off again (`verify`). Dreaming's proposals are human-reviewed via `/dream-apply` by default; an opt-in `optimistic_integration` mode (default off) can auto-integrate instead, behind a 24h dwell window, per-slug blast caps, and a self-healing circuit breaker, with post-hoc review and rollback via `/dream-review`.
+
+Activate it with the idempotent setup script, which enables session-start injection, initializes the learnings git store, and (if `dreaming` is installed) offers to configure the nightly analyzer and, separately, optimistic auto-integration:
 
 ```bash
 bash ~/.claude/bin/memory-setup.sh
 ```
 
-The setup script enables session-start injection, initializes the learnings git store, and (if `dreaming` is installed) offers to configure the nightly analyzer and, separately, optimistic auto-integration. Injection applies to new sessions only. See **[Memory System](docs/memory-system.md)** for the full guide.
+**→ See [docs/memory-system.md](docs/memory-system.md) for the comprehensive technical reference** — the op-event data model, the projection and confidence-decay math, the integrity/quarantine layers, cross-machine git sync, the full dreaming pipeline, and the safety gates. A visual overview lives in [docs/memory-system.html](docs/memory-system.html).
 
 ## Customization
 

--- a/docs/memory-system.html
+++ b/docs/memory-system.html
@@ -1,0 +1,556 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>How CCGM's Memory System Works</title>
+<meta name="description" content="A plain-language walkthrough of CCGM's durable, cross-session memory: the local read path, the nightly dreaming write path, the safeguards against hallucinated memories, and how the weekly scorecard proves it's working.">
+<style>
+  :root {
+    --bg: #faf9f7;
+    --bg-soft: #f2f0ec;
+    --card: #ffffff;
+    --ink: #1b1b2b;
+    --ink-soft: #4a4a5e;
+    --ink-faint: #74748a;
+    --line: #e6e3dd;
+    --line-strong: #d6d2ca;
+    --read: #0d9488;        /* read path = teal: local, free, always-on */
+    --read-soft: #ecfdf9;
+    --read-line: #a7f0e2;
+    --write: #7c3aed;       /* write path = violet: nightly, opt-in, dreaming */
+    --write-soft: #f5f0ff;
+    --write-line: #d8c7ff;
+    --amber: #b45309;
+    --amber-soft: #fef6ec;
+    --amber-line: #f3d9ad;
+    --code-bg: #f4f2ee;
+    --shadow: 0 1px 2px rgba(20,20,40,.05), 0 8px 24px -12px rgba(20,20,40,.14);
+    --radius: 16px;
+    --maxw: 880px;
+    --mono: ui-monospace, "SF Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, Helvetica, Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d0d17;
+      --bg-soft: #14141f;
+      --card: #16161f;
+      --ink: #e9e9f2;
+      --ink-soft: #b7b7c8;
+      --ink-faint: #8686a0;
+      --line: #262636;
+      --line-strong: #33334a;
+      --read: #2dd4bf;
+      --read-soft: #0e211f;
+      --read-line: #1c4f49;
+      --write: #a78bfa;
+      --write-soft: #1a1330;
+      --write-line: #3d2d66;
+      --amber: #fbbf24;
+      --amber-soft: #241b0d;
+      --amber-line: #4d3b17;
+      --code-bg: #1c1c28;
+      --shadow: 0 1px 2px rgba(0,0,0,.3), 0 12px 30px -14px rgba(0,0,0,.6);
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #faf9f7; --bg-soft: #f2f0ec; --card: #fff; --ink: #1b1b2b; --ink-soft: #4a4a5e;
+    --ink-faint: #74748a; --line: #e6e3dd; --line-strong: #d6d2ca; --read: #0d9488;
+    --read-soft: #ecfdf9; --read-line: #a7f0e2; --write: #7c3aed; --write-soft: #f5f0ff;
+    --write-line: #d8c7ff; --amber: #b45309; --amber-soft: #fef6ec; --amber-line: #f3d9ad;
+    --code-bg: #f4f2ee; --shadow: 0 1px 2px rgba(20,20,40,.05), 0 8px 24px -12px rgba(20,20,40,.14);
+  }
+  :root[data-theme="dark"] {
+    --bg: #0d0d17; --bg-soft: #14141f; --card: #16161f; --ink: #e9e9f2; --ink-soft: #b7b7c8;
+    --ink-faint: #8686a0; --line: #262636; --line-strong: #33334a; --read: #2dd4bf;
+    --read-soft: #0e211f; --read-line: #1c4f49; --write: #a78bfa; --write-soft: #1a1330;
+    --write-line: #3d2d66; --amber: #fbbf24; --amber-soft: #241b0d; --amber-line: #4d3b17;
+    --code-bg: #1c1c28; --shadow: 0 1px 2px rgba(0,0,0,.3), 0 12px 30px -14px rgba(0,0,0,.6);
+  }
+
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 17px;
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+
+  /* ---- top bar ---- */
+  .topbar {
+    border-bottom: 1px solid var(--line);
+    background: color-mix(in srgb, var(--bg) 88%, transparent);
+    position: sticky; top: 0; z-index: 10;
+    backdrop-filter: saturate(1.2) blur(8px);
+  }
+  .topbar .wrap { display: flex; align-items: center; justify-content: space-between; height: 56px; }
+  .brand { font-weight: 700; letter-spacing: -.01em; font-size: 15px; display: flex; align-items: center; gap: 9px; }
+  .brand .dot { width: 10px; height: 10px; border-radius: 50%;
+    background: linear-gradient(135deg, var(--read), var(--write)); box-shadow: 0 0 12px -2px var(--write); }
+  .brand small { color: var(--ink-faint); font-weight: 500; }
+  .themebtn {
+    font: inherit; font-size: 13px; color: var(--ink-soft); cursor: pointer;
+    background: var(--card); border: 1px solid var(--line-strong); border-radius: 999px;
+    padding: 5px 13px; display: inline-flex; align-items: center; gap: 6px;
+  }
+  .themebtn:hover { border-color: var(--write); color: var(--ink); }
+
+  /* ---- hero ---- */
+  header.hero { padding: 72px 0 40px; }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 12.5px; font-weight: 650; letter-spacing: .09em; text-transform: uppercase;
+    color: var(--write); background: var(--write-soft); border: 1px solid var(--write-line);
+    padding: 5px 12px; border-radius: 999px;
+  }
+  h1 {
+    font-size: clamp(32px, 6vw, 52px); line-height: 1.06; letter-spacing: -.025em;
+    margin: 22px 0 0; font-weight: 800;
+  }
+  .lede { font-size: clamp(18px, 2.4vw, 21px); color: var(--ink-soft); margin: 20px 0 0; max-width: 40ch; }
+  .lede strong { color: var(--ink); font-weight: 650; }
+
+  .halfchips { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 30px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 9px;
+    font-size: 14px; font-weight: 600; padding: 9px 15px; border-radius: 12px;
+    border: 1px solid var(--line-strong); background: var(--card);
+  }
+  .chip .tag { font-size: 11px; font-weight: 700; letter-spacing: .04em; padding: 2px 7px; border-radius: 6px; text-transform: uppercase; }
+  .chip.read .tag { color: var(--read); background: var(--read-soft); border: 1px solid var(--read-line); }
+  .chip.write .tag { color: var(--write); background: var(--write-soft); border: 1px solid var(--write-line); }
+  .chip .meta { color: var(--ink-faint); font-weight: 500; font-size: 13px; }
+
+  /* ---- sections ---- */
+  section { padding: 30px 0; }
+  .sectlabel {
+    font-size: 12.5px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase;
+    color: var(--ink-faint); margin: 0 0 6px;
+  }
+  h2 { font-size: clamp(24px, 4vw, 31px); letter-spacing: -.02em; margin: 0 0 6px; font-weight: 750; }
+  h2 + .sub { color: var(--ink-soft); margin: 0 0 22px; font-size: 17px; max-width: 62ch; }
+  h3 { font-size: 18px; margin: 0 0 8px; letter-spacing: -.01em; }
+  p { margin: 0 0 16px; }
+  a { color: var(--write); text-decoration-color: color-mix(in srgb, var(--write) 40%, transparent); text-underline-offset: 2px; }
+  hr.div { border: 0; border-top: 1px solid var(--line); margin: 8px 0; }
+  code {
+    font-family: var(--mono); font-size: .86em; background: var(--code-bg);
+    padding: 1.5px 6px; border-radius: 6px; border: 1px solid var(--line);
+  }
+
+  /* ---- two-half cards ---- */
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  .pathcard {
+    background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 24px; box-shadow: var(--shadow); position: relative; overflow: hidden;
+  }
+  .pathcard::before { content:""; position: absolute; inset: 0 auto 0 0; width: 4px; }
+  .pathcard.read::before { background: var(--read); }
+  .pathcard.write::before { background: var(--write); }
+  .pathcard .head { display: flex; align-items: center; gap: 10px; margin-bottom: 4px; }
+  .pathcard .head .name { font-weight: 750; font-size: 19px; letter-spacing: -.01em; }
+  .pathcard.read .name { color: var(--read); }
+  .pathcard.write .name { color: var(--write); }
+  .pathcard .oneline { color: var(--ink-soft); font-size: 15.5px; margin: 0 0 16px; }
+  .facts { list-style: none; padding: 0; margin: 0; display: grid; gap: 9px; }
+  .facts li { display: flex; gap: 10px; font-size: 14.5px; color: var(--ink-soft); }
+  .facts li b { color: var(--ink); font-weight: 650; min-width: 78px; display: inline-block; }
+  .facts .k { color: var(--ink-faint); font-weight: 600; min-width: 74px; }
+
+  /* ---- flow ---- */
+  .flow { display: flex; align-items: stretch; gap: 0; overflow-x: auto; padding: 4px 2px 12px; }
+  .flow .step {
+    flex: 1 0 0; min-width: 132px; background: var(--card); border: 1px solid var(--line);
+    border-radius: 13px; padding: 15px 15px 14px; position: relative;
+  }
+  .flow.read .step { border-top: 3px solid var(--read); }
+  .flow.write .step { border-top: 3px solid var(--write); }
+  .flow .step + .step { margin-left: 26px; }
+  .flow .step + .step::before {
+    content: "→"; position: absolute; left: -22px; top: 50%; transform: translateY(-50%);
+    color: var(--ink-faint); font-size: 18px; font-weight: 700;
+  }
+  .flow .n { font-size: 11px; font-weight: 800; letter-spacing: .06em; color: var(--ink-faint); }
+  .flow.read .n { color: var(--read); }
+  .flow.write .n { color: var(--write); }
+  .flow .t { font-weight: 700; font-size: 15px; margin: 3px 0 4px; letter-spacing: -.01em; }
+  .flow .d { font-size: 13px; color: var(--ink-soft); line-height: 1.45; }
+  .flowcap { font-size: 13.5px; color: var(--ink-faint); margin: 2px 0 0; }
+
+  /* ---- type pills ---- */
+  .types { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+  .type {
+    background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 14px 15px;
+  }
+  .type .name { font-weight: 700; font-size: 14.5px; font-family: var(--mono); color: var(--read); letter-spacing: -.01em; }
+  .type .ex { font-size: 13px; color: var(--ink-soft); margin-top: 3px; line-height: 1.4; }
+
+  /* ---- callout ---- */
+  .callout {
+    border: 1px solid var(--line); border-left: 4px solid var(--write);
+    background: var(--card); border-radius: 12px; padding: 18px 20px; margin: 6px 0 18px;
+  }
+  .callout.amber { border-left-color: var(--amber); background: var(--amber-soft); border-color: var(--amber-line); }
+  .callout.read { border-left-color: var(--read); }
+  .callout .ct { font-weight: 700; font-size: 15px; margin: 0 0 6px; display: flex; align-items: center; gap: 8px; }
+  .callout p { margin: 0; font-size: 15px; color: var(--ink-soft); }
+  .callout p + p { margin-top: 10px; }
+
+  /* ---- safeguards ---- */
+  .guards { display: grid; gap: 14px; margin-top: 4px; }
+  .guard {
+    display: grid; grid-template-columns: 40px 1fr; gap: 15px; align-items: start;
+    background: var(--card); border: 1px solid var(--line); border-radius: 13px; padding: 17px 18px;
+  }
+  .guard .ico {
+    width: 40px; height: 40px; border-radius: 10px; display: grid; place-items: center;
+    font-size: 19px; background: var(--write-soft); border: 1px solid var(--write-line);
+  }
+  .guard h3 { margin: 2px 0 4px; font-size: 16px; }
+  .guard p { margin: 0; font-size: 14.5px; color: var(--ink-soft); }
+  .guard code { font-size: .82em; }
+
+  /* ---- scorecard sample ---- */
+  .scorecard {
+    background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+    box-shadow: var(--shadow); overflow: hidden;
+  }
+  .scorecard .sc-head {
+    padding: 16px 20px; border-bottom: 1px solid var(--line);
+    display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap;
+  }
+  .scorecard .sc-head .title { font-weight: 750; font-size: 16px; display: flex; align-items: center; gap: 9px; }
+  .scorecard .sc-head .win { font-size: 12.5px; color: var(--ink-faint); font-family: var(--mono); }
+  .sc-metrics { display: grid; grid-template-columns: repeat(4, 1fr); }
+  .sc-metric { padding: 20px; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+  .sc-metric:nth-child(4n) { border-right: 0; }
+  .sc-metric .lab { font-size: 11.5px; font-weight: 700; letter-spacing: .07em; text-transform: uppercase; color: var(--ink-faint); }
+  .sc-metric .val { font-size: 34px; font-weight: 800; letter-spacing: -.02em; font-variant-numeric: tabular-nums; margin-top: 2px; }
+  .sc-metric .cap { font-size: 12.5px; color: var(--ink-soft); margin-top: 1px; }
+  .sc-metric.key { background: var(--read-soft); }
+  .sc-metric.key .val { color: var(--read); }
+  .sc-metric.key .lab { color: var(--read); }
+  .sc-foot { padding: 15px 20px; font-size: 13.5px; color: var(--ink-soft); display: flex; align-items: center; gap: 10px; }
+  .sc-foot .bar { flex: 1; height: 8px; border-radius: 999px; background: var(--bg-soft); overflow: hidden; display: flex; }
+  .sc-foot .bar span { height: 100%; }
+  .sc-foot .hi { background: var(--read); }
+  .sc-foot .mid { background: color-mix(in srgb, var(--read) 45%, var(--bg-soft)); }
+  .sc-foot .lo { background: var(--line-strong); }
+
+  .note { font-size: 13.5px; color: var(--ink-faint); margin-top: 10px; }
+
+  /* ---- footer ---- */
+  footer { border-top: 1px solid var(--line); margin-top: 30px; padding: 28px 0 60px; }
+  footer .refs { display: grid; gap: 6px; font-size: 14px; }
+  footer .refs a { color: var(--ink-soft); }
+  footer .fine { color: var(--ink-faint); font-size: 13px; margin-top: 18px; }
+
+  @media (max-width: 720px) {
+    body { font-size: 16px; }
+    .grid2 { grid-template-columns: 1fr; }
+    .types { grid-template-columns: 1fr 1fr; }
+    .sc-metrics { grid-template-columns: 1fr 1fr; }
+    .sc-metric:nth-child(4n) { border-right: 1px solid var(--line); }
+    .sc-metric:nth-child(2n) { border-right: 0; }
+    header.hero { padding: 48px 0 28px; }
+  }
+  @media (max-width: 460px) {
+    .types { grid-template-columns: 1fr; }
+    .guard { grid-template-columns: 1fr; }
+    .guard .ico { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<div class="topbar">
+  <div class="wrap">
+    <div class="brand"><span class="dot"></span> CCGM <small>· Memory System</small></div>
+    <button class="themebtn" id="themebtn" aria-label="Toggle theme">◐ Theme</button>
+  </div>
+</div>
+
+<div class="wrap">
+
+  <header class="hero">
+    <span class="eyebrow">◑ Durable memory</span>
+    <h1>How CCGM remembers what it learns</h1>
+    <p class="lede">A cross-session memory that <strong>surfaces what you've learned</strong> at the start of every session — and a nightly job that mines your own transcripts to grow it, <strong>behind a human gate</strong>.</p>
+
+    <div class="halfchips">
+      <div class="chip read"><span class="tag">Read path</span> self-improving <span class="meta">· local · free · always on</span></div>
+      <div class="chip write"><span class="tag">Write path</span> dreaming <span class="meta">· nightly · opt-in · human-gated</span></div>
+    </div>
+  </header>
+
+  <!-- ============ THE TWO HALVES ============ -->
+  <section>
+    <p class="sectlabel">The shape of it</p>
+    <h2>Two halves, one store</h2>
+    <p class="sub">The memory system splits cleanly into a <em>read path</em> that never leaves your machine and does the valuable work, and an optional <em>write path</em> that automates capture. The read path is complete on its own — you never need the write path to benefit from memory.</p>
+
+    <div class="grid2">
+      <div class="pathcard read">
+        <div class="head"><span class="name">Read path</span></div>
+        <p class="oneline">Stores learnings and surfaces the top-ranked ones at each fresh session start.</p>
+        <ul class="facts">
+          <li><span class="k">Module</span> <span><code>self-improving</code></span></li>
+          <li><span class="k">Storage</span> <span><code>~/.claude/learnings/</code> — a local git repo of append-only JSONL</span></li>
+          <li><span class="k">Cost</span> <span>Free. No network calls.</span></li>
+          <li><span class="k">Trigger</span> <span><code>SessionStart</code> hook injects; <code>/reflect</code> &amp; the CLI capture</span></li>
+        </ul>
+      </div>
+      <div class="pathcard write">
+        <div class="head"><span class="name">Write path</span></div>
+        <p class="oneline">A nightly analyzer mines your session transcripts and <em>proposes</em> new learnings for you to accept.</p>
+        <ul class="facts">
+          <li><span class="k">Module</span> <span><code>dreaming</code></span></li>
+          <li><span class="k">Storage</span> <span><code>~/.claude/dreaming/</code> — proposals, digests, scorecards</span></li>
+          <li><span class="k">Cost</span> <span>Opt-in. Spends Anthropic API tokens (analyzer only).</span></li>
+          <li><span class="k">Trigger</span> <span>Nightly <code>launchd</code> job → review via <code>/dream-apply</code></span></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ THE LOOP ============ -->
+  <section>
+    <p class="sectlabel">The loop</p>
+    <h2>How a memory travels</h2>
+    <p class="sub">The read path is a four-step cycle: capture once, and it resurfaces itself at the right moment ever after. Reuse feeds back and strengthens it.</p>
+
+    <div class="flow read" role="list" aria-label="Read path steps">
+      <div class="step" role="listitem"><div class="n">01 · CAPTURE</div><div class="t">Log a learning</div><div class="d"><code>/reflect</code>, <code>/consolidate</code> or the CLI write a pattern, pitfall, preference, or fact.</div></div>
+      <div class="step" role="listitem"><div class="n">02 · STORE</div><div class="t">Rank &amp; decay</div><div class="d">Lands in append-only JSONL, scored by confidence with time-decay and staleness.</div></div>
+      <div class="step" role="listitem"><div class="n">03 · INJECT</div><div class="t">Surface at start</div><div class="d">The next fresh session gets the project's top-ranked learnings, token-budgeted.</div></div>
+      <div class="step" role="listitem"><div class="n">04 · REUSE</div><div class="t">Reinforce</div><div class="d">When a learning pays off again, a <code>verify</code> raises its confidence and freshness.</div></div>
+    </div>
+    <p class="flowcap">Injection is frozen into the session's prompt prefix at start — so a memory is picked up by the <em>next</em> fresh session, not the one that logged it.</p>
+
+    <div style="height:20px"></div>
+
+    <div class="flow write" role="list" aria-label="Write path steps">
+      <div class="step" role="listitem"><div class="n">01 · MINE</div><div class="t">Read transcripts</div><div class="d">A deterministic Python miner extracts friction, corrections &amp; PR links — no LLM yet.</div></div>
+      <div class="step" role="listitem"><div class="n">02 · ANALYZE</div><div class="t">Map → reduce</div><div class="d">One API call per project + one across all of them turns evidence into candidate deltas.</div></div>
+      <div class="step" role="listitem"><div class="n">03 · PROPOSE</div><div class="t">Pending deltas</div><div class="d">Each proposal is a per-change delta, written <code>pending</code>, tagged with its evidence.</div></div>
+      <div class="step" role="listitem"><div class="n">04 · APPLY</div><div class="t">Human accepts</div><div class="d">You review the digest and <code>/dream-apply</code> — the default path from proposal to store.</div></div>
+    </div>
+    <p class="flowcap">Accepted proposals become ordinary learnings and feed the same read path above.</p>
+  </section>
+
+  <!-- ============ WHAT GETS REMEMBERED ============ -->
+  <section>
+    <p class="sectlabel">What gets remembered</p>
+    <h2>Six kinds of learning</h2>
+    <p class="sub">Every entry is one idea, actionably phrased, ideally anchored to real files so staleness detection can flag drift.</p>
+
+    <div class="types">
+      <div class="type"><div class="name">pattern</div><div class="ex">An approach that worked and should be reused.</div></div>
+      <div class="type"><div class="name">pitfall</div><div class="ex">A known trap to avoid next time.</div></div>
+      <div class="type"><div class="name">preference</div><div class="ex">A taste call — how you like things done.</div></div>
+      <div class="type"><div class="name">architecture</div><div class="ex">A durable fact about how the codebase fits together.</div></div>
+      <div class="type"><div class="name">tool</div><div class="ex">A tool or framework gotcha.</div></div>
+      <div class="type"><div class="name">operational</div><div class="ex">An ops fact — deploys, CLIs, infra timing.</div></div>
+    </div>
+
+    <div style="height:22px"></div>
+
+    <div class="callout amber">
+      <p class="ct">⚖︎ &nbsp;“Only log human-validated decisions” — the honest version</p>
+      <p>The store legitimately holds <em>observed</em> patterns, not just decisions a human explicitly ratified. But the integrity property you actually care about is real and enforced two ways: <strong>every memory is grounded in real, on-disk session evidence</strong> (nothing is invented), and <strong>every model-<em>proposed</em> memory passes a human gate before it is stored</strong>. Manual capture via <code>/reflect</code> is human-confirmed; automated capture via <code>dreaming</code> is human-accepted. A model never writes to the store on its own.</p>
+    </div>
+  </section>
+
+  <!-- ============ THE NIGHTLY JOB ============ -->
+  <section>
+    <p class="sectlabel">The background job</p>
+    <h2>What “dreaming” does at night</h2>
+    <p class="sub">Once a day a <code>launchd</code> LaunchAgent runs a chain — analyze → eval-refresh → optimistic-integrate → digest → reconcile → retention. Each step is exit-tolerant, so one failure never kills the rest of the chain. (Digest runs <em>after</em> integrate, so tonight's just-integrated batch is reported while its dwell window is still ahead of it.)</p>
+
+    <div class="guards">
+      <div class="guard">
+        <div class="ico" style="background:var(--read-soft);border-color:var(--read-line)">🔎</div>
+        <div>
+          <h3>Deterministic mining, no model</h3>
+          <p>Pure-Python <code>transcript_miner</code> reads the JSONL every session already writes and pulls out friction events (tool/hook errors), user-correction sequences, PR links, and token economics. A <em>schema canary</em> fails loud if Claude Code's transcript format drifts, rather than silently mining nothing.</p>
+        </div>
+      </div>
+      <div class="guard">
+        <div class="ico">🧠</div>
+        <div>
+          <h3>Map → reduce over a direct API call</h3>
+          <p>The evidence bundle goes to the Anthropic Messages API over <code>curl</code> — <strong>no nested agent runtime</strong>, which removes the exec-escape attack surface. One map call per project, one reduce call across all of them, produces per-change proposals validated against a schema before touching disk.</p>
+        </div>
+      </div>
+      <div class="guard">
+        <div class="ico" style="background:var(--amber-soft);border-color:var(--amber-line)">🛡️</div>
+        <div>
+          <h3>Two-layer redaction before anything leaves the machine</h3>
+          <p>Every evidence excerpt runs through secret-token redaction (17 vendor shapes) <em>and</em> PII redaction (email, phone, address), then is truncated to ≤400 chars — redaction always applied <em>before</em> truncation so a boundary can't split a redaction marker.</p>
+        </div>
+      </div>
+      <div class="guard">
+        <div class="ico">📄</div>
+        <div>
+          <h3>A digest you review, not a change you discover</h3>
+          <p><code>/dream-digest</code> renders the day's proposals grouped by project and kind, each with its evidence excerpts, prevalence count, and confidence. A durable canary banner flags schema drift or reduce failures until acknowledged.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ SAFEGUARDS ============ -->
+  <section>
+    <p class="sectlabel">Why it doesn't hallucinate memories</p>
+    <h2>The safeguards</h2>
+    <p class="sub">A memory system that grows itself is a poisoning surface — a wrong or malicious “learning” that gets injected into every future session. These are the layers that keep that from happening.</p>
+
+    <div class="guards">
+      <div class="guard">
+        <div class="ico">🙋</div>
+        <div>
+          <h3>Human gate — nothing model-proposed is silent</h3>
+          <p>Every dreaming proposal starts <code>pending</code> and stays there until you run <code>/dream-apply</code> and accept it. That is the <em>only</em> path from a mined proposal into the store.</p>
+        </div>
+      </div>
+      <div class="guard">
+        <div class="ico">🔗</div>
+        <div>
+          <h3>Origin binding — evidence must be real</h3>
+          <p>A proposal's cited sessions must resolve to actual transcript files on disk. The learning's <em>writer</em> is derived from that transcript's own recorded <code>cwd</code> — never from a caller-supplied env var — so a proposal can't forge a more-trusted origin than it has.</p>
+        </div>
+      </div>
+      <div class="guard">
+        <div class="ico">🧴</div>
+        <div>
+          <h3>Injection sanitizer + quarantine</h3>
+          <p>Untrusted transcript text is neutralized on write (role prefixes, “ignore previous instructions”, prompt tags). Independently, <em>every read</em> re-validates each entry and drops — quarantines — anything carrying unneutralized injection-shaped content. The analyzer's own prompts open by declaring excerpts are <strong>data, never instructions</strong>.</p>
+        </div>
+      </div>
+      <div class="guard">
+        <div class="ico">📉</div>
+        <div>
+          <h3>Confidence decay &amp; staleness</h3>
+          <p>Every entry carries a 1–10 confidence that <em>decays over time</em> (≈90-day half-life) and is excluded once it falls below threshold. Reuse strengthens it; a <code>contradict</code> cuts it hard. Old memory doesn't silently masquerade as current truth.</p>
+        </div>
+      </div>
+      <div class="guard">
+        <div class="ico">🚫</div>
+        <div>
+          <h3>Optimistic auto-integration is OFF by default — and bounded when on</h3>
+          <p>The one optional automated write path, <code>optimistic_integration</code> (default <code>false</code>), never blanket-applies. Each op-kind gets a <em>posture</em>: <code>verify</code> integrates immediately (purely additive, reversible), while <code>add</code> / <code>supersede</code> and the eviction-shaped <code>contradict</code> / <code>deprecate</code> are written but held behind a <strong>24-hour dwell window</strong> — excluded from every read path until it elapses, so a bad row can't reach a live session first. Per-slug caps bound how many land in one night, a batch-anomaly check watches eviction concentration, and a self-healing <strong>circuit breaker</strong> trips on repeated anomalies. Any <code>_global</code> change stays fully human-gated.</p>
+        </div>
+      </div>
+      <div class="guard">
+        <div class="ico">✅</div>
+        <div>
+          <h3>An eval gate that fails closed</h3>
+          <p>Before optimistic integration may act at all, <code>dream-eval.sh --gate</code> runs a with/without-memory A/B regression suite. Missing or red ⇒ no integration that run. Today the gate stays deliberately closed: the harness hasn't yet shown auto-integration beats human review, so <code>/dream-apply</code> remains the real write path.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ SCORECARD ============ -->
+  <section>
+    <p class="sectlabel">How we know it's working</p>
+    <h2>The weekly scorecard</h2>
+    <p class="sub">Run <code>/dream-scorecard</code> for a deterministic, read-only weekly report — every number is a count of something already on disk. It's the honest answer to “is this memory system actually paying off?”</p>
+
+    <div class="scorecard" aria-label="Sample scorecard">
+      <div class="sc-head">
+        <div class="title">◑ &nbsp;Memory scorecard</div>
+        <div class="win">7 days ending 2026-07-04 · read-only</div>
+      </div>
+      <div class="sc-metrics">
+        <div class="sc-metric">
+          <div class="lab">Captured</div>
+          <div class="val">—</div>
+          <div class="cap">new learnings added</div>
+        </div>
+        <div class="sc-metric">
+          <div class="lab">Injected</div>
+          <div class="val">—</div>
+          <div class="cap">sessions given memory</div>
+        </div>
+        <div class="sc-metric key">
+          <div class="lab">Reused ★</div>
+          <div class="val">—</div>
+          <div class="cap">learnings that paid off</div>
+        </div>
+        <div class="sc-metric">
+          <div class="lab">Applied</div>
+          <div class="val">—</div>
+          <div class="cap">proposals accepted</div>
+        </div>
+      </div>
+      <div class="sc-foot">
+        <span>Store health · effective-confidence bands</span>
+        <span class="bar"><span class="hi" style="width:46%"></span><span class="mid" style="width:34%"></span><span class="lo" style="width:20%"></span></span>
+      </div>
+    </div>
+    <p class="note">The sample above shows the <em>shape</em> of the report, not live numbers. <strong>Reused</strong> is the metric that matters most — a reuse (<code>verify</code>) means a stored learning actually helped in a later session, which is the whole point. Captured and injected show the pipeline is flowing; store-health bands show it isn't rotting.</p>
+
+    <div class="callout read">
+      <p class="ct">📊 &nbsp;What each section counts</p>
+      <p><strong>Captured</strong> — new <code>add</code> events, by type and project (in-window <code>supersede</code> refinements shown separately). &nbsp;<strong>Injected</strong> — sessions that received memory, from per-machine injection telemetry (IDs + counts only, never content). &nbsp;<strong>Reused</strong> — <code>verify</code> events, the key value signal. &nbsp;<strong>Applied</strong> — proposals applied, by kind. &nbsp;<strong>Store health</strong> — active count and effective-confidence bands, plus deprecated / superseded tallies.</p>
+    </div>
+  </section>
+
+  <!-- ============ PRIVACY ============ -->
+  <section>
+    <p class="sectlabel">Where your memory lives</p>
+    <h2>Local by default</h2>
+    <p class="sub">The read path is entirely on-machine. Opting into anything that leaves it is deliberate and explicit.</p>
+    <div class="guards">
+      <div class="guard">
+        <div class="ico" style="background:var(--read-soft);border-color:var(--read-line)">💾</div>
+        <div>
+          <h3>Learnings never leave the machine</h3>
+          <p><code>~/.claude/learnings/</code> is a local git repo with no remote by default. Cross-machine sync is opt-in — add your own <em>private</em> remote and <code>ccgm-learnings-sync push</code>. Never point it at a public repo.</p>
+        </div>
+      </div>
+      <div class="guard">
+        <div class="ico" style="background:var(--read-soft);border-color:var(--read-line)">🔕</div>
+        <div>
+          <h3>Telemetry records counts, not content</h3>
+          <p>Injection telemetry logs memory IDs, counts, and a token estimate — never the memory text. It's per-machine, lives outside the synced store, and is best-effort: any failure is swallowed and never alters the injected block.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <p class="sectlabel">Read the source</p>
+    <div class="refs">
+      <a href="../modules/self-improving/rules/learnings-store.md">learnings-store.md — schema, confidence decay, supersede chains, git sync</a>
+      <a href="../modules/self-improving/rules/self-improving.md">self-improving.md — the reflection loop &amp; capture triggers</a>
+      <a href="../modules/dreaming/rules/dreaming.md">dreaming.md — the nightly pipeline &amp; the proposal / evidence / gate contract</a>
+      <a href="./memory-system.md">memory-system.md — the operator guide this page distills</a>
+    </div>
+    <p class="fine">CCGM — Claude Code God Mode · Memory system overview · Read path local &amp; free · Write path opt-in &amp; human-gated.</p>
+  </footer>
+
+</div>
+
+<script>
+  (function () {
+    var btn = document.getElementById('themebtn');
+    var root = document.documentElement;
+    btn.addEventListener('click', function () {
+      var cur = root.getAttribute('data-theme');
+      var isDark = cur ? cur === 'dark'
+        : window.matchMedia('(prefers-color-scheme: dark)').matches;
+      root.setAttribute('data-theme', isDark ? 'light' : 'dark');
+    });
+  })();
+</script>
+</body>
+</html>

--- a/docs/memory-system.md
+++ b/docs/memory-system.md
@@ -1,52 +1,348 @@
 # Memory System
 
-CCGM's durable, cross-session memory. It comes in two halves:
+CCGM's durable, cross-session memory: a store that learns from your work and surfaces what it knows at the start of each new session. This is the comprehensive technical reference. For the visual overview, see [`memory-system.html`](./memory-system.html); for the concise pitch, see the [Memory System](../README.md#memory-system) section of the README.
 
-- **Read path** — the [`self-improving`](../modules/self-improving/rules/self-improving.md) learnings store plus a SessionStart hook that surfaces what you've learned at the start of each new session. Local and free.
-- **Write path** — the [`dreaming`](../modules/dreaming/rules/dreaming.md) module: a nightly analyzer that mines your session transcripts and proposes new learnings behind a human gate. Opt-in; spends Anthropic API tokens.
+---
 
-The read path is the valuable, always-safe half and works on its own. The write path is an optional layer on top that automates capture — you never need it to benefit from memory.
+## Overview
+
+The memory system splits into two halves that share one store:
+
+- **Read path** — the [`self-improving`](../modules/self-improving/rules/self-improving.md) learnings store plus a `SessionStart` hook that surfaces the current project's top-ranked learnings at the start of each new session. **Local and free — no network calls.**
+- **Write path** — the [`dreaming`](../modules/dreaming/rules/dreaming.md) module: a nightly analyzer that mines your session transcripts into evidence-tagged *proposals* for new learnings, behind a human gate. **Opt-in; spends Anthropic API tokens.**
+
+The read path is the valuable, always-safe half and is complete on its own. The write path is an optional layer that automates capture — you never need it to benefit from memory.
 
 | Half | Module | Storage | Cost | Network |
 |------|--------|---------|------|---------|
 | Read path | `self-improving` | `~/.claude/learnings/` (local git repo) | free | none |
 | Write path | `dreaming` | `~/.claude/dreaming/` | Anthropic API tokens | analyzer only, opt-in |
 
-## The end-to-end loop
+### The end-to-end loop
 
-**Read path (manual/assisted capture → reuse):**
+**Read path (capture → reuse):**
 
 1. **Capture** — `/reflect`, `/consolidate`, `/retro`, or a direct `ccgm-learnings-log` call write a learning (a pattern, pitfall, preference, architecture fact, tool gotcha, or ops fact).
-2. **Store** — it lands in the append-only JSONL learnings store, ranked by confidence with time-based decay and staleness detection.
+2. **Store** — it appends to a per-agent JSONL shard, projected at read time into a ranked view with confidence decay and staleness detection.
 3. **Inject** — at the *next* fresh session start, the injection hook surfaces the project's top-ranked learnings into context.
-4. **Reuse** — when a learning proves useful again, a `verify` op reinforces it, which raises its effective confidence and refreshes its freshness.
+4. **Reuse** — when a learning proves useful again, a `verify` op reinforces it, raising its effective confidence and refreshing its freshness.
 
 **Write path (dreaming, automated capture):**
 
-Nightly, the analyzer mines the day's session transcripts into a redacted evidence bundle → proposes per-change deltas against the same learnings store → writes them to `~/.claude/dreaming/proposals/{date}.jsonl`. From there, one of two things happens:
+Nightly, the analyzer mines the day's transcripts into a redacted evidence bundle → proposes per-change deltas against the same store → writes them `pending` to `~/.claude/dreaming/proposals/{date}.jsonl`. From there, one of two things happens:
 
 - **Human-gated (default)** — you review the digest and accept/reject with `/dream-apply`. Nothing reaches the store until you do.
-- **Optimistic auto-integration (opt-in)** — a per-op-kind engine writes the change immediately, holds it behind a dwell window before it can reach agent context, and reports it in the next digest for a post-hoc `/dream-review` or one-command rollback. See "Safety posture" below.
+- **Optimistic auto-integration (opt-in)** — a per-op-kind engine writes the change immediately, holds it behind a dwell window before it can reach agent context, and reports it for a post-hoc veto or one-command rollback.
 
-Either way, the change feeds the same read path above once it's live.
+Either way, an applied change feeds the same read path above once it's live.
 
-## Components
+### Architecture at a glance
 
 | Component | Where | Role |
 |-----------|-------|------|
-| Learnings store | `~/.claude/learnings/` (git repo) | Append-only, per-agent-sharded JSONL: confidence decay, staleness, supersede chains, prompt-injection sanitization |
-| Store CLI | `ccgm-learnings-log` / `-search` / `-sync` | Write/verify/supersede/deprecate; query + inject; git init/commit/pull/push |
+| Learnings store | `~/.claude/learnings/` (git repo) | Append-only, per-agent-sharded JSONL op-events; confidence decay, staleness, supersede chains, injection sanitization, read-time quarantine |
+| Store library | `modules/self-improving/lib/learnings_store.py` | The projection, ranking, validation, and write functions all three CLIs and the hook call into |
+| Store CLI | `ccgm-learnings-log` / `-search` / `-sync` | Write/verify/supersede/deprecate; query + inject; git init/commit/pull/push/revert |
 | Reflection | `/reflect`, `/consolidate`, `/retro` | Capture and maintain learnings |
-| Injection hook | `learnings-inject.py` (SessionStart) | Gated on `CCGM_LEARNINGS_INJECT` **and** `source == "startup"`; emits one `<ccgm-learnings-injection>` block of top-ranked learnings for the current project |
-| Nightly analyzer | `dreaming` LaunchAgent | Mines transcripts → evidence → proposals (direct Anthropic API, no nested agent) |
-| Digest | `/dream-digest` | Renders the day's proposals, plus tonight's auto-integrated batch, for human review |
-| Apply | `/dream-apply` | The always-available, human-gated write path from a proposal into the store |
-| Optimistic engine | `optimistic_integration.enabled` (opt-in) | Per-op-kind posture engine: writes immediately behind a dwell window, bounded by per-slug caps, a batch-anomaly check, and a circuit breaker |
-| Post-hoc review | `/dream-review` | Surfaces auto-integrated and still-dwelling rows for a veto; `ccgm-learnings-sync revert <sha>` rolls back a bad batch |
-| Eval gate | `dream-eval.sh --gate` | With/without-memory A/B regression gate that optimistic auto-integration must pass every night |
-| Scorecard | `/dream-scorecard` | Weekly, read-only observability: captured / injected / reused / applied, plus auto-integrated / mid-dwell / reverted / breaker-trips + store health |
+| Injection hook | `learnings-inject.py` (`SessionStart`) | Gated on `CCGM_LEARNINGS_INJECT` **and** `source == "startup"`; emits one `<ccgm-learnings-injection>` block of top-ranked learnings |
+| Reflection triggers | `reflection-trigger.py` (`PostToolUse`), `precompact-reflection.py` (`PreCompact`) | Nudge a reflection pass after merges/issue-closes and before context compaction |
+| Nightly analyzer | `dreaming` LaunchAgent → `dream_analyze.py` | Mines transcripts → evidence → proposals via direct Anthropic API (no nested agent) |
+| Digest / apply | `/dream-digest`, `/dream-apply` | Render the day's proposals; the always-available human-gated write path |
+| Optimistic engine | `apply_dream_proposal.py` (opt-in) | Per-op-kind posture engine: dwell window, per-slug caps, batch-anomaly check, circuit breaker |
+| Post-hoc review | `/dream-review`, `ccgm-learnings-sync revert <sha>` | Veto a still-dwelling row; roll back a bad batch |
+| Eval gate | `dream-eval.sh --gate` | With/without-memory A/B regression gate optimistic integration must pass nightly |
+| Scorecard | `/dream-scorecard` | Weekly, read-only observability of captured / injected / reused / applied + store health |
 
-The read path uses only the first four rows. The rest ship with `dreaming`.
+The read path uses only the first six rows. The rest ship with `dreaming`.
+
+---
+
+# Part 1 — The read path (`self-improving`)
+
+## The data model: op-events and the projected view
+
+The store is an **append-only op-event log**, not a mutable record store. Every write appends exactly one JSON line describing a *change*; the current state of any learning is *reconstructed* by folding its op-events at read time. Nothing on disk is ever mutated in place — this is what makes the store safe to sync with a union merge (see Part 3).
+
+There are five op kinds:
+
+| Op | Written by | Effect on the target |
+|----|-----------|----------------------|
+| `add` | `ccgm-learnings-log` (default subcommand) | Creates a new learning with zeroed counters |
+| `verify` | `ccgm-learnings-log verify <id>` | `uses += 1`; refreshes `last_verified` (unless `--auto`) |
+| `contradict` | `ccgm-learnings-log contradict <id>` | `contradictions += 1` |
+| `deprecate` | `ccgm-learnings-log deprecate <id> --expected-sha …` | `deprecated = True` |
+| `supersede` | `ccgm-learnings-log supersede <old_id> --content … --expected-sha …` | Retires the old head, seeds a replacement, links both directions |
+
+An **on-disk op row** (`_build_op_row`) carries these keys, `json.dumps` with sorted keys: `id`, `op`, `target_id`, `timestamp`, `type`, `source`, `content`, `confidence`, `tags`, `files`, `project`, `key`, `content_sha256`, `writer`, `source_session`, `expected_sha256`, `supersede_reason`, `last_verified`, `deprecated`. Optional keys appear only when relevant: `auto: true` for engine-written ops, `dwell_until` when the row is held back, `evidence_sessions` for adds, and `reviewed_by` + `evidence_sessions` for global promotions.
+
+The **projected read-time entry** — the shape every caller actually consumes — is the fold of those ops:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string | 12-char uuid4 fragment |
+| `timestamp` | ISO 8601 UTC | write time of the `add` |
+| `type` | enum | `pattern`, `pitfall`, `preference`, `architecture`, `tool`, `operational` |
+| `source` | enum | `observed` (default), `user-stated`, `inferred`, `cross-model` |
+| `content` | string | sanitized single paragraph, ≤2000 chars |
+| `confidence` | 1–10 | default 5 |
+| `tags`, `files` | string[] | `files` are repo-relative; used for staleness |
+| `key` | string | dedup key; content-hash-derived if omitted |
+| `last_verified` | ISO 8601 UTC | bumped by non-`--auto` `verify` |
+| `uses` | int | derived — count of `verify` ops |
+| `contradictions` | int | derived — count of `contradict` ops |
+| `deprecated` | bool | hard-excludes from reads |
+| `supersedes` / `superseded_by` | string | supersede-chain links |
+| `dwell_until` | ISO 8601 UTC | optimistic-integration only; absent = live |
+
+Writing a raw line by hand is unsupported. Always go through `ccgm-learnings-log`, which emits the correct op-event; the derived counters (`uses`, `contradictions`, `superseded_by`, …) come only from the fold, never from a hand-edited field.
+
+## Storage layout and sharding
+
+```
+~/.claude/learnings/                     ← LEARNINGS_ROOT (env: CCGM_LEARNINGS_DIR)
+  config.json                            ← tunables (see below)
+  .gitattributes                         ← "*.jsonl merge=union"
+  {project-slug}/
+    learnings.jsonl                      ← legacy v1 rows: read-only, still folded
+    agents/{agent-id}.jsonl              ← v2: ALL new writes append here
+    .quarantine.jsonl                    ← gitignored, per-machine (see Part 2)
+  _global/
+    agents/{agent-id}.jsonl              ← promotion-only (see Part 4)
+```
+
+Sharding is **per agent**: every writer appends only to its own `agents/{agent-id}.jsonl`, so two clones (or two machines) never write the same file and a union merge is conflict-free by construction. The legacy pre-shard `learnings.jsonl` is still folded on every read for backward compatibility, but no new writes land there.
+
+**Agent id** resolves in precedence order: `CCGM_AGENT_ID` env → `AGENT_ID=` in the cwd's `.env.clone` → `"solo"`. This id is a *display / shard label only* — it is never trusted for provenance. Privileged operations (global promotion, tier-raising supersede) derive the trusted `writer` from the *transcript's own recorded `cwd`*, never from `CCGM_AGENT_ID`.
+
+**Project slug** (`detect_project_slug`) resolves in precedence order: `CCGM_LEARNINGS_PROJECT` env → the git `remote.origin.url` slugified to `{owner}_{repo}` → the basename of the repo toplevel → the basename of cwd. Because the slug keys on the git remote, every clone of a repo shares one store even though each clone's session transcripts live under a different `~/.claude/projects/` directory.
+
+**config.json** (read by `load_config`, defaults merged under any file values):
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `cross_project_search` | `false` | Allow `--cross-project` reads |
+| `half_life_days` | `90` | Confidence decay half-life |
+| `deprecate_threshold` | `2.0` | Effective-confidence floor below which entries are hidden |
+| `stale_days` | `180` | `last_verified` age past which entries are hidden by default |
+| `token_budget` | `2000` | Injection budget (≈ chars/4) |
+| `max_results` | `8` | Injection result cap |
+
+## The projection: how a read is computed
+
+`project_slug()` is the canonical entry point; `load_all()` and `search()` both call it. The fold (`_project_lines` → `_fold`) is deterministic:
+
+1. **Dedupe by op `id`**, first occurrence wins — *not* by content `key`, so counter-ops (which carry no key) don't collide.
+2. **Total order** every op by `(parsed_timestamp, id)`. The `id` tiebreaker keeps the order stable when two ops share a timestamp.
+3. **Two-phase fold.** *Phase A* seeds a head for each `add` (empty counters) and each legacy v1 row (projected verbatim — its counters already *are* state). *Phase B* applies `verify` / `contradict` / `deprecate` / `supersede` onto their target heads. An op whose target hasn't been seeded yet is deferred and retried each pass until a fixpoint; any op that never resolves is surfaced as an **orphan op**, never silently dropped.
+
+**Conflict handling.** If two `supersede` ops target the same live head (two machines refined the same entry independently), the fold does *not* pick a last-writer winner. It marks `conflict: True` on the old head and on both competing replacements and records a `conflicting_superseded_by` list. Conflicted rows are surfaced to the CLI (flagged) but **suppressed from session injection** — they aren't settled truth. `/consolidate` resolves them.
+
+`load_all()` returns all heads (including superseded/deprecated). `search()` layers filtering, ranking, and budgeting on top.
+
+## Confidence, decay, and staleness
+
+Confidence is explicit and ages automatically. `effective_confidence()` computes, at read time:
+
+```
+base      = clamp(confidence + min(uses * 0.25, 2.0) − contradictions * 1.5, 0, 10)
+effective = base * 0.5 ^ (age_days / half_life_days)
+```
+
+- **Reuse boosts, but caps.** Each `verify` adds 0.25, capped at +2.0 total, so a learning can't accumulate unbounded authority by being verified over and over.
+- **Contradiction cuts hard.** Each `contradict` subtracts 1.5, so "one session found this wrong" meaningfully weakens it.
+- **Age halves it.** Decay is anchored on `last_verified` (falling back to `timestamp`), with a 90-day half-life by default. A learning nobody has re-verified in a quarter is worth half its base.
+- `deprecated: true` zeroes effective confidence unconditionally.
+
+Entries whose effective confidence falls below `deprecate_threshold` (2.0) are skipped at read time but never deleted — the audit trail stays intact. **Staleness** is a separate axis: an entry is stale if `last_verified` is older than `stale_days` (180). Stale entries are hidden by default (`--include-stale` to see them). An entry can be high-confidence *and* stale.
+
+`search()` ranks surviving entries by `effective_confidence * (0.5 + relevance)`, dedupes by `(key, type)` keeping the latest, then trims to `max_results` (8) within a token budget of `token_budget * 4` chars.
+
+## Supersede chains
+
+`supersede` is the audit-preserving way to *replace* a learning (refined wording, evolved pattern, corrected `files[]` anchor, changed preference). It is atomic and bidirectional: the new head gets `supersedes: <old_id>`, the old head gets `superseded_by: <new_id>` and a `supersede_reason`. Omitted fields (`type`, `confidence`, `tags`, `files`) are inherited from the old entry, so the common "refine the wording" case is a one-flag call. Both rows persist; `search()` hides the old one unless `--include-superseded` walks the chain.
+
+Supersede requires a **CAS check** (`--expected-sha`) so a replacement written against a stale view is rejected rather than silently clobbering a concurrent edit. A *tier-raising* supersede (e.g. bumping `source` from `inferred` to `user-stated`) additionally derives its trusted `writer` from the transcript cwd — you can't forge a more-trusted origin.
+
+Prefer supersede over "deprecate + re-add": `deprecate` says *this is wrong, with no replacement*; supersede says *this was replaced by X*, and the chain is the record of how the entry evolved. `/consolidate` is deliberately supersede- and verify-heavy and deprecate-light.
+
+## The dwell window
+
+`dwell_until` marks a row **written but not yet live**. It is the mechanism behind dreaming's optimistic auto-integration (Part 4). A row whose `dwell_until` is in the future is excluded from `search()` — and therefore from session injection and the mining reduce projection — until the timestamp passes.
+
+- `is_dwelling()` returns true iff `dwell_until` parses to a time strictly after now. Absent or malformed → false ("live"): a parse bug can never trap a row in permanent dwell.
+- **Dwell only extends, never shortens.** Whenever a head is rebuilt, `dwell_until` is folded with `max(old, new)`, so a cheap follow-up op can't be chained to release a poisoned row early or shorten a human-set quarantine.
+- Only the *ranked, injectable* result set (`search()`) hides a dwelling row. It stays resolvable by id — `load_all()`, `update_entry_by_id()`, `supersede_entry()` all see it — so it can still be reviewed, superseded, or reverted.
+
+---
+
+# Part 2 — Store integrity
+
+A memory system that grows itself is a poisoning surface: a wrong or malicious "learning" injected into every future session. Three independent layers defend the store.
+
+## The prompt-injection sanitizer
+
+On **write**, `content` (and `supersede_reason`) pass through `sanitize_content()`, which neutralizes eight instruction-shaped patterns (all line-anchored, case-insensitive):
+
+- `System:` / `Assistant:` / `User:` role prefixes
+- `ignore (all|previous|prior) (instructions|prompts)`
+- `you are (now|a|an) …`
+- `disregard … (rules|instructions|guidelines)`
+- `<system>` / `<instructions>` / `<prompt>` tags
+- ` ```system ` fence openers
+
+Matches are **wrapped** with `[neutralized]…[/neutralized]` rather than stripped, so the text stays readable while losing its instruction shape. Content is then whitespace-collapsed and capped at 2000 chars. The sanitizer is intentionally *not idempotent* (re-running would double-nest), so it is applied only on write.
+
+## Read-time validation and quarantine
+
+`git merge=union` operates on raw text — it never re-runs `validate_entry()`. So a row arriving via merge from another machine, a hand-edited shard, or a raw `git pull` that bypassed the sync tool is **not** re-validated by git. The projection closes that gap and is the load-bearing safety property:
+
+On **every** projection, `_suppress_quarantined_heads()` re-runs `validate_entry()` (schema check) and `contains_unneutralized_injection()` (detection-only — it recognizes text already wrapped in `[neutralized]…` and passes it, but catches the same injection shapes surviving unwrapped) against each head's `content` and `supersede_reason`. A head that fails either check is:
+
+- **dropped** from the heads returned to the caller on the spot, and
+- recorded by id in `{slug}/.quarantine.jsonl` (gitignored, per-machine).
+
+The offending line is **never removed or rewritten** in its shard — mutating another writer's line would break the append-only invariant union-merge safety depends on. Quarantine is an *exclusion at read time*, enforced inside the projection itself, so it catches every ingestion path, not just the one command that happened to run an eager check. `ccgm-learnings-sync pull` additionally runs an *eager* post-merge pass (new-since-merge lines only) for an immediate `{"quarantined": N}` report and to pre-populate the index; that's an optimization, not the guarantee.
+
+## The compaction guard
+
+When `/consolidate` rewrites an entry's content to save tokens, `compact_preserves_facts(old, new, threshold=0.05)` guards the rewrite. It extracts fact-bearing tokens from both texts — identifiers (`foo_bar`, `Foo.Bar`), proper-noun phrases, quoted strings, dates, version numbers, acronyms — and **rejects** the rewrite if more than 5% of unique old tokens went missing. It's a cheap regex backstop against the "rewrote the prose but lost the `users` table name" failure; false positives fail safe (flag for human review), false negatives are possible (it only sees tokens it recognizes). This is why consolidation prefers supersede (a delta) over whole-entry rewrite (which also discards `uses`/`contradictions` history and severs the audit chain).
+
+---
+
+# Part 3 — Versioning and cross-machine sync
+
+`~/.claude/learnings/` is its own git repository, managed exclusively through `ccgm-learnings-sync` — never with raw `git pull`/`git rebase` against it. Every shard carries the `*.jsonl merge=union` gitattribute, so two machines appending to the same shard merge line-union-wise with no conflict.
+
+**`init`** — idempotent. `git init` only if `.git` is missing; ensures the union gitattribute and a `.gitignore` covering per-machine state (`.env*`, `*.quarantine.jsonl`, `config.json`); commits whatever that leaves dirty. The read-time snapshot cache lives in a sibling `-cache/` directory *outside* the repo, so it's structurally never a sync participant.
+
+**`commit`** — takes a store-wide lock, stands down as a provable no-op if a merge/rebase/cherry-pick is in progress (never commits over an unresolved merge), and commits only when the tree is actually dirty. `CCGM_LEARNINGS_AUTOCOMMIT=true` makes every mutating write spawn a detached `commit` afterward — best-effort, never blocking the write.
+
+**`pull` is merge-only — never rebase.** It is `git fetch` + `git merge --no-edit`, and only that. This was tightened after an empirical finding (git 2.50.1): a rebase-based pull's conflict fallback required `git rebase --abort`, and that abort **silently wiped a concurrently-appended learning** — no commit, no reflog, unrecoverable. Removing rebase (and the abort it needs) removes the defect. On a real conflict (rare — only non-shard files like `.gitattributes` conflict), `pull` leaves the repo exactly as a human would: `MERGE_HEAD` present, markers in place, nothing aborted.
+
+**`revert <sha>` is a line-set-difference, not `git revert`.** A plain `git revert` is *unsound* here: once a shard has had any write since the reverted commit, `git revert` invokes the union merge driver, whose whole job is "never let a line disappear" — it silently re-adds the very content the revert was trying to remove and reports "nothing to commit." Instead, `revert` computes the exact set of lines the commit *added* (`git diff --unified=0`) and removes that multiset directly from each touched shard's current content — a plain text transform git's merge machinery never sees. This is sound *because of* the append-only invariant: reverting always reduces to "remove the lines it added," regardless of what else was appended since. If any file in the commit shows *removed* or *modified* lines (which this store's write path never produces), the whole revert is refused before touching anything.
+
+`pull` / `commit` / `push` / `revert` all serialize on a store-wide lock (`.git/ccgm-sync.lock`). **Cross-machine ordering** assumes roughly NTP-sane clocks: the fold orders by `(timestamp, id)` using each writer's local wall clock, so two machines racing the same shard under significant clock drift may order ops by the more-skewed clock. Badly-ordered ops still fold deterministically and safely (an op ahead of its target is deferred, then surfaced as an orphan if unresolved) — only the *causal* cross-machine order isn't guaranteed. Keep machines on NTP.
+
+> **Rollback caveat.** `revert` stops *future* reads of a row, not the current session's. A row already read into a live session's frozen `SessionStart` prefix stays in that session until it restarts. This is also the honest limit of dreaming's dwell window (Part 4).
+
+---
+
+# Part 4 — The write path (`dreaming`)
+
+Dreaming is a nightly, cost-capped, out-of-band pipeline that mines session transcripts into evidence-tagged *proposals* against the learnings store, behind a human gate. It never runs inside a Claude Code agent runtime — every model call is a direct `curl` to the Anthropic Messages API, which removes the nested-agent exec-escape surface. It runs headless under `launchd`.
+
+## Stage 1 — deterministic mining (no model)
+
+`transcript_miner.py` is pure stdlib. Its pipeline is `discover() → mine() → cluster() → budget()`:
+
+- **`discover()`** enumerates the session-transcript JSONLs under `~/.claude/projects/*/`. Crucially, it re-derives each transcript's owning learnings slug by *peeking the transcript's own recorded `cwd`* and running `detect_project_slug()` — never from the `~/.claude/projects/` directory name, which is keyed by encoded cwd path (one per clone) and does *not* agree with the git-remote slug. A per-slug watermark (epoch-compared, fcntl-locked, forward-only) skips already-mined transcripts; slugs with no watermark fall back to a 7-day lookback.
+- **`mine()`** extracts, in one deterministic forward pass: **friction events** (`tool_error` from `is_error`/non-zero Bash exit, `hook_error`, `prevented_continuation`), **user-correction events** (a human-origin user turn containing one of 22 negation phrases within 2 turns *after* a friction event), **PR links**, and **token economics** (per-session input/output/cache token sums + cache-read ratio). Every excerpt is redacted (secrets *then* PII) and truncated to 400 chars before storage.
+- **`cluster()`** groups events by `(kind, tool, normalized-command-prefix)`, friction-first. Friction clusters keep ≤3 exemplars; routine clusters carry none.
+- **`budget()`** trims to a token cap (default 200k) by round-robin down-sampling exemplars — but **never drops a friction cluster entirely** (each keeps ≥1 mandatory exemplar).
+- **`schema_canary()`** validates three field-level structural invariants (`friction_events`, `token_economics`, `turn_structure`), each gated on a corroborating signal so a genuinely quiet window doesn't false-trip. On real drift it **raises `SchemaDriftError`** naming the broken extraction, field, and observed versions, and the run records a durable canary incident and excludes that slug — rather than silently mining nothing. Benign version bumps pass silently (no allowlist to maintain).
+
+## Stage 2 — map-reduce analysis
+
+`dream_analyze.py` runs a map-reduce over the mined slugs:
+
+- **Map** — one call per due slug (default model `claude-sonnet-5`): the redacted evidence bundle → candidate learnings, each schema-validated.
+- **Reduce** — one call across every planned slug's candidates plus a current-store projection (default model `claude-opus-4-8`): candidates → per-change proposals. Unparseable JSON is retried once with a JSON-only nudge; still unparseable fails the reduce, records an incident, and advances no watermark.
+
+A preflight cost plan walks due slugs *least-recently-dreamed first*, accumulating estimated map+reduce cost and stopping before it would exceed a `$10/day` cap (configurable). `--offline <dir>` replaces every `curl` with canned fixtures for deterministic, no-network testing. `load_config()` auto-migrates a legacy `auto_apply_counters: true` flag to `optimistic_integration.enabled: true` **in memory** (never rewriting disk) so a prior opt-in survives the rename.
+
+## The proposal / evidence / gate contract
+
+Every proposal (`~/.claude/dreaming/proposals/{date}.jsonl`) is a **per-change delta** against the store — `learning_add | verify | contradict | supersede | deprecate` — never a whole-store swap. Each carries: the evidence sessions that support it (redacted, ≤400-char excerpts), a prevalence count, a confidence score, and a justification. Proposals are fingerprinted (`sha256(kind:project:key_basis)`) and deduped against all prior proposal files. Nothing is applied silently: a proposal starts `pending` and stays there until a human `/dream-apply` accepts it — or the opt-in optimistic engine acts on it under its own gates.
+
+**Two-layer redaction** runs before anything leaves the machine: every evidence excerpt passes through secret-token redaction *and* PII redaction (email / phone / address), then is truncated to ≤400 chars — redaction always *before* truncation so a boundary can't split a redaction marker. Untrusted proposal text, excerpts, and justifications are sanitized before they ever reach a digest a human reads or an agent session.
+
+## Apply path A — human-gated (`/dream-apply`)
+
+Always available, no opt-in required. `/dream-apply list` shows pending proposals; `/dream-apply <id>` accepts or rejects one. `apply_proposal()` is the single write entry point for both human and engine applies: it holds an exclusive lock across read → not-pending-check → dispatch → status-rewrite (so a proposal is applied at most once), maps the kind to a `ccgm-learnings-log` op (with CAS retry for supersede/deprecate), and always writes an audit record. This is the **only** path a `_global` proposal can ever be promoted through: `promote_to_global()` is invoked only after a recorded human accept, verifies every cited evidence session resolves to a real transcript, and derives the writer from that transcript's cwd.
+
+## Apply path B — optimistic auto-integration (opt-in, default OFF)
+
+`optimistic_integration.enabled` is `false` in the shipped module — a public module must not silently auto-write on install. Turning it on is a deliberate choice made through `memory-setup.sh` (see Part 6), never a buried JSON edit. When on, every pending proposal is resolved to a **posture** (the single source of truth every gate reads):
+
+| Op-kind | Posture | Dwell? | Confidence floor | Per-run cap |
+|---|---|---|---|---|
+| `learning_verify` | `optimistic-immediate` | no | 7 | none |
+| `learning_add` | `optimistic-dwell` | yes | 8 (or composite gate) | `max_add_supersede_per_run` (10) |
+| `learning_supersede` | `optimistic-dwell` | yes | 8 (or composite gate) | shared with add |
+| `learning_contradict` | `dwell-quarantine` | yes | 8 | `min(max_eviction_absolute, fraction × live heads)` |
+| `learning_deprecate` | `dwell-quarantine` | yes | 8 | shared with contradict |
+| any → `_global` | `gated` | n/a | n/a | human accept stays required |
+
+`learning_verify` integrates immediately because it's purely additive (bounded `+0.25/use`) and reversible by a later contradict — nothing to hold back. Everything else is written to the store *immediately* but carries a `dwell_until` (default 24h) that excludes it from every read path until the window elapses. Anything that misses its floor/cap, targets `_global`, or arrives on an anomalous/tripped run falls back to `pending` — never silently dropped.
+
+### The composite eligibility gate (add/supersede only, default OFF)
+
+A *second*, independent opt-in beneath the engine. While off, add/supersede keep flat floors (conf ≥ 8, and prevalence ≥ 2 verified sessions for add) — bit-for-bit today's behavior. When on, those two op-kinds pass a deterministic, no-LLM waterfall (no model anywhere in the write decision):
+
+1. **Static floor** — `confidence < static_floor` (default 5, never below the hard-coded `MIN_STATIC_FLOOR = 4`) → skip.
+2. **Legacy escape** — a conf ≥ 8 add with ≥ 2 verified sessions (or conf ≥ 8 supersede) still admits, so enabling only *widens* what admits.
+3. **Origin gate** (non-compensatory) — admit only if evidence tier is `user-corrected` OR ≥ 2 transcript-verified sessions. No soft signal rescues a weak origin.
+4. **Composite score** — `S = Σ wᵢ·signalᵢ ≥ θ` (θ default 0.58) over four signals: `confidence` (.40, the only model-assigned input), `prevalence` (.30, distinct verified sessions, capped), `recency` (.20, 30-day half-life on evidence age), `novelty` (.10). Every signal is re-derived from the transcripts and live store *at apply time*, never trusted from the proposal row.
+
+The point is admitting the useful conf-5–7 memories the flat floor held back (user-corrected or seen across sessions) while making each newly-admitted class *harder to forge* than confidence inflation. Evictions and `verify` are untouched. Every scored row writes its full per-signal breakdown to the audit trail.
+
+### Blast-radius controls and the circuit breaker
+
+All caps are scoped **per project slug** (a legitimate focused night on one project is topically narrow by nature):
+
+- **Per-run caps** — `max_add_supersede_per_run` (10) on adds+supersedes; the smaller of `max_eviction_absolute` (3) or `max_eviction_fraction_per_run` (0.20 × the slug's live head count) on contradicts+deprecates. Live head count is computed once, before any write, so same-run adds can't inflate it.
+- **Batch-anomaly check** — keys on *eviction concentration* (contradict/deprecate piling onto one row or tag ≥ 0.6 of the batch), never on add-tag overlap, so an all-one-tag night of adds never false-trips it.
+- **Cross-night accumulation** — counts `auto:true` add/supersede volume per slug over a rolling 14-night window (threshold 40), the one control that looks across nights. It bounds the "patient attacker drips one plausible add per night" case that stays under every per-run cap.
+- **Windowed self-healing circuit breaker** — trips when anomalies (a batch-anomaly fire, a red eval gate, a dirty tree, a timeout, session-citation concentration, or rolling-rate exceeded) reach 2 within a trailing 7 nights (not strictly consecutive). A trip is surfaced loudly and **auto-resumes** after 7 quiet nights; `optimistic-resume` forces an immediate manual re-enable. It fails *closed* on a corrupt state file.
+
+### The eval gate
+
+Before optimistic integration may act **at all**, `dream-eval.sh --gate` must pass. It runs a three-arm A/B (`baseline`, `treatment` = with mined memory, `full_context` = the whole transcript dumped in) over a seed task suite, classifying each into four buckets (`regression > high_value > redundant > gap > inconclusive`). `gate_check()` fails **closed** on any of nine conditions — no results, stale results, results predating the last content-shaping store mutation, any regression row, no high-value row, no *live* (non-offline) dreamed high-value row, a nonzero judge-error rate, or a noise-only control that produced a high-value proposal. Missing or red ⇒ no integration that night, and a red gate is itself recorded as a breaker anomaly.
+
+> **Today the gate stays deliberately closed** for capable models: the harness has not yet demonstrated that mined memory beats a full-context dump on outcome *or* clears the efficiency path on realistic agentic tasks (the injected facts block is a minority of each turn's input, dominated by Claude Code's own re-read system context). So `/dream-apply` (human review) remains the real write path; optimistic auto-integration is wired, gated, and off.
+
+## Poisoning defenses (why "promote what's prevalent" is safe here)
+
+- **Origin binding is transcript-verified, not caller-supplied.** A proposal's evidence must resolve to real transcript files; `writer` is derived from the transcript's recorded `cwd`, never from an exportable env var. A supersede can never *raise* an entry's source tier without an independently-verified new session.
+- **`_global` is promotion-only, through exactly one path** — `promote_to_global()`, invoked only after a recorded human accept. No automated `_global` add exists anywhere.
+- **Breadth is informational, not a bypass.** Under-prevalence `_global` proposals are labeled `needs_manual_promotion` in the digest — never dropped, never silently applied. (For a solo/single-clone user the "≥2 agents" breadth condition is realistically unsatisfiable, so treat fleet-wide auto-promotion as a latent multi-agent capability, not a solo-user outcome.)
+
+## The nightly scheduler chain
+
+A `launchd` LaunchAgent (`com.$USER.ccgm.dreaming.daily`, default 03:30) runs `dream-daily.sh`, an exit-tolerant chain — one step's failure never kills the rest or trips a launchd cooldown:
+
+```
+analyze → eval-refresh → optimistic-integrate → digest → reconcile → retention
+```
+
+`digest` runs *after* `optimistic-integrate` so tonight's just-integrated batch is reported while its dwell window is still entirely ahead of it. `optimistic-integrate` is both config-gated (raw on-disk `enabled` read) and eval-gated (a missing eval script fails *closed*), and runs under a 600s timeout. `retention` gzips artifacts older than 30 days and deletes gzipped ones older than 60, scoped to `proposals/`, `digests/`, and `state/runs/` (never the perpetual state files).
+
+## Reconciliation (read-only)
+
+`reconcile_automemory.py` compares Claude Code's own harness auto-memory (`~/.claude/projects/*/memory/`) against the learnings store and appends a `## Reconciliation` section to the day's digest: **import candidates** (auto-memory facts absent from the store) and **contradictions** (store rows that dispute a topic auto-memory still presents as current, flagged for `/consolidate`). It **never writes** to `~/.claude/projects/` — the harness's own consolidator owns that file, and colliding writers on it is exactly the failure class this whole system exists to prevent.
+
+---
+
+# Part 5 — Observability
+
+## The weekly scorecard
+
+`/dream-scorecard` renders a deterministic, read-only weekly report to `~/.claude/dreaming/scorecards/{date}.md` — every number is a count of something already on disk; it never touches the store. Metrics, over a half-open 7-day window:
+
+- **Captured** — new `add` events, by type and project.
+- **Injected** — sessions that received memory, from the per-machine injection telemetry (IDs + counts only, never content).
+- **Reused** — `verify` events. **This is the key signal**: a reuse means a stored learning actually helped in a later session, which is the whole point.
+- **Applied** — proposals applied (keyed strictly on `outcome == "applied"`), by kind.
+- **Optimistic integration** — auto-integrated / mid-dwell / reverted-after-review / circuit-breaker trips.
+- **Store health** — active count and effective-confidence bands, plus deprecated/superseded tallies.
+
+## Injection telemetry
+
+Each surfacing appends one record to `~/.claude/dreaming/injection-log/{date}.jsonl`: `timestamp`, `session_id`, `source`, `project_slug`, `injected_count`, `injected_ids`, and an `approx_tokens` estimate — **memory IDs + counts + a token estimate only, never the memory content** (so it never becomes a second PII surface). It's per-machine, lives *outside* the synced learnings store, and is best-effort: any failure is swallowed and never blocks or alters the injected block. Because the read-path hook writes it, telemetry accrues even without `dreaming` installed; the `/dream-scorecard` command that renders it ships with `dreaming`.
+
+---
+
+# Part 6 — Operating the system
 
 ## Enabling it
 
@@ -56,64 +352,29 @@ Run the activation script (idempotent — re-running reports current state and c
 bash ~/.claude/bin/memory-setup.sh
 ```
 
-It confirms before every write and:
+It confirms before every write and walks three prompts in order:
 
-1. **Read path** — explains it, then on your yes sets `CCGM_LEARNINGS_INJECT=true` in `~/.claude/settings.json` (via a deep merge that preserves your existing `env` keys) and runs `ccgm-learnings-sync init` so the store is a versioned git repo. Local, free, no network.
-2. **Write path** — if `dreaming` is installed, it offers to activate it: this costs Anthropic API tokens and installs a nightly LaunchAgent. It prompts for your API key, writes it to `~/.claude/dreaming/.env` (mode `0600`, never echoed), and runs `dream-install.sh`. If `dreaming` isn't installed, it prints how to add it:
-
-   ```bash
-   bash start.sh --add dreaming
-   ```
-
-3. **Optimistic mode** — if `dreaming` is installed, it also asks directly: "enable auto-integration with a 24h dwell window + daily report?" On yes it sets `optimistic_integration.enabled = true` in `~/.claude/dreaming/config.json` — the only way this ever turns on; there is no separate manual JSON edit required, and the shipped default stays `false` until you say yes. Re-run the script any time to change your answer; an already-`true` config reports as such and makes no change.
+1. **Read path** — on your yes, it jq-deep-merges `env.CCGM_LEARNINGS_INJECT = "true"` into `~/.claude/settings.json` (preserving your existing keys, read-back verified) and runs `ccgm-learnings-sync init` so the store is a versioned git repo. Local, free, no network.
+2. **Write path** — if `dreaming` is installed, it offers to activate it: this costs Anthropic API tokens and installs the nightly LaunchAgent. It prompts for your API key with hidden input, writes it to `~/.claude/dreaming/.env` (mode `0600`, never echoed), and runs `dream-install.sh`. If `dreaming` isn't installed, it prints `bash start.sh --add dreaming`.
+3. **Optimistic mode** — if `dreaming` is installed, it asks directly: "enable auto-integration with a 24h dwell window + daily report?" On yes it sets `optimistic_integration.enabled = true` in `~/.claude/dreaming/config.json` — the only way this ever turns on. A nested follow-up offers the composite eligibility gate; enabling it forces the outer flag on in the same write, so eligibility can never land with the engine off.
 
 The read path alone is a complete, useful configuration. Add `dreaming` only when you want automated nightly capture and accept the token cost; add optimistic mode only when you want that capture to reach the store without running `/dream-apply` yourself.
 
-## Safety posture: optimistic, dwell-bounded, and reversible
-
-By default, nothing a model proposes reaches your store automatically. Every dreaming proposal is **human-gated** — it stays `pending` until you run `/dream-apply` and accept it. This is still true today and remains available regardless of anything below.
-
-`optimistic_integration.enabled` in `~/.claude/dreaming/config.json` is an opt-in second path, **`false` by default** (the shipped-module posture — a public module must not silently start auto-writing on install). Turning it on is a deliberate choice, never a buried JSON edit: `memory-setup.sh` asks directly — "enable auto-integration with a 24h dwell window + daily report?" — and only a `y` flips the flag (see "Enabling it" above). A config that already had the OLD verify-only `auto_apply_counters` flag set `true` is migrated automatically (the same conservative defaults apply) so a prior opt-in survives the rename, without you having to re-consent by hand.
-
-When it's on, a per-op-kind **posture** decides what happens to each proposal instead of a single blanket rule:
-
-- **`learning_verify`** integrates immediately — no dwell. It is purely additive (confidence rises, capped) and reversible by a later contradict, so there is nothing to hold back.
-- **`learning_add` / `learning_supersede`** integrate behind a **24h dwell window** (configurable): written to the store right away, but excluded from search/injection until the window elapses.
-- **`learning_contradict` / `learning_deprecate`** — the eviction-shaped ops — get the same dwell treatment, capped tighter per run, since these are the ops most worth a second look before they suppress something.
-- Any change to the shared `_global` store stays **fully human-gated**, unchanged — the optimistic engine never touches it.
-
-For the two admission-shaped ops (`learning_add` / `learning_supersede`), an **opt-in composite eligibility gate** can decide admission by score instead of a flat confidence floor. It is a second, independent opt-in *beneath* the flag above — `memory-setup.sh` offers it as a separate prompt, and only once optimistic integration itself is on — and it is **`false` by default**, so add/supersede keep their flat floors bit-for-bit until you turn it on (an invalid eligibility config fails closed to this same disabled path). When enabled, each mined add/supersede passes a deterministic, no-LLM waterfall — a static floor, a non-compensatory origin gate, then a four-signal composite score — with every signal re-derived from the transcripts and live store at apply time, never trusted from the proposal row. Evictions and `verify` are untouched. See `modules/dreaming/rules/dreaming.md` > "Eligibility composite" for the full contract.
-
-Every run is bounded whether or not you ever read the report: a per-slug cap on how many adds/supersedes/evictions can land in one night, a batch-anomaly check that flags eviction concentration, a cross-night signal that catches a slow drip an attacker might use to stay under any single night's cap, and a windowed circuit breaker that trips on repeated anomalies (and later resumes on its own once things are quiet again). The nightly eval/regression gate (`dream-eval.sh --gate`) must also pass — missing or red fails closed, no integration that night, full stop.
-
-**Why this is safe even if you never read the report.** Prevention (the caps, the anomaly check, the eval gate, confidence floors, decay) and exposure-bounding (the dwell window) both work with zero human reads — nothing above depends on you looking at anything. Only *correction* needs a read, and only for timeliness: the daily report, `/dream-review`, and `ccgm-learnings-sync revert <sha>` let you catch and undo a bad integration. If you never read the report, nothing worse happens than what the caps already bounded — the row just decays on its usual schedule or gets caught by a later eval run.
-
-**The honest residual.** The dwell window shrinks the *pre-exposure* blind spot to zero — a bad row cannot reach a live agent session before the window elapses. It does **not** shrink the *post-exposure* one: once the window has passed and a session has already read a row into its frozen SessionStart context (see "Injection applies to new sessions only" below), that session keeps it for its own lifetime. A revert or `/dream-review` veto stops *future* sessions from seeing it; an already-running session must be restarted to actually drop it. Nothing shortens this except a shorter dwell window (more report lead time) and ordinary confidence decay.
-
 ## Injection applies to new sessions only
 
-The injection hook fires on `SessionStart` **only when `source == "startup"`** — never on resume or compact. The injected block is frozen into the session's prompt prefix at start (this prefix-cache safety is deliberate; re-injecting per turn is the exact anti-pattern the hook avoids).
-
-Consequences:
+The injection hook fires on `SessionStart` **only when `source == "startup"`** — never on resume or compact. The injected block is frozen into the session's prompt prefix at start (this prefix-cache safety is deliberate; re-injecting per turn is the exact anti-pattern the hook avoids). Consequences:
 
 - An **already-open session will not gain** newly-logged learnings. Start a *fresh* session to pick them up.
 - A learning you log **during** a session is not visible to that same session's injected block — it appears at the next fresh start.
-
-## Observability
-
-- **Scorecard** — `/dream-scorecard` renders a deterministic weekly report to `~/.claude/dreaming/scorecards/{date}.md`: how many learnings were **captured**, **injected**, **reused**, and **applied**, plus store-health confidence bands. Every number is a count of something already on disk (read-only; it never touches the store). Reuse (`verify` events) is the key signal that memory is paying off across sessions.
-- **Injection telemetry** — each surfacing appends one record (memory **IDs + counts + a token estimate only — never memory content**) to `~/.claude/dreaming/injection-log/{date}.jsonl`. It is per-machine, lives outside the synced learnings store, and is best-effort (any failure is swallowed and never blocks or alters the injected block). The scorecard's "Injected" section reads this log.
-
-The injection telemetry is written by the read-path hook itself, so it accrues even without `dreaming` installed; the `/dream-scorecard` command that renders it ships with `dreaming`.
 
 ## Troubleshooting
 
 **Injection isn't firing.** Check, in order:
 
-1. **The flag.** `CCGM_LEARNINGS_INJECT` must be truthy (`true` / `1` / `yes`) in the environment the session starts with — look in `~/.claude/settings.json` under `env` (this is what `memory-setup.sh` sets). With the flag unset the hook is a strict no-op.
-2. **A fresh session.** The hook only runs on `source == "startup"`. Resuming or continuing an existing session will not inject; open a new session.
+1. **The flag.** `CCGM_LEARNINGS_INJECT` must be truthy (`true` / `1` / `yes`) in the environment the session starts with — under `env` in `~/.claude/settings.json` (what `memory-setup.sh` sets). With the flag unset the hook is a strict no-op.
+2. **A fresh session.** The hook only runs on `source == "startup"`. Resuming or continuing won't inject; open a new session.
 3. **Learnings for this project.** Injection surfaces the *current project's* store. A brand-new project with nothing logged has nothing to inject — confirm with `ccgm-learnings-search --query <topic>`.
-4. **Conflicted rows are suppressed.** A learning flagged as conflicted (two competing edits racing the same entry) is withheld from injection because it isn't settled truth — run `/consolidate` to resolve it.
+4. **Conflicted rows are suppressed.** A conflicted learning (two competing edits racing the same entry) is withheld from injection because it isn't settled truth — run `/consolidate` to resolve it.
 
 ## Privacy
 
@@ -126,12 +387,35 @@ The injection telemetry is written by the read-path hook itself, so it accrues e
   ```
 
 - Injection telemetry records IDs + counts only, never content, and is never committed to the synced store.
-- When you opt into `dreaming`, the analyzer sends **redacted** transcript evidence to the Anthropic API. The read path makes no network calls of its own; use your own API key (`<your-anthropic-api-key>`), which the setup script stores in `~/.claude/dreaming/.env`.
+- When you opt into `dreaming`, the analyzer sends **redacted** transcript evidence to the Anthropic API using your own API key (stored in `~/.claude/dreaming/.env`). The read path makes no network calls of its own.
+
+---
 
 ## Reference
 
-The rule files below are the authoritative, agent-facing specs this guide distills:
+### CLI surface
+
+```bash
+# Capture / maintain
+ccgm-learnings-log --type pattern --content "…" --tag git --confidence 8
+ccgm-learnings-log verify <id>            # reinforce (uses += 1, refresh freshness)
+ccgm-learnings-log contradict <id>        # weaken (contradictions += 1)
+ccgm-learnings-log supersede <old_id> --content "…" --expected-sha <sha> --reason "…"
+ccgm-learnings-log deprecate <id> --expected-sha <sha>
+ccgm-learnings-log config cross-project on
+
+# Query / inject
+ccgm-learnings-search --query <topic> --max 5 --format preamble
+ccgm-learnings-search --tag tailwind --cross-project
+ccgm-learnings-search --query auth --format jsonl --include-superseded --include-stale
+
+# Sync
+ccgm-learnings-sync init | commit [-m …] | pull | push | revert <sha> | status
+```
+
+### Source (the authoritative, agent-facing specs this guide distills)
 
 - [`self-improving.md`](../modules/self-improving/rules/self-improving.md) — the reflection loop and capture triggers
 - [`learnings-store.md`](../modules/self-improving/rules/learnings-store.md) — store schema, confidence decay, supersede chains, the dwell window, git sync, and rollback
 - [`dreaming.md`](../modules/dreaming/rules/dreaming.md) — the nightly pipeline, the proposal / evidence / gate contract, and the optimistic auto-integration engine
+- Store library: `modules/self-improving/lib/learnings_store.py` · hooks: `modules/self-improving/hooks/` · dreaming pipeline: `modules/dreaming/lib/`


### PR DESCRIPTION
Closes #860.

## Summary

The memory system had an operator-focused `docs/memory-system.md` and an untracked visual `docs/memory-system.html`, but no single deep technical reference. This PR turns the markdown into the comprehensive technical reference, tightens the README section to a concise pitch that links out to it, and refreshes the HTML (which was stale on the safety model).

## Changes

- **`docs/memory-system.md`** — rewritten into a source-grounded technical reference:
  - Read path: op-event data model vs. projected view, per-agent sharding, the deterministic fold (order by `(timestamp, id)`, two-phase with deferral-to-fixpoint, orphan ops, conflict marking), the exact confidence-decay formula + constants, supersede chains + CAS, the dwell window.
  - Integrity: the injection sanitizer, read-time validation + `.quarantine.jsonl` exclusion, the compaction guard.
  - Sync: `merge=union` sharding, why `pull` is merge-only, `revert` as line-set-difference.
  - Write path: deterministic mining → map-reduce over `curl` → the proposal/evidence/gate contract, the per-op-kind posture table, the composite eligibility gate, blast-radius caps, circuit breaker, and the eval gate (and why it stays closed today).
  - Observability, activation, and a CLI/source reference.
- **`README.md`** — `## Memory System` tightened into a two-halves table + one paragraph + prominent link to the deep doc and the HTML.
- **`docs/memory-system.html`** — now tracked; refreshed the stale auto-apply safeguard (was `auto_apply_counters`; now the current `optimistic_integration` posture + dwell window + caps + circuit breaker) and corrected the nightly chain order.

Technical claims were extracted directly from `learnings_store.py`, the dreaming pipeline, and the hooks, not paraphrased from the rule specs.

## Test plan

- `bash tests/test-no-personal-data.sh` → PASS
- Verified every internal link target in the doc and README resolves on disk
- Grepped the HTML to confirm no stale-model references remain and the footer `memory-system.md` link is intact