### PR TITLE
#866: git worktrees as the default parallel-delegation isolation, with enforced teardown

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -460,7 +460,7 @@
     },
     {
       "category": "workflow",
-      "description": "Solo-agent worktree-based isolation for feature work. Lighter alternative to multi-clone setup when only one agent is active.",
+      "description": "Git worktrees as the default isolation for parallel sub-agent delegation on one machine, with a safe janitor that enforces teardown so worktrees never silently fill the disk.",
       "name": "git-worktrees",
       "source": "./git-worktrees",
       "tags": [

--- a/modules/git-workflow/rules/git-workflow.md
+++ b/modules/git-workflow/rules/git-workflow.md
@@ -109,3 +109,16 @@ git fetch origin && git checkout -b <type>/<short-desc> origin/main
 with `<type>` one of `feature | fix | chore | docs`. Uncommitted work on main is destroyed the next time main is synced to origin — branch first, then work.
 
 When the **branch-guard** module is installed, this is not advisory: a PreToolUse hook hard-blocks Edit/Write/NotebookEdit and `git commit`/`add`/`stage`/`apply` while HEAD is on the default branch (escape hatch for intentional main-only ops: `ALLOW_MAIN_COMMIT=1`; rebase/merge/cherry-pick states are exempt). See `branch-guard.md` for the full contract.
+
+---
+
+# Worktrees: Ephemeral Isolation With Mandatory Teardown
+
+For **parallel sub-agent delegation on one machine**, the default isolation is a git worktree (`isolation: "worktree"`), not an extra permanent clone. A worktree is a second working tree from the same `.git` with its own index and HEAD, so parallel agents build, test, and commit without colliding. Reserve permanent clones for the cases a worktree cannot serve: per-branch dev-server ports (worktrees share `.env`), hook-driven per-branch `tracking.csv`, multiple long-lived independent agents, or cross-machine dispatch. Full contract in `git-worktrees.md`.
+
+**Branch-guard compatibility.** A worktree is always created on a feature branch off `origin/main`, never the default branch — so the branch-guard hook never fires inside it, and all the git rules above (rebase by default, no stash, no AI attribution, sync before history changes) apply unchanged. Worktrees change *where* the working tree lives, not how branches, commits, or PRs are managed.
+
+**The lifecycle — and why teardown is mandatory.** Every worktree is created for exactly one unit of work and has one owner (the delegator). The lifecycle is: create one worktree per unit → sub-agent implements and opens a PR → PR merges → **the delegator removes that worktree** → any orphans are swept as a backstop. That fourth step is load-bearing: the harness's `isolation: "worktree"` auto-removes a worktree **only if it is unchanged**, and a worktree an agent built in is "changed" and lingers forever. On 2026-07-13, forgotten built-in worktrees consumed ~237 GB on one repo. So:
+
+- **Remove each worktree the moment its PR merges** — `git worktree remove <path>` (non-force) then `git worktree prune`. Removing a clean worktree never deletes its branch or committed work; the branch ref stays in `.git` and only the checkout (and its build tree) is removed.
+- **Cleanup must not depend on the happy path.** Run `/worktree-sweep` — the safe repo-wide janitor — after any delegation run and on early exits. It removes only clean worktrees, preserves any with uncommitted changes / untracked files / in-progress rebases, and never forces. For unattended machines, schedule it as a backstop so disk is reclaimed whether or not anyone remembers.

--- a/modules/git-worktrees/.claude-plugin/plugin.json
+++ b/modules/git-worktrees/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "author": {
     "name": "CCGM"
   },
-  "description": "Solo-agent worktree-based isolation for feature work. Lighter alternative to multi-clone setup when only one agent is active.",
+  "description": "Git worktrees as the default isolation for parallel sub-agent delegation on one machine, with a safe janitor that enforces teardown so worktrees never silently fill the disk.",
   "displayName": "Git Worktrees",
   "hooks": {
     "SessionStart": [

--- a/modules/git-worktrees/README.md
+++ b/modules/git-worktrees/README.md
@@ -1,36 +1,44 @@
 # git-worktrees
 
-Solo-agent worktree-based isolation for feature work. A lighter alternative to the multi-clone architecture when only a single agent is active.
+Git worktrees as the **default isolation for parallel sub-agent delegation on one machine**, with enforced teardown so worktrees never silently fill the disk.
 
 ## What This Module Does
 
-Installs rules and commands that instruct Claude to use `git worktree` for parallel branch work in a single clone. Worktrees let you keep multiple branches checked out simultaneously in sibling directories without duplicating the entire repository.
+A worktree is a second working tree from the same `.git`, with its own index and HEAD. That independence is what makes parallel agents safe: each builds, tests, and commits on its own branch without touching the others. When a delegator (you, `/etp`, `/mawf`, `/xplan`, or the Agent/Workflow `isolation: "worktree"` option) fans work out to parallel implementers, each gets its own worktree — created per unit of work and destroyed when that unit merges — instead of a permanent extra clone.
 
 Key capabilities:
 
-- **Solo-agent isolation**: keep a feature branch's working tree separate from `main` without switching branches in place
-- **`/worktree-start`**: create a new worktree with gitignore verification and project-setup auto-detection
-- **`/worktree-finish`**: four-option finishing gate (merge locally / push + PR / keep / discard with typed confirmation)
+- **Default parallel-delegation isolation**: one ephemeral worktree per unit of work, sharing the parent `.git`.
+- **`/worktree-start`**: create a worktree hands-on, with gitignore verification and project-setup auto-detection.
+- **`/worktree-finish`**: finish one worktree via a four-option gate (merge locally / push + PR / keep / discard).
+- **`/worktree-sweep`**: repo-wide safe janitor — remove clean worktrees, preserve anything with unsaved work, prune stale metadata. The enforced-teardown backstop.
 
-## When to Use vs Multi-Agent Clones
+## Why It Exists
+
+On 2026-07-13, delegated work using `isolation: "worktree"` left 33 stale worktrees consuming ~237 GB on one repo. The harness auto-removes a worktree only if it is *unchanged*; a built-in worktree lingers forever, and nothing mandated cleaning them up. This module makes worktrees the default (ephemeral, shared `.git`) **and** makes teardown load-bearing (mandatory per-unit removal + `/worktree-sweep` orphan backstop). See `rules/git-worktrees.md` for the full lifecycle and removal-safety rule.
+
+## Worktrees vs Multi-Agent Clones
 
 | Situation | Use |
 |-----------|-----|
-| Single agent, wants to try an idea on a branch without stashing | **Worktree** (`/worktree-start`) |
-| Single agent, wants to compare two branches side by side | **Worktree** |
-| Multiple agents working on the same repo in parallel | **Multi-clone** (see `multi-agent` module) |
-| Need isolated dev server ports per branch | **Multi-clone** (worktrees share `.env`) |
-| Need per-branch `node_modules` only temporarily | **Worktree** (cheap, local-only) |
+| Parallel sub-agent delegation on one machine (the default) | **Worktree** — one per unit, removed on merge |
+| Single agent trying an idea / comparing two branches | **Worktree** |
+| Multiple long-lived independent agents owning a repo for days | **Clone** (`multi-agent` module) |
+| Per-branch dev-server ports (worktrees share `.env`) | **Clone** |
+| Hook-driven per-branch `tracking.csv` | **Clone** |
+| Cross-machine / cloud dispatch | **Clone** / remote isolation |
 
-Worktrees are cheaper than clones (shared `.git`, no re-fetch) but lack the port-registry, tracking-CSV, and cross-agent log coordination that the `multi-agent` module provides. Use clones when coordination matters, worktrees when isolation alone is enough.
+Worktrees share `.git` objects and external caches, but **each still builds its own `.build`** — the disk win over clones is ephemerality and the shared `.git`, not a smaller build. That win only materializes if teardown actually happens, which is why `/worktree-sweep` exists.
 
 ## Files
 
 | File | Type | Description |
 |------|------|-------------|
-| `rules/git-worktrees.md` | rule | When to use worktrees, creation/cleanup, pitfalls |
+| `rules/git-worktrees.md` | rule | Default-isolation framing, delegation lifecycle, honest economics, removal-safety rule, pitfalls |
 | `commands/worktree-start.md` | command | `/worktree-start {branch-name}` |
-| `commands/worktree-finish.md` | command | `/worktree-finish` with four-option gate |
+| `commands/worktree-finish.md` | command | `/worktree-finish` — four-option gate for one worktree |
+| `commands/worktree-sweep.md` | command | `/worktree-sweep` — safe repo-wide orphan janitor |
+| `lib/worktree-sweep.sh` | lib | Deterministic sweep implementation (classify → non-force remove → prune → report) |
 
 ## Dependencies
 
@@ -45,6 +53,12 @@ cp rules/git-worktrees.md ~/.claude/rules/git-worktrees.md
 
 # Commands
 mkdir -p ~/.claude/commands
-cp commands/worktree-start.md ~/.claude/commands/worktree-start.md
+cp commands/worktree-start.md  ~/.claude/commands/worktree-start.md
 cp commands/worktree-finish.md ~/.claude/commands/worktree-finish.md
+cp commands/worktree-sweep.md  ~/.claude/commands/worktree-sweep.md
+
+# Lib
+mkdir -p ~/.claude/lib
+cp lib/worktree-sweep.sh ~/.claude/lib/worktree-sweep.sh
+chmod +x ~/.claude/lib/worktree-sweep.sh
 ```

--- a/modules/git-worktrees/commands/worktree-finish.md
+++ b/modules/git-worktrees/commands/worktree-finish.md
@@ -88,7 +88,7 @@ Do NOT pick an option on the user's behalf. If the reply is not `1`, `2`, `3`, o
 3. Push: `git push -u origin <branch>`
 4. Create PR: `gh pr create` with title and body. Use the repo's PR template if one exists (check `.github/pull_request_template.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and repo root). Do not add AI attribution footers.
 5. Report the PR URL.
-6. Leave the worktree in place - the user will run `/worktree-finish` again after the PR is merged to clean up (or manually `git worktree remove`).
+6. Leave the worktree in place until the PR merges — then remove it. Per the worktree lifecycle (`git-worktrees.md`), teardown is mandatory, not optional: run `/worktree-finish` again after the merge, or `git worktree remove <path>`. `/worktree-sweep` is the backstop that reclaims this worktree if it is ever forgotten.
 
 #### Option 3: Keep
 
@@ -133,3 +133,5 @@ Always report:
 - Never force-push to `main` from any option.
 - Never `rm -rf` a worktree - always use `git worktree remove` (with `--force` only for option 4).
 - If any phase fails, stop and report. Do not fall through to a different option silently.
+
+`/worktree-finish` handles **one** worktree at a time, interactively. To clean up **many** leaked worktrees at once (the orphan-sweep backstop in the lifecycle), use `/worktree-sweep` — it never forces and only removes verified-clean worktrees.

--- a/modules/git-worktrees/commands/worktree-start.md
+++ b/modules/git-worktrees/commands/worktree-start.md
@@ -1,11 +1,15 @@
 ---
-description: Create a new git worktree for solo-agent feature work with gitignore verification and project setup
+description: Create a new git worktree for feature work with gitignore verification and project setup
 allowed-tools: Bash, Read, Edit, Write
 ---
 
 # /worktree-start - Start a New Worktree
 
-Creates an isolated git worktree in a sibling directory so feature work does not disturb the main checkout. Use this for solo-agent parallel branch work. For multi-agent parallel work, use the `multi-agent` module's clone setup instead.
+Creates an isolated git worktree so feature work does not disturb the main checkout. This is the **hands-on** single-worktree creator (you, working a branch directly).
+
+For **parallel sub-agent delegation**, you usually do not run this by hand — the delegating command (`/etp`, `/mawf`, `/xplan`) or the Agent/Workflow `isolation: "worktree"` option creates one worktree per unit automatically, and removes it when the unit merges. Worktrees are the default isolation for that; see `git-worktrees.md`. Reach for a permanent clone only for long-lived independent agents, per-branch dev-server ports, per-branch `tracking.csv`, or cross-machine dispatch.
+
+Whichever path creates the worktree, its lifecycle ends the same way: removed when its PR merges, with `/worktree-sweep` as the orphan backstop.
 
 ## Usage
 
@@ -28,34 +32,34 @@ Creates an isolated git worktree in a sibling directory so feature work does not
 
 4. **Check branch uniqueness**: `git branch --list <branch-name>`. If the branch already exists and the user did not pass `[existing-branch]` as the base, ask whether they meant to check out the existing branch in a worktree.
 
-5. **Verify `.worktrees/` is gitignored**: read `.gitignore` and check for a line matching `.worktrees/` or `.worktrees`. If missing, add it:
+5. **Verify the worktree parent is gitignored**: the canonical location is `.claude/worktrees/`. Check `git check-ignore .claude/worktrees` — if it exits 0, the path is already ignored (the harness usually gitignores `.claude/`) and there is nothing to do. If not, add it:
 
    ```bash
-   echo ".worktrees/" >> .gitignore
+   echo ".claude/worktrees/" >> .gitignore
    git add .gitignore
-   git commit -m "chore: ignore .worktrees directory"
+   git commit -m "chore: ignore .claude/worktrees directory"
    ```
 
-   Do this BEFORE creating the worktree. Creating `.worktrees/` without gitignoring it risks committing the entire worktree back into the repo on a careless `git add .`.
+   Do this BEFORE creating the worktree. Creating a worktree under a non-gitignored path risks committing the entire worktree back into the repo on a careless `git add .`.
 
 ### Phase 2: Create the Worktree
 
 Choose the directory:
 
-- Preferred: `<repo-root>/.worktrees/<branch-name>/`
-- Fallback if `.worktrees/` gitignore cannot be added: `~/code/worktrees/<repo-name>-<branch-name>/` (create this directory first, mkdir -p)
+- Canonical: `<repo-root>/.claude/worktrees/<branch-name>/` — the same tree the harness's `isolation: "worktree"` uses, so `/worktree-sweep` reclaims everything from one place.
+- Fallback if `.claude/worktrees/` gitignore cannot be added: `~/code/worktrees/<repo-name>-<branch-name>/` (create this directory first, mkdir -p).
 
 Create the worktree:
 
 ```bash
 # New branch off base-branch (default: origin/main)
-git worktree add -b <branch-name> .worktrees/<branch-name> <base-branch>
+git worktree add -b <branch-name> .claude/worktrees/<branch-name> <base-branch>
 ```
 
 If the branch already exists and the user confirmed reuse:
 
 ```bash
-git worktree add .worktrees/<branch-name> <branch-name>
+git worktree add .claude/worktrees/<branch-name> <branch-name>
 ```
 
 ### Phase 3: Project Setup (Auto-Detect)
@@ -77,12 +81,12 @@ Run only the FIRST match. If the project uses a lockfile, respect it. If the ins
 
 ### Phase 4: Copy Non-Tracked Local Config
 
-Worktrees do not inherit `.env` or other gitignored local config. Offer to copy them from the main checkout:
+Worktrees do not inherit `.env` or other gitignored local config. Offer to copy them from the main checkout. Locate the main checkout root robustly (do not hard-code `../../` — the depth depends on the worktree path):
 
 ```bash
-# Examples - adjust to what exists in the main checkout
-cp ../../.env .env 2>/dev/null || true
-cp ../../.env.local .env.local 2>/dev/null || true
+ROOT="$(git rev-parse --git-common-dir)/.."   # main checkout root, from anywhere inside the worktree
+cp "$ROOT/.env"       .env       2>/dev/null || true
+cp "$ROOT/.env.local" .env.local 2>/dev/null || true
 ```
 
 Only copy files that are gitignored. Never copy a file that could be committed back.

--- a/modules/git-worktrees/commands/worktree-sweep.md
+++ b/modules/git-worktrees/commands/worktree-sweep.md
@@ -36,6 +36,7 @@ The script classifies each worktree (never the main checkout, never the one you 
 |----------------|--------|
 | Uncommitted tracked changes, or untracked non-ignored files | **PRESERVE** |
 | In-progress rebase / merge / cherry-pick / revert / bisect | **PRESERVE** |
+| Detached HEAD carrying commits reachable from no ref | **PRESERVE** (removal would orphan them) |
 | Locked | **PRESERVE** (report; run `git worktree unlock` if intended) |
 | Clean, in a managed location | **REMOVE** (non-force) |
 | Clean, outside managed locations | **SKIP** (unless `--all`) |

--- a/modules/git-worktrees/commands/worktree-sweep.md
+++ b/modules/git-worktrees/commands/worktree-sweep.md
@@ -1,0 +1,53 @@
+---
+description: Repo-wide safe worktree janitor - remove clean worktrees, preserve anything with unsaved work, prune stale metadata
+allowed-tools: Bash, Read
+---
+
+# /worktree-sweep - Sweep Orphaned Worktrees
+
+The backstop that keeps worktree isolation from silently filling the disk. It enumerates every worktree of the current repo, removes the **clean** ones with a non-force `git worktree remove`, preserves anything with unsaved work, prunes already-gone entries, and reports what it did. It is the orphan-sweep step of the worktree lifecycle (`git-worktrees.md`) — run it after a delegation run, or any time `git worktree list` looks crowded.
+
+It exists because the harness's `isolation: "worktree"` auto-removes a worktree **only if it is unchanged** — a worktree an agent built in is "changed" and lingers forever. On 2026-07-13 that left 33 stale worktrees consuming ~237 GB on one repo. This command reclaims them safely.
+
+## Usage
+
+```
+/worktree-sweep [--dry-run] [--conservative] [--all]
+```
+
+- **(no flags)** — report + remove every clean worktree in the managed locations. Safe by construction: a clean worktree's commits survive on its branch ref after removal (only the checkout and its build artifacts go), so nothing committed is ever lost.
+- **`--dry-run`** — classify and show what *would* happen; remove nothing. Run this first if you want a preview.
+- **`--conservative`** — additionally preserve clean worktrees whose branch has commits not yet on the origin default branch (keep in-progress-but-committed checkouts around). Removes only fully-merged, detached, or behind worktrees.
+- **`--all`** — also sweep clean worktrees outside the two managed locations (`.claude/worktrees/`, `.worktrees/`). Off by default so a deliberately-placed worktree elsewhere is never touched.
+
+## What It Does
+
+Run the installed janitor and present its report to the user:
+
+```bash
+bash ~/.claude/lib/worktree-sweep.sh $ARGUMENTS
+```
+
+(When running from a CCGM checkout instead of an install, the script is at `modules/git-worktrees/lib/worktree-sweep.sh`.)
+
+The script classifies each worktree (never the main checkout, never the one you are standing in):
+
+| Classification | Action |
+|----------------|--------|
+| Uncommitted tracked changes, or untracked non-ignored files | **PRESERVE** |
+| In-progress rebase / merge / cherry-pick / revert / bisect | **PRESERVE** |
+| Locked | **PRESERVE** (report; run `git worktree unlock` if intended) |
+| Clean, in a managed location | **REMOVE** (non-force) |
+| Clean, outside managed locations | **SKIP** (unless `--all`) |
+| Directory already gone (prunable) | **PRUNE** metadata |
+
+It **never uses `--force`.** A non-force `git worktree remove` is itself a safety gate — git refuses on any modified-or-untracked worktree — so even if the classification missed something, git will not let the sweep destroy unsaved work. A gitignored build artifact (`.build/`, `target/`) does not block a clean removal.
+
+## After the Sweep
+
+Report the summary the script prints: how many worktrees were removed (and disk reclaimed), how many were preserved and why, and how many prunable entries were cleaned. For any removed worktree whose branch had commits not on the default branch, the report includes the exact `git worktree add ...` command to restore the checkout — the branch and its commits were never deleted.
+
+## Related
+
+- `git-worktrees.md` — the worktree lifecycle, removal-safety rule, and honest economics.
+- `/worktree-finish` — finish **one** worktree interactively (merge / PR / keep / discard). Use `/worktree-sweep` for the many-at-once orphan cleanup.

--- a/modules/git-worktrees/lib/worktree-sweep.sh
+++ b/modules/git-worktrees/lib/worktree-sweep.sh
@@ -8,10 +8,12 @@
 # a modified-or-untracked worktree is a second safety gate on top of the
 # classification. See modules/git-worktrees/rules/git-worktrees.md.
 #
-# KEY SAFETY FACT: removing a clean worktree never loses committed work - the
-# branch ref stays in the parent .git; only the working-tree checkout (and its
-# build artifacts) are removed. Re-create the checkout later with
-# `git worktree add <path> <branch>`. So a clean worktree is always safe.
+# KEY SAFETY FACT: removing a clean ON-BRANCH worktree never loses committed
+# work - the branch ref stays in the parent .git; only the working-tree checkout
+# (and its build artifacts) are removed. Re-create it later with
+# `git worktree add <path> <branch>`. A DETACHED worktree has no branch ref, so
+# if it carries commits reachable from no other ref, removal would orphan them -
+# those are preserved, not removed.
 #
 # By default it only touches worktrees under the two managed locations,
 # `.claude/worktrees/` (harness `isolation:"worktree"` default) and `.worktrees/`
@@ -60,6 +62,23 @@ fi
 if [ -z "$DEFAULT_REF" ] && git show-ref --verify --quiet refs/remotes/origin/master 2>/dev/null; then
   DEFAULT_REF="origin/master"
 fi
+# Local fallback for a repo with no origin, so --conservative still works there.
+if [ -z "$DEFAULT_REF" ] && git show-ref --verify --quiet refs/heads/main 2>/dev/null; then
+  DEFAULT_REF="main"
+fi
+if [ -z "$DEFAULT_REF" ] && git show-ref --verify --quiet refs/heads/master 2>/dev/null; then
+  DEFAULT_REF="master"
+fi
+
+# The main checkout (parent of the shared .git dir) must never be swept, no
+# matter which worktree we run from. Empty for a bare repo (it has no checkout).
+MAIN_CHECKOUT=""
+_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)"
+if [ -n "$_common_dir" ] && [ "$(git rev-parse --is-bare-repository 2>/dev/null)" != "true" ]; then
+  # pwd -P resolves symlinks so this matches git's canonical porcelain paths
+  # (e.g. macOS /var -> /private/var), so the comparison in process_record holds.
+  MAIN_CHECKOUT="$(cd "$_common_dir/.." 2>/dev/null && pwd -P)"
+fi
 
 is_managed() {
   # True if the path lives under a managed worktree dir.
@@ -89,18 +108,18 @@ SKIPPED=0
 SKIPPED_LINES=""
 PRUNABLE=0
 
-# Walk `git worktree list --porcelain`. Records are blank-line separated. The
-# FIRST record is always the main checkout - skip it.
-FIRST=1
+# Walk `git worktree list --porcelain`. Records are blank-line separated.
 CUR_PATH=""
 CUR_BRANCH=""
 CUR_DETACHED=0
 CUR_LOCKED=0
 CUR_PRUNABLE=0
+CUR_BARE=0
 
 process_record() {
   [ -z "$CUR_PATH" ] && return 0
-  if [ "$FIRST" = "1" ]; then FIRST=0; return 0; fi   # main checkout
+  [ "$CUR_BARE" = "1" ] && return 0                                  # the bare repo itself is not a checkout
+  if [ -n "$MAIN_CHECKOUT" ] && [ "$CUR_PATH" = "$MAIN_CHECKOUT" ]; then return 0; fi   # main checkout
   local path="$CUR_PATH"
   local label="$path"
   if [ "$CUR_DETACHED" = "1" ]; then label="$label  (detached)"; else label="$label  [$CUR_BRANCH]"; fi
@@ -125,7 +144,20 @@ process_record() {
   if [ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]; then
     declare_preserved "  - $label -> PRESERVE (uncommitted or untracked changes)"; return 0
   fi
-  # From here the worktree is CLEAN.
+  # Preserve: a detached-HEAD worktree whose commit is reachable from NO ref.
+  # A branch worktree's commits survive removal on the branch ref, but a detached
+  # HEAD has no ref - removing it orphans any commits made on top (gc-eligible).
+  # If some branch/tag/remote already contains the tip (the common "parked at an
+  # existing commit" case), removal is safe and we fall through.
+  if [ "$CUR_DETACHED" = "1" ]; then
+    local head_sha reached
+    head_sha="$(git -C "$path" rev-parse HEAD 2>/dev/null)"
+    reached="$(git -C "$path" for-each-ref --contains "$head_sha" --format='%(refname)' 2>/dev/null | head -1)"
+    if [ -z "$reached" ]; then
+      declare_preserved "  - $label -> PRESERVE (detached HEAD; commits reachable from no ref would be orphaned)"; return 0
+    fi
+  fi
+  # From here the worktree is CLEAN and its committed work survives removal.
   local unmerged=""
   if [ -n "$DEFAULT_REF" ] && [ "$CUR_DETACHED" != "1" ]; then
     local n
@@ -159,12 +191,12 @@ process_record() {
 
 while IFS= read -r line || [ -n "$line" ]; do
   case "$line" in
-    "worktree "*) process_record; CUR_PATH="${line#worktree }"; CUR_BRANCH=""; CUR_DETACHED=0; CUR_LOCKED=0; CUR_PRUNABLE=0 ;;
+    "worktree "*) process_record; CUR_PATH="${line#worktree }"; CUR_BRANCH=""; CUR_DETACHED=0; CUR_LOCKED=0; CUR_PRUNABLE=0; CUR_BARE=0 ;;
     "branch "*)   CUR_BRANCH="${line#branch refs/heads/}" ;;
     "detached")   CUR_DETACHED=1 ;;
     "locked"*)    CUR_LOCKED=1 ;;
     "prunable"*)  CUR_PRUNABLE=1 ;;
-    "bare")       CUR_PATH="" ;;   # never touch a bare repo entry
+    "bare")       CUR_BARE=1 ;;   # the bare repo entry has no checkout; skip it
   esac
 done <<EOF
 $(git worktree list --porcelain)

--- a/modules/git-worktrees/lib/worktree-sweep.sh
+++ b/modules/git-worktrees/lib/worktree-sweep.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# worktree-sweep.sh - repo-wide safe worktree janitor.
+#
+# Enumerates every worktree of the current repo, classifies each as CLEAN
+# (safe to remove) or PRESERVE (unsaved work / in-progress operation / locked),
+# removes ONLY the clean ones with a NON-FORCE `git worktree remove`, prunes
+# stale metadata, and prints a report. It NEVER forces, so git's own refusal on
+# a modified-or-untracked worktree is a second safety gate on top of the
+# classification. See modules/git-worktrees/rules/git-worktrees.md.
+#
+# KEY SAFETY FACT: removing a clean worktree never loses committed work - the
+# branch ref stays in the parent .git; only the working-tree checkout (and its
+# build artifacts) are removed. Re-create the checkout later with
+# `git worktree add <path> <branch>`. So a clean worktree is always safe.
+#
+# By default it only touches worktrees under the two managed locations,
+# `.claude/worktrees/` (harness `isolation:"worktree"` default) and `.worktrees/`
+# (legacy module location), plus prunable entries whose directory is already
+# gone. Worktrees elsewhere are reported but left alone unless --all is given.
+#
+# Usage: worktree-sweep.sh [--dry-run|-n] [--conservative] [--all] [-h|--help]
+#   --dry-run       Report the classification and planned actions; remove nothing.
+#   --conservative  Also PRESERVE clean worktrees whose branch has commits not on
+#                   the origin default branch (keep in-progress-but-committed
+#                   checkouts around). Default removes clean worktrees regardless,
+#                   since their commits survive on the branch ref.
+#   --all           Also sweep clean worktrees outside the two managed locations.
+#   -h, --help      Print this header.
+set -u
+
+MODE="apply"
+CONSERVATIVE=0
+ALL=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run|-n) MODE="dry-run" ;;
+    --conservative) CONSERVATIVE=1 ;;
+    --all) ALL=1 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "worktree-sweep: unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "worktree-sweep: not inside a git repository" >&2
+  exit 2
+fi
+
+CWD_WT="$(git rev-parse --show-toplevel)"
+
+# Best-effort default-branch ref, for the unmerged-commit note in the report.
+DEFAULT_REF=""
+if git show-ref --verify --quiet refs/remotes/origin/HEAD 2>/dev/null; then
+  DEFAULT_REF="$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null)"
+fi
+if [ -z "$DEFAULT_REF" ] && git show-ref --verify --quiet refs/remotes/origin/main 2>/dev/null; then
+  DEFAULT_REF="origin/main"
+fi
+if [ -z "$DEFAULT_REF" ] && git show-ref --verify --quiet refs/remotes/origin/master 2>/dev/null; then
+  DEFAULT_REF="origin/master"
+fi
+
+is_managed() {
+  # True if the path lives under a managed worktree dir.
+  case "$1" in
+    */.claude/worktrees/*|*/.worktrees/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+in_progress_op() {
+  # True if the worktree has a paused rebase/merge/cherry-pick/revert/bisect.
+  wt="$1"
+  for m in rebase-merge rebase-apply MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG; do
+    mp="$(git -C "$wt" rev-parse --git-path "$m" 2>/dev/null)"
+    if [ -n "$mp" ] && [ -e "$mp" ]; then return 0; fi
+  done
+  return 1
+}
+
+REMOVED=0
+RECLAIMED_KB=0
+declare_preserved() { PRESERVED_LINES="${PRESERVED_LINES}$1"$'\n'; PRESERVED=$((PRESERVED+1)); }
+PRESERVED=0
+PRESERVED_LINES=""
+REMOVED_LINES=""
+SKIPPED=0
+SKIPPED_LINES=""
+PRUNABLE=0
+
+# Walk `git worktree list --porcelain`. Records are blank-line separated. The
+# FIRST record is always the main checkout - skip it.
+FIRST=1
+CUR_PATH=""
+CUR_BRANCH=""
+CUR_DETACHED=0
+CUR_LOCKED=0
+CUR_PRUNABLE=0
+
+process_record() {
+  [ -z "$CUR_PATH" ] && return 0
+  if [ "$FIRST" = "1" ]; then FIRST=0; return 0; fi   # main checkout
+  local path="$CUR_PATH"
+  local label="$path"
+  if [ "$CUR_DETACHED" = "1" ]; then label="$label  (detached)"; else label="$label  [$CUR_BRANCH]"; fi
+
+  # Already-gone directory: git prunable will drop the metadata.
+  if [ "$CUR_PRUNABLE" = "1" ] || [ ! -d "$path" ]; then
+    PRUNABLE=$((PRUNABLE+1)); return 0
+  fi
+  # Never touch the worktree we are standing in.
+  if [ "$path" = "$CWD_WT" ]; then
+    SKIPPED_LINES="${SKIPPED_LINES}  - $label -> current worktree (skipped)"$'\n'; SKIPPED=$((SKIPPED+1)); return 0
+  fi
+  # Preserve: locked.
+  if [ "$CUR_LOCKED" = "1" ]; then
+    declare_preserved "  - $label -> PRESERVE (locked; run 'git worktree unlock' if intended)"; return 0
+  fi
+  # Preserve: in-progress operation.
+  if in_progress_op "$path"; then
+    declare_preserved "  - $label -> PRESERVE (in-progress rebase/merge/cherry-pick)"; return 0
+  fi
+  # Preserve: uncommitted tracked changes or untracked non-ignored files.
+  if [ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]; then
+    declare_preserved "  - $label -> PRESERVE (uncommitted or untracked changes)"; return 0
+  fi
+  # From here the worktree is CLEAN.
+  local unmerged=""
+  if [ -n "$DEFAULT_REF" ] && [ "$CUR_DETACHED" != "1" ]; then
+    local n
+    n="$(git -C "$path" rev-list --count "${DEFAULT_REF}..HEAD" 2>/dev/null || echo 0)"
+    [ "$n" -gt 0 ] 2>/dev/null && unmerged="$n"
+  fi
+  # Conservative mode preserves clean-but-unmerged branch checkouts.
+  if [ "$CONSERVATIVE" = "1" ] && [ -n "$unmerged" ]; then
+    declare_preserved "  - $label -> PRESERVE (--conservative: $unmerged commit(s) not on $DEFAULT_REF)"; return 0
+  fi
+  # Only sweep managed locations unless --all.
+  if [ "$ALL" != "1" ] && ! is_managed "$path"; then
+    SKIPPED_LINES="${SKIPPED_LINES}  - $label -> clean, outside managed dirs (skipped; --all to include)"$'\n'; SKIPPED=$((SKIPPED+1)); return 0
+  fi
+
+  local kb; kb="$(du -sk "$path" 2>/dev/null | awk '{print $1}')"; [ -z "$kb" ] && kb=0
+  local note=""
+  [ -n "$unmerged" ] && note=" (branch kept: $unmerged commit(s) not on $DEFAULT_REF; restore with 'git worktree add $path $CUR_BRANCH')"
+  if [ "$MODE" = "dry-run" ]; then
+    REMOVED_LINES="${REMOVED_LINES}  - $label -> WOULD REMOVE, ~$((kb/1024)) MB$note"$'\n'
+    REMOVED=$((REMOVED+1)); RECLAIMED_KB=$((RECLAIMED_KB+kb)); return 0
+  fi
+  if git worktree remove "$path" 2>/dev/null; then
+    REMOVED_LINES="${REMOVED_LINES}  - $label -> removed, ~$((kb/1024)) MB$note"$'\n'
+    REMOVED=$((REMOVED+1)); RECLAIMED_KB=$((RECLAIMED_KB+kb))
+  else
+    # Non-force refused: git found something unsafe the checks missed. Never force.
+    declare_preserved "  - $label -> PRESERVE (git refused non-force removal)"
+  fi
+}
+
+while IFS= read -r line || [ -n "$line" ]; do
+  case "$line" in
+    "worktree "*) process_record; CUR_PATH="${line#worktree }"; CUR_BRANCH=""; CUR_DETACHED=0; CUR_LOCKED=0; CUR_PRUNABLE=0 ;;
+    "branch "*)   CUR_BRANCH="${line#branch refs/heads/}" ;;
+    "detached")   CUR_DETACHED=1 ;;
+    "locked"*)    CUR_LOCKED=1 ;;
+    "prunable"*)  CUR_PRUNABLE=1 ;;
+    "bare")       CUR_PATH="" ;;   # never touch a bare repo entry
+  esac
+done <<EOF
+$(git worktree list --porcelain)
+EOF
+process_record   # flush the final record
+
+# Drop administrative state for worktrees whose directories are gone or removed.
+if [ "$MODE" = "dry-run" ]; then
+  echo "=== worktree-sweep (DRY RUN - nothing removed) ==="
+else
+  git worktree prune 2>/dev/null
+  echo "=== worktree-sweep ==="
+fi
+[ -n "$DEFAULT_REF" ] && echo "default branch: $DEFAULT_REF"
+echo ""
+if [ "$REMOVED" -gt 0 ]; then
+  echo "REMOVED ($REMOVED, ~$((RECLAIMED_KB/1024)) MB reclaimed):"
+  printf "%s" "$REMOVED_LINES"
+  echo ""
+fi
+if [ "$PRESERVED" -gt 0 ]; then
+  echo "PRESERVED ($PRESERVED, unsaved work / in-progress / locked):"
+  printf "%s" "$PRESERVED_LINES"
+  echo ""
+fi
+if [ "$SKIPPED" -gt 0 ]; then
+  echo "SKIPPED ($SKIPPED):"
+  printf "%s" "$SKIPPED_LINES"
+  echo ""
+fi
+[ "$PRUNABLE" -gt 0 ] && echo "PRUNED $PRUNABLE worktree(s) whose directory was already gone."
+echo "Done. $REMOVED removed, $PRESERVED preserved, $SKIPPED skipped."

--- a/modules/git-worktrees/module.json
+++ b/modules/git-worktrees/module.json
@@ -1,7 +1,7 @@
 {
   "name": "git-worktrees",
   "displayName": "Git Worktrees",
-  "description": "Solo-agent worktree-based isolation for feature work. Lighter alternative to multi-clone setup when only one agent is active.",
+  "description": "Git worktrees as the default isolation for parallel sub-agent delegation on one machine, with a safe janitor that enforces teardown so worktrees never silently fill the disk.",
   "category": "workflow",
   "scope": ["global"],
   "dependencies": [],
@@ -19,6 +19,16 @@
     "commands/worktree-finish.md": {
       "target": "commands/worktree-finish.md",
       "type": "command",
+      "template": false
+    },
+    "commands/worktree-sweep.md": {
+      "target": "commands/worktree-sweep.md",
+      "type": "command",
+      "template": false
+    },
+    "lib/worktree-sweep.sh": {
+      "target": "lib/worktree-sweep.sh",
+      "type": "lib",
       "template": false
     }
   },

--- a/modules/git-worktrees/rules/git-worktrees.md
+++ b/modules/git-worktrees/rules/git-worktrees.md
@@ -95,20 +95,25 @@ The procedure that worked in the incident, stated exactly:
 2. **PRESERVE** — never remove — any worktree that has:
    - **uncommitted tracked changes** (work not yet committed), or
    - **untracked non-ignored files** (new files not yet added), or
-   - an **in-progress rebase / merge / cherry-pick / revert / bisect** (a paused operation, whether or not it currently shows a conflict).
+   - an **in-progress rebase / merge / cherry-pick / revert / bisect** (a paused operation, whether or not it currently shows a conflict), or
+   - a **detached HEAD carrying commits reachable from no ref** (removing it would orphan those commits — a detached HEAD has no branch ref to survive on; see the KEY FACT).
 3. **Force-remove only the verified-safe ones**, and only if a non-force remove unexpectedly refuses a worktree you have already classified clean. A sweep should default to *never* forcing — let git's refusal protect unsaved work.
 4. **Then `git worktree prune`** to clear metadata for worktrees whose directories are already gone.
 5. **Always report what was preserved and why**, so a preserved worktree is a visible decision, not a silent skip.
 
-### KEY FACT: removing a clean worktree never loses work
+One accepted footgun: a non-force remove also discards a clean worktree's **gitignored** local files — that is what makes it useful (the multi-GB `.build` goes with the checkout), but it also means a worktree-local `.env` or secret that is gitignored is removed too. Those are normally copied from the main checkout (`/worktree-start` does this), so losing them is recoverable; do not keep unique un-committed secrets only inside a worktree.
 
-Removing a worktree does **not** delete its branch or any committed work. The branch ref stays in the parent `.git`; only the working-tree checkout (and its `.build`) is removed. You can always re-materialize the checkout later:
+### KEY FACT: removing a clean worktree never loses committed work
+
+Removing a worktree does **not** delete its branch or any committed work. For a worktree **on a branch**, the branch ref stays in the parent `.git`; only the working-tree checkout (and its `.build`) is removed. You can always re-materialize the checkout later:
 
 ```bash
 git worktree add .claude/worktrees/<branch-name> <branch-name>
 ```
 
-**Therefore a clean worktree is ALWAYS safe to remove** — its commits survive on the branch ref even though the checkout is gone. This is why a clean worktree on an unmerged feature branch is still safe to reclaim: you lose a re-creatable checkout, never the commits.
+**So a clean worktree on a branch is ALWAYS safe to remove** — its commits survive on the branch ref even though the checkout is gone. This is why a clean worktree on an unmerged feature branch is still safe to reclaim: you lose a re-creatable checkout, never the commits.
+
+The one exception is a **detached-HEAD** worktree. It has no branch ref, so commits made on top of a detached checkout (e.g. `git worktree add <path> <sha>` then a fixup commit) are reachable from *nothing* once the checkout is gone — removing it orphans them (gc-eligible). So a clean detached worktree is safe to remove **only if** its HEAD is already reachable from some other ref (the common "parked at an existing commit" case); if it carries ref-orphan commits, preserve it.
 
 ### The four cases, decided
 
@@ -117,7 +122,8 @@ git worktree add .claude/worktrees/<branch-name> <branch-name>
 | Clean worktree on a feature branch | **Remove** | Branch ref (and all its commits) preserved in `.git`; only the checkout goes |
 | Uncommitted tracked edits present | **Preserve** | The edits are not committed anywhere — removal would lose them |
 | Mid-rebase with an unresolved conflict | **Preserve** | An in-progress operation; removal discards the resolution-in-progress |
-| Clean detached-HEAD worktree | **Remove** | Nothing uncommitted; the commit is reachable from wherever it was based |
+| Clean detached HEAD, reachable from a ref | **Remove** | The commit survives on that other ref; only the checkout goes |
+| Clean detached HEAD, commits on no ref | **Preserve** | No ref survives removal — the commits would be orphaned |
 
 `/worktree-sweep` implements exactly this classification.
 

--- a/modules/git-worktrees/rules/git-worktrees.md
+++ b/modules/git-worktrees/rules/git-worktrees.md
@@ -1,123 +1,156 @@
-# Git Worktrees (Solo-Agent Isolation)
+# Git Worktrees (Default Parallel-Delegation Isolation)
 
-Worktrees let a single agent keep multiple branches checked out at once in sibling directories, sharing one `.git` folder. They are the solo-agent equivalent of the multi-clone setup - lighter, no port registry, no cross-agent coordination.
+A worktree is a second working tree checked out from the **same** `.git`. Each worktree has its **own index, HEAD, and working directory**, so two agents can build, test, and commit on different branches at the same time without touching each other's files. That independent-index-and-HEAD property is exactly what makes worktrees safe for parallel work.
 
-## When to Use a Worktree
+**Worktrees are the default isolation for parallel sub-agent delegation on a single machine.** When a delegator (you, or a command like `/etp`, `/mawf`, `/xplan`) fans out work to parallel implementer agents, give each agent its own worktree — not its own permanent clone. Worktrees are created per unit of work and destroyed when that unit is done, so disk is reclaimed instead of accumulating.
 
-Use `git worktree` when:
+> This corrects earlier guidance that said worktrees are "solo-agent only, not for parallel." The real caveats are narrow (shared `.git/hooks` + `.git/config`, and tolerated ref-lock contention — see Pitfalls); they do **not** make parallel worktrees unsafe. The harness's own `isolation: "worktree"` runs parallel worktrees successfully every day.
 
-- You are the only agent working on the repo right now
-- You want to try a change on a new branch without switching or stashing in place
-- You want to compare two branches side by side (run both, diff outputs)
-- You want a clean test baseline that a destructive experiment cannot pollute
+## The Incident This Exists To Prevent
 
-## When NOT to Use a Worktree (Use Clones Instead)
+On 2026-07-13, delegated work on the `evoglyph` repo using the Agent/Workflow `isolation: "worktree"` feature left **33 stale worktrees** across two clones' `.claude/worktrees/` directories, consuming **~237 GB** — each worktree carried its own 9–13 GB `.build`. Free disk fell to 63 GB (99% full).
 
-Reach for the `multi-agent` module's multi-clone architecture when:
+Root cause: the harness's `isolation: "worktree"` auto-removes a worktree **only if it is unchanged**. A worktree that got *built* in is "changed" and lingers forever, and nothing mandated removing a worktree after its PR merged or sweeping orphaned ones. The multi-clone alternative is worse: each clone is a permanent 4 GB fresh / 13 GB built that never gets reclaimed at all.
 
-- Multiple agents are running in parallel on the same repo (worktrees share the index and HEAD ref database - two simultaneous writers cause lock contention)
-- You need per-branch dev server ports (worktrees share `.env`; clones have per-clone `.env.clone` with pre-computed `FRONTEND_PORT` / `BACKEND_PORT`)
-- You need per-branch issue tracking via the hook-driven `tracking.csv`
-- The work will span days and you want persistent per-branch session logs
+The fix has two halves, and both are load-bearing: **(1)** worktrees are the default (ephemeral, shared `.git`), and **(2)** teardown is mandatory, not best-effort.
 
-See `multi-agent/rules/multi-agent.md` and `~/.claude/multi-agent-system.md` for the clone-based alternative.
+## Worktrees vs Clones — When Each Is Right
 
-## Directory Selection
+| Situation | Use |
+|-----------|-----|
+| **Parallel sub-agent delegation on one machine** (the default) | **Worktree** — one per unit of work, removed when the unit merges |
+| Single agent trying an idea on a branch without stashing / switching in place | **Worktree** |
+| Comparing two branches side by side (run both, diff outputs) | **Worktree** |
+| **Multiple long-lived independent agents** each owning a repo for days | **Clone** |
+| Per-branch **dev-server ports** (worktrees share `.env`; clones have per-clone `.env.clone` with pre-computed `FRONTEND_PORT`/`BACKEND_PORT`) | **Clone** |
+| Hook-driven **per-branch `tracking.csv`** issue tracking | **Clone** |
+| **Cross-machine / cloud dispatch** (a worktree cannot span machines) | **Clone** (or remote isolation) |
 
-Prefer project-local worktree directories over a global one.
+Reach for the `multi-agent` module's clones only for those specific cases. For ordinary "fan out N independent units across N agents on this machine," worktrees are the answer — see `multi-agent/rules/multi-agent.md` and `subagent-patterns/rules/subagent-patterns.md`, which both now default to worktrees.
 
-- **Project-local (preferred)**: `<repo>/.worktrees/<branch-name>/`
-  - Keeps worktrees next to the repo they belong to
-  - Easier cleanup when the repo is archived
-  - Requires `.worktrees/` to be gitignored
-- **Global fallback**: `~/code/worktrees/<repo>-<branch-name>/`
-  - Use only when the repo refuses to gitignore `.worktrees/` (e.g., enforced `.gitignore` policy)
-  - Never commit files from a global worktree back without re-verifying paths
+## Honest Economics (Do Not Overclaim)
 
-## Pre-Flight Checks (Before Creating a Worktree)
+Worktrees share the parent repo's `.git` object store and any **external** caches (downloaded models, package caches, `~/.cache`), so they avoid the re-fetch and re-download cost of a fresh clone. **But each worktree still builds its own `.build` / `target/` / `node_modules`-of-record.** Two worktrees compiling the same project produce two full build trees.
 
-1. **Verify `.worktrees/` is gitignored** when using project-local. If not, add it to `.gitignore` in the same commit or before creating the worktree. Committing `.worktrees/` is catastrophic - it nests the entire working tree inside the repo.
-2. **Verify the current working tree is clean** or has only tracked changes. Worktrees share the index with the main checkout; dirty state can confuse `git worktree add`.
-3. **Verify the target branch does not already have a worktree**: `git worktree list` shows all existing worktrees.
-4. **Verify the new branch name is unique**: `git branch --list {name}` must be empty unless you are deliberately re-checking out an existing branch.
+So the disk win over clones is **ephemerality** (a worktree is created for one unit and destroyed on completion, whereas a clone persists) plus the **shared `.git`** — **not** a smaller build. A worktree you build in and never remove costs the same disk as a clone you built in and never removed. The savings are entirely in the lifecycle. If teardown does not happen, worktrees are no cheaper than clones — they are the incident.
+
+## The Delegation Lifecycle (Every Worktree Has an Owner)
+
+A worktree is created for **exactly one unit of work** and has one owner — the delegator that created it. The lifecycle:
+
+1. **Create** — the delegator makes one worktree per unit (via the Agent/Workflow `isolation: "worktree"`, or `/worktree-start` for hands-on work). One branch, one unit.
+2. **Implement / test / PR** — the sub-agent does the work inside its worktree, on its feature branch, and opens a PR.
+3. **Merge** — the PR is reviewed and merged.
+4. **Remove** — **the delegator removes that unit's worktree as soon as its PR merges** (or the unit is abandoned). This step is mandatory, not "when I get around to it." See Cleanup below.
+5. **Sweep orphans** — as a backstop, run `/worktree-sweep` to remove any clean worktree that leaked past step 4 (an early exit, a crash, a `isolation:"worktree"` worktree the harness could not auto-remove because it was built in).
+
+Steps 4 and 5 are the half of the fix that the incident was missing. A delegator that spawns worktrees and does not tear them down has not finished the job.
+
+## Worktree Location
+
+Going forward, **new worktrees live under `<repo>/.claude/worktrees/`** — the same directory the harness's `isolation: "worktree"` already uses. Standardizing there means:
+
+- Delegated (`isolation:"worktree"`) and hands-on (`/worktree-start`) worktrees share one tree.
+- One sweep target covers everything.
+- `.claude/` is conventionally gitignored by the harness, so worktrees never risk being committed.
+
+`<repo>/.worktrees/` is the module's **legacy** location. `/worktree-sweep` still recognizes and cleans it, but do not create new worktrees there.
+
+Whichever location is used, its parent directory **must be gitignored**. Committing a worktree directory is catastrophic — it nests an entire working tree inside the repo. `/worktree-start` verifies this before creating anything.
 
 ## Creating a Worktree
 
+**Delegated (the default for parallel work):** pass `isolation: "worktree"` to the Agent or Workflow tool. The harness creates `.claude/worktrees/agent-<hash>/`, runs the agent there, and auto-removes it **only if the agent left it unchanged**. Because implementers build and commit, their worktrees are "changed" and will **not** auto-remove — the delegator must remove them (lifecycle step 4) and `/worktree-sweep` catches the rest.
+
+**Hands-on:** use `/worktree-start <branch-name> [base-branch]`, which does pre-flight checks (gitignore, uniqueness, clean tree), creates the worktree under `.claude/worktrees/<branch-name>/`, runs project setup, and confirms a green baseline. Manually, the underlying commands are:
+
 ```bash
-# New branch off main
 git fetch origin main
-git worktree add -b <branch-name> .worktrees/<branch-name> origin/main
-
-# Existing branch
-git worktree add .worktrees/<branch-name> <existing-branch>
+git worktree add -b <branch-name> .claude/worktrees/<branch-name> origin/main   # new branch
+git worktree add    .claude/worktrees/<branch-name> <existing-branch>            # existing branch
 ```
 
-After creation, run project setup inside the worktree. Auto-detect based on files present:
+## Cleanup Is Mandatory, Not Best-Effort
 
-- `package.json` + `pnpm-lock.yaml` -> `pnpm install`
-- `package.json` + `package-lock.json` -> `npm install`
-- `package.json` + `yarn.lock` -> `yarn install`
-- `Cargo.toml` -> `cargo build`
-- `requirements.txt` -> `pip install -r requirements.txt`
-- `Gemfile` -> `bundle install`
-- `go.mod` -> `go mod download`
+This is the whole lesson of the incident: **cleanup must not depend on the happy path.**
 
-Then verify a clean test baseline: run the project's test command once, confirm it exits 0, and only then hand off to feature work. A failing baseline makes later test failures ambiguous.
+- **On the happy path**, the delegator removes each worktree the moment its PR merges (lifecycle step 4).
+- **On any abnormal exit** (early stop, gate rejection, crash, a `isolation:"worktree"` worktree the harness could not reclaim), the worktree leaks. So a **standalone safe sweep must be runnable at any time** to reclaim orphans: `/worktree-sweep`.
+- **For unattended runs**, schedule the sweep as a backstop so cleanup happens even if no one remembers (see "Scheduled backstop" below). This mirrors the principle that *safety must not depend on a report being read*: the disk is reclaimed whether or not the operator notices.
 
-## Cleanup
-
-When the branch is done (merged, abandoned, or paused), remove the worktree:
+Removing a single worktree by hand:
 
 ```bash
-# Preferred - refuses if there are uncommitted changes
-git worktree remove .worktrees/<branch-name>
-
-# Force - use only after reviewing what would be lost
-git worktree remove --force .worktrees/<branch-name>
+git worktree remove .claude/worktrees/<branch-name>   # non-force; refuses if there is unsaved work
+git worktree prune                                    # drop administrative state for deleted worktrees
 ```
 
-After removal, prune stale administrative state:
+Never `rm -rf` a worktree directory — it leaves dangling `.git/worktrees/<name>/` metadata. Always use `git worktree remove` (then `git worktree prune`).
+
+## Removal Safety (Codified From the Incident)
+
+The procedure that worked in the incident, stated exactly:
+
+1. **Prefer non-force `git worktree remove`.** It is itself a safety gate: git **refuses** (`fatal: '<path>' contains modified or untracked files, use --force to delete it`) whenever the worktree has uncommitted tracked changes **or** untracked non-ignored files. A gitignored build artifact (`.build/`, `target/`, `dist/`) does **not** block a non-force remove — verified on git 2.50.1: a clean worktree with a multi-GB gitignored `.build` removes cleanly without `--force`.
+2. **PRESERVE** — never remove — any worktree that has:
+   - **uncommitted tracked changes** (work not yet committed), or
+   - **untracked non-ignored files** (new files not yet added), or
+   - an **in-progress rebase / merge / cherry-pick / revert / bisect** (a paused operation, whether or not it currently shows a conflict).
+3. **Force-remove only the verified-safe ones**, and only if a non-force remove unexpectedly refuses a worktree you have already classified clean. A sweep should default to *never* forcing — let git's refusal protect unsaved work.
+4. **Then `git worktree prune`** to clear metadata for worktrees whose directories are already gone.
+5. **Always report what was preserved and why**, so a preserved worktree is a visible decision, not a silent skip.
+
+### KEY FACT: removing a clean worktree never loses work
+
+Removing a worktree does **not** delete its branch or any committed work. The branch ref stays in the parent `.git`; only the working-tree checkout (and its `.build`) is removed. You can always re-materialize the checkout later:
 
 ```bash
-git worktree prune
+git worktree add .claude/worktrees/<branch-name> <branch-name>
 ```
+
+**Therefore a clean worktree is ALWAYS safe to remove** — its commits survive on the branch ref even though the checkout is gone. This is why a clean worktree on an unmerged feature branch is still safe to reclaim: you lose a re-creatable checkout, never the commits.
+
+### The four cases, decided
+
+| Worktree state | Outcome | Why |
+|----------------|---------|-----|
+| Clean worktree on a feature branch | **Remove** | Branch ref (and all its commits) preserved in `.git`; only the checkout goes |
+| Uncommitted tracked edits present | **Preserve** | The edits are not committed anywhere — removal would lose them |
+| Mid-rebase with an unresolved conflict | **Preserve** | An in-progress operation; removal discards the resolution-in-progress |
+| Clean detached-HEAD worktree | **Remove** | Nothing uncommitted; the commit is reachable from wherever it was based |
+
+`/worktree-sweep` implements exactly this classification.
+
+## Scheduled backstop (opt-in)
+
+For machines that run unattended delegation, schedule the sweep so orphaned worktrees are reclaimed without anyone remembering. A launchd/cron entry that runs the sweep's non-interactive remove-clean pass per active repo is enough; keep it read-mostly (it only ever removes *clean* worktrees, never forces). This is opt-in because auto-removing worktrees on a timer is a standing action the operator should choose, not a default daemon.
 
 ## Pitfalls
 
 ### Worktree Lock
+`git worktree add` can mark a worktree "locked" (`.git/worktrees/<name>/locked`). A locked worktree cannot be removed until `git worktree unlock .claude/worktrees/<name>`. Do not lock worktrees unless you have a specific reason; `/worktree-sweep` reports locked worktrees rather than fighting the lock.
 
-`git worktree add` creates `.git/worktrees/<name>/` with a `locked` file if the worktree is marked as permanent. A locked worktree cannot be removed by `git worktree remove` without first running `git worktree unlock .worktrees/<name>`. Do not lock worktrees unless you have a specific reason.
-
-### Moving a Worktree with Uncommitted Changes
-
-`mv .worktrees/foo .worktrees/bar` breaks Git's internal pointers - the `.git/worktrees/foo/` metadata still refers to the old path. Instead:
-
-```bash
-git worktree move .worktrees/foo .worktrees/bar
-```
-
-Never `mv` or `cp -r` a worktree directory manually. Use `git worktree move` or remove + re-add.
+### Moving a Worktree
+`mv` / `cp -r` breaks Git's internal pointers — `.git/worktrees/<name>/` still refers to the old path. Use `git worktree move <from> <to>`, or remove + re-add. Never move a worktree by hand.
 
 ### Two Worktrees, Same Branch
-
-Git refuses to check out the same branch in two worktrees simultaneously. This is a feature, not a bug - it prevents divergent commits on the same branch ref. If you see `fatal: 'branch' is already checked out at ...`, either reuse the existing worktree or switch one of them to a different branch.
+Git refuses to check out the same branch in two worktrees at once (`fatal: '<branch>' is already checked out at ...`). This is a feature — it prevents divergent commits on one ref. Reuse the existing worktree or pick a different branch.
 
 ### Shared Hooks and Config
+Worktrees share `.git/hooks/` and `.git/config` with the main checkout and every sibling worktree. A hook installed in one affects all of them. Treat hook and config changes as global, not per-branch. (This — not the index — is the real reason worktrees are not a full substitute for clones in some setups.)
 
-Worktrees share `.git/hooks/` and `.git/config` with the main checkout. A hook installed in one affects all worktrees. Treat hook changes as global, not per-branch.
+### Ref-Lock Contention
+Parallel worktrees each have their own index and HEAD, so builds and commits do not collide. They do share the ref database, so simultaneous ref updates (two agents pushing/branching at the exact same instant) can briefly contend on a ref lock. Git retries transparently; this is tolerated, not a correctness problem.
 
 ### Stale `.env` Files
+Worktrees do NOT inherit `.env` or other gitignored local config from the main checkout. Copy or symlink it in if the worktree needs local secrets. Never commit `.env` from a worktree.
 
-Worktrees do NOT copy `.env` from the main checkout. Symlink or copy it manually if the worktree needs local secrets. Never commit `.env` from a worktree - it is typically gitignored in the main checkout but a fresh worktree may not inherit that context if the gitignore rule is out of date.
+## Integration With Existing Git Rules
 
-## Integration with Existing Git Rules
+Worktree work follows every existing git rule — worktrees change **where** the working tree lives, not how branches, commits, or PRs are managed:
 
-Worktree feature work still follows the repo's git-workflow rules:
-
-- Branch from `origin/main` (fetch first)
-- Rebase by default when pulling main into a feature branch
-- No AI attribution in commits or PRs
-- Always sync before history-altering commands
-- Never `git stash` - commit WIP instead
-
-The only thing worktrees change is **where** the working tree lives, not how branches, commits, or PRs are managed.
+- **Branch-guard is satisfied automatically.** A worktree is always created on a feature branch (never the default branch), so the branch-guard hook never fires inside it. Create the worktree's branch off `origin/main`, then work.
+- **No AI attribution** in commits or PR bodies.
+- **Never `git stash`** — commit WIP instead (a worktree's whole point is that you never need to stash to switch context).
+- **Rebase by default** when pulling `origin/main` into a feature branch; sync before any history-altering command.
+- **Follow the repo's PR template** if one exists.

--- a/modules/github-protocols/github-repo-protocols.md
+++ b/modules/github-protocols/github-repo-protocols.md
@@ -77,9 +77,9 @@ Total: 14 base labels (agent labels are not part of the standard set).
 
 ### D. Clone Setup (Multi-Agent Repos)
 
-Two models are available. See `~/.claude/multi-agent-system.md` for full details.
+Two models are available. See `~/.claude/multi-agent-system.md` for full details. Note that for single-machine parallel delegation, worktrees (`git-worktrees` module) are now the default isolation — provision permanent clones only when you need persistent per-clone ports, per-branch `tracking.csv`, long-lived independent agents, or cross-machine dispatch.
 
-**Workspace model** (preferred for delegated parallel work):
+**Workspace model** (the clone-based option for delegated parallel work):
 
 ```
 /workspace-setup {repo-name}

--- a/modules/multi-agent/README.md
+++ b/modules/multi-agent/README.md
@@ -6,6 +6,8 @@ Multi-clone architecture for running parallel Claude Code agents on the same rep
 
 Enables multiple Claude Code agents to work on the same repository simultaneously using independent git clones. Each agent runs in its own clone directory with full git isolation - independent branches, independent PRs, no conflicts.
 
+> For **single-machine** parallel sub-agent delegation, the default isolation is a git worktree, not an extra clone (see the `git-worktrees` module). This multi-clone architecture is the heavier alternative — use it for persistent per-clone dev-server ports, hook-driven per-branch `tracking.csv`, long-lived independent agents, or cross-machine dispatch.
+
 Key capabilities:
 
 - **Parallel work**: Multiple agents work on different issues simultaneously

--- a/modules/multi-agent/commands/mawf.md
+++ b/modules/multi-agent/commands/mawf.md
@@ -111,9 +111,13 @@ Collect all created issue numbers.
 
 ### Phase 4: Plan Agent Allocation
 
+**Isolation — worktrees by default.** Each parallel issue agent runs in its own **git worktree** (`isolation: "worktree"`) created from the current clone: ephemeral, sharing the parent `.git`, and torn down after its PR merges (Phase 5.3). The branch-creation tracking hook fires inside a worktree exactly as it does in a clone (worktrees share `.git/hooks`), so `tracking.csv` still works. Provision or reuse permanent clones only when the repo *already* has a multi-clone/workspace setup, or a specific need forces it (per-branch dev-server ports, multiple long-lived agents). See `git-worktrees.md`.
+
+The clone discovery + occupancy checks below apply **only when reusing an existing multi-clone setup**; for the default worktree path, the concurrency cap (Phase 5.1) — not a fixed clone count — bounds the wave.
+
 Determine how to allocate agents based on:
 
-1. **Available clones**: Check how many clones exist
+1. **Available clones** (only if reusing a multi-clone setup): Check how many clones exist
    ```bash
    # Detect model and discover clones
    WC_MATCH=$(basename "$PWD" | grep -oP 'w\d+-c\d+$')
@@ -200,19 +204,18 @@ For each wave:
 
 #### 5.1 Spawn Agents
 
-Use the Agent tool to launch one agent per assigned issue, each in its own clone directory:
+Use the Agent tool to launch one agent per assigned issue, each in its own **worktree** (`isolation: "worktree"`) by default — or its assigned clone directory when reusing a multi-clone setup (Phase 4):
 
-> **Concurrency — avoid the 429 throttle.** Wave size is naturally bounded by the number of clones, and execution agents run on `sonnet` — both keep this fan-out safe. If a workspace ever has more than ~8 clones, cap each wave at 8 light agents (or 4 if you escalate them to a heavier model). If a wave reports `Server is temporarily limiting requests · Rate limited`, wait 30–60s and re-launch only the failed issues. See `~/.claude/rules/concurrency-and-rate-limits.md`.
+> **Concurrency — avoid the 429 throttle.** With worktrees the wave is bounded by the concurrency cap; with clones it is bounded by the clone count. Execution agents run on `sonnet` (light), so a wave of up to ~8 is safe. If a wave has more units than that (or you escalate agents to a heavier model, cap 4), split into sub-waves. If a wave reports `Server is temporarily limiting requests · Rate limited`, wait 30–60s and re-launch only the failed issues. See `~/.claude/rules/concurrency-and-rate-limits.md`.
 
 Each agent should:
-1. Navigate to its assigned clone directory
+1. Work in its own worktree (`isolation: "worktree"`) — or navigate to its assigned clone directory when reusing a multi-clone setup
 2. Run `/startup` to initialize the session
-3. Claim the issue by creating a branch (`git checkout -b {issue}-{desc} origin/main`). The PostToolUse hook auto-registers the claim in tracking.csv.
-4. Create a feature branch from `origin/main`
-5. Implement the work with tests
-6. Run verification (lint, type-check, test, build)
-7. Commit, push, and create a PR
-8. Report completion
+3. Claim the issue by creating a branch (`git checkout -b {issue}-{desc} origin/main`). The PostToolUse hook auto-registers the claim in tracking.csv (it fires inside a worktree too).
+4. Implement the work with tests
+5. Run verification (lint, type-check, test, build)
+6. Commit, push, and create a PR
+7. Report completion
 
 #### 5.2 Monitor Progress
 
@@ -226,7 +229,13 @@ Wait for all agents in the current wave to complete. Track:
 When all agents in a wave complete:
 1. Review all PRs (check CI status)
 2. Merge passing PRs: `gh pr merge --squash --delete-branch`
-3. Sync all clones to latest main:
+3. **Tear down each merged issue's worktree** (mandatory — a built-in worktree never auto-removes, and merged worktrees left behind are the leak that consumed 237 GB in the 2026-07-13 incident):
+   ```bash
+   git worktree remove <issue-worktree-path>   # non-force; branch + merged work survive removal
+   git worktree prune
+   ```
+   Or run `/worktree-sweep` once after the wave to reclaim every merged worktree at once (it removes only clean ones, preserves any with unsaved work). Issues that ran in a reused clone are synced instead (next step), not removed.
+4. Sync any reused clones to latest main:
    ```bash
    # Detect model and iterate clones
    WC_MATCH=$(basename "$PWD" | grep -oP 'w\d+-c\d+$')
@@ -253,11 +262,11 @@ When all agents in a wave complete:
      done
    fi
    ```
-4. Proceed to next wave
+5. Proceed to next wave
 
 #### 5.4 Continue Until Complete
 
-Repeat for each wave until all automatable issues are resolved.
+Repeat for each wave until all automatable issues are resolved. When all waves finish — or if the run exits early — run `/worktree-sweep` once as the teardown backstop, so no issue's worktree outlives the run (it removes only clean worktrees and preserves any with unsaved work). Teardown must not depend on every wave completing cleanly.
 
 ### Phase 6: Report
 

--- a/modules/multi-agent/multi-agent-system.md
+++ b/modules/multi-agent/multi-agent-system.md
@@ -5,6 +5,8 @@
 Multiple Claude Code agents work on the same repository in parallel using independent clones.
 Each agent runs in its own clone with full git isolation - independent branches, independent PRs.
 
+> **Worktrees are the default isolation for parallel sub-agent delegation on one machine** (see `git-worktrees.md`). This multi-clone system is the heavier alternative — reach for it when you genuinely need persistent per-clone dev-server ports, hook-driven per-branch `tracking.csv`, multiple long-lived independent agents, or cross-machine dispatch. For ordinary "fan out N units across N agents on this machine," use worktrees (ephemeral, shared `.git`, torn down on merge) instead of provisioning permanent clones.
+
 Two directory models are supported:
 
 | Model | Directory Pattern | Agent Identity | Use Case |

--- a/modules/multi-agent/rules/multi-agent.md
+++ b/modules/multi-agent/rules/multi-agent.md
@@ -1,17 +1,26 @@
 # Parallel Work Preference
 
-When a task involves multiple independent issues or work items, prefer spawning parallel agents in separate clones to complete them simultaneously. Use the Agent tool to launch agents, each working in its own clone directory.
+When a task involves multiple independent issues or work items, prefer spawning parallel agents to complete them simultaneously. **On a single machine, isolate each agent in its own git worktree by default** (`isolation: "worktree"`): created per unit of work, torn down when that unit merges. Do **not** provision extra permanent clones just to get parallelism. Worktrees share the parent `.git` (no re-fetch), reclaim disk on teardown, and each has its own index and HEAD, so parallel builds and commits never collide. This is the default isolation for parallel sub-agent delegation — see `git-worktrees.md` and `subagent-patterns.md`.
+
+**Reserve separate clones** for the cases a worktree cannot serve:
+- Multiple long-lived independent agents each owning the repo for days
+- Per-branch dev-server ports (worktrees share `.env`; clones get per-clone `.env.clone` with pre-computed `FRONTEND_PORT`/`BACKEND_PORT`)
+- Hook-driven per-branch `tracking.csv` issue tracking that the multi-clone setup provides
+- Cross-machine / cloud dispatch (a worktree cannot span machines)
 
 **When to parallelize:**
 - Multiple independent GitHub issues need to be completed
 - A project has issues that do not block each other
-- The repo has a multi-clone setup (workspace model: `~/code/{repo}-workspaces/` or flat model: `~/code/{repo}-repos/`)
 
-**How:** Launch agents pointed at different clone directories. Each agent claims its own issue via the tracking CSV (auto-registered by hooks on branch creation) and works independently. See `~/.claude/multi-agent-system.md` for the full coordination guide.
+**How (default, worktrees):** Launch agents with `isolation: "worktree"`; each works on its own feature branch off `origin/main` in an isolated worktree. Remove each worktree when its PR merges, and run `/worktree-sweep` as the orphan backstop.
+
+**How (clones):** When one of the reserved cases applies and a multi-clone setup exists (workspace model: `~/code/{repo}-workspaces/`, or flat model: `~/code/{repo}-repos/`), launch agents pointed at different clone directories. Each agent claims its own issue via the tracking CSV (auto-registered by hooks on branch creation) and works independently. See `~/.claude/multi-agent-system.md` for the full coordination guide.
+
+**Teardown is mandatory, not best-effort.** A worktree an agent built in does **not** auto-remove — remove each unit's worktree the moment its PR merges, and run `/worktree-sweep` to reclaim any orphans (including built-in `isolation:"worktree"` worktrees the harness could not auto-reclaim). Leaving built worktrees behind is exactly what filled 237 GB on one repo on 2026-07-13. See `git-worktrees.md`.
 
 **Issue tracking**: Uses `~/code/{log-repo-name}/{repo}/tracking.csv`. Hooks auto-update tracking on branch creation, commits, PR creation, merge, and issue close. See `~/.claude/multi-agent-system.md` for details.
 
-**Workspace model** (preferred for delegated work): Use `/workspace-setup {repo}` to create isolated workspace groups. Each workspace has 4 clones. Point a coordinator agent at a workspace directory - it discovers its clones and delegates.
+**Workspace model** (the heavier clone-based alternative, for the reserved cases above): Use `/workspace-setup {repo}` to create isolated workspace groups. Each workspace has 4 clones. Point a coordinator agent at a workspace directory - it discovers its clones and delegates. Prefer worktrees for ordinary single-machine parallel delegation; reach for the workspace model when you genuinely need persistent per-clone ports, per-branch `tracking.csv`, or long-lived independent agents.
 
 **Cap peak concurrency.** Preferring parallelism does NOT mean launching everything at once. Too many heavy agents firing simultaneously - whether via the Workflow tool's `parallel()`/`pipeline()` or many Agent calls in one message - trips a server-side 429 throttle (`Server is temporarily limiting requests · Rate limited`) that fails the *entire* burst, not just the marginal agent. Keep simultaneous **heavy** agents (Opus, high/max effort, or large-context) to **4** (never exceed 5), launch in waves, and default fan-out agents to cheaper models / lower effort unless thoroughness is explicitly requested. If you have `subagent-patterns` installed, `concurrency-and-rate-limits.md` carries the full defaults table and the throttled-mid-run recovery procedure.
 

--- a/modules/subagent-patterns/rules/subagent-patterns.md
+++ b/modules/subagent-patterns/rules/subagent-patterns.md
@@ -60,6 +60,10 @@ Agent 3: "Write shared validation helpers in src/utils/validate.ts"
 
 Note: If agents share dependencies (Agent 3's output is needed by 1 and 2), run the dependency first, then the dependents in parallel.
 
+### Isolate Parallel Implementers in Worktrees
+
+When parallel implementers modify files, give each its own **git worktree** (`isolation: "worktree"`) — the default isolation for parallel sub-agent delegation on one machine. Each worktree has its own index and HEAD, so agents editing, building, and committing at the same time never collide; this is the structural enforcement of the "no shared state" coordination rule below. Worktrees are ephemeral — created per unit, removed when the unit's PR merges, with `/worktree-sweep` as the orphan backstop. Do **not** spin up extra permanent clones just for parallelism; reserve clones for long-lived independent agents, per-branch dev-server ports, hook-driven per-branch `tracking.csv`, or cross-machine dispatch. **Teardown is mandatory**: a worktree an agent built in does not auto-remove, and forgetting to remove merged worktrees is what filled 237 GB on one repo (2026-07-13). See `git-worktrees.md` and `multi-agent.md`.
+
 **Throttle heavy fan-outs.** Launching too many heavy agents at once (whether via the Workflow tool's `parallel()`/`pipeline()` or multiple Agent calls in one message) trips a server-side 429 throttle that fails the entire burst. Cap simultaneous heavy agents to 4 (never exceed 5), launch in waves, and default fan-out agents to cheaper models / lower effort unless thoroughness is explicitly requested. See `concurrency-and-rate-limits.md` for the defaults, the exact error, and the throttled-mid-run recovery procedure.
 
 ## Pass Paths, Not Contents

--- a/modules/xplan/commands/etp.md
+++ b/modules/xplan/commands/etp.md
@@ -136,17 +136,17 @@ Group independent units into **waves** (parallel within a wave, sequential acros
 ### 1.3 Identify the target repo, isolation, and ceremony level
 
 - Find the target repo (from the plan, the issue's repo, or the cwd).
-- **Isolation**: detect the multi-agent setup - workspace (`~/code/{repo}-workspaces/...`), flat clones (`~/code/{repo}-repos/...`), or single clone. With clones, assign one unit per clone; otherwise give each implementation agent its own **git worktree** (`isolation: "worktree"`) so parallel agents never share a working tree.
-- **"As many agents as makes sense"** = `min(units in this wave, available isolation slots, --max-agents)`. Never spawn more agents than the wave has independent units.
+- **Isolation — worktrees are the default.** Give each parallel implementation agent its own **git worktree** (`isolation: "worktree"`) so they never share a working tree. Worktrees are ephemeral (one per unit, torn down on merge — see 4.4), share the parent `.git`, and reclaim disk automatically. **Do not provision extra permanent clones for parallelism.** Use clones only when the repo *already* has a multi-clone setup you should reuse, or a specific need forces it: per-branch dev-server ports (worktrees share `.env`), hook-driven per-branch `tracking.csv`, multiple long-lived independent agents, or cross-machine dispatch. When an existing workspace/flat-clone setup is present, assign one unit per clone; otherwise (the common case) use worktrees. See `git-worktrees.md`.
+- **"As many agents as makes sense"** = `min(units in this wave, available isolation slots, --max-agents)`. Never spawn more agents than the wave has independent units. With worktrees the "isolation slots" are effectively the concurrency cap (below), not a fixed clone count.
 - **Ceremony scales to the work.** Match the apparatus to the size:
 
   | Target | Waves | Isolation | Bring-up runbook | Checkpoint record |
   |--------|-------|-----------|------------------|-------------------|
-  | Single issue | none (1 unit) | one worktree/clone | only if the issue calls for it | the issue + its PR |
-  | Issue batch | group independents | one per parallel unit | per-issue if any call for it | live GitHub state (re-run reconciles) |
-  | Plan | from the plan | full clone/workspace setup | per the plan (Phase 4.5) | progress file beside the plan |
+  | Single issue | none (1 unit) | one worktree | only if the issue calls for it | the issue + its PR |
+  | Issue batch | group independents | one worktree per parallel unit | per-issue if any call for it | live GitHub state (re-run reconciles) |
+  | Plan | from the plan | worktrees (or an existing clone/workspace setup) | per the plan (Phase 4.5) | progress file beside the plan |
 
-  Do not impose plan-scale ceremony (multi-clone provisioning, wave checkpoints, bring-up runbooks) on a single issue. Do not skip it for a real multi-epic plan.
+  Do not impose plan-scale ceremony (multi-clone provisioning, wave checkpoints, bring-up runbooks) on a single issue. Do not skip it for a real multi-epic plan. Every worktree created here is torn down after its unit merges (4.4) and any leaks are swept at the end (Phase 8) — teardown is mandatory, not best-effort.
 
 ### 1.4 Surface prerequisites and human-only steps (bucket them to the edges)
 
@@ -217,7 +217,7 @@ For each wave, in order (a single issue is a wave of one). This is the core loop
 
 ### 4.1 Implement (parallel within a wave)
 
-Spawn one `implementer` agent per unit (model sonnet), each in its own clone or worktree. Each agent:
+Spawn one `implementer` agent per unit (model sonnet), each in its own **worktree** (`isolation: "worktree"`) — or its assigned clone when the repo uses the multi-clone setup (1.3). Each agent:
 
 > **Concurrency — avoid the 429 throttle.** `implementer` agents run on `sonnet` (light), so a wave of up to ~8 is safe. But the default `--max-agents` (widest wave, clamped to isolation slots) can exceed that in a workspace with many clones — **cap the live wave at 8 light agents, or 4 if you raise `implementer` to a heavier model / higher effort**. If a wave has more units than the cap, split it into sub-waves. Bursting too many heavy agents trips a server-side rate limit (`Server is temporarily limiting requests · Rate limited`) that fails the whole wave; if you hit it, wait 30–60s and re-spawn only the unfinished units in smaller sub-waves. See `~/.claude/rules/concurrency-and-rate-limits.md`.
 - Branches from `origin/main` (`git checkout -b {issue#}-{desc} origin/main` for an issue unit, `{slug}-{desc}` for a plan unit).
@@ -279,9 +279,18 @@ Classify the result:
 
 A PR that cannot be driven green within the bound is treated exactly like a PR frozen at 4.3: blocked, recorded, escalated, and stepped around - not merged, not abandoned silently.
 
-### 4.4 Merge
+### 4.4 Merge and tear down the unit's worktree
 
 Merge a PR only when: it passed review (both stages, or Stage 1 under `--light-review`), CI is **green and mergeable** (verified fresh via 4.35, not assumed), and it does not conflict. Merge in dependency order within the wave. Squash merge (the repo default). Never merge a PR that failed adversarial review or has red/unresolved CI to "keep moving" - that defeats the entire loop.
+
+**Then immediately remove that unit's worktree** (when the unit ran in a worktree, the default). This is mandatory, not best-effort — a built-in worktree does **not** auto-remove, so a merged unit whose worktree lingers is exactly the leak that filled 237 GB in the incident:
+
+```bash
+git worktree remove <unit-worktree-path>   # non-force; the branch ref and its commits survive removal
+git worktree prune
+```
+
+Removing the worktree does not delete the branch or the merged work — only the checkout (and its build tree). If the non-force remove refuses (unexpected for a just-merged clean unit), do not force it blindly; leave it for the Phase 8 sweep to classify. A unit that ran in a reused clone (multi-clone setup) is not a worktree — reset that clone to `origin/main` instead of removing anything.
 
 ### 4.5 Bring-up & integration verification (when applicable)
 
@@ -331,6 +340,7 @@ Loop Phases 4-6 until every condition holds:
 - All PRs merged (or frozen-and-recorded as blocked); all target issues closed by their merged PRs.
 - Every merged PR reached CI-green via the bounded loop (4.35); any PR that could not be driven green within the bound is among the frozen-and-recorded blockers, not silently merged.
 - CI green, no uncommitted changes in any clone, no unexpected open PRs.
+- No merged unit's worktree left behind — each removed at 4.4, and `/worktree-sweep` (Phase 8) reclaimed any leak.
 - All layers confirmed live (where the work has runtime impact); the **autonomous E2E suite is green** against the running system (the plan's §8 suite, or the E2E tests covering a changed issue surface) — the certainty oracle, not a bare smoke test. Any surface a plan's §8.5 names as not-certified is the only acceptable manual residue.
 
 "Don't stop until everything is complete" means: do not stop while completable work remains. Blocked units are set aside with a clear notification; they do not end the run. The run ends when the only thing left is genuinely human-blocked, and the user has been told exactly what each blocker needs.
@@ -346,6 +356,14 @@ gh pr list --state open
 gh issue list --state open
 # per clone: git status; then run the project's test + build
 ```
+
+**Sweep leaked worktrees (mandatory teardown backstop).** Even with per-unit removal at 4.4, a worktree can leak — a unit that errored before its merge-and-remove, a `isolation:"worktree"` worktree the harness could not auto-reclaim because it was built in, an early exit. Run the safe sweep so no worktree outlives the run:
+
+```bash
+/worktree-sweep        # removes only clean worktrees; preserves any with unsaved work; prunes stale metadata
+```
+
+Report what it reclaimed and anything it preserved (a preserved worktree means unsaved work an implementer left behind — surface it, do not force it away). **Run this even when the run exits early** (a blocker halts a unit, a gate stops the run): teardown must not depend on reaching a clean completion — that is the whole lesson of the incident.
 
 ### 8.2 Report to the user
 
@@ -377,6 +395,8 @@ A plan run: mark the progress file `COMPLETE`, or `BLOCKED - WAITING ON HUMAN` w
 **The E2E suite is the completion oracle — no manual testing bounced to the user.** "Done" means the autonomous end-to-end suite is green against the running system, not "I believe it works" or "the user can check." Provision whatever the suite needs — testing agents for flows that can't be asserted programmatically, third-party compute (RunPod, cloud Mac, real devices) as a front-loaded prerequisite; there is no resource constraint on testing. A changed surface without an E2E test gets one before completion (adrev tenet T4 / plan §8). The only manual residue permitted is a surface a plan's §8.5 explicitly names as not-certified.
 
 **Safety on irreversible / outward actions.** Even in autonomous mode, anything destructive or externally-visible that the work did not clearly authorize - production deploys, resource deletion, force-pushing shared branches, sending external communications - requires notifying the user first. The work authorizes its own scope; it does not authorize off-scope irreversible acts.
+
+**Worktree teardown is mandatory.** Parallel units run in ephemeral worktrees by default (1.3). Each is removed the moment its PR merges (4.4), and Phase 8 sweeps any leak (`/worktree-sweep`) — including on early exit. A built-in worktree never auto-removes; leaving merged units' worktrees behind is the exact failure that consumed 237 GB in the incident. Removing a clean worktree never loses committed work (the branch ref survives). Do not force-remove worktrees with unsaved work — the sweep preserves those.
 
 **No AI attribution** in commits or PR bodies (per the git-workflow rule). Use the repo's PR template if one exists.
 

--- a/modules/xplan/commands/xplan-resume.md
+++ b/modules/xplan/commands/xplan-resume.md
@@ -122,9 +122,17 @@ For epics that were in progress when interrupted:
    - Create the PR if work is complete
    - Continue the work if incomplete
 
-### 6. Sync All Clones
+### 6. Sync Isolation State
 
-Before resuming execution, ensure all clones are on latest main:
+If the run used **worktrees** (the single-machine default), reclaim any that leaked when the run was interrupted — a merged epic's worktree that was never removed, or a built-in `isolation:"worktree"` worktree the harness could not auto-reclaim — before resuming:
+
+```bash
+/worktree-sweep    # removes only clean worktrees; preserves any with unsaved in-flight work (see Section 5)
+```
+
+Run the sweep *after* Section 5 has recovered in-flight work, so a worktree holding uncommitted progress is preserved (the sweep never removes a worktree with unsaved changes) rather than swept.
+
+If the run used **clones**, ensure all clones are on latest main:
 ```bash
 for i in 0 1 2 3; do
   dir=~/code/{project-name}-repos/{project-name}-$i

--- a/modules/xplan/commands/xplan.md
+++ b/modules/xplan/commands/xplan.md
@@ -1788,8 +1788,10 @@ options:
    gh repo create {username}/{project-name} --private --description "{description}"
    ```
 
-2. **Create local clones** based on Phase 2.7 decision:
+2. **Provision isolation** based on the Phase 2.7 decision. **On a single machine, worktrees are the default** — each parallel epic gets its own `isolation: "worktree"` worktree (ephemeral, shared `.git`, torn down after its PR merges at 7.3.4). Provision permanent clones only for the cases that actually need them (a large multi-epic plan run under the workspace model, per-branch dev-server ports, hook-driven per-branch `tracking.csv`, or long-lived independent agents). When execution runs via `/etp`, it already applies this worktree-default-with-mandatory-teardown model. See `git-worktrees.md`.
+
    ```bash
+   # Only when Phase 2.7 chose clones (heavier multi-clone plans):
    # Flat clone model:
    mkdir -p ~/code/{project-name}-repos
    for i in 0 1 2 3; do
@@ -1869,6 +1871,7 @@ When all wave agents complete:
 - Verify all PRs are created and passing CI
 - Verify all tests pass, no conflicts between PRs
 - Merge all PRs for the wave
+- **Tear down each merged epic's worktree** (when epics ran in worktrees — the single-machine default; see 7.1). Removal is mandatory: a built-in worktree never auto-removes, and a merged epic whose worktree lingers is the leak that consumed 237 GB in the 2026-07-13 incident. `git worktree remove <path>` (non-force) then `git worktree prune`; the branch ref and merged work survive removal, only the checkout goes. Epics that ran in a reused clone are reset to `origin/main` instead.
 - **Execute the wave's Bring-Up Runbook (plan.md Section 9.1)**: run migrations in order, install new deps, regenerate types, set new env vars/secrets, restart local dev servers, trigger/verify deploys, invalidate caches, load seed data. Do not declare the wave done until every step has run and passed.
 - **Run the full autonomous E2E suite (plan.md Section 8) against the reactivated system** — this supersedes a bare smoke test. Every PR in the wave already passed the E2E suite as a blocking CI check before merge; now the full suite must be green against the integrated system. A wave is NOT done while the E2E suite is red.
 
@@ -2049,16 +2052,25 @@ README structure:
 
 Update agent log with full session summary. Mark progress.md as COMPLETE with final statistics and link to retro.md.
 
-### 8.7 Source Freshness Teardown
+### 8.7 Worktree Teardown
 
-If Phase 0.4.0 created a temp anchor worktree (`--repo` with a remote), remove it now so it does not linger:
+Two kinds of worktree can be left behind; reclaim both here. **Run this whenever the command exits, including early exits** (the user stopped at the Phase 6.5 gate, a blocker halted execution, a gate rejected the plan) — teardown must not depend on reaching a clean completion.
+
+**Execution worktrees** — if the execution phase ran epics in worktrees (the single-machine default, 7.1), each should already have been removed at 7.3.4 when its PR merged. Sweep any that leaked (an errored epic, an early exit, a built-in `isolation:"worktree"` worktree the harness could not auto-reclaim):
+
+```bash
+/worktree-sweep    # removes only clean worktrees, preserves any with unsaved work, prunes stale metadata
+```
+
+**The temp anchor worktree** — if Phase 0.4.0 created one (`--repo` with a remote), remove it explicitly so it does not linger:
 
 ```bash
 git -C "$REPO" worktree remove --force "$WORKTREE" 2>/dev/null
 rmdir "$(dirname "$WORKTREE")" 2>/dev/null
+git -C "$REPO" worktree prune 2>/dev/null   # also reclaims a leaked anchor worktree if this teardown was skipped on a prior early exit
 ```
 
-This is safe to run even if planning ended early (e.g., the user stopped at the Phase 6.5 gate) — run the teardown whenever the command exits after a guard ran. Removing the worktree does not touch the user's clone, branches, or working tree.
+The anchor lives in a temp dir outside the two managed worktree locations, so `/worktree-sweep` will not remove it directly — but its `git worktree prune` step *does* clear the metadata once the temp dir is gone. Removing either kind of worktree does not touch the user's clone, branches, or committed work — only the throwaway checkout.
 
 ---
 

--- a/modules/xplan/commands/xplana.md
+++ b/modules/xplan/commands/xplana.md
@@ -70,6 +70,7 @@ Autonomous mode is where these four plan tenets matter most: there is no human i
 - It does NOT skip the four execution tenets above. The adversarial review enforces minimal edge-bucketed human work (T1), a follow-up-completion contract (T2), enough decision context to direct unplanned work without a human (T3), and a comprehensive autonomous E2E suite over all testable surfaces (T4) — expanding the plan when any is missing.
 - It does NOT skip the final execution gate. 6.5 is non-bypassable.
 - It does NOT automatically proceed to execution. The default recommendation at 6.5 in autonomous mode leans toward "save plan, don't execute yet" so the user can review before committing to multi-agent work.
+- It does NOT leave a worktree behind on that gate-stop path. When `--repo` is set, Phase 0.4.0 creates a temp anchor worktree; because autonomous mode usually stops at the 6.5 gate *without* executing, run the Phase 8.7 worktree teardown on exit anyway (it is explicitly early-exit-safe). If any execution worktrees were created, `/worktree-sweep` reclaims the leaks. Nothing worktree-shaped outlives the run — see `git-worktrees.md`.
 
 For the fast path (reduced depth, minimal interaction), use `/xplan --light` instead.
 


### PR DESCRIPTION
Closes #866.

## What this does for you

Makes **git worktrees the default isolation for parallel sub-agent delegation on a single machine** — replacing extra permanent clones for that purpose — and makes worktree **teardown load-bearing** instead of best-effort. The result: fan out N units across N agents, each in its own ephemeral worktree, and the disk gets reclaimed automatically instead of silently filling up.

### The incident this prevents
On 2026-07-13, delegated work using `isolation: "worktree"` left **33 stale worktrees (~237 GB)** on one repo — each built-in worktree carried a 9–13 GB `.build`. The harness auto-removes a worktree **only if it is unchanged**, so a built-in worktree lingers forever, and nothing mandated removing them after merge or sweeping orphans. (Reproduced live here: this clone had 24 stale `agent-*` worktrees + 2 prunable leftovers.)

## Changes

- **`git-worktrees.md`** — reframed from "solo-agent only, not for parallel" to **the default parallel-delegation isolation**. Adds the delegation lifecycle (one worktree per unit → PR merges → delegator removes it → orphans swept), honest economics (shared `.git` + ephemerality are the win, **not** smaller builds — each worktree still builds its own `.build`), and the codified removal-safety rule with the four incident cases decided.
- **New `/worktree-sweep`** (`commands/worktree-sweep.md` + `lib/worktree-sweep.sh`) — safe repo-wide janitor. Classifies each worktree, removes only **clean** ones with a **non-force** `git worktree remove` (git's own refusal is a second safety gate), prunes stale metadata, and reports. Covers both `.claude/worktrees/` (harness default) and legacy `.worktrees/`. Flags: `--dry-run`, `--conservative` (also preserve clean-but-unmerged branch checkouts), `--all`.
- **`etp` / `xplan` / `xplana` / `xplan-resume` / `mawf`** — worktrees as the default parallel isolation with **mandatory per-merge teardown** + a `/worktree-sweep` backstop that runs **even on early exit / gate-stop**.
- **`multi-agent.md`, `subagent-patterns.md`, `git-workflow.md`** — flipped the default from "separate clones" to "worktrees for parallel delegation on one machine." Clones reserved for the cases a worktree can't serve: per-branch dev-server ports, hook-driven per-branch `tracking.csv`, multiple long-lived independent agents, cross-machine dispatch. Reconciled the `multi-agent-system.md` / `github-repo-protocols.md` framing so nothing contradicts the new default.
- Standardized new worktrees on `.claude/worktrees/` (matches the harness default; one sweep target); regenerated `marketplace.json` + `plugin.json`.

## Removal-safety rule (codified from the incident)
- Prefer **non-force** `git worktree remove`. Pinned on git 2.50.1: a clean worktree with a multi-GB **gitignored** `.build` removes cleanly *without* `--force`; a worktree with uncommitted or untracked-non-ignored content is **refused** by git.
- **PRESERVE** any worktree with uncommitted tracked changes, untracked non-ignored files, or an in-progress rebase/merge/cherry-pick.
- **KEY FACT taught in the docs:** removing a clean worktree never deletes its branch or committed work — the branch ref stays in `.git`; only the checkout (and its build tree) goes. So a clean worktree is *always* safe to remove.

## Verification
- `/worktree-sweep --dry-run` against this clone's **real 27 worktrees**: correctly plans to remove the 24 clean `agent-*` worktrees (~237 MB), prune the 2 gone `xplan-anchor` leftovers, and skip main + current.
- Synthetic repo exercising all four incident cases + more, apply + dry-run + `--conservative` + `--all`: clean feature branch → **remove** (branch preserved); uncommitted → **preserve**; mid-rebase-with-conflict → **preserve**; clean detached → **remove**; clean-but-built → **remove**; interrupted cherry-pick on a clean index → **preserve**; outside-managed-dir clean → **skip** (unless `--all`).
- `bash -n` clean on bash 3.2 (macOS `/bin/bash`) and 5.3.
- `gen_marketplace.py --check` clean; `test_marketplace.sh` (699 checks), `test-no-personal-data.sh`, `test-frontmatter-yaml.sh` all pass. `test-modules.sh` passes except a **pre-existing, unrelated** `orphan-reaper is missing module.json` (missing on `origin/main` too).

Note: this PR ships the tooling; it does not auto-run the destructive sweep on this clone (those 24 branches may belong to sibling sessions). Running `/worktree-sweep` here afterward would reclaim them safely.