### PR TITLE
#888: strip the vestigial lem-deepresearch sync step from /ccgm-sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -286,7 +286,7 @@
     },
     {
       "category": "commands",
-      "description": "Utility commands and scripts: /cws-submit, /ccgm-sync (reverse-sync local config to CCGM + lem-deepresearch), /user-test, statusline, agent-team launcher.",
+      "description": "Utility commands and scripts: /cws-submit, /ccgm-sync (reverse-sync local config to CCGM), /user-test, statusline, agent-team launcher.",
       "name": "commands-utility",
       "source": "./commands-utility",
       "tags": [

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | **plugin-marketplace** [BETA] | core | Maintainer tooling that projects CCGM modules into a native Claude Code plugin marketplace. The bash installer stays canonical | - |
 | **commands-core** | commands | /commit, /pr, /cpm (commit-PR-merge), /gs (git status), /ghi (create issue) | - |
 | **commands-extra** | commands | /audit (codebase audit), /pwv (Playwright verify), /walkthrough, /promote-rule | - |
-| **commands-utility** | commands | /cws-submit (Chrome Web Store walkthrough), /ccgm-sync (sync config to CCGM + lem-deepresearch), /user-test (browser user testing) | - |
+| **commands-utility** | commands | /cws-submit (Chrome Web Store walkthrough), /ccgm-sync (sync config back to the CCGM repo), /user-test (browser user testing) | - |
 | **ce-review** | commands | /ce-review unified code-review orchestrator. Composes scope-drift, learnings-researcher, tier-sharpener, and review-synthesizer with structured JSON findings | - |
 | **onboarding** | commands | /onboarding - analyzes a repository and generates a structured ONBOARDING.md for new contributors | - |
 | **pr-review-toolkit** | commands | Augments the external pr-review-toolkit plugin with scope-drift detection on top of the standard code/test/comment/silent-failure/type passes | - |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -307,16 +307,15 @@ Walks through the process of packaging and submitting a Chrome extension to the 
 
 ### /ccgm-sync
 
-**Sync local Claude Code config changes back to the CCGM repo and lem-deepresearch repo.**
+**Sync local Claude Code config changes back to the CCGM repo.**
 
-When you've customized files in `~/.claude/` directly, this command syncs those changes back to your local CCGM clone and lem-deepresearch repo, keeping them as the source of truth.
+When you've customized files in `~/.claude/` directly, this command syncs those changes back to your local CCGM clone, keeping it as the source of truth.
 
 **What happens**:
 1. Identifies which CCGM-managed files have been modified locally
 2. Diffs the changes
 3. Copies modified files back into the appropriate `modules/` subdirectories
-4. Checks if deepresearch command or CLI script have changed and syncs to lem-deepresearch repo
-5. Prompts to commit the changes
+4. Prompts to commit the changes
 
 **Usage**:
 ```

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -256,7 +256,7 @@ Miscellaneous utility commands for common workflow tasks.
 | Command | Description |
 |---------|-------------|
 | `/cws-submit` | Guided walkthrough for submitting a Chrome extension to the Chrome Web Store |
-| `/ccgm-sync` | Sync local Claude Code config changes back to CCGM and lem-deepresearch repos |
+| `/ccgm-sync` | Sync local Claude Code config changes back to the CCGM repo |
 | `/user-test` | Browser-based user testing simulation using Chrome automation tools |
 
 **Dependencies**: None

--- a/modules/commands-utility/.claude-plugin/plugin.json
+++ b/modules/commands-utility/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "author": {
     "name": "CCGM"
   },
-  "description": "Utility commands and scripts: /cws-submit, /ccgm-sync (reverse-sync local config to CCGM + lem-deepresearch), /user-test, statusline, agent-team launcher.",
+  "description": "Utility commands and scripts: /cws-submit, /ccgm-sync (reverse-sync local config to CCGM), /user-test, statusline, agent-team launcher.",
   "displayName": "Utility Commands",
   "keywords": [
     "browser",

--- a/modules/commands-utility/README.md
+++ b/modules/commands-utility/README.md
@@ -17,15 +17,15 @@ Handles: extension identification, prerequisites check, store assets preparation
 
 Note: Reads `docs/cws-submission-process.md` in the repo for step-by-step instructions.
 
-### `/ccgm-sync` - Sync Local Config to CCGM + lem-deepresearch
+### `/ccgm-sync` - Sync Local Config to CCGM
 
-Delegates to a Haiku agent to reverse-sync local `~/.claude/` changes back to source repos. Syncs CCGM-managed files to the CCGM repo and deepresearch files to the lem-deepresearch repo. Shows a dry run first, then applies changes.
+Delegates to a cheaper-model agent to reverse-sync local `~/.claude/` changes back to the CCGM repo. Shows a dry run first, then applies changes.
 
 ```
 /ccgm-sync
 ```
 
-Reads CCGM root from `~/.claude/.ccgm-manifest.json`. Checks `~/code/lem-deepresearch` for deepresearch sync.
+Reads CCGM root from `~/.claude/.ccgm-manifest.json`.
 
 ### `/user-test` - Browser-Based User Testing
 

--- a/modules/commands-utility/commands/ccgm-sync.md
+++ b/modules/commands-utility/commands/ccgm-sync.md
@@ -1,5 +1,5 @@
 ---
-description: Sync local Claude Code config changes back to the CCGM repo and lem-deepresearch repo
+description: Sync local Claude Code config changes back to the CCGM repo
 allowed-tools: Agent
 ---
 
@@ -18,12 +18,9 @@ After the agent completes, relay its report to the user exactly as received.
 
 ## Workflow Instructions
 
-Reverse-sync local `~/.claude/` changes back to source repos:
-1. **CCGM repo** - the source of truth for all global Claude Code configs
-2. **lem-deepresearch repo** - the source of truth for the /deepresearch command and CLI script
+Reverse-sync local `~/.claude/` changes back to the **CCGM repo** - the source of truth for all global Claude Code configs.
 
 **CCGM root**: Read from `~/.claude/.ccgm-manifest.json` -> `ccgmRoot` field.
-**lem-deepresearch root**: `~/code/lem-deepresearch` (if it exists).
 
 ### 0. Broken Symlink Check
 
@@ -58,74 +55,16 @@ bash ~/.claude/scripts/ccgm-sync.sh
 
 This copies local changes back to CCGM module directories, commits, and pushes.
 
-### 3. Deepresearch Sync
-
-Check if the local deepresearch files have changed compared to the lem-deepresearch repo:
-
-```bash
-DEEPRESEARCH_REPO="$HOME/code/lem-deepresearch"
-
-if [ -d "$DEEPRESEARCH_REPO" ]; then
-  CHANGED=false
-
-  # Check command file
-  if [ -f "$HOME/.claude/commands/deepresearch.md" ] && [ -f "$DEEPRESEARCH_REPO/deepresearch.md" ]; then
-    if ! diff -q "$HOME/.claude/commands/deepresearch.md" "$DEEPRESEARCH_REPO/deepresearch.md" &>/dev/null; then
-      echo "CHANGED: deepresearch.md (command file)"
-      CHANGED=true
-    fi
-  fi
-
-  # Check CLI script
-  if [ -f "$HOME/.claude/bin/deepresearch-cli.py" ] && [ -f "$DEEPRESEARCH_REPO/bin/deepresearch-cli.py" ]; then
-    if ! diff -q "$HOME/.claude/bin/deepresearch-cli.py" "$DEEPRESEARCH_REPO/bin/deepresearch-cli.py" &>/dev/null; then
-      echo "CHANGED: bin/deepresearch-cli.py (CLI script)"
-      CHANGED=true
-    fi
-  fi
-
-  if [ "$CHANGED" = true ]; then
-    echo "Syncing deepresearch changes to lem-deepresearch repo..."
-  else
-    echo "lem-deepresearch is in sync."
-  fi
-fi
-```
-
-If changes were detected:
-
-1. Copy the changed files from `~/.claude/` to the lem-deepresearch repo:
-   - `~/.claude/commands/deepresearch.md` -> `$DEEPRESEARCH_REPO/deepresearch.md`
-   - `~/.claude/bin/deepresearch-cli.py` -> `$DEEPRESEARCH_REPO/bin/deepresearch-cli.py`
-2. **Fix the shebang** in the copied CLI script - replace any user-specific venv path with the portable `#!/usr/bin/env python3`:
-   ```bash
-   if head -1 "$DEEPRESEARCH_REPO/bin/deepresearch-cli.py" | grep -q "research-tools-venv"; then
-     sed -i '' '1s|^#!.*|#!/usr/bin/env python3|' "$DEEPRESEARCH_REPO/bin/deepresearch-cli.py"
-   fi
-   ```
-3. Commit and push:
-   ```bash
-   cd "$DEEPRESEARCH_REPO"
-   git add -A
-   if ! git diff --cached --quiet; then
-     ALLOW_MAIN_COMMIT=1 git commit -m "sync: update deepresearch from local config ($(date +%Y-%m-%d))"
-     ALLOW_MAIN_COMMIT=1 git push origin main
-   fi
-   ```
-
-If `~/code/lem-deepresearch` does not exist, skip this step silently (the user may not have the repo cloned).
-
-### 4. Report Results
+### 3. Report Results
 
 Tell the user:
 - Which broken symlinks were found and fixed (if any)
 - Which CCGM module files were updated (if any)
-- Which deepresearch files were updated (if any)
 - Which files are unmanaged (not tracked by any CCGM module)
-- Whether changes were committed and pushed to each repo
+- Whether changes were committed and pushed
 - The current sync status
 
-### 5. Run /docupdate (if CCGM files changed)
+### 4. Run /docupdate (if CCGM files changed)
 
 If any files were synced back to CCGM (step 2 made changes), run `/docupdate` to catch any documentation drift introduced by those changes.
 

--- a/modules/commands-utility/module.json
+++ b/modules/commands-utility/module.json
@@ -1,7 +1,7 @@
 {
   "name": "commands-utility",
   "displayName": "Utility Commands",
-  "description": "Utility commands and scripts: /cws-submit, /ccgm-sync (reverse-sync local config to CCGM + lem-deepresearch), /user-test, statusline, agent-team launcher.",
+  "description": "Utility commands and scripts: /cws-submit, /ccgm-sync (reverse-sync local config to CCGM), /user-test, statusline, agent-team launcher.",
   "category": "commands",
   "scope": ["global"],
   "dependencies": [],


### PR DESCRIPTION
Closes #888

Follow-up to #885. /ccgm-sync still treated ~/code/lem-deepresearch as the source of truth for the /deepresearch command and synced two files back to it. Both targets are vestigial: the command's source of truth is modules/deepresearch/ in CCGM, and bin/deepresearch-cli.py belongs to the old pipeline the Exa module does not ship.

What changed:

- Removes the "Deepresearch Sync" step from the /ccgm-sync command and renumbers the remaining steps; the workflow now targets the CCGM repo only
- Drops the deepresearch report bullet and the lem-deepresearch root lookup
- Updates the commands-utility module description and README to match
- Regenerates the plugin manifests (plugin.json + marketplace.json) from the changed module.json
- Fixes the mirroring doc surfaces: /ccgm-sync entries in docs/commands.md and docs/modules.md, and the commands-utility row in the README catalog

The only remaining lem-deepresearch references are the two intentional history notes from #886.

Test plan: `bash tests/test-modules.sh` (1594 pass), `bash tests/test-no-personal-data.sh` (pass), `bash tests/test-installer.sh` (54 pass), `gen_marketplace.py` regenerated clean, and a repo grep confirming only the history notes remain.