### PR TITLE
#874: docupdate after #873 — preset rows, counts, catalog entry, TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ Modular configuration system for [Claude Code](https://docs.anthropic.com/en/doc
 ## Table of Contents
 
 - [What is CCGM?](#what-is-ccgm)
-- [Requirements](#requirements)
 - [Install via agent (paste this)](#install-via-agent-paste-this)
+- [Requirements](#requirements)
 - [Install](#install)
 - [Module Catalog](#module-catalog)
-  - [Companion module: /deepresearch](#companion-module-deepresearch)
 - [Memory System](#memory-system)
 - [Customization](#customization)
 - [Manual Installation](#manual-installation)
@@ -56,7 +55,7 @@ Steps:
 3. Read the available presets: ls ~/code/ccgm/presets/
    Available presets and what they include:
      - minimal  : global-claude-md, autonomy, git-workflow
-     - standard : the above + identity, hooks, settings, commands-core, commands-utility
+     - standard : the above + identity, hooks, branch-guard, model-vetting, settings, commands-core, commands-utility, self-improving, output-formatting, statusline
      - team     : standard core + github-protocols, code-quality, systematic-debugging, verification
      - cloud-agent : large set for power users running autonomous agents
      - full     : every stable module
@@ -132,9 +131,10 @@ For a quick install with a preset:
 | Preset | Modules | Best For |
 |--------|---------|----------|
 | **minimal** | global-claude-md, autonomy, git-workflow | Getting started |
-| **standard** | global-claude-md, autonomy, identity, git-workflow, hooks, branch-guard, settings, commands-core, commands-utility, output-formatting, statusline | Most users |
+| **standard** | global-claude-md, autonomy, identity, git-workflow, hooks, branch-guard, model-vetting, settings, commands-core, commands-utility, self-improving, output-formatting, statusline | Most users |
 | **full** | 70 modules | Power users |
-| **team** | global-claude-md, autonomy, git-workflow, hooks, branch-guard, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification, autoheal, output-formatting, ce-review, pr-feedback, document-review, compound-knowledge (+ deps) | Teams |
+| **team** | global-claude-md, autonomy, git-workflow, hooks, branch-guard, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification, autoheal, output-formatting, ce-review, pr-feedback, pr-review-toolkit, document-review, compound-knowledge (+ deps) | Teams |
+| **cloud-agent** | 54 modules | Autonomous/headless agents |
 
 ### Other install options
 
@@ -361,8 +361,8 @@ The `docs/` directory contains comprehensive documentation:
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
 | [Install via Agent](docs/install-via-agent.md) | Per-preset paste-blocks and how to dry-run them safely |
 | [Module Catalog](docs/modules.md) | Detailed reference for all 74 modules |
-| [Commands Reference](docs/commands.md) | All 74 slash commands with usage examples |
-| [Hooks Reference](docs/hooks.md) | All 18 hooks explained - what they do and when they fire |
+| [Commands Reference](docs/commands.md) | All 76 slash commands with usage examples |
+| [Hooks Reference](docs/hooks.md) | All 23 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |
 | [Configuration](docs/configuration.md) | Customization, template variables, settings overrides |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ The installer offers five presets, or you can select modules one by one:
 |--------|-------------|----------|
 | **minimal** | Core autonomy + git workflow rules | Trying CCGM for the first time |
 | **standard** | Minimal + hooks, settings, core commands | Most individual developers |
-| **team** | Standard + github-protocols, code-quality, debugging, verification | Teams with shared repos |
+| **team** | Standard + github-protocols, code-quality, systematic-debugging, verification | Teams with shared repos |
 | **full** | 70 modules | Power users who want everything |
 | **cloud-agent** | Full minus desktop-only modules, plus agent orchestration | Headless cloud VMs dispatching parallel agents |
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -167,6 +167,18 @@ Security vetting gate for integrating any new AI model — open-weights or hoste
 
 ---
 
+### plugin-marketplace [BETA]
+
+Maintainer tooling that projects CCGM's modules into a native Claude Code plugin marketplace.
+
+**Installs**: `rules/plugin-marketplace.md`, `lib/gen_marketplace.py`, `lib/validate_marketplace.py`, `hooks/plugin-rule-inject.py`
+
+**What it does**: Generates `.claude-plugin/marketplace.json` plus a per-module `plugin.json` from every `modules/*/module.json`, additively — the bash installer remains the canonical full-fidelity install path. Ships the generator, a JSON-schema validator (CI runs `gen_marketplace.py --check` to fail on drift), and a SessionStart rule-injection hook that bridges the plugin-CLAUDE-md-not-loaded gap.
+
+**Dependencies**: None
+
+---
+
 ## Category: commands
 
 Slash commands that extend Claude Code with new capabilities.
@@ -453,6 +465,35 @@ A decision map for CCGM's overlapping command/skill clusters - answers "which on
 
 ---
 
+### youtube-transcripts
+
+`/transcript <url>` - extract a YouTube transcript AND analyze it against your project memory in one invocation.
+
+**Installs**: 1 command file, 1 rule file, 1 shell script (`lib/grab-transcript.sh`), 1 prompt template (`lib/analyze-transcript.md`)
+
+**What it does**: One slash command runs the full pipeline:
+
+- **Phase 1 (deterministic)**: `lib/grab-transcript.sh` calls `yt-dlp` to pull captions, then awk/sed clean the VTT into prose with `>>` speaker turns. Writes `~/code/docs/transcripts/<slug>-<upload_date>.md` with YAML frontmatter (title, source, url, uploader, upload_date, duration, type, caption_source, note).
+- **Phase 2 (latent)**: dispatches a subagent in headless mode that reads the saved transcript + your `MEMORY.md` + workspace `CLAUDE.md`, follows the analysis template, and writes an opinionated 6-section implications doc to `~/code/docs/transcript-analysis/<same-slug>-<upload_date>.md`.
+
+Both filenames share the same slug + upload-date so the pair correlates by name. The analysis is intentionally opinionated and project-specific — it names files, names projects from `MEMORY.md`, and explicitly flags low-confidence claims.
+
+`--no-analysis` skips Phase 2. `mode:headless` suppresses prompts and emits paths only.
+
+The Phase 1 script is callable directly from a shell (`~/.claude/lib/grab-transcript.sh <url>`) for extraction without analysis.
+
+Commands installed:
+
+| Command | Description |
+|---------|-------------|
+| `/transcript <url>` | Extract YouTube transcript + dispatch analysis subagent |
+
+**Requirements**: `yt-dlp` (`brew install yt-dlp` or `pipx install yt-dlp`)
+
+**Dependencies**: None
+
+---
+
 ## Category: workflow
 
 Development workflow patterns and coordination systems.
@@ -585,35 +626,6 @@ Commands installed:
 | Command | Description |
 |---------|-------------|
 | `/atdd` | Build app code to pass vision specs in `e2e/tests/{feature}/` |
-
-**Dependencies**: None
-
----
-
-### youtube-transcripts
-
-`/transcript <url>` - extract a YouTube transcript AND analyze it against your project memory in one invocation.
-
-**Installs**: 1 command file, 1 rule file, 1 shell script (`lib/grab-transcript.sh`), 1 prompt template (`lib/analyze-transcript.md`)
-
-**What it does**: One slash command runs the full pipeline:
-
-- **Phase 1 (deterministic)**: `lib/grab-transcript.sh` calls `yt-dlp` to pull captions, then awk/sed clean the VTT into prose with `>>` speaker turns. Writes `~/code/docs/transcripts/<slug>-<upload_date>.md` with YAML frontmatter (title, source, url, uploader, upload_date, duration, type, caption_source, note).
-- **Phase 2 (latent)**: dispatches a subagent in headless mode that reads the saved transcript + your `MEMORY.md` + workspace `CLAUDE.md`, follows the analysis template, and writes an opinionated 6-section implications doc to `~/code/docs/transcript-analysis/<same-slug>-<upload_date>.md`.
-
-Both filenames share the same slug + upload-date so the pair correlates by name. The analysis is intentionally opinionated and project-specific — it names files, names projects from `MEMORY.md`, and explicitly flags low-confidence claims.
-
-`--no-analysis` skips Phase 2. `mode:headless` suppresses prompts and emits paths only.
-
-The Phase 1 script is callable directly from a shell (`~/.claude/lib/grab-transcript.sh <url>`) for extraction without analysis.
-
-Commands installed:
-
-| Command | Description |
-|---------|-------------|
-| `/transcript <url>` | Extract YouTube transcript + dispatch analysis subagent |
-
-**Requirements**: `yt-dlp` (`brew install yt-dlp` or `pipx install yt-dlp`)
 
 **Dependencies**: None
 


### PR DESCRIPTION
Closes #874

Post-merge /docupdate audit (three parallel read-only agents + deterministic cross-checks) after #873. All fixes are doc-only; most drift was pre-existing.

## Changes
- **README**: standard-preset row and agent-paste block now list the real 13-module preset (were missing `model-vetting`, `self-improving`, and more); team row gains `pr-review-toolkit` (in preset, undocumented); new `cloud-agent` row (54 modules) for parity with getting-started; stale counts fixed (74→76 slash commands, 18→23 hooks); TOC reordered to match body (`Install via agent` before `Requirements`) and made consistently ##-only
- **docs/modules.md**: added missing `### plugin-marketplace [BETA]` entry under core; moved `### youtube-transcripts` from workflow to commands to match its manifest category
- **docs/getting-started.md**: team row `debugging` → `systematic-debugging` (the module actually in the preset)

## Verification
- `tests/test-doc-counts.sh` — all checks passed
- `tests/test-no-personal-data.sh` — pass
- Deterministic catalog cross-check: every `modules/*/module.json` has a catalog entry in its manifest category (`[BETA]` suffix convention respected)
- Preset/count claims verified against `presets/*.json`, `docs/commands.md` (76 `### /` headers), `docs/hooks.md` (23 `###` entries)