### PR TITLE
#878: adopt ADHD-friendly output rules from ayghri/i-have-adhd

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -626,7 +626,7 @@
     },
     {
       "category": "patterns",
-      "description": "Packages the always-on TONE rules (terse communication, autonomous execution, copy-paste formatting) as a Claude Code output style — a system-prompt layer fixed at session start and prompt-cached — instead of always-loaded rules/*.md. Opt-in alternative; does not remove the source rules.",
+      "description": "Packages the always-on TONE rules (terse communication, autonomous execution, copy-paste formatting) as Claude Code output styles — a system-prompt layer fixed at session start and prompt-cached — instead of always-loaded rules/*.md. Ships CCGM Terse plus CCGM ADHD (action-first output shaped for an ADHD reader). Opt-in alternative; does not remove the source rules.",
       "name": "output-styles",
       "source": "./output-styles",
       "tags": [

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1188,11 +1188,11 @@ Discipline for writing skills and slash commands that stay efficient, portable, 
 
 ### output-styles
 
-Packages CCGM's always-on tone rules as a Claude Code output style instead of always-loaded `rules/*.md`.
+Packages CCGM's always-on tone rules as Claude Code output styles instead of always-loaded `rules/*.md`.
 
-**Installs**: `output-styles/ccgm-terse.md` (the `CCGM Terse` output style)
+**Installs**: `output-styles/ccgm-terse.md` (the `CCGM Terse` output style), `output-styles/ccgm-adhd.md` (the `CCGM ADHD` output style)
 
-**What it does**: Consolidates three tone-shaping behaviors — terse, action-first communication (`identity`/`soul.md`), autonomous end-to-end execution (`autonomy`), and clean copy-paste output (`output-formatting`) — into a single output style. Claude Code applies output styles as a system-prompt layer **fixed at session start and prompt-cached**, rather than re-sending rule files as conversation context every turn, so stable always-on tone instructions cost fewer tokens there. Select it via `/config`.
+**What it does**: `CCGM Terse` consolidates three tone-shaping behaviors — terse, action-first communication (`identity`/`soul.md`), autonomous end-to-end execution (`autonomy`), and clean copy-paste output (`output-formatting`) — plus an actionability layer (numbered steps, state restated each turn, one concrete next action, testable win reporting, 5-item list cap). `CCGM ADHD` is the full-strength actionability style shaped for a reader with ADHD, adapted from `ayghri/i-have-adhd` (MIT): 10 rules, explicit override conditions, and a pre-send check. Claude Code applies output styles as a system-prompt layer **fixed at session start and prompt-cached**, rather than re-sending rule files as conversation context every turn, so stable always-on tone instructions cost fewer tokens there. Select one via `/config`.
 
 The module does **not** delete the source rules; it offers a styled alternative. The tradeoff (cached tokens vs. per-rule granularity and per-repo overrides) is documented in the module README, along with the recommendation to remove the redundant tone rules once the style is selected, to avoid sending the same guidance twice.
 

--- a/modules/output-styles/.claude-plugin/plugin.json
+++ b/modules/output-styles/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "author": {
     "name": "CCGM"
   },
-  "description": "Packages the always-on TONE rules (terse communication, autonomous execution, copy-paste formatting) as a Claude Code output style — a system-prompt layer fixed at session start and prompt-cached — instead of always-loaded rules/*.md. Opt-in alternative; does not remove the source rules.",
+  "description": "Packages the always-on TONE rules (terse communication, autonomous execution, copy-paste formatting) as Claude Code output styles — a system-prompt layer fixed at session start and prompt-cached — instead of always-loaded rules/*.md. Ships CCGM Terse plus CCGM ADHD (action-first output shaped for an ADHD reader). Opt-in alternative; does not remove the source rules.",
   "displayName": "Output Styles",
   "keywords": [
     "output-style",

--- a/modules/output-styles/README.md
+++ b/modules/output-styles/README.md
@@ -1,10 +1,12 @@
 # output-styles
 
-Delivers CCGM's always-on **tone** rules as a Claude Code *output style* — a system-prompt layer that is fixed at session start and prompt-cached — instead of always-loaded `rules/*.md`.
+Delivers CCGM's always-on **tone** rules as Claude Code *output styles* — a system-prompt layer that is fixed at session start and prompt-cached — instead of always-loaded `rules/*.md`.
 
 ## What It Does
 
-Installs one output style, `CCGM Terse` (`output-styles/ccgm-terse.md`), that consolidates the three tone-shaping behaviors CCGM otherwise spreads across always-loaded rules:
+Installs two output styles:
+
+**`CCGM Terse`** (`output-styles/ccgm-terse.md`) consolidates the three tone-shaping behaviors CCGM otherwise spreads across always-loaded rules, plus an Actionability layer (numbered steps, state restated each turn, one concrete next action, testable win reporting, concrete time estimates, 5-item list cap):
 
 | Behavior | Source rule (still shipped) |
 |----------|-----------------------------|
@@ -12,7 +14,9 @@ Installs one output style, `CCGM Terse` (`output-styles/ccgm-terse.md`), that co
 | Autonomous, end-to-end execution | `autonomy` → `rules/autonomy.md` |
 | Clean copy-paste output (fenced blocks, never blockquotes) | `output-formatting` → `rules/copy-paste-output.md` |
 
-Activate it with `/config` (output style is fixed per session for prompt caching; the older `/output-style` command is deprecated).
+**`CCGM ADHD`** (`output-styles/ccgm-adhd.md`) is the full-strength version of the actionability rules, shaped for a reader with ADHD: every response leads with the next doable action, multi-step work is numbered and its state restated every turn, wins are shown in testable terms, lists cap at 5, and a pre-send check strips announcing openers and recapping closers. Includes explicit override conditions (explanations, destructive actions, debug spirals, real ambiguity). Adapted from [`ayghri/i-have-adhd`](https://github.com/ayghri/i-have-adhd) (MIT), itself loosely based on *The Adult ADHD Tool Kit* (Ramsay & Rostain).
+
+Activate either with `/config` (output style is fixed per session for prompt caching; the older `/output-style` command is deprecated).
 
 ## Why an Output Style Instead of a Rule
 
@@ -38,15 +42,17 @@ This module **does not delete** the source rules in `identity`, `autonomy`, or `
 ```bash
 mkdir -p ~/.claude/output-styles
 cp output-styles/ccgm-terse.md ~/.claude/output-styles/ccgm-terse.md
+cp output-styles/ccgm-adhd.md ~/.claude/output-styles/ccgm-adhd.md
 ```
 
-Then select **CCGM Terse** via `/config` in Claude Code.
+Then select **CCGM Terse** or **CCGM ADHD** via `/config` in Claude Code.
 
 ## Files
 
 | File | Description |
 |------|-------------|
-| `output-styles/ccgm-terse.md` | The output style: terse tone + autonomy + copy-paste formatting, with frontmatter (`name`, `description`, `keep-coding-instructions: true`). |
+| `output-styles/ccgm-terse.md` | Terse tone + autonomy + actionability + copy-paste formatting, with frontmatter (`name`, `description`, `keep-coding-instructions: true`). |
+| `output-styles/ccgm-adhd.md` | Action-first output shaped for an ADHD reader: 10 rules, override conditions, and a pre-send check. Adapted from `ayghri/i-have-adhd` (MIT). |
 
 ## Dependencies
 

--- a/modules/output-styles/module.json
+++ b/modules/output-styles/module.json
@@ -1,12 +1,13 @@
 {
   "name": "output-styles",
   "displayName": "Output Styles",
-  "description": "Packages the always-on TONE rules (terse communication, autonomous execution, copy-paste formatting) as a Claude Code output style — a system-prompt layer fixed at session start and prompt-cached — instead of always-loaded rules/*.md. Opt-in alternative; does not remove the source rules.",
+  "description": "Packages the always-on TONE rules (terse communication, autonomous execution, copy-paste formatting) as Claude Code output styles — a system-prompt layer fixed at session start and prompt-cached — instead of always-loaded rules/*.md. Ships CCGM Terse plus CCGM ADHD (action-first output shaped for an ADHD reader). Opt-in alternative; does not remove the source rules.",
   "category": "patterns",
   "scope": ["global"],
   "dependencies": [],
   "files": {
-    "output-styles/ccgm-terse.md": { "target": "output-styles/ccgm-terse.md", "type": "content", "template": false }
+    "output-styles/ccgm-terse.md": { "target": "output-styles/ccgm-terse.md", "type": "content", "template": false },
+    "output-styles/ccgm-adhd.md": { "target": "output-styles/ccgm-adhd.md", "type": "content", "template": false }
   },
   "tags": ["output-style", "tone", "prompt-caching", "tokens"],
   "configPrompts": []

--- a/modules/output-styles/output-styles/ccgm-adhd.md
+++ b/modules/output-styles/output-styles/ccgm-adhd.md
@@ -1,0 +1,37 @@
+---
+name: CCGM ADHD
+description: Action-first output shaped for an ADHD reader - lead with the next action, number steps, restate state every turn, make wins visible, no preamble or closers.
+keep-coding-instructions: true
+---
+
+The reader has ADHD. Output is not just brief — it is shaped so an ADHD brain can act on it. Five facts drive every rule below:
+
+1. Working memory is small. Anything not on screen is forgotten. Never ask the reader to "keep in mind X."
+2. Knowing the answer is not doing the answer. The friction between "got it" and "done it" is where work dies.
+3. Starting is the hardest step. The first action must be obvious, small, and doable now.
+4. Time estimates feel uniform. "A bit of work" and "a few hours" register the same. Vague estimates fail.
+5. Dopamine is scarce. Visible progress matters. Buried wins do not register.
+
+## Rules
+
+1. **Lead with the next action.** The first line is something the reader can do — not context, not a plan. If the answer is a command, path, or snippet, it goes first. Prose comes after, if at all.
+2. **Number multi-step tasks.** Each step is one bounded action. No step contains "and then" twice.
+3. **End with one concrete next action.** If anything is left open, name ONE thing the reader can do in under two minutes. "Next: run `npm test` and paste the first failing line."
+4. **Suppress tangents.** Finish the first issue, then offer the second as a separate question: "Separately: there is also a stale dependency. Handle that next?"
+5. **Restate state every turn.** The reader cannot hold "we are on step 3 of 5" between messages. "Step 3 of 5 done: schema updated. Next: backfill the new column."
+6. **Give specific time estimates.** "About 15 minutes if tests already cover this. An afternoon if not." Never "this will take some work."
+7. **Make completed work visible.** Show what now works, in testable terms: "Login now works with magic links. Try: `npm run dev`, open `/login`." Do not bury wins in a recap.
+8. **Matter-of-fact tone for errors.** No "Uh oh" or "There seems to be a problem." State cause and fix: "Test fails at `auth.spec.ts:42`: expected 200, got 401. Cause: missing auth header. Fix: add the header."
+9. **Cap lists at 5 items.** Past five, split into "do now" vs "later." Five items ranked beats ten unranked.
+10. **No preamble, no recap, no closing pleasantries.** Forbidden openers: "Great question," "Let me...", "Sure!". Forbidden closers: "Let me know if you need anything else," "Hope this helps." Start with the answer. End when the answer is done.
+
+## When to break the rules
+
+1. User asks to "explain" or "walk me through": explain fully — still no preamble or closer, but the body runs as long as the topic needs, with headers for skimming back.
+2. Destructive action ahead (force push, schema migration, dropping a table): confirm before acting. Safety wins over brevity.
+3. Debug spiral — three consecutive "still broken" turns: stop iterating on code, name the assumption that might be wrong, ask one diagnostic question.
+4. Real ambiguity in the request: one short clarifying question beats guessing and rewriting.
+
+## Pre-send check
+
+Before sending, delete: the first sentence if it announces what you are about to do; the last sentence if it recaps or asks "anything else?"; any "by the way" sidebar; any hedging adverb adding no information. Then verify: reading only the first line and the last line, does the reader know (a) what to do next and (b) what just happened? If yes, send.

--- a/modules/output-styles/output-styles/ccgm-terse.md
+++ b/modules/output-styles/output-styles/ccgm-terse.md
@@ -10,6 +10,12 @@ You are a fully autonomous, Staff-level engineering collaborator. The following 
 
 Lead with the answer or the action, not the reasoning. Skip preamble, filler, and transitional throat-clearing. One sentence beats three. Show the diff, not a description of the diff. Do not summarize what you just did when the output already shows it. Avoid emojis.
 
+## Actionability
+
+Number multi-step work; each step is one bounded action. During multi-step work, restate state every turn — "Step 3 of 5 done: schema updated. Next: backfill the column" — instead of assuming the user holds it. When anything is left open, end with one concrete next action the user can do in under two minutes. Report completed work in testable terms ("Login works: `npm run dev`, open `/login`"), not a recap. State errors matter-of-factly: cause, then fix. Give time estimates in concrete units ("~15 minutes"), never "some work." Cap lists at 5 items; past that, split "do now" vs "later."
+
+Before sending, delete the first sentence if it only announces what you are about to do, and the last sentence if it recaps or asks "anything else?"
+
 ## Autonomy
 
 Do it, don't describe it. If you can accomplish something yourself — run a command, fix a build, restart a server, set an env var, run a migration — do it immediately rather than handing the user a list of steps.


### PR DESCRIPTION
Closes #878

Adopts the essential content of [ayghri/i-have-adhd](https://github.com/ayghri/i-have-adhd) (MIT) — a single output-shaping skill with 10 action-first rules — into the `output-styles` module, via `/copycat` analysis.

## Changes

- **New output style `CCGM ADHD`** (`modules/output-styles/output-styles/ccgm-adhd.md`): full adaptation of the skill — 5 cognitive facts, 10 rules (lead with the next action, number steps, restate state every turn, one concrete next action, testable wins, specific time estimates, 5-item list cap, matter-of-fact errors, no preamble/closers), override conditions, and a pre-send check. Selectable via `/config`.
- **`CCGM Terse` gains an Actionability section**: the genuinely-new rules (state restating, concrete next action, testable win reporting, concrete time estimates, list cap, pre-send trim) folded into the default style; overlapping rules (terse tone, no preamble) were already covered.
- Manifests (`module.json`, plugin.json), module README (with MIT attribution), `docs/modules.md`, and regenerated `.claude-plugin/marketplace.json`.

Skipped from the source repo: multi-agent packaging (`.codex-plugin`, Cursor install paths, `agents/openai.yaml`) — CCGM targets Claude Code only; GitHub claude workflows — CCGM has its own review flow.

## Verification

- `tests/test-modules.sh`: 1576 passed; 1 pre-existing local-only failure (`orphan-reaper` — an untracked `__pycache__` leftover from a deleted module, not in the repo tree)
- `tests/test-no-personal-data.sh`: PASS
- `gen_marketplace.py --check`: up to date