### PR TITLE
#894: document the 12 missing stable commands and hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,8 +374,8 @@ The `docs/` directory contains comprehensive documentation:
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
 | [Install via Agent](docs/install-via-agent.md) | Per-preset paste-blocks and how to dry-run them safely |
 | [Module Catalog](docs/modules.md) | Detailed reference for all 76 modules |
-| [Commands Reference](docs/commands.md) | All 78 slash commands with usage examples |
-| [Hooks Reference](docs/hooks.md) | All 24 hooks explained - what they do and when they fire |
+| [Commands Reference](docs/commands.md) | All 83 slash commands with usage examples |
+| [Hooks Reference](docs/hooks.md) | All 31 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |
 | [Configuration](docs/configuration.md) | Customization, template variables, settings overrides |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -882,6 +882,29 @@ Every plan is engineered to execute with minimal human involvement (human work b
 
 ---
 
+### /xplana
+
+**Autonomous xplan - the same pipeline with no mid-flow prompts.**
+
+Thin alias for `/xplan --autonomous`. Runs research, naming, tech stack, scope, multi-agent setup, plan creation, the full standard review, the self-review loop, and all three sequential adversarial review passes end to end, then presents the finished plan as a structured artifact at a single final gate.
+
+Depth is identical to `/xplan`. The difference is where you spend your attention: `/xplan` asks at each phase boundary, `/xplana` asks once, at the end. Use it when you would have approved every gate anyway, or when you want to start a plan and walk away. Use `/xplan` when you expect to redirect it mid-flight - once `/xplana` is running, the next decision point is the final artifact.
+
+**Flags**:
+- `--repo <path>` - Analyze and plan work for an existing repo
+- `--deepen [<plan-dir>]` - Load an existing plan and run targeted deepening passes instead of planning fresh
+
+**Usage**:
+```
+/xplana "Build a SaaS dashboard with auth, billing, and analytics"
+/xplana "Add offline sync" --repo ~/code/myapp
+/xplana --deepen ~/code/plans/my-feature
+```
+
+**Installed by**: xplan module
+
+---
+
 ### /xplan-status
 
 **Check progress on a running or completed xplan.**
@@ -1311,6 +1334,37 @@ Generates 5-10 adversarial scenarios targeting a rule's discipline, dispatches s
 
 ---
 
+## Skillify commands
+
+Installed by the **skillify** module.
+
+---
+
+### /skillify
+
+**Promote a session capability into a durable skill.**
+
+Takes a multi-step process that just worked in conversation and makes it permanent: a command file with triggers and rules, deterministic code for the parts that need no judgment, a test that pins the behavior, and a learnings-store entry so later sessions find it.
+
+The split between prose and code is the point. Steps that need judgment stay as instructions; steps with one right answer become a helper script the skill calls, with a test around it. A process that lives only in a transcript is gone next session.
+
+**Reach for it when**:
+- A multi-step process just worked and is likely to recur (an OAuth setup, a deploy sequence, a verification ritual)
+- The agent made a mistake that should be structurally impossible to repeat
+- You said some version of "remember this" or "make that a skill"
+
+Takes an optional kebab-case name for the new skill. With no argument it proposes one from what just happened and confirms before writing any files.
+
+**Usage**:
+```
+/skillify
+/skillify cloudflare-pages-setup
+```
+
+**Installed by**: skillify module
+
+---
+
 ## Git worktrees commands
 
 Installed by the **git-worktrees** module.
@@ -1482,6 +1536,35 @@ Walks every doc under `docs/solutions/**/*.md` and classifies each as Keep / Upd
 
 ---
 
+### /compound-reproject
+
+**Generate derived artifacts from existing `docs/solutions/` entries.**
+
+Reads the solutions already captured by `/compound` and projects them into a new shape without touching the source files. Four projection types:
+
+| Type | What it produces |
+|------|------------------|
+| `qa` | Question-and-answer pairs drawn from the entries |
+| `contradictions` | Entries that disagree with each other, made explicit |
+| `summary` | A restructured alternative summary of the set |
+| `outline` | A synthesized narrative outline across entries |
+
+Output lands in `docs/solutions/_reprojections/{type}-{timestamp}.md` with source IDs kept on every derived claim, so anything in a projection traces back to the entry it came from. Source entries are never mutated - a bad projection is deleted, not reverted.
+
+`type:` is required. `tag:` filters source entries by frontmatter tag (repeatable, any-match), `n:` caps how many entries are read (default 50), and `topic:` biases selection after the tag filter.
+
+**Usage**:
+```
+/compound-reproject type:qa tag:supabase
+/compound-reproject type:contradictions n:30
+/compound-reproject type:outline topic:authentication
+/compound-reproject type:summary tag:migrations tag:postgres
+```
+
+**Installed by**: compound-knowledge module
+
+---
+
 ### /argus
 
 **Visual-ATDD convergence loop.**
@@ -1566,6 +1649,26 @@ Takes a loose, half-formed idea and interviews you until the concept is sharp en
 
 ---
 
+### /launch
+
+**One-page spec to a deployed Cloudflare Pages site.**
+
+Ten phases, run end to end: pre-flight, parse the spec, create the GitHub repo, scaffold, implement the deliverables, push, create the Pages project via Connect-to-Git, provision secrets, optionally attach a custom domain, then verify and report. Default scaffold is Vite + React + TypeScript; the spec can override it.
+
+The skill stops exactly once, for the Cloudflare Connect-to-Git dashboard step, which needs your browser session. That stop is deliberate and not worked around: `/launch` never runs `wrangler pages deploy <new-name>` to create a project, because a direct-upload Pages project cannot be given Git integration afterward. Recovering from that mistake means deleting the project and migrating domains, env vars, and bindings to a replacement.
+
+**Modes**: interactive (default), `mode:dry-run`. Dry-run prints every `gh`, `git`, `npm`, `wrangler`, and `curl` command that would run, in order, with the inputs each would receive, and executes nothing - no repos created, no files written, no deployments. Use it to check the skill against a spec before spending a real Cloudflare project.
+
+**Usage**:
+```
+/launch path/to/spec.md
+/launch path/to/spec.md mode:dry-run
+```
+
+**Installed by**: launch module
+
+---
+
 ### /make-interfaces-feel-better
 
 **Design-engineering principles for polished interfaces.**
@@ -1578,6 +1681,27 @@ Reference skill for making interfaces feel polished. Covers concentric border ra
 ```
 
 **Installed by**: make-interfaces-feel-better module
+
+---
+
+### /pr-description
+
+**Write a PR title and body. Nothing else.**
+
+Takes a PR reference or the current branch, reads the diff, the commits, the linked issue, and the repo's PR template if one exists, and returns a structured `{title, body}` in CCGM voice: value first, then the concrete changes, then how it was verified.
+
+It does not call `gh pr create` or `gh pr edit`. That separation is what makes it composable - `/pr` and `/cpm` call it for the prose and keep the publishing to themselves, and any other caller can do the same without inheriting a side effect it did not ask for.
+
+Accepts a PR as a bare number, `#561`, `pr:561`, a full GitHub URL, or a branch name; with no argument it uses the current branch. Free-text is treated as a steering hint and can be combined with any of those, so `pr:561 emphasize the perf numbers` means "PR #561, lean on perf." When no PR exists yet it works off `origin/main...HEAD`, so a caller can preview the body before pushing.
+
+**Usage**:
+```
+/pr-description                              # current branch
+/pr-description 893                          # a specific PR
+/pr-description pr:561 emphasize the benchmarks
+```
+
+**Installed by**: commands-core module
 
 ---
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -18,7 +18,7 @@ Hooks are registered in `settings.json` under the `hooks` key. Each hook specifi
 
 ## Installed hooks
 
-The **hooks** module installs 15 hooks, 6 Python libraries, and a settings partial. The **self-improving** module installs 3 additional hooks, the **branch-guard** module 1, and the **ask-context** module 1. Total: 20 hooks across 4 modules (the **autoheal** module's observational hooks are documented in their own section below).
+The **hooks** module installs 15 hooks, 6 Python libraries, and a settings partial. Seven other modules add the rest: **self-improving** 3, **subagent-patterns** 2, and one each from **branch-guard**, **ask-context**, **startup-dashboard**, **commands-preamble**, and **relevance-injection**. Total: 25 hooks across 8 modules (the **autoheal** module's 6 observational hooks are documented in their own section below, bringing the installed total to 31).
 
 ---
 
@@ -321,6 +321,127 @@ Hard gate ensuring every AskUserQuestion carries visible decision context. The u
 Experimental (OFF by default). Injects a rule-enforcement meta-instruction at fresh session start, reminding the agent to route through the discipline rules (TDD, systematic-debugging, verification) as real gates.
 
 **Opt in**: Set `CCGM_RULE_ENFORCEMENT=true` in `~/.claude/.ccgm.env`. Fires only on `source == "startup"`, not on resume or compaction.
+
+---
+
+### pretooluse-bash-dispatch.py
+
+**Type**: PreToolUse:Bash
+**Module**: hooks
+**Can block**: Yes (hard block, deny, allow, or ask)
+
+The default PreToolUse:Bash handler, and the single process every Bash command passes through. It replaces what used to be a six-process chain (`enforce-git-workflow` → `auto-approve-bash` → `port-check` → `agent-tracking-pre` → `check-migration-timestamps` → `check-careful`) with one process that runs the same checks in-process, by priority.
+
+Two things this buys over the old chain. Each command previously spawned six Python interpreters in sequence, each re-importing `hook_utils` and re-parsing stdin. And precedence was an emergent property of array order in `settings.json` across modules that knew nothing about each other; it is now declared.
+
+**Declarative manifest** (priority order mirrors the legacy registration order):
+
+| Priority | Check | Decisions | Runs in bypass | Short-circuit |
+|----------|-------|-----------|----------------|---------------|
+| 10 | `git_workflow_check` | hard_block / advisory | Yes | No |
+| 20 | `destructive_check` | hard_block | Yes | Yes |
+| 30 | `smart_rules_check` | hard_block / allow | Yes | Yes |
+| 40 | `port_advisory_check` | advisory | No | No |
+| 50 | `agent_tracking_check` | advisory | No | No |
+| 60 | `migration_timestamp_check` | hard_block | Yes | No |
+| 70 | `force_push_main_check` | hard_block | Yes | No |
+| 80 | `careful_check` | ask | No | No |
+| 90 | `pattern_check` | deny / allow | No | No |
+
+**Precedence**: `hard_block` > `deny` > `allow` > `ask`. The first `hard_block` wins and exits 2, the only signal Claude Code honors regardless of permission mode. Advisory output never affects the decision and is flushed for every check that produced it.
+
+**Bypass mode**: a check declaring `runs_in_bypass=False` is skipped in bypass mode, matching the legacy hooks that exited early there. The destructive set, data-integrity blocks, and protected-branch enforcement declare `runs_in_bypass=True` and run above that short-circuit.
+
+**Reverting**: the six standalone hooks stay installed and individually runnable. Restoring their six PreToolUse:Bash entries in `settings.json` returns the legacy path.
+
+**Equivalence**: `modules/hooks/tests/test-dispatcher.sh` runs both paths over an adversarial command battery across all four permission modes and asserts identical decisions on all 224 (command × mode) pairs. Run it through that script, not `equivalence_harness.py` directly - the harness needs the fixture `HOME` the script builds.
+
+---
+
+### sync-ccgm-canonical.py
+
+**Type**: PostToolUse:Bash
+**Module**: hooks
+**Can block**: No
+
+Keeps the canonical CCGM checkout current after a CCGM PR merges. `~/.claude/` symlinks point at one canonical clone; when PRs merge from workspace clones, that checkout drifts until something pulls it.
+
+**Fires when all three hold**:
+- The Bash command invokes `gh pr merge` in any segment (it is usually chained after a `cd`, so the hook scans segments rather than the first token)
+- The cwd's git remote points at a repo named `ccgm`, any owner
+- The canonical clone exists at `$CCGM_CANONICAL_DIR` (default `~/code/ccgm`)
+
+Runs `git fetch origin main && git pull --ff-only origin main` there, logs the result to stderr, and always exits 0. A failed sync never blocks the merge.
+
+---
+
+### auto-startup.py
+
+**Type**: SessionStart (matcher `startup|resume`)
+**Module**: startup-dashboard
+**Can block**: No (context injection only)
+
+Prompts Claude to run `/startup` on fresh sessions and surfaces recent handoffs left by other clones of the same repo.
+
+Fires only when `source == "startup"`. It stays silent on `resume` on purpose, so a resumed session picks up mid-task instead of being pushed into a dashboard render.
+
+**Also does**: prunes handoffs older than 30 days for the current repo, opportunistically.
+
+**Gated by**: `CCGM_AUTO_STARTUP` in `~/.claude/.ccgm.env`. Disable by setting it to `false` or removing it.
+
+---
+
+### inject-preamble.py
+
+**Type**: UserPromptSubmit
+**Module**: commands-preamble
+**Can block**: No (context injection only)
+
+Experimental, opt-in, off by default. Prepends a compact preamble of iron-law principles to slash-command prompts.
+
+Rules in `~/.claude/rules/` cover the main conversation thread, but a slash command expands into its own context and can drift from principles that should be active from the first token rather than whenever the agent next rereads `CLAUDE.md`. This hook puts a distilled version in front of the command at invocation time.
+
+**Enable**: `touch ~/.claude/preamble.enabled`. Remove that file to disable; without it the hook exits silently and the prompt is unchanged. Content lives at `~/.claude/preamble/preamble.md` and is read at runtime, so edits take effect with no rebuild.
+
+---
+
+### relevance-inject.py
+
+**Type**: SessionStart (matcher `startup`)
+**Module**: relevance-injection
+**Can block**: No (context injection only)
+
+Opt-in and off by default. CCGM installs every selected module's rules to `~/.claude/rules/`, where Claude Code auto-loads all of them every session. This hook offers an alternative: surface a pointer to the subset relevant to the current task profile, with a safety core that is always included.
+
+**Safety properties**, in the order they matter:
+- With `CCGM_RELEVANCE_INJECTION` unset in `~/.claude/.ccgm.env` — the default on every install — the hook reads stdin, finds no flag, and returns without emitting anything. The normal all-rules-loaded behavior is untouched.
+- It only ever adds a pointer. It never deletes a rule file and never suppresses the auto-load path.
+- The pointer is `additionalContext`, not authority. Every rule file stays on disk and stays loadable; the pointer biases attention, it does not gate access.
+- Fires only on `source == "startup"`, not resume or compaction.
+
+---
+
+### subagent-stop-check.py
+
+**Type**: SubagentStop
+**Module**: subagent-patterns
+**Can block**: Yes (one narrow case)
+
+Blocks only when a subagent's last assistant message is empty or whitespace-only. Allows everything else, and allows immediately when `stop_hook_active` is set, for loop protection.
+
+An earlier version called Haiku on every subagent stop to judge whether the agent had finished its task. It over-blocked, because the hook input carries too little transcript context for that judgment, and it added up to 15 seconds per stop event. Completion discipline belongs upstream, in the subagent-patterns rules (the DONE / DONE_WITH_CONCERNS / BLOCKED / NEEDS_CONTEXT protocol) and in the reviewer agents — not in static analysis of a single message.
+
+---
+
+### task-completed-check.py
+
+**Type**: TaskCompleted
+**Module**: subagent-patterns
+**Can block**: No (always allows)
+
+Always allows completion. Writes a stderr warning when the task description is empty or placeholder-like (`todo`, `tbd`, `wip`, and similar), but never blocks on it.
+
+The slot is kept registered so deterministic logic can be added later — telemetry, description linting — without a new registration. Like `subagent-stop-check.py`, this replaced a Haiku-backed version that blocked legitimate completions from inputs (`task_subject`, `task_description`) that cannot support the judgment.
 
 ---
 


### PR DESCRIPTION
Closes #894

The post-merge `/docupdate` audit after #893 found both reference docs undercounting: `docs/commands.md` documented 78 commands with 10 missing entirely, and `docs/hooks.md` documented 24 hooks with 7 missing. This closes the stable-module half of that gap.

## Commands (+5)

`/xplana`, `/skillify`, `/compound-reproject`, `/launch`, `/pr-description`.

`/xplana` is the one that prompted this: it was invisible in every reference doc, which is why it read as a missing module rather than a command inside `xplan`. Its section spells out the actual tradeoff against `/xplan` — same depth, one gate at the end instead of gates throughout, so use `/xplan` when you expect to redirect it mid-flight.

The 5 beta `dreaming` commands (`/dream`, `/dream-apply`, `/dream-digest`, `/dream-review`, `/dream-scorecard`) are deliberately out of scope; that module is still beta and its surface may move.

## Hooks (+7)

`pretooluse-bash-dispatch.py`, `sync-ccgm-canonical.py`, `auto-startup.py`, `inject-preamble.py`, `relevance-inject.py`, `subagent-stop-check.py`, `task-completed-check.py`.

The dispatcher is the significant one. It is the **default** PreToolUse:Bash handler — every shell command in every session passes through it — and it had no entry at all. Its section documents the priority manifest, the `hard_block > deny > allow > ask` precedence, which checks survive bypass mode and which stand down, how to revert to the legacy six-process chain, and the 224/224 equivalence result plus the warning to run it via `test-dispatcher.sh` rather than the harness directly.

The two `subagent-patterns` hooks both document why they are deliberately near-no-ops: each replaced a Haiku-backed version that over-blocked from inputs too thin to support the judgment.

## Accuracy

Every usage block is taken from the source file's own argument parsing rather than reconstructed from the description. Three of my first drafts were wrong and got fixed against source:

| Command | Wrong | Actual |
|---|---|---|
| `/compound-reproject` | `/compound-reproject qa` | `type:qa`, plus optional `tag:` / `n:` / `topic:` |
| `/launch` | `--dry-run` | `mode:dry-run` |
| `/skillify` | free-text description | optional kebab-case skill name |

## Counts

83 commands, 31 hooks. The `Installed hooks` intro said 20 hooks across 4 modules; it is 25 across 8, plus autoheal's 6. The derived checks added in #893 enforce both README claims, so these cannot drift silently again.

## Verification

```
tests/run-all.sh          13 passed, 0 failed  (incl. /audit suite 33 passed)
tests/test-doc-counts.sh  all checks passed -- derived 83 commands / 31 hooks
internal links            0 broken across 15 doc files
coverage re-check         hooks: none undocumented; commands: only the 5 beta dreaming ones
```