### PR TITLE
#868: sync git-worktrees docs after #866 (add /worktree-sweep, update description)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | **compound-knowledge** | workflow | Team-shared learnings in `docs/solutions/`. After solving a non-trivial problem, capture the pattern in a versioned schema | - |
 | **document-review** | workflow | Seven-lens plan-quality gate. /document-review fans out to 7 role-specific reviewers (coherence, feasibility, product, scope, design, security, adversarial) with structured JSON findings | skill-authoring, subagent-patterns |
 | **adversarial-review** | workflow | /adrev - adversarial review of a plan or any entity (file, PR, issue, dir, concept). Separate reviewer agent attacks premises and failure modes; plan targets get findings incorporated automatically and four autonomous-execution tenets enforced (minimal human work, follow-up completion, decision context, comprehensive E2E coverage) unless told not to | subagent-patterns |
-| **git-worktrees** | workflow | Solo-agent worktree-based isolation for feature work. Lighter alternative to multi-clone | - |
+| **git-worktrees** | workflow | Git worktrees as the default isolation for parallel sub-agent delegation on one machine, with a safe janitor (/worktree-sweep) that enforces teardown so worktrees never silently fill the disk | - |
 | **pr-feedback** | workflow | /resolve-pr-feedback - fetches unresolved PR review threads via GraphQL, clusters 3+ items by category, dispatches parallel resolver agents | skill-authoring, subagent-patterns |
 | **todos** | workflow | File-based review-finding tracker. Review findings, PR nitpicks, and tech debt tracked with structured YAML | - |
 | **code-quality** | patterns | Code standards, testing requirements, error handling, security, build verification | - |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1299,9 +1299,9 @@ Installed by the **git-worktrees** module.
 
 ### /worktree-start
 
-**Start a new worktree for solo-agent feature work.**
+**Create a worktree for feature work (hands-on).**
 
-Creates an isolated git worktree in `.worktrees/<branch-name>/` (or `~/code/worktrees/` as fallback), verifies `.worktrees/` is gitignored, detects project type, runs install and a baseline test, and copies local `.env` files from the main checkout. For solo-agent parallel branch work - for multi-agent, use the `multi-agent` module's clone setup.
+Creates an isolated git worktree in `.claude/worktrees/<branch-name>/` (or `~/code/worktrees/` as fallback), verifies the parent is gitignored, detects project type, runs install and a baseline test, and copies local `.env` files from the main checkout. This is the hands-on single-worktree creator; parallel sub-agent delegation uses `isolation: "worktree"` automatically (worktrees are the default isolation — see the git-worktrees module).
 
 **Usage**:
 ```
@@ -1321,6 +1321,22 @@ Ends feature work in a worktree without silently merging, pushing, or discarding
 ```
 /worktree-finish                    # Current directory if it is a worktree
 /worktree-finish <worktree-path>
+```
+
+---
+
+### /worktree-sweep
+
+**Safe repo-wide worktree janitor — the enforced-teardown backstop.**
+
+Enumerates every worktree of the current repo, removes the clean ones with a non-force `git worktree remove` (git's own refusal is a second safety gate), preserves anything with uncommitted changes / untracked files / an in-progress rebase / a detached HEAD whose commits are on no ref, prunes already-gone entries, and reports. Covers `.claude/worktrees/` (harness default) and legacy `.worktrees/`. Removing a clean on-branch worktree never deletes its branch or committed work.
+
+**Usage**:
+```
+/worktree-sweep                 # report + remove clean worktrees in managed dirs
+/worktree-sweep --dry-run       # classify only; remove nothing
+/worktree-sweep --conservative  # also preserve clean worktrees with commits not on the default branch
+/worktree-sweep --all           # also sweep clean worktrees outside the managed dirs
 ```
 
 ---

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -831,11 +831,11 @@ One hostile lens against a plan or any entity, with automatic plan incorporation
 
 ### git-worktrees
 
-Solo-agent worktree-based isolation for feature work.
+Git worktrees as the default isolation for parallel sub-agent delegation on one machine, with a safe janitor that enforces teardown so worktrees never silently fill the disk.
 
-**Installs**: `rules/git-worktrees.md`, `commands/worktree-start.md`, `commands/worktree-finish.md`
+**Installs**: `rules/git-worktrees.md`, `commands/worktree-start.md`, `commands/worktree-finish.md`, `commands/worktree-sweep.md`, `lib/worktree-sweep.sh`
 
-**What it does**: Lighter alternative to the multi-clone setup when only one agent is active. `/worktree-start` creates a new worktree for a feature branch; `/worktree-finish` merges and cleans up. Uses git's native worktree command so the main checkout stays on whatever branch you want.
+**What it does**: Makes git worktrees the default isolation for parallel sub-agent delegation on a single machine (replacing extra permanent clones for that purpose) and makes teardown load-bearing. `/worktree-start` creates a worktree for a feature branch; `/worktree-finish` finishes one via a four-option gate; `/worktree-sweep` is the safe repo-wide janitor that removes clean worktrees, preserves any with unsaved work, and prunes stale metadata. Motivated by a 2026-07-13 incident where built-in worktrees the harness could not auto-reclaim consumed ~237 GB. Reserve permanent clones for per-branch dev-server ports, per-branch `tracking.csv`, long-lived independent agents, or cross-machine dispatch.
 
 **Dependencies**: None
 


### PR DESCRIPTION
Closes #868. Fast-follow documentation sync after #866 (PR #867).

The worktree refactor added `/worktree-sweep` + `lib/worktree-sweep.sh` and rewrote the git-worktrees module description; the reference docs still showed the old "solo-agent, not for parallel" state. This brings them in sync.

## Changes
- **README.md** — git-worktrees module-catalog row updated to the new default-parallel-isolation description.
- **docs/modules.md** — updated description, `Installs` list (now includes `commands/worktree-sweep.md` + `lib/worktree-sweep.sh`), and What-it-does.
- **docs/commands.md** — `/worktree-start` reframed (`.claude/worktrees/`, hands-on vs delegated); new `/worktree-sweep` entry with its flags.

## Scope
Limited to the git-worktrees drift introduced by #866. The pre-existing "74 slash commands" vs 67 command-file count discrepancy predates this work, is not test-enforced (`test-doc-counts` checks module counts only), and is left for a dedicated count-reconciliation pass.

Verified: `test-doc-counts.sh` passes.