### PR TITLE
#885: fix stale /deepresearch docs — describe the bundled Exa module, not the superseded pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,25 +250,21 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | **shadcn** | tech-specific | shadcn/ui patterns: composition, semantic theming tokens, form architecture, accessibility | - |
 | **tailwind** | tech-specific | Tailwind CSS v4 design system: CSS-first config, design tokens, CVA variants, dark mode, responsive grids | - |
 
-*\* `/research` works out of the box with no setup. For higher-quality results, install [/deepresearch](#companion-module-deepresearch) - a local pipeline that's faster, cheaper, and more reliable, but requires additional infrastructure.*
+*\* `/research` works out of the box with no setup. For higher-quality results, install [/deepresearch](#companion-module-deepresearch) - the same fan-out backed by Exa semantic search with full page contents. Needs a free Exa API key.*
 
 ### Companion module: /deepresearch
 
-The `/deepresearch` command is a more powerful research pipeline that lives in its own repo: **[lem-deepresearch](https://github.com/lucasmccomb/lem-deepresearch)**. It replaces `/research`'s parallel subagent approach with a local-first pipeline that produces higher-quality, source-backed research documents.
+`/deepresearch` is the bundled `deepresearch` module: multi-query semantic research over the Exa MCP server. Claude generates diverse queries from your topic, fans them out as parallel Exa tool calls, and synthesizes a structured `research.md` from the full page contents Exa returns. `/xplan` delegates its research phase to it.
 
-**How it works:** Ollama (qwen2.5:72b) generates search queries and extracts facts, SearXNG (self-hosted Docker) runs parallel web searches across Google/Bing/DuckDuckGo, and Claude Code synthesizes everything into a structured research.md. The pipeline is fully local - no external API keys required beyond what Claude Code already uses.
-
-**Why it's separate:** It requires local infrastructure (Docker, Ollama with a ~40GB model, a Python venv) that not every CCGM user will want. But if you use `/xplan`, you'll want this - xplan delegates its research phase to `/deepresearch`.
-
-**Install:**
+**Setup:** an Exa account (free tier: 1000 searches/mo at [exa.ai](https://exa.ai)), `EXA_API_KEY` in your shell, and the Exa MCP server registered once:
 
 ```bash
-git clone https://github.com/lucasmccomb/lem-deepresearch.git
-cd lem-deepresearch
-./install.sh
+claude mcp add --scope user --env EXA_API_KEY="$EXA_API_KEY" -- exa npx -y exa-mcp-server
 ```
 
-The installer sets up SearXNG, Ollama, the Python environment, and copies the command files into `~/.claude/`. See the [lem-deepresearch README](https://github.com/lucasmccomb/lem-deepresearch) for manual setup and troubleshooting.
+Then restart Claude Code and verify with `claude mcp get exa`. Full walkthrough: [modules/deepresearch/README.md](modules/deepresearch/README.md).
+
+**History:** this module supersedes the standalone [lem-deepresearch](https://github.com/lucasmccomb/lem-deepresearch) repo (Ollama + self-hosted SearXNG, fully local). That pipeline degraded as SearXNG's scraped engines hit CAPTCHAs and rate limits; Exa's neural search returns reliable results without scraping.
 
 ## Memory System
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -382,7 +382,7 @@ Installed by the **documentation** module.
 
 ## Research commands
 
-Installed by the **research** module.
+Installed by the **research** and **deepresearch** modules.
 
 ---
 
@@ -409,15 +409,36 @@ Spawns up to 7 parallel research agents that each investigate a topic from a dif
 /research "my topic" --extend ~/docs/research/prior/research.md
 ```
 
-For higher-quality results, install [/deepresearch](https://github.com/lucasmccomb/lem-deepresearch) - a local pipeline that's faster, cheaper, and more reliable.
+For higher-quality results, use `/deepresearch` (below) - the same fan-out backed by Exa semantic search with full page contents.
 
 **Installed by**: research module
 
 ---
 
+### /deepresearch
+
+**Multi-query semantic research over the Exa MCP server.**
+
+Claude generates diverse queries from your topic, fans them out as parallel Exa MCP tool calls (`web_search_exa` and friends), and synthesizes a structured `research.md` from the full page contents Exa returns. Supersedes the standalone lem-deepresearch repo (Ollama + SearXNG); the scraping pipeline degraded, Exa's neural search does not.
+
+**Requires**: an Exa API key (free tier: 1000 searches/mo) and the Exa MCP server registered via `claude mcp add`. Setup walkthrough in `modules/deepresearch/README.md`.
+
+**Depth presets**: Lite (3 queries), Standard (5, default), Full (7)
+
+**Usage**:
+```
+/deepresearch "dark mode browser extensions"
+/deepresearch "SaaS pricing strategies" --depth full
+/deepresearch "React vs Vue" --depth lite --output ~/notes/react-vue.md
+```
+
+**Installed by**: deepresearch module
+
+---
+
 ## Debugging commands
 
-Installed by the **debugging** module. For `/deepresearch`, see [lem-deepresearch](https://github.com/lucasmccomb/lem-deepresearch) (standalone repo, installed separately).
+Installed by the **debugging** module.
 
 ---
 


### PR DESCRIPTION
Closes #885

The README and commands doc still presented /deepresearch as the standalone lem-deepresearch repo (Ollama + self-hosted SearXNG). The bundled deepresearch module superseded that repo: the scraping pipeline degraded as SearXNG's engines hit CAPTCHAs and rate limits, and the module now runs on the Exa MCP server.

What changed:

- Rewrites README's "Companion module: /deepresearch" section around the bundled module: Exa fan-out, setup (free Exa key + claude mcp add + restart), and a History note marking lem-deepresearch as superseded. The heading stays, so the two in-page anchors to it still work.
- Fixes the /research footnote in README and docs/commands.md: points at the bundled module instead of "a local pipeline ... requires additional infrastructure"
- Adds the missing /deepresearch entry to docs/commands.md (Research commands section) and drops the stale lem-deepresearch pointer from the Debugging section intro

Left alone on purpose: /ccgm-sync still syncs to ~/code/lem-deepresearch and its docs mirror that behavior. Whether to remove that sync step is a command-behavior decision, tracked in the issue.

Test plan: `bash tests/test-modules.sh` (1594 pass), `bash tests/test-no-personal-data.sh` (pass), `bash tests/test-installer.sh` (54 pass), plus a grep confirming the only remaining lem-deepresearch references are the history notes and the ccgm-sync behavior docs.