### PR TITLE
#882: docupdate after #881 — writing-system docs, marketplace regen, README catalog backfill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -971,6 +971,19 @@
       ]
     },
     {
+      "category": "patterns",
+      "description": "Orwell's six writing rules (1946) as an always-on prose standard for docs, PR text, commit messages, reports, and copy, plus a /rewrite command that applies them to existing text. Governs prose only, never code or technical terms.",
+      "name": "writing-system",
+      "source": "./writing-system",
+      "tags": [
+        "communication",
+        "orwell",
+        "prose",
+        "style",
+        "writing"
+      ]
+    },
+    {
       "category": "workflow",
       "description": "Deep research + planning + execution framework. Spawns parallel research/review agents, creates comprehensive plans, and executes via parallel agent waves.",
       "name": "xplan",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Instructions for Claude Code when working on the CCGM (Claude Code God Mode) rep
 
 ## What This Repo Is
 
-CCGM is a modular Claude Code configuration system. It contains 74 modules that users can selectively install to configure Claude Code's behavior, hooks, commands, and permissions.
+CCGM is a modular Claude Code configuration system. It contains 75 modules that users can selectively install to configure Claude Code's behavior, hooks, commands, and permissions.
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Steps:
 3. Read the available presets: ls ~/code/ccgm/presets/
    Available presets and what they include:
      - minimal  : global-claude-md, autonomy, git-workflow
-     - standard : the above + identity, hooks, branch-guard, model-vetting, settings, commands-core, commands-utility, self-improving, output-formatting, statusline
+     - standard : the above + identity, hooks, branch-guard, model-vetting, settings, commands-core, commands-utility, self-improving, output-formatting, writing-system, statusline
      - team     : standard core + github-protocols, code-quality, systematic-debugging, verification
      - cloud-agent : large set for power users running autonomous agents
      - full     : every stable module
@@ -131,9 +131,9 @@ For a quick install with a preset:
 | Preset | Modules | Best For |
 |--------|---------|----------|
 | **minimal** | global-claude-md, autonomy, git-workflow | Getting started |
-| **standard** | global-claude-md, autonomy, identity, git-workflow, hooks, branch-guard, model-vetting, settings, commands-core, commands-utility, self-improving, output-formatting, statusline | Most users |
-| **full** | 70 modules | Power users |
-| **team** | global-claude-md, autonomy, git-workflow, hooks, branch-guard, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification, autoheal, output-formatting, ce-review, pr-feedback, pr-review-toolkit, document-review, compound-knowledge (+ deps) | Teams |
+| **standard** | global-claude-md, autonomy, identity, git-workflow, hooks, branch-guard, model-vetting, settings, commands-core, commands-utility, self-improving, output-formatting, writing-system, statusline | Most users |
+| **full** | 71 modules | Power users |
+| **team** | global-claude-md, autonomy, git-workflow, hooks, branch-guard, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification, autoheal, output-formatting, writing-system, ce-review, pr-feedback, pr-review-toolkit, document-review, compound-knowledge (+ deps) | Teams |
 | **cloud-agent** | 54 modules | Autonomous/headless agents |
 
 ### Other install options
@@ -180,6 +180,9 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | **git-workflow** | core | Git rules: sync before history changes, rebase by default, post-merge cleanup, no AI attribution | - |
 | **settings** | core | Base settings.json with 800+ tool permissions, deny list, plugin config. Defaults to safe 'ask' mode | - |
 | **hooks** | core | Python hooks: issue-first workflow, commit format, branch protection, auto-approval for safe ops | settings |
+| **branch-guard** | core | Hard PreToolUse gate: no edits or git mutations while HEAD is on the default branch. Fires before the first edit | settings |
+| **model-vetting** | core | Security vetting gate for new AI models: weights provenance, format safety, license/data terms, serving path, staged agentic access | - |
+| **plugin-marketplace** [BETA] | core | Maintainer tooling that projects CCGM modules into a native Claude Code plugin marketplace. The bash installer stays canonical | - |
 | **commands-core** | commands | /commit, /pr, /cpm (commit-PR-merge), /gs (git status), /ghi (create issue) | - |
 | **commands-extra** | commands | /audit (codebase audit), /pwv (Playwright verify), /walkthrough, /promote-rule | - |
 | **commands-utility** | commands | /cws-submit (Chrome Web Store walkthrough), /ccgm-sync (sync config to CCGM + lem-deepresearch), /user-test (browser user testing) | - |
@@ -197,6 +200,8 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | **brainstorm** | commands | /brainstorm - design-before-implementation gate: forbids code until a design spec with 2-3 approach tradeoffs is written and user-approved, then hands off to /xplan | - |
 | **research** | commands | /research - multi-channel research using parallel agents with WebSearch, WebFetch, GitHub, Reddit. Zero dependencies.* | - |
 | **youtube-transcripts** | commands | /transcript - extracts a YouTube transcript via yt-dlp AND dispatches a subagent to write an opinionated implications doc against your project memory. One slug+date, two saved files | - |
+| **capability-router** | commands | /capabilities - decision map for CCGM's overlapping command clusters (research, review, planning, debugging, knowledge), plus a tight always-on pointer rule | - |
+| **deepresearch** | commands | /deepresearch - multi-query semantic research via the Exa MCP server: parallel query fan-out synthesized into a structured research.md | - |
 | **github-protocols** | workflow | Issue-first workflow, PR conventions, label taxonomy, code review standards | - |
 | **startup-dashboard** | workflow | Plain-text `/startup` dashboard: git state, tracking claims, live sessions, recent activity (via session-history /recall) | session-history |
 | **session-history** | workflow | `/recall` for unified session transcript history across all clones of a repo; session-historian agent for deeper retrieval | - |
@@ -218,6 +223,13 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | **git-worktrees** | workflow | Git worktrees as the default isolation for parallel sub-agent delegation on one machine, with a safe janitor (/worktree-sweep) that enforces teardown so worktrees never silently fill the disk | - |
 | **pr-feedback** | workflow | /resolve-pr-feedback - fetches unresolved PR review threads via GraphQL, clusters 3+ items by category, dispatches parallel resolver agents | skill-authoring, subagent-patterns |
 | **todos** | workflow | File-based review-finding tracker. Review findings, PR nitpicks, and tech debt tracked with structured YAML | - |
+| **argus** | workflow | /argus - closed-loop visual-ATDD harness: deterministic gates plus a separate judge agent score UI renders against a design spec until convergence | subagent-patterns |
+| **ccgm-doctor** | workflow | Audit tool for Claude Code installs: dangling hook/command refs, lexical overlap between command descriptions, and a routing eval | - |
+| **launch** | workflow | /launch - takes a one-page spec to a deployed Cloudflare Pages site, stopping only for the Connect-to-Git dashboard step | cloudflare, git-workflow, docs-for-agents |
+| **relevance-injection** [BETA] | workflow | Opt-in relevance-scoped rule injection with a tiered always-on safety core. Off by default | hooks |
+| **session-lifecycle** | workflow | /sds - autonomous session shutdown: commit dirty work, update issues, reflect, write a handoff, broadcast to sibling clones | multi-agent, self-improving, git-workflow |
+| **skillify** | workflow | /skillify - promotes an ad-hoc session capability into a durable skill with triggers, an optional helper script, and a pinning test | - |
+| **statusline** | workflow | Compact statusline: model + effort, clone identity, dir + branch, context %, session cost, rate-limit bars | - |
 | **code-quality** | patterns | Code standards, testing requirements, error handling, security, build verification | - |
 | **browser-automation** | patterns | Browser tool selection (Chrome, Playwright, WebMCP), verification priority, UI testing workflow | - |
 | **common-mistakes** | patterns | 8 battle-tested anti-patterns: shallow exploration, dependency blindness, ESLint Fast Refresh, more | - |
@@ -228,6 +240,10 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | **make-interfaces-feel-better** | patterns | Design-engineering details that compound into polished interfaces. Model-invoked skill covering design direction, typography, surfaces, animations, performance | - |
 | **rule-authoring** | patterns | Discipline for writing rules that hold up under pressure. Treats rule authoring as a first-class skill with iron-law structure | - |
 | **skill-authoring** | patterns | Discipline for writing skills and slash commands that stay efficient, portable, and structured across models | - |
+| **docs-for-agents** | patterns | AGENTS.md rule + template: machine-readable docs with copy-pasteable command blocks alongside the human docs | - |
+| **output-formatting** | patterns | Copy-pasteable content goes in fenced code blocks, never blockquotes, so it pastes clean anywhere | - |
+| **output-styles** | patterns | Packages the always-on tone rules as Claude Code output styles - a prompt-cached system-prompt layer instead of per-turn rule files | - |
+| **writing-system** | patterns | Orwell's six rules as the global prose standard for docs, PR text, commits, and reports, plus /rewrite (violations list, then rewrite; mode:landing swap test) | - |
 | **cloudflare** | tech-specific | Pages vs Workers selection, deployment methods, Git integration requirements | - |
 | **supabase** | tech-specific | API key terminology, env var naming, migration validation, database workflow | - |
 | **mcp-development** | tech-specific | Building MCP servers: project structure, tool design, error handling, testing, evaluation patterns | - |
@@ -360,8 +376,8 @@ The `docs/` directory contains comprehensive documentation:
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
 | [Install via Agent](docs/install-via-agent.md) | Per-preset paste-blocks and how to dry-run them safely |
-| [Module Catalog](docs/modules.md) | Detailed reference for all 74 modules |
-| [Commands Reference](docs/commands.md) | All 76 slash commands with usage examples |
+| [Module Catalog](docs/modules.md) | Detailed reference for all 75 modules |
+| [Commands Reference](docs/commands.md) | All 77 slash commands with usage examples |
 | [Hooks Reference](docs/hooks.md) | All 23 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1341,6 +1341,27 @@ Enumerates every worktree of the current repo, removes the clean ones with a non
 
 ---
 
+## Writing system commands
+
+Installed by the **writing-system** module.
+
+---
+
+### /rewrite
+
+**Apply the six writing rules to existing text.**
+
+Single-pass rewrite under the Orwell rules in `rules/writing-system.md`. Lists every violation first - stale phrase, long word with its short replacement, cuttable word, passive construction, jargon - then produces the rewrite. Every fact, number, and name survives unchanged; code blocks, identifiers, and links stay byte-for-byte. `mode:landing` adds two checks for marketing copy: one concrete claim per line, and the swap test (a line a competitor could paste unchanged says nothing - rewrite or delete it). For deep multi-lens review use `/editorial-critique`; this is the cheap pass.
+
+**Usage**:
+```
+/rewrite path/to/file.md              # violations list + rewrite, asks before applying
+/rewrite path/to/file.md --apply      # apply the rewrite to the file
+/rewrite mode:landing hero.md         # add the one-claim-per-line and swap tests
+```
+
+---
+
 ## Skills
 
 Skills are packaged capabilities invokable by name (e.g. `/brainstorm`). Each skill installs to `~/.claude/skills/{name}/SKILL.md` and lives under `modules/<name>/skills/<skill>/SKILL.md` in the CCGM source.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ The installer offers five presets, or you can select modules one by one:
 | **minimal** | Core autonomy + git workflow rules | Trying CCGM for the first time |
 | **standard** | Minimal + hooks, settings, core commands | Most individual developers |
 | **team** | Standard + github-protocols, code-quality, systematic-debugging, verification | Teams with shared repos |
-| **full** | 70 modules | Power users who want everything |
+| **full** | 71 modules | Power users who want everything |
 | **cloud-agent** | Full minus desktop-only modules, plus agent orchestration | Headless cloud VMs dispatching parallel agents |
 
 See [Presets](presets.md) for detailed breakdowns.
@@ -151,7 +151,7 @@ Removes only CCGM-installed files (tracked via a manifest). Your personal files 
 
 ## Next steps
 
-- [Module Catalog](modules.md) - explore all 74 modules in detail
+- [Module Catalog](modules.md) - explore all 75 modules in detail
 - [Commands Reference](commands.md) - learn every slash command
 - [Hooks Reference](hooks.md) - understand the workflow automation
 - [Configuration](configuration.md) - customize CCGM after installation

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,6 @@
 # Module Catalog
 
-CCGM contains 74 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
+CCGM contains 75 modules across 5 categories. Each module is self-contained in `modules/{name}/` with a `module.json` manifest and its content files.
 
 ## How modules work
 
@@ -1055,6 +1055,18 @@ Formatting rules for user-facing output, starting with copy-pasteable content.
 **Installs**: `rules/copy-paste-output.md`
 
 **What it does**: When output is meant to be copy-pasted somewhere else (emails, texts, social posts, bios, form answers, prompts for other tools, config snippets), Claude delivers it in a fenced code block containing exactly the text that should land at the destination - never a blockquote, which renders as a vertical line in the terminal and copies dirty. Commentary stays outside the block; plain text by default, markdown source only when the destination renders markdown.
+
+**Dependencies**: None
+
+---
+
+### writing-system
+
+Orwell's six writing rules (1946) as the always-on prose standard, plus `/rewrite` to apply them to existing text.
+
+**Installs**: `rules/writing-system.md`, `commands/rewrite.md`
+
+**What it does**: Replaces one-word bans ("no delve", "no em dashes") with a writing system. The rule loads in every session and governs prose - docs, READMEs, PR descriptions, commit messages, issue comments, session reports, chat responses, marketing copy - never code, identifiers, or technical terms whose plain-word swap would change the meaning. It adds two workflow subsections: commit/PR prose (plain words, no achievement language, one-read test) and session reports (plain sentences, what changed / what failed / what comes next; no emoji checkmarks, no "Successfully"). `/rewrite [file] [mode:landing] [--apply]` lists every violation (stale phrase, long word with its short replacement, cuttable word, passive construction, jargon), then rewrites, keeping every fact, number, and name unchanged; `mode:landing` adds the swap test for marketing copy. `/editorial-critique` remains the deep multi-lens review; both judge against the same six rules.
 
 **Dependencies**: None
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -19,16 +19,19 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 **Best for**: Most individual developers. The recommended starting point.
 
-**Modules (11)**:
+**Modules (14)**:
 - Everything in **minimal**, plus:
 - `identity` - two foundational context files: soul.md and human-context.md
 - `settings` - base `settings.json` with 800+ pre-configured tool permissions
 - `hooks` - Python hooks for workflow enforcement (branch protection, commit format, auto-approval)
 - `branch-guard` - hard PreToolUse gate: no edits or git mutations while HEAD is on the default branch
+- `model-vetting` - security vetting gate for new AI models before they touch the harness
 - `statusline` - custom status line for Claude Code sessions
 - `commands-core` - essential slash commands (`/commit`, `/pr`, `/cpm`, `/gs`, `/ghi`)
 - `commands-utility` - utility commands (`/cws-submit`, `/ccgm-sync`, `/user-test`)
+- `self-improving` - reflection loop and learnings store (`/reflect`, `/consolidate`)
 - `output-formatting` - copy-pasteable content goes in fenced code blocks, never blockquotes
+- `writing-system` - Orwell's six rules as the prose standard, plus `/rewrite`
 
 **What you get**: Rules, identity context, hooks, commands, and a permissions configuration that lets Claude operate effectively while keeping guardrails on destructive operations.
 
@@ -36,9 +39,8 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 **Best for**: Teams with shared repositories who want consistent practices across contributors.
 
-**Modules (20)**:
-- Everything in **standard** (minus `identity` and `commands-utility`), plus:
-- `branch-guard` - hard PreToolUse gate: no edits or git mutations while HEAD is on the default branch
+**Modules (21)**:
+- Everything in **standard** (minus `identity`, `commands-utility`, `model-vetting`, `self-improving`, and `statusline`), plus:
 - `github-protocols` - issue-first workflow, PR conventions, label taxonomy, code review standards
 - `code-quality` - code standards, testing requirements, error handling, security, build verification
 - `systematic-debugging` - structured 4-phase debugging methodology
@@ -52,7 +54,7 @@ Presets are named collections of modules for quick installation. Each preset is 
 
 **Best for**: Power users who want the complete CCGM experience, including multi-agent coordination, brand research, and tech-specific guides.
 
-**Modules (69)**: Every stable module — `full` is defined as the set of all modules whose `module.json` status is not `beta` or `deprecated`. This includes **autoheal** (continuous self-improvement; opt-in real-time alerts and auto-apply) and `cloud-dispatch`. The only modules omitted are the beta ones (`plugin-marketplace`, `relevance-injection`) and the deprecated `agent-manager`; install those individually via the module selector if you need them.
+**Modules (71)**: Every stable module — `full` is defined as the set of all modules whose `module.json` status is not `beta` or `deprecated`. This includes **autoheal** (continuous self-improvement; opt-in real-time alerts and auto-apply) and `cloud-dispatch`. The only modules omitted are the beta ones (`plugin-marketplace`, `relevance-injection`, `dreaming`) and the deprecated `agent-manager`; install those individually via the module selector if you need them.
 
 **What you get**: The full suite. Includes multi-agent workflows, planning frameworks, tech-specific patterns (Cloudflare, Supabase, Tailwind, shadcn, MCP development), specialized commands, and the autoheal observability loop with three opt-in toggles (`/autoheal-toggle realtime|autoapply|webhook`).
 

--- a/docs/project-story.md
+++ b/docs/project-story.md
@@ -227,16 +227,17 @@ Highlights of the catalog:
 - **Change philosophy** — redesign as if the requirement had been foundational, rather than bolting on.
 - **Common mistakes** — a living record of recurring failure patterns (shallow monorepo exploration, branching without checking open PRs, platform-specific traps) with the concrete behavior change each demands.
 - **Model vetting** — the staged-access security gate for new models (provenance → format safety → license/terms → serving path → staged agentic access from chat-only to sandboxed to reviewed-implementer).
+- **Writing system** — Orwell's six rules (1946) as the always-on prose standard, added July 2026 after the observation that banning AI-tell words one at a time ("no delve", "no em dashes") treats symptoms while every README still ships in the same voice. The rule governs prose only (never code or technical terms), `/rewrite` applies it to existing text, and `/editorial-critique`'s detectors now cite the same six rules as their baseline — one standard, two enforcement points.
 
 ## Command Surface
 
-76 slash commands, grouped:
+77 slash commands, grouped:
 
 | Cluster | Commands |
 |---------|----------|
 | Git & GitHub | `/commit`, `/pr`, `/cpm`, `/gs`, `/ghi` |
 | Planning & execution | `/xplan`, `/xplana`, `/xplan-status`, `/xplan-resume`, `/etp`, `/mawf`, `/ideate`, `/brainstorm` |
-| Review & quality | `/adrev`, `/ce-review`, `/document-review`, `/audit`, `/design-review`, `/editorial-critique`, `/resolve-pr-feedback`, `/scope-drift`, `/ship-ready`, `/pwv` |
+| Review & quality | `/adrev`, `/ce-review`, `/document-review`, `/audit`, `/design-review`, `/editorial-critique`, `/rewrite`, `/resolve-pr-feedback`, `/scope-drift`, `/ship-ready`, `/pwv` |
 | Testing | `/atdd`, `/test-vision`, `/e2e`, `/argus`, `/user-test` |
 | Memory & learning | `/reflect`, `/consolidate`, `/retro`, `/dream`, `/dream-digest`, `/dream-apply`, `/dream-review`, `/dream-scorecard`, `/compound`, `/compound-refresh`, `/skillify` |
 | Autoheal | `/autoheal`, `/autoheal-digest`, `/autoheal-toggle`, `/autoheal-snooze`, `/autoheal-apply`, `/permission-fix`, `/permission-audit` |

--- a/modules/writing-system/.claude-plugin/plugin.json
+++ b/modules/writing-system/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "author": {
+    "name": "CCGM"
+  },
+  "description": "Orwell's six writing rules (1946) as an always-on prose standard for docs, PR text, commit messages, reports, and copy, plus a /rewrite command that applies them to existing text. Governs prose only, never code or technical terms.",
+  "displayName": "Writing System",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py\"",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "communication",
+    "orwell",
+    "prose",
+    "style",
+    "writing"
+  ],
+  "license": "MIT",
+  "name": "writing-system"
+}

--- a/modules/writing-system/hooks/plugin-rule-inject.py
+++ b/modules/writing-system/hooks/plugin-rule-inject.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""SessionStart hook: inject an installed plugin's bundled rules (issue #703).
+
+WHY THIS EXISTS
+---------------
+When CCGM is installed via the native Claude Code plugin marketplace, a plugin's
+root CLAUDE.md is NOT loaded as context, and a plugin can only contribute the
+`agent`/`subagentStatusLine` settings keys. CCGM modules that are rules-only
+(autonomy, code-quality, git-workflow, systematic-debugging, ...) would
+therefore contribute nothing under the plugin path.
+
+This hook is the documented workaround: at fresh session start it reads the
+rules/*.md files bundled in THIS plugin (resolved via ${CLAUDE_PLUGIN_ROOT}) and
+emits them as `additionalContext`, so the plugin's guidance reaches Claude the
+same way the bash installer's ~/.claude/rules/ files do.
+
+The generator (gen_marketplace.py) copies this exact file into every
+rules-bearing plugin's hooks/ directory and wires the plugin.json SessionStart
+hook to call ${CLAUDE_PLUGIN_ROOT}/hooks/plugin-rule-inject.py.
+
+OPT-IN BY DEFAULT
+-----------------
+Injecting full rule bodies costs tokens. To stay conservative and match the
+relevance-injection module's posture (issue #695), this hook is a strict NO-OP
+unless an explicit opt-in flag is set:
+
+    CCGM_PLUGIN_RULE_INJECTION=true   in ~/.claude/.ccgm.env  (or the environment)
+
+With the flag unset, the plugin's commands/agents/skills still work natively;
+only the rule-body injection is suppressed. When the flag is set, the hook emits
+a header plus the concatenated rule files for this one plugin.
+
+SAFETY
+------
+- Fires only on source == "startup" (not resume/compact).
+- Never raises: any failure path returns without emitting, so it can never crash
+  a session.
+- Reads only files inside ${CLAUDE_PLUGIN_ROOT}/rules/; no network, no writes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ENV_FILE = Path.home() / ".claude" / ".ccgm.env"
+FLAG = "CCGM_PLUGIN_RULE_INJECTION"
+
+
+def _read_env_file() -> "dict[str, str]":
+    """Parse ~/.claude/.ccgm.env into a flat dict. Missing file -> {}."""
+    out: "dict[str, str]" = {}
+    if not ENV_FILE.exists():
+        return out
+    try:
+        with open(ENV_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, val = line.split("=", 1)
+                out[key.strip()] = val.strip()
+    except OSError:
+        return {}
+    return out
+
+
+def _truthy(val: "str | None") -> bool:
+    return (val or "").strip().lower() in ("true", "1", "yes")
+
+
+def _flag_enabled() -> bool:
+    """Opt-in flag from the environment first, then ~/.claude/.ccgm.env."""
+    if _truthy(os.environ.get(FLAG)):
+        return True
+    return _truthy(_read_env_file().get(FLAG))
+
+
+def _plugin_root() -> "Path | None":
+    """Resolve the plugin's installed root.
+
+    Prefers $CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin hook processes).
+    Falls back to two levels up from this file (hooks/ -> plugin root) so the
+    hook is testable in-repo without the env var.
+    """
+    env_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p
+    here = Path(__file__).resolve()
+    cand = here.parent.parent  # hooks/<file> -> plugin root
+    return cand if cand.is_dir() else None
+
+
+def _plugin_name(root: Path) -> str:
+    """Best-effort plugin name from .claude-plugin/plugin.json, else dir name."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str) and name:
+                return name
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+    return root.name
+
+
+def _rule_files(root: Path) -> "list[Path]":
+    rules_dir = root / "rules"
+    if not rules_dir.is_dir():
+        return []
+    return sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+
+
+def build_context(root: "Path | None") -> "str | None":
+    """Build the additionalContext block, or None if there is nothing to emit."""
+    if not _flag_enabled():
+        return None
+    if root is None:
+        return None
+    rule_paths = _rule_files(root)
+    if not rule_paths:
+        return None
+
+    name = _plugin_name(root)
+    parts: "list[str]" = [
+        f"<ccgm-plugin-rules plugin=\"{name}\">",
+        "These rules are bundled with the installed CCGM plugin "
+        f"'{name}'. A plugin's CLAUDE.md is not auto-loaded, so they are "
+        "injected here at session start. Treat them as project/global rules.",
+        "",
+    ]
+    for path in rule_paths:
+        try:
+            body = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not body:
+            continue
+        parts.append(f"## rule: {path.name}")
+        parts.append(body)
+        parts.append("")
+    parts.append("</ccgm-plugin-rules>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, EOFError):
+        hook_input = {}
+
+    # Only fire on fresh sessions, matching the other CCGM session-start hooks.
+    if hook_input.get("source", "") != "startup":
+        return
+
+    context = build_context(_plugin_root())
+    if context:
+        sys.stdout.write(context)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #882

Brings the docs and the generated marketplace in line with the writing-system module (#881), and backfills catalog drift the audit surfaced from earlier merges.

Why: the README module catalog had drifted 16 modules behind, and preset/count references were stale in five files. Drift compounds; this closes all of it found by the post-merge /docupdate.

What changed:

- Regenerates the plugin marketplace (gen_marketplace.py): writing-system plugin.json, rule-inject hook, marketplace.json entry
- Adds 16 rows to the README module catalog: writing-system plus the 15 modules missing from earlier merges (argus, branch-guard, capability-router, ccgm-doctor, deepresearch, docs-for-agents, launch, model-vetting, output-formatting, output-styles, plugin-marketplace, relevance-injection, session-lifecycle, skillify, statusline)
- Fixes counts everywhere they appear: 75 modules (README, docs/modules.md, docs/getting-started.md, CLAUDE.md), 77 commands (README, docs/project-story.md), full preset 71
- Fixes docs/presets.md: standard list gains model-vetting and self-improving (missing before #881) plus writing-system; team count and minus-list corrected; full section's beta list gains dreaming
- Adds the writing-system section to docs/modules.md, the /rewrite entry to docs/commands.md, and a short writing-system note to docs/project-story.md

Test plan: `python3 modules/plugin-marketplace/lib/gen_marketplace.py --check` (in sync), `bash tests/test-modules.sh` (1594 pass), `bash tests/test-no-personal-data.sh` (pass), `bash tests/test-installer.sh` (54 pass), plus a script check that no module is missing from the README catalog.

Known drift not fixed here: README's "Companion module: /deepresearch" section still describes the old Ollama+SearXNG pipeline while the module now uses Exa MCP. Needs a decision on how that section should read, so it is left for a follow-up.