### PR TITLE
#864: stop hunting for PR templates (local check only, no org gh api call)

### DIFF
--- a/modules/commands-core/commands/pr.md
+++ b/modules/commands-core/commands/pr.md
@@ -94,17 +94,11 @@ git push --force-with-lease -u origin "$BRANCH"
 
 ### 6. Check for PR Template
 
-Look for a PR template in this order:
+One local check — if a template file is in the repo, use it; otherwise write a value-first body (do NOT query the org's `.github` repo or create a template):
 
 ```bash
-# 1. Repo root
-ls pull_request_template.md PULL_REQUEST_TEMPLATE.md 2>/dev/null
-
-# 2. .github directory
-ls .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null
-
-# 3. Organization .github repo (if applicable)
-# gh api repos/{org}/.github/contents/.github/PULL_REQUEST_TEMPLATE.md 2>/dev/null
+ls pull_request_template.md PULL_REQUEST_TEMPLATE.md \
+   .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null
 ```
 
 If a template is found, read it and structure the PR body using the template's sections and headings.

--- a/modules/commands-core/skills/pr-description/references/default-template.md
+++ b/modules/commands-core/skills/pr-description/references/default-template.md
@@ -42,4 +42,5 @@ If any of these are true, do NOT use this template - the skill should have detec
 
 - A file named `pull_request_template.md` or `PULL_REQUEST_TEMPLATE.md` exists in the repo root
 - A file exists under `.github/` with either casing
-- The org's `.github` repo ships a default template (rare; check only if repo-level search returns nothing)
+
+The check is local-only: do not query the org's `.github` repo over the API. A missing repo-level template means use this default, not that you should hunt further.

--- a/modules/git-workflow/README.md
+++ b/modules/git-workflow/README.md
@@ -1,13 +1,13 @@
 # git-workflow
 
-Git workflow rules: sync before history changes, rebase by default, post-merge cleanup, PR template detection, no AI attribution in commits.
+Git workflow rules: sync before history changes, rebase by default, post-merge cleanup, follow a repo's PR template if it has one (local check only), no AI attribution in commits.
 
 ## What It Does
 
 This module installs a rules file that instructs Claude to:
 
 - Never add AI attribution (Co-Authored-By, "Generated with Claude Code") to commits or PRs
-- Check for and use PR templates when creating pull requests
+- Follow a repo's PR template when one is present (a single local check); otherwise write a value-first body without hunting the org's `.github` repo or creating a template
 - Always sync with remote before running history-altering git commands
 - Use rebase by default when updating feature branches from main
 - Return to a clean main branch state after PR merges

--- a/modules/git-workflow/rules/git-workflow.md
+++ b/modules/git-workflow/rules/git-workflow.md
@@ -15,17 +15,17 @@ This also applies to:
 
 ---
 
-# CRITICAL: Use PR Templates When Creating Pull Requests
+# Follow a Repo's PR Template If It Has One
 
-**Before creating any pull request**, check for a PR template in this order:
+When creating a PR, if a template file is **already sitting in the repo** — `pull_request_template.md` or `PULL_REQUEST_TEMPLATE.md` in the root or under `.github/` — structure the PR body using its sections and headings. Detecting it is a single local `ls` (`ls pull_request_template.md PULL_REQUEST_TEMPLATE.md .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE.md 2>/dev/null`); do it only when you are actually opening a PR.
 
-1. **Check the repo root**: Look for `pull_request_template.md` or `PULL_REQUEST_TEMPLATE.md` in the repository root
-2. **Check `.github/`**: Look for `.github/PULL_REQUEST_TEMPLATE.md` or `.github/pull_request_template.md`
-3. **Check the org**: If no repo-level template exists, check the org's `.github` repo (e.g., `gh api repos/{org}/.github/contents/.github/PULL_REQUEST_TEMPLATE.md`)
-4. **Use the template**: If a template is found, structure the PR description using the template's sections and headings exactly
-5. **No template found**: Fall back to a standard Summary / Changes / Test Plan format
+If there is **no** template file in the repo, do NOT hunt for one:
 
-**Why**: Teams use PR templates to ensure consistent review processes. Ignoring the template creates extra work for reviewers and may miss required fields (ticket links, QA steps, etc.).
+- Do **not** query the org's `.github` repo over the API (`gh api …`). Most repos have no template; the network round-trip is wasted ceremony.
+- Do **not** create a template file. A missing template is the normal case, not a gap to fill.
+- Just write a value-first PR body: lead with what the PR does for the user, then the concrete changes, then how it was verified. (`Closes #N` first if it closes an issue.)
+
+**Why**: honoring a committed template keeps team repos consistent, and a single local `ls` catches that for free. But the real goal is a clear, value-first body — not the template search. Don't let template-hunting become mandatory ritual on every PR.
 
 ---
 


### PR DESCRIPTION
Closes #864

## Summary

Agents checked for a PR template on every PR — in up to three locations, including a `gh api` call to the org's `.github` repo — because the always-loaded global rule (`git-workflow.md`) framed it as `# CRITICAL:` "before ANY pull request, check in this order." For solo repos that have no template, that's a wasted network round-trip and visible ceremony on every PR. This trims it to a single free local check and stops the hunting.

## Why

Template support is only valuable when a template file actually exists in the repo — which a single local `ls` detects for free. The org-level API check almost never finds anything and is the real cost. The `# CRITICAL` framing made template-hunting read as mandatory ritual rather than "honor a template if one happens to be there."

## What changed

- **`modules/git-workflow/rules/git-workflow.md`** (the always-loaded global rule, root cause) — reworded from `# CRITICAL: Use PR Templates` to `# Follow a Repo's PR Template If It Has One`. Keeps the free local check (repo root + `.github/`), **drops the org `gh api` check**, and explicitly says: no template → don't hunt the org repo, don't create a template, just write a value-first body.
- **`modules/commands-core/commands/pr.md`** — collapsed the 3-step check to one local `ls`; removed the commented-out org `gh api` lines so they can't be silently re-enabled.
- **`modules/commands-core/skills/pr-description/references/default-template.md`** — dropped the "org's `.github` repo" bullet; noted the check is local-only.
- **`modules/git-workflow/README.md`** — description + behavior bullet updated to match.

Local checks in `/cpm` (command + skill), `/pr`, and the `pr-description` skill are kept — they're the one cheap local check. `worktree-finish.md` and `etp.md` already used the light "use the repo's template if one exists" framing and needed no change. No `module.json` touched, so no marketplace regen.

## Verification

- `grep` for any active org-level template check across `modules/` → none remain (only the new *prohibition* against it)
- `bash tests/test-modules.sh` → 1558 passed, 0 failed
- `bash tests/test-no-personal-data.sh` → PASS