### PR TITLE
#901: orrery Epic 2 — deterministic ingestion core (anchor + census)

### DIFF
--- a/modules/orrery/module.json
+++ b/modules/orrery/module.json
@@ -10,6 +10,8 @@
     "agents/orrery-scout.md": { "target": "agents/orrery-scout.md", "type": "agent", "template": false },
     "skills/orrery/references/fragment.schema.json": { "target": "skills/orrery/references/fragment.schema.json", "type": "doc", "template": false },
     "skills/orrery/references/model.schema.json": { "target": "skills/orrery/references/model.schema.json", "type": "doc", "template": false },
+    "skills/orrery/scripts/anchor_repo.sh": { "target": "skills/orrery/scripts/anchor_repo.sh", "type": "script", "template": false },
+    "skills/orrery/scripts/enumerate_repo.py": { "target": "skills/orrery/scripts/enumerate_repo.py", "type": "script", "template": false },
     "skills/orrery/scripts/likec4.sh": { "target": "skills/orrery/scripts/likec4.sh", "type": "script", "template": false },
     "skills/orrery/scripts/render_map.sh": { "target": "skills/orrery/scripts/render_map.sh", "type": "script", "template": false },
     "skills/orrery/scripts/toolchain/package.json": { "target": "skills/orrery/scripts/toolchain/package.json", "type": "doc", "template": false },

--- a/modules/orrery/skills/orrery/scripts/anchor_repo.sh
+++ b/modules/orrery/skills/orrery/scripts/anchor_repo.sh
@@ -47,7 +47,9 @@ emit_error() {
 strip_userinfo() {
   # Remove any user[:token]@ userinfo before the host, for both
   # scheme://user:token@host/... and scp-like user@host:... URL forms.
-  printf '%s' "$1" | LC_ALL=C sed -e 's#^\([a-z][a-z0-9+.-]*://\)\{0,1\}[^/@]*@#\1#'
+  # Schemes are case-insensitive (RFC 3986), so the class allows A-Z too:
+  # an HTTPS:// URL must strip exactly like https:// (review finding 3).
+  printf '%s' "$1" | LC_ALL=C sed -e 's#^\([a-zA-Z][a-zA-Z0-9+.-]*://\)\{0,1\}[^/@]*@#\1#'
 }
 
 sanitize_slug() {
@@ -86,10 +88,23 @@ fi
 REPO_ARG="$1"
 
 # --- validate the repo -------------------------------------------------------
+# Control characters anywhere in the path would corrupt the single-line JSON
+# output while exiting 0 (review finding 2). Reject them up front, and never
+# echo the offending path back - emit_error must stay valid JSON.
+case "$REPO_ARG" in
+  *[[:cntrl:]]*)
+    emit_error "repo path contains control characters" ""
+    ;;
+esac
 if [ ! -d "$REPO_ARG" ]; then
   emit_error "repo path does not exist or is not a directory" "$REPO_ARG"
 fi
 REPO="$(cd "$REPO_ARG" && pwd -P)"
+case "$REPO" in
+  *[[:cntrl:]]*)
+    emit_error "resolved repo path contains control characters" ""
+    ;;
+esac
 if ! git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
   emit_error "not a git repository" "$REPO"
 fi
@@ -124,6 +139,11 @@ if [ "$NO_REMOTE" = "false" ]; then
   if ! git -C "$REPO" fetch origin >/dev/null 2>&1; then
     emit_error "git fetch origin failed (remote: $REMOTE_URL)" "$REPO"
   fi
+  # Refresh the origin/HEAD symref before reading it: a plain fetch neither
+  # updates the symref nor prunes a renamed-away default branch, so a stale
+  # symref would silently anchor the dead branch's old tip (review finding 1).
+  # Tolerate failure - the fallback chain below then behaves as before.
+  git -C "$REPO" remote set-head origin --auto >/dev/null 2>&1 || true
   ORIGIN_HEAD="$(git -C "$REPO" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)"
   if [ -n "$ORIGIN_HEAD" ]; then
     DEFAULT_REF="origin/${ORIGIN_HEAD#refs/remotes/origin/}"

--- a/modules/orrery/skills/orrery/scripts/anchor_repo.sh
+++ b/modules/orrery/skills/orrery/scripts/anchor_repo.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# orrery anchor stage (plan section 3.1 stages 1 + 6, Epic 2).
+#
+# Usage:
+#   anchor_repo.sh <repo-path>
+#       Pins the target repo to its default-ref SHA, creates a uniquely-named
+#       detached temp worktree at that SHA, derives the strict slug, creates
+#       the chmod-700 output dir, and emits a single-line JSON anchor record
+#       on stdout:
+#         {"repo_path", "remote_url", "default_ref", "anchor_sha", "worktree",
+#          "slug", "behind", "dirty", "no_remote", "visibility"}
+#   anchor_repo.sh --teardown <repo-path> <worktree>
+#       Removes the anchor worktree and prunes worktree metadata. Idempotent,
+#       never fatal - the single entry point every exit path calls (stage 6).
+#
+# Exit codes: 0 success; 2 with a single-line JSON error object on an
+# unreachable repo, a fetch failure, or an unsanitizable slug.
+#
+# Security notes:
+#   C6 - remote_url userinfo (user[:token]@) is stripped BEFORE any output;
+#        the raw URL is never echoed, not even in error messages.
+#   C7 - the slug must match ^[a-z0-9][a-z0-9_-]*$ after sanitization or we
+#        exit 2; it is derived from the repo directory basename only, so a
+#        path-shaped argument can never smuggle separators into the slug.
+#   R4 - the output dir ~/code/orrery/{slug} is chmod 700.
+#
+# The run mutates the target repo in exactly two ways - `git fetch origin`
+# and `git worktree add`. The worktree is the only durable side effect, so
+# any failure after it is created triggers teardown from the error path.
+#
+# Portable: macOS bash 3.2 + BSD tools. Deterministic: no LLM or tool calls.
+
+json_escape() {
+  # Escape backslash and double quote for embedding in a JSON string.
+  printf '%s' "$1" | LC_ALL=C sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+emit_error() {
+  # $1 = message, $2 = repo path (may be empty). Single-line JSON, exit 2.
+  printf '{"error":"%s","repo_path":"%s"}\n' \
+    "$(json_escape "$1")" "$(json_escape "${2:-}")"
+  exit 2
+}
+
+strip_userinfo() {
+  # Remove any user[:token]@ userinfo before the host, for both
+  # scheme://user:token@host/... and scp-like user@host:... URL forms.
+  printf '%s' "$1" | LC_ALL=C sed -e 's#^\([a-z][a-z0-9+.-]*://\)\{0,1\}[^/@]*@#\1#'
+}
+
+sanitize_slug() {
+  # STRICT slug rule (security C7): lowercase, collapse every run of
+  # non-[a-z0-9] to _, trim leading/trailing _, truncate to 64 chars.
+  # The caller verifies the result against ^[a-z0-9][a-z0-9_-]*$.
+  printf '%s' "$1" \
+    | LC_ALL=C tr '[:upper:]' '[:lower:]' \
+    | LC_ALL=C sed -e 's/[^a-z0-9]\{1,\}/_/g' -e 's/^_*//' -e 's/_*$//' \
+    | LC_ALL=C cut -c1-64
+}
+
+teardown_worktree() {
+  # Stage 6: idempotent, never fatal. $1 = repo, $2 = worktree path.
+  git -C "$1" worktree remove --force "$2" >/dev/null 2>&1 || true
+  git -C "$1" worktree prune >/dev/null 2>&1 || true
+  # The worktree lives inside a private mktemp base dir; reclaim it when empty.
+  rmdir "$(dirname "$2")" >/dev/null 2>&1 || true
+  return 0
+}
+
+# --- teardown mode -----------------------------------------------------------
+if [ "${1:-}" = "--teardown" ]; then
+  if [ $# -ne 3 ]; then
+    echo "usage: anchor_repo.sh --teardown <repo-path> <worktree>" >&2
+    exit 2
+  fi
+  teardown_worktree "$2" "$3"
+  exit 0
+fi
+
+if [ $# -ne 1 ]; then
+  echo "usage: anchor_repo.sh <repo-path> | anchor_repo.sh --teardown <repo-path> <worktree>" >&2
+  exit 2
+fi
+REPO_ARG="$1"
+
+# --- validate the repo -------------------------------------------------------
+if [ ! -d "$REPO_ARG" ]; then
+  emit_error "repo path does not exist or is not a directory" "$REPO_ARG"
+fi
+REPO="$(cd "$REPO_ARG" && pwd -P)"
+if ! git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
+  emit_error "not a git repository" "$REPO"
+fi
+
+# --- worktree prune FIRST ----------------------------------------------------
+# A prior run killed before teardown leaves stale worktree metadata that a
+# later worktree add can collide with.
+git -C "$REPO" worktree prune >/dev/null 2>&1 || true
+
+# --- slug (before the worktree exists, so a failure here needs no cleanup) ---
+SLUG="$(sanitize_slug "$(basename "$REPO")")"
+if ! printf '%s' "$SLUG" | LC_ALL=C grep -Eq '^[a-z0-9][a-z0-9_-]*$'; then
+  emit_error "repo directory name cannot be sanitized to a valid slug" "$REPO"
+fi
+
+# --- remote detection + credential stripping BEFORE any output ---------------
+NO_REMOTE=false
+REMOTE_URL=""
+# config --get (not remote get-url): get-url expands insteadOf rewrites, and
+# the credential-bearing string to strip is the URL as configured.
+RAW_URL="$(git -C "$REPO" config --get remote.origin.url 2>/dev/null || true)"
+if [ -n "$RAW_URL" ]; then
+  REMOTE_URL="$(strip_userinfo "$RAW_URL")"
+else
+  NO_REMOTE=true
+fi
+RAW_URL=""
+
+# --- fetch + default ref resolution + SHA pin --------------------------------
+DEFAULT_REF=""
+if [ "$NO_REMOTE" = "false" ]; then
+  if ! git -C "$REPO" fetch origin >/dev/null 2>&1; then
+    emit_error "git fetch origin failed (remote: $REMOTE_URL)" "$REPO"
+  fi
+  ORIGIN_HEAD="$(git -C "$REPO" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [ -n "$ORIGIN_HEAD" ]; then
+    DEFAULT_REF="origin/${ORIGIN_HEAD#refs/remotes/origin/}"
+  elif git -C "$REPO" show-ref --verify --quiet refs/remotes/origin/main; then
+    DEFAULT_REF="origin/main"
+  fi
+fi
+if [ -z "$DEFAULT_REF" ]; then
+  # Local default branch: the no-remote case (flagged via no_remote), or a
+  # remote whose origin/HEAD and origin/main are both unresolvable.
+  DEFAULT_REF="$(git -C "$REPO" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  if [ -z "$DEFAULT_REF" ]; then
+    DEFAULT_REF="HEAD"
+  fi
+fi
+
+ANCHOR_SHA="$(git -C "$REPO" rev-parse --verify "$DEFAULT_REF^{commit}" 2>/dev/null || true)"
+if [ -z "$ANCHOR_SHA" ]; then
+  emit_error "cannot resolve default ref $DEFAULT_REF to a commit" "$REPO"
+fi
+
+# --- behind + dirty ----------------------------------------------------------
+BEHIND="$(git -C "$REPO" rev-list --count "HEAD..$ANCHOR_SHA" 2>/dev/null | tr -cd '0-9' || true)"
+if [ -z "$BEHIND" ]; then
+  BEHIND=0
+fi
+DIRTY=false
+if [ -n "$(git -C "$REPO" status --porcelain 2>/dev/null)" ]; then
+  DIRTY=true
+fi
+
+# --- detached temp worktree (uniquely named) ---------------------------------
+CLEANUP_WT=""
+on_exit() {
+  STATUS=$?
+  if [ "$STATUS" -ne 0 ] && [ -n "$CLEANUP_WT" ]; then
+    # Error path after the worktree exists: tear it down (stage 6).
+    teardown_worktree "$REPO" "$CLEANUP_WT"
+  fi
+}
+trap on_exit EXIT
+
+WT_BASE="$(mktemp -d "${TMPDIR:-/tmp}/orrery-anchor-${SLUG}.XXXXXX")"
+WT="$WT_BASE/wt"
+if ! git -C "$REPO" worktree add --detach "$WT" "$ANCHOR_SHA" >/dev/null 2>&1; then
+  rmdir "$WT_BASE" >/dev/null 2>&1 || true
+  emit_error "git worktree add failed" "$REPO"
+fi
+CLEANUP_WT="$WT"
+
+# --- repo visibility (gh-based, never fatal) ---------------------------------
+VISIBILITY="unknown"
+OWNER_REPO=""
+case "$REMOTE_URL" in
+  *github.com/*|*github.com:*)
+    OWNER_REPO="$(printf '%s' "$REMOTE_URL" \
+      | LC_ALL=C sed -e 's#^.*github\.com[:/]##' -e 's#\.git$##' -e 's#/*$##' \
+      | cut -d/ -f1,2)"
+    ;;
+esac
+if [ -n "$OWNER_REPO" ] && command -v gh >/dev/null 2>&1; then
+  IS_PRIVATE="$(gh repo view "$OWNER_REPO" --json isPrivate --jq .isPrivate 2>/dev/null || true)"
+  case "$IS_PRIVATE" in
+    true)  VISIBILITY="private" ;;
+    false) VISIBILITY="public" ;;
+  esac
+fi
+
+# --- output dir (security R4) ------------------------------------------------
+OUT_DIR="$HOME/code/orrery/$SLUG"
+if ! mkdir -p "$OUT_DIR" 2>/dev/null; then
+  emit_error "cannot create output dir $OUT_DIR" "$REPO"
+fi
+if ! chmod 700 "$OUT_DIR" 2>/dev/null; then
+  emit_error "cannot chmod 700 output dir $OUT_DIR" "$REPO"
+fi
+
+# --- single-line JSON anchor record ------------------------------------------
+printf '{"repo_path":"%s","remote_url":"%s","default_ref":"%s","anchor_sha":"%s","worktree":"%s","slug":"%s","behind":%s,"dirty":%s,"no_remote":%s,"visibility":"%s"}\n' \
+  "$(json_escape "$REPO")" \
+  "$(json_escape "$REMOTE_URL")" \
+  "$(json_escape "$DEFAULT_REF")" \
+  "$ANCHOR_SHA" \
+  "$(json_escape "$WT")" \
+  "$SLUG" \
+  "$BEHIND" \
+  "$DIRTY" \
+  "$NO_REMOTE" \
+  "$VISIBILITY"
+exit 0

--- a/modules/orrery/skills/orrery/scripts/enumerate_repo.py
+++ b/modules/orrery/skills/orrery/scripts/enumerate_repo.py
@@ -385,11 +385,15 @@ def _bucketize(survivors, misc_exists):
         by_parent.setdefault(parent, []).append(cand)
     groups = sorted(by_parent.items())
     if len(groups) > ceiling:
-        raise SystemExit(
+        # Same error shape as the documented CLI failure: one line on stderr,
+        # exit 2 (review finding 8).
+        print(
             "enumerate_repo.py: %d sibling groups exceed the %d-bucket "
             "ceiling (outside the v1 boundary - plan section 3.5a)"
-            % (len(groups), ceiling)
+            % (len(groups), ceiling),
+            file=sys.stderr,
         )
+        raise SystemExit(2)
 
     target = min(ceiling, max(CANDIDATE_TARGET, -(-n // 3)))
     bucket_total = max(target, len(groups))
@@ -457,10 +461,13 @@ def compute_areas(paths):
     areas.sort(key=lambda a: a["id"])
     for area in areas:
         if not AREA_ID_PATTERN.match(area["id"]):
-            raise SystemExit(
+            # Same error shape as the documented CLI failure (review finding 8).
+            print(
                 "enumerate_repo.py: internal error - area id %r is not "
-                "element-id-legal" % area["id"]
+                "element-id-legal" % area["id"],
+                file=sys.stderr,
             )
+            raise SystemExit(2)
     return areas, bucketing
 
 

--- a/modules/orrery/skills/orrery/scripts/enumerate_repo.py
+++ b/modules/orrery/skills/orrery/scripts/enumerate_repo.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Deterministic census of an anchored worktree (plan section 3.1 stage 2, Epic 2).
+
+Usage:
+    enumerate_repo.py --worktree <path> --out <census.json>
+
+Tracked paths come from ``git ls-files`` and file contents from
+``git cat-file blob :0:<path>`` - NEVER from raw filesystem walks. The fixture
+repo tracks both ``web/`` and ``Web/``, which case-insensitive filesystems
+collapse into one on-disk directory; the git index is the only truthful
+listing, so the filesystem is never consulted for enumeration or content.
+
+Output is byte-deterministic: sorted keys, sorted lists, ASCII escapes, one
+trailing newline. Two runs over the same worktree produce identical bytes.
+No LLM or tool calls - pure deterministic computation (plan 1.4 principle 3).
+
+Census shape (plan section 3.2):
+    {
+      "areas":        [...],  # section 3.5a clustering + bucketing
+      "bucketing":    {"applied", "bucket_count", "candidate_count"},
+      "entrypoints":  [...],
+      "id_namespace": {...},  # published area ids + reserved ids
+      "languages":    {...},  # extension -> tracked-file count
+      "manifests":    [...],  # detection table hits
+      "tree":         {...}   # tracked-file stats
+    }
+
+MANIFEST_TABLE below is the single source of truth for manifest detection;
+Epic 5's diff_since.py imports it from this module - never duplicate it.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from fnmatch import fnmatchcase
+from fractions import Fraction
+
+# --- manifest detection table (imported by diff_since.py - Epic 5) -----------
+# Rows are (kind, match_type, pattern). Match types:
+#   basename - the file's basename equals pattern
+#   suffix   - the path ends with pattern (extension-style, e.g. *.tf)
+#   glob     - fnmatch of the full path against pattern
+#   dir      - any tracked file sits under a directory named pattern; the hit
+#              path is that directory (e.g. db/migrations)
+# Row order mirrors the plan's Epic 2 table for easy diffing against the spec.
+MANIFEST_TABLE = (
+    ("package.json", "basename", "package.json"),
+    ("pnpm-workspace", "basename", "pnpm-workspace.yaml"),
+    ("requirements", "basename", "requirements.txt"),
+    ("pyproject", "basename", "pyproject.toml"),
+    ("gemfile", "basename", "Gemfile"),
+    ("go-mod", "basename", "go.mod"),
+    ("cargo", "basename", "Cargo.toml"),
+    ("swiftpm", "basename", "Package.swift"),
+    ("composer", "basename", "composer.json"),
+    ("wrangler", "basename", "wrangler.toml"),
+    ("vercel", "basename", "vercel.json"),
+    ("netlify", "basename", "netlify.toml"),
+    ("fly", "basename", "fly.toml"),
+    ("dockerfile", "basename", "Dockerfile"),
+    ("docker-compose", "basename", "docker-compose.yml"),
+    ("terraform", "suffix", ".tf"),
+    ("github-workflow", "glob", ".github/workflows/*.yml"),
+    ("env-example", "basename", ".env.example"),
+    ("supabase", "dir", "supabase"),
+    ("prisma", "dir", "prisma"),
+    ("drizzle", "dir", "drizzle"),
+    ("migrations", "dir", "migrations"),
+)
+
+# Entry-point heuristics: a tracked file whose basename (extension stripped)
+# is one of these names is a candidate entry point.
+ENTRYPOINT_BASENAMES = frozenset(
+    ("__main__", "app", "cli", "index", "main", "manage", "server", "worker")
+)
+
+# --- section 3.5a constants --------------------------------------------------
+AREA_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+AREA_ID_MAX_LEN = 24
+CANDIDATE_TARGET = 12   # candidate count above which bucketing engages
+BUCKET_CEILING = 24     # hard ceiling on areas (3 waves of 8)
+MERGE_THRESHOLD = 5     # candidates with fewer files merge into misc
+SPLIT_THRESHOLD = 400   # candidates with more files split by subdirectory
+EXPAND_NUM, EXPAND_DEN = 3, 5  # expand when a single dir holds > 3/5 of files
+
+RESERVED_IDS = ("misc", "system", "users")
+RESERVED_BUCKET_IDS = tuple("bucket_%02d" % i for i in range(1, BUCKET_CEILING + 1))
+# Wave-0 packs (product-vision, external-systems) publish the container, actor,
+# and external element ids at orchestration time (plan section 3.5).
+WAVE0_OWNED_KINDS = ("actor", "container", "external")
+
+
+def sanitize_area_id(path, taken):
+    """FROZEN section-3.5a step-5 rule. Do not alter without a plan revision.
+
+    lowercase -> collapse every run of non-[a-z0-9] to _ -> if the result does
+    not start with [a-z], prefix a_ -> trim trailing _ -> truncate to 24 chars
+    -> on collision against `taken`, append _2, _3, ... in candidate order.
+
+    Element-id-legal by construction: the result always matches
+    ^[a-z][a-z0-9_]*$. `taken` is mutated with the id handed out.
+    """
+    s = path.lower()
+    s = re.sub(r"[^a-z0-9]+", "_", s)
+    if not s or not ("a" <= s[0] <= "z"):
+        s = "a_" + s
+    s = s.rstrip("_")
+    if not s:  # a name with no [a-z0-9] at all collapses to the a_ prefix
+        s = "a"
+    s = s[:AREA_ID_MAX_LEN]
+    base = s
+    if base not in taken:
+        taken.add(base)
+        return base
+    n = 2
+    while True:
+        candidate = "%s_%d" % (base, n)
+        if candidate not in taken:
+            taken.add(candidate)
+            return candidate
+        n += 1
+
+
+# --- git plumbing ------------------------------------------------------------
+def _git(worktree, *args):
+    return subprocess.run(
+        ["git", "-C", worktree] + list(args),
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    ).stdout
+
+
+def tracked_paths(worktree):
+    raw = _git(worktree, "ls-files", "-z")
+    return sorted(p.decode("utf-8", "replace") for p in raw.split(b"\0") if p)
+
+
+def read_blob(worktree, path):
+    """Index (stage 0) content of a tracked path; None when unreadable."""
+    try:
+        return _git(worktree, "cat-file", "blob", ":0:%s" % path)
+    except subprocess.CalledProcessError:
+        return None
+
+
+# --- census pieces -----------------------------------------------------------
+def _basename(path):
+    return path.rsplit("/", 1)[-1]
+
+
+def _extension(path):
+    base = _basename(path)
+    if "." in base[1:]:
+        return base.rsplit(".", 1)[1].lower()
+    return "(none)"
+
+
+def language_stats(paths):
+    counts = {}
+    for p in paths:
+        ext = _extension(p)
+        counts[ext] = counts.get(ext, 0) + 1
+    return counts
+
+
+def detect_entrypoints(paths):
+    hits = []
+    for p in paths:
+        base = _basename(p)
+        stem = base.rsplit(".", 1)[0] if "." in base[1:] else base
+        if stem.lower() in ENTRYPOINT_BASENAMES:
+            hits.append(p)
+    return sorted(hits)
+
+
+def _package_dependencies(worktree, path):
+    """Sorted dependency + devDependency names; None on a parse failure."""
+    blob = read_blob(worktree, path)
+    if blob is None:
+        return None
+    try:
+        data = json.loads(blob.decode("utf-8", "replace"))
+    except ValueError:
+        return None
+    deps = set()
+    for key in ("dependencies", "devDependencies"):
+        section = data.get(key)
+        if isinstance(section, dict):
+            deps.update(str(name) for name in section)
+    return sorted(deps)
+
+
+def detect_manifests(worktree, paths):
+    hits = {}
+    for p in paths:
+        base = _basename(p)
+        for kind, match_type, pattern in MANIFEST_TABLE:
+            hit_path = None
+            if match_type == "basename":
+                if base == pattern:
+                    hit_path = p
+            elif match_type == "suffix":
+                if p.endswith(pattern):
+                    hit_path = p
+            elif match_type == "glob":
+                if fnmatchcase(p, pattern):
+                    hit_path = p
+            elif match_type == "dir":
+                components = p.split("/")[:-1]
+                if pattern in components:
+                    idx = components.index(pattern)
+                    hit_path = "/".join(components[: idx + 1])
+            if hit_path is not None:
+                hits.setdefault((hit_path, kind), None)
+    manifests = []
+    for (hit_path, kind) in sorted(hits):
+        entry = {"kind": kind, "path": hit_path}
+        if kind == "package.json":
+            deps = _package_dependencies(worktree, hit_path)
+            if deps is None:
+                entry["dependencies"] = []
+                entry["parse_error"] = True
+            else:
+                entry["dependencies"] = deps
+        manifests.append(entry)
+    return manifests
+
+
+# --- section 3.5a area clustering + bucketing --------------------------------
+def _split_candidate(path, files):
+    """Partition a candidate one level down: per-subdir candidates plus a
+    residual candidate (same path) for files directly inside it."""
+    prefix = path + "/"
+    loose = []
+    by_child = {}
+    for f in files:
+        rest = f[len(prefix):]
+        if "/" in rest:
+            child = rest.split("/", 1)[0]
+            by_child.setdefault(child, []).append(f)
+        else:
+            loose.append(f)
+    out = [
+        {"path": prefix + child, "files": child_files}
+        for child, child_files in sorted(by_child.items())
+    ]
+    if loose:
+        out.append({"path": path, "files": loose})
+    return out
+
+
+def compute_candidates(paths):
+    """Steps 1-2 of section 3.5a. Returns (survivors, misc_members) where
+    survivors are candidate dicts in byte-sorted path order and misc_members
+    are {"file_count", "path"} rows (tiny candidates + root loose files)."""
+    total = len(paths)
+    root_files = [p for p in paths if "/" not in p]
+    by_top = {}
+    for p in paths:
+        if "/" in p:
+            top = p.split("/", 1)[0]
+            by_top.setdefault(top, []).append(p)
+    candidates = [{"path": d, "files": fs} for d, fs in sorted(by_top.items())]
+
+    # Step 1: expand one level deeper when a single directory holds >60% of
+    # tracked files (the modules/-style case). Integer math: n/total > 3/5.
+    expanded = []
+    for cand in candidates:
+        if len(cand["files"]) * EXPAND_DEN > total * EXPAND_NUM:
+            expanded.extend(_split_candidate(cand["path"], cand["files"]))
+        else:
+            expanded.append(cand)
+    candidates = sorted(expanded, key=lambda c: c["path"])
+
+    # Step 2: split any candidate >400 files by subdirectory (split first so
+    # tiny split residue can still merge), then merge <5-file candidates into
+    # misc.
+    split_out = []
+    for cand in candidates:
+        if len(cand["files"]) > SPLIT_THRESHOLD:
+            split_out.extend(_split_candidate(cand["path"], cand["files"]))
+        else:
+            split_out.append(cand)
+    candidates = sorted(split_out, key=lambda c: c["path"])
+
+    survivors = []
+    misc_members = []
+    for cand in candidates:
+        if len(cand["files"]) < MERGE_THRESHOLD:
+            misc_members.append({"file_count": len(cand["files"]), "path": cand["path"]})
+        else:
+            survivors.append(cand)
+    for f in sorted(root_files):
+        misc_members.append({"file_count": 1, "path": f})
+    misc_members.sort(key=lambda m: m["path"])
+    return survivors, misc_members
+
+
+def _allocate_buckets(groups, bucket_total, total_files):
+    """Largest-remainder allocation of bucket_total buckets across sibling
+    groups, proportional to file count, each group getting 1..len(group).
+    Exact Fraction arithmetic keeps it deterministic."""
+    quotas = []
+    for _parent, members in groups:
+        group_files = sum(len(c["files"]) for c in members)
+        if total_files:
+            quotas.append(Fraction(bucket_total * group_files, total_files))
+        else:
+            quotas.append(Fraction(1))
+    alloc = []
+    for (_parent, members), quota in zip(groups, quotas):
+        alloc.append(max(1, min(len(members), int(quota))))
+    while sum(alloc) < bucket_total:
+        best = None
+        for i, (_parent, members) in enumerate(groups):
+            if alloc[i] < len(members):
+                key = (quotas[i] - alloc[i], -i)
+                if best is None or key > best[0]:
+                    best = (key, i)
+        if best is None:
+            break
+        alloc[best[1]] += 1
+    while sum(alloc) > bucket_total:
+        best = None
+        for i in range(len(groups)):
+            if alloc[i] > 1:
+                key = (alloc[i] - quotas[i], -i)
+                if best is None or key > best[0]:
+                    best = (key, i)
+        if best is None:
+            break
+        alloc[best[1]] -= 1
+    return alloc
+
+
+def _partition_min_max(sizes, runs):
+    """Contiguous partition of `sizes` into `runs` runs minimizing the max run
+    sum (classic linear-partition DP). Deterministic: strict improvement only,
+    so ties resolve to the earliest cut. Returns (start, end) index pairs."""
+    n = len(sizes)
+    prefix = [0]
+    for s in sizes:
+        prefix.append(prefix[-1] + s)
+    inf = float("inf")
+    dp = [[inf] * (n + 1) for _ in range(runs + 1)]
+    cut = [[0] * (n + 1) for _ in range(runs + 1)]
+    dp[0][0] = 0
+    for j in range(1, runs + 1):
+        for i in range(j, n - (runs - j) + 1):
+            best = inf
+            best_m = j - 1
+            for m in range(j - 1, i):
+                value = max(dp[j - 1][m], prefix[i] - prefix[m])
+                if value < best:
+                    best = value
+                    best_m = m
+            dp[j][i] = best
+            cut[j][i] = best_m
+    bounds = []
+    i = n
+    for j in range(runs, 0, -1):
+        m = cut[j][i]
+        bounds.append((m, i))
+        i = m
+    bounds.reverse()
+    return bounds
+
+
+def _bucketize(survivors, misc_exists):
+    """Step 3: balanced bin-packing of sibling candidates (same parent,
+    alphabetical adjacency preserved) into at most BUCKET_CEILING buckets,
+    balanced by file count. Bucket count targets CANDIDATE_TARGET and grows
+    ~1 bucket per 3 candidates so a sibling explosion (the ccgm demo, ~66
+    candidates) lands at 22-24 buckets."""
+    n = len(survivors)
+    total_files = sum(len(c["files"]) for c in survivors)
+    ceiling = BUCKET_CEILING - (1 if misc_exists else 0)
+
+    by_parent = {}
+    for cand in survivors:  # already path-sorted: adjacency == list order
+        parent = cand["path"].rsplit("/", 1)[0] if "/" in cand["path"] else ""
+        by_parent.setdefault(parent, []).append(cand)
+    groups = sorted(by_parent.items())
+    if len(groups) > ceiling:
+        raise SystemExit(
+            "enumerate_repo.py: %d sibling groups exceed the %d-bucket "
+            "ceiling (outside the v1 boundary - plan section 3.5a)"
+            % (len(groups), ceiling)
+        )
+
+    target = min(ceiling, max(CANDIDATE_TARGET, -(-n // 3)))
+    bucket_total = max(target, len(groups))
+    alloc = _allocate_buckets(groups, bucket_total, total_files)
+
+    areas = []
+    number = 0
+    for (_parent, members), runs in zip(groups, alloc):
+        sizes = [len(c["files"]) for c in members]
+        for start, end in _partition_min_max(sizes, runs):
+            number += 1
+            run = members[start:end]
+            areas.append(
+                {
+                    "bucketed": True,
+                    "file_count": sum(len(c["files"]) for c in run),
+                    "id": "bucket_%02d" % number,
+                    "members": [
+                        {"file_count": len(c["files"]), "path": c["path"]}
+                        for c in run
+                    ],
+                    "root_paths": [c["path"] for c in run],
+                }
+            )
+    return areas
+
+
+def compute_areas(paths):
+    """Full section 3.5a pipeline. Returns (areas, bucketing_stats)."""
+    survivors, misc_members = compute_candidates(paths)
+
+    bucketing = {"applied": False, "bucket_count": 0, "candidate_count": len(survivors)}
+    if len(survivors) > CANDIDATE_TARGET:
+        areas = _bucketize(survivors, misc_exists=bool(misc_members))
+        bucketing["applied"] = True
+        bucketing["bucket_count"] = len(areas)
+    else:
+        taken = set(RESERVED_IDS) | set(RESERVED_BUCKET_IDS)
+        areas = []
+        for cand in survivors:  # candidate order: byte-sorted paths
+            area_id = sanitize_area_id(cand["path"], taken)
+            areas.append(
+                {
+                    "bucketed": False,
+                    "file_count": len(cand["files"]),
+                    "id": area_id,
+                    "members": [
+                        {"file_count": len(cand["files"]), "path": cand["path"]}
+                    ],
+                    "root_paths": [cand["path"]],
+                }
+            )
+
+    if misc_members:
+        areas.append(
+            {
+                "bucketed": False,
+                "file_count": sum(m["file_count"] for m in misc_members),
+                "id": "misc",
+                "members": misc_members,
+                "root_paths": [m["path"] for m in misc_members],
+            }
+        )
+
+    areas.sort(key=lambda a: a["id"])
+    for area in areas:
+        if not AREA_ID_PATTERN.match(area["id"]):
+            raise SystemExit(
+                "enumerate_repo.py: internal error - area id %r is not "
+                "element-id-legal" % area["id"]
+            )
+    return areas, bucketing
+
+
+# --- census ------------------------------------------------------------------
+def build_census(worktree):
+    paths = tracked_paths(worktree)
+    areas, bucketing = compute_areas(paths)
+    top_level_dirs = sorted({p.split("/", 1)[0] for p in paths if "/" in p})
+    top_level_files = sorted(p for p in paths if "/" not in p)
+    return {
+        "areas": areas,
+        "bucketing": bucketing,
+        "entrypoints": detect_entrypoints(paths),
+        "id_namespace": {
+            "area_ids": sorted(a["id"] for a in areas),
+            "reserved_bucket_ids": list(RESERVED_BUCKET_IDS),
+            "reserved_ids": list(RESERVED_IDS),
+            "wave0_owned_kinds": list(WAVE0_OWNED_KINDS),
+        },
+        "languages": language_stats(paths),
+        "manifests": detect_manifests(worktree, paths),
+        "tree": {
+            "top_level_dirs": top_level_dirs,
+            "top_level_files": top_level_files,
+            "tracked_files": len(paths),
+        },
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--worktree", required=True, help="anchored worktree path")
+    parser.add_argument("--out", required=True, help="census.json output path")
+    args = parser.parse_args(argv)
+
+    try:
+        _git(args.worktree, "rev-parse", "--git-dir")
+    except (subprocess.CalledProcessError, OSError):
+        print(
+            "enumerate_repo.py: %s is not a git worktree" % args.worktree,
+            file=sys.stderr,
+        )
+        return 2
+
+    census = build_census(args.worktree)
+    payload = json.dumps(census, sort_keys=True, indent=2, ensure_ascii=True) + "\n"
+    with open(args.out, "w", encoding="ascii") as fh:
+        fh.write(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/orrery/tests/unit/test_anchor_repo.py
+++ b/modules/orrery/tests/unit/test_anchor_repo.py
@@ -1,0 +1,414 @@
+"""Unit tests for anchor_repo.sh (plan Epic 2).
+
+Hermetic: every test runs against throwaway git repos with local bare origins
+under tempdirs, with HOME pointed at a tempdir so ~/code/orrery lands there
+too. No network: credentialed remote URLs are rewritten to local paths via
+git's url.<base>.insteadOf, and gh is stubbed on PATH.
+
+The fake token below (ghp_fake) is safe to commit ONLY because this file
+lives under a tests/ path, which the repo's Class-2 secret scan excludes.
+"""
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+MODULE_DIR = Path(__file__).resolve().parents[2]
+SCRIPT = MODULE_DIR / "skills" / "orrery" / "scripts" / "anchor_repo.sh"
+
+CRED_URL = "https://x-token:ghp_fake@github.com/o/r.git"
+FAKE_TOKEN = "ghp_fake"
+
+
+# --- helpers -----------------------------------------------------------------
+def make_env(home, path_prepend=None):
+    home.mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ)
+    env.update(
+        {
+            "HOME": str(home),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": str(home / "gitconfig-does-not-exist"),
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_AUTHOR_NAME": "Fixture",
+            "GIT_AUTHOR_EMAIL": "fixture@example.com",
+            "GIT_COMMITTER_NAME": "Fixture",
+            "GIT_COMMITTER_EMAIL": "fixture@example.com",
+        }
+    )
+    if path_prepend is not None:
+        env["PATH"] = str(path_prepend) + os.pathsep + env["PATH"]
+    return env
+
+
+def git(repo, env, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo)] + list(args),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def make_repo(path, env, origin=None):
+    """Init a repo at `path` on branch main with one commit. When `origin` is
+    a path, create a bare origin there and push main to it."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(path)],
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+    (path / "hello.txt").write_text("hello\n")
+    git(path, env, "add", "hello.txt")
+    git(path, env, "commit", "-q", "-m", "c1")
+    if origin is not None:
+        subprocess.run(
+            ["git", "init", "-q", "--bare", str(origin)],
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+        git(path, env, "remote", "add", "origin", str(origin))
+        git(path, env, "push", "-q", "origin", "main")
+    return path
+
+
+def run_anchor(env, *args, cwd=None):
+    return subprocess.run(
+        ["bash", str(SCRIPT)] + [str(a) for a in args],
+        env=env,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+    )
+
+
+def anchor_json(result):
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lines) == 1, "expected single-line JSON, got: %r" % result.stdout
+    return json.loads(lines[0])
+
+
+def worktree_count(repo, env):
+    out = git(repo, env, "worktree", "list", "--porcelain")
+    return out.count("worktree ")
+
+
+def stub_gh(home, body):
+    """Install a gh stub on a PATH-prepend dir; returns the dir."""
+    stub_dir = home / "stub-bin"
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    gh = stub_dir / "gh"
+    gh.write_text("#!/bin/sh\n" + body + "\n")
+    gh.chmod(0o755)
+    return stub_dir
+
+
+# --- success path ------------------------------------------------------------
+def test_success_fields_worktree_and_teardown(tmp_path):
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "repo", env, origin=tmp_path / "origin.git")
+
+    data = anchor_json(run_anchor(env, repo))
+    assert set(data) == {
+        "repo_path",
+        "remote_url",
+        "default_ref",
+        "anchor_sha",
+        "worktree",
+        "slug",
+        "behind",
+        "dirty",
+        "no_remote",
+        "visibility",
+    }
+    assert data["repo_path"] == str(repo.resolve())
+    assert data["remote_url"] == str(tmp_path / "origin.git")
+    assert data["default_ref"] == "origin/main"
+    assert data["slug"] == "repo"
+    assert data["behind"] == 0
+    assert data["dirty"] is False
+    assert data["no_remote"] is False
+    # A local file remote is not GitHub: visibility falls back to unknown.
+    assert data["visibility"] == "unknown"
+
+    expected_sha = git(repo, env, "rev-parse", "origin/main").strip()
+    assert data["anchor_sha"] == expected_sha
+
+    wt = Path(data["worktree"])
+    assert wt.is_dir()
+    assert git(wt, env, "rev-parse", "HEAD").strip() == expected_sha
+    assert worktree_count(repo, env) == 2
+
+    result = run_anchor(env, "--teardown", repo, wt)
+    assert result.returncode == 0
+    assert worktree_count(repo, env) == 1
+    assert not wt.exists()
+
+
+def test_dirty_repo_flagged(tmp_path):
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "repo", env, origin=tmp_path / "origin.git")
+    (repo / "hello.txt").write_text("changed\n")
+
+    data = anchor_json(run_anchor(env, repo))
+    assert data["dirty"] is True
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+def test_behind_counts_commits(tmp_path):
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "repo", env, origin=tmp_path / "origin.git")
+    (repo / "second.txt").write_text("second\n")
+    git(repo, env, "add", "second.txt")
+    git(repo, env, "commit", "-q", "-m", "c2")
+    git(repo, env, "push", "-q", "origin", "main")
+    remote_tip = git(repo, env, "rev-parse", "HEAD").strip()
+    git(repo, env, "reset", "-q", "--hard", "HEAD~1")
+
+    data = anchor_json(run_anchor(env, repo))
+    assert data["behind"] == 1
+    # The anchor pins the fetched origin tip, not the stale local HEAD.
+    assert data["anchor_sha"] == remote_tip
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+def test_no_remote_supported_and_flagged(tmp_path):
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+
+    data = anchor_json(run_anchor(env, repo))
+    assert data["no_remote"] is True
+    assert data["remote_url"] == ""
+    assert data["default_ref"] == "main"
+    assert data["visibility"] == "unknown"
+    assert data["anchor_sha"] == git(repo, env, "rev-parse", "HEAD").strip()
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+# --- error paths -------------------------------------------------------------
+def test_nonexistent_path_exits_2_with_json_error(tmp_path):
+    env = make_env(tmp_path / "home")
+    result = run_anchor(env, tmp_path / "does-not-exist")
+    assert result.returncode == 2
+    assert "error" in json.loads(result.stdout.strip())
+
+
+def test_non_repo_dir_exits_2_with_json_error(tmp_path):
+    env = make_env(tmp_path / "home")
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    result = run_anchor(env, plain)
+    assert result.returncode == 2
+    assert "error" in json.loads(result.stdout.strip())
+
+
+# --- slug rule (security C7) -------------------------------------------------
+def test_slug_sanitizes_messy_name(tmp_path):
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "My Repo (v2)!", env, origin=None)
+    data = anchor_json(run_anchor(env, repo))
+    assert data["slug"] == "my_repo_v2"
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+def test_slug_unsanitizable_unicode_exits_2(tmp_path):
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "日本語", env, origin=None)
+    result = run_anchor(env, repo)
+    assert result.returncode == 2
+    assert "error" in json.loads(result.stdout.strip())
+    # The failure happens before any worktree is created.
+    assert worktree_count(repo, env) == 1
+
+
+def test_slug_200_char_name_truncated_to_64(tmp_path):
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / ("a" * 200), env, origin=None)
+    data = anchor_json(run_anchor(env, repo))
+    assert data["slug"] == "a" * 64
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+def test_slug_relative_traversal_arg_uses_basename_only(tmp_path):
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "evil", env, origin=None)
+    workdir = tmp_path / "somewhere"
+    workdir.mkdir()
+
+    result = run_anchor(env, "../evil", cwd=workdir)
+    data = anchor_json(result)
+    assert data["slug"] == "evil"
+    assert data["repo_path"] == str(repo.resolve())
+    # The output dir stays inside ~/code/orrery - no traversal.
+    out_dir = tmp_path / "home" / "code" / "orrery" / "evil"
+    assert out_dir.is_dir()
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+def test_slug_absolute_path_shaped_arg_uses_basename_only(tmp_path):
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "abs-shaped", env, origin=None)
+    data = anchor_json(run_anchor(env, repo.resolve()))
+    assert data["slug"] == "abs_shaped"
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+# --- credential stripping (security C6) --------------------------------------
+def test_credentialed_remote_url_stripped_in_output(tmp_path):
+    env_home = tmp_path / "home"
+    stub = stub_gh(env_home, "echo true")
+    env = make_env(env_home, path_prepend=stub)
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+    bare = tmp_path / "bare.git"
+    subprocess.run(
+        ["git", "init", "-q", "--bare", str(bare)],
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+    git(repo, env, "push", "-q", str(bare), "main")
+    git(repo, env, "remote", "add", "origin", CRED_URL)
+    # Rewrite the credentialed URL to the local bare so fetch succeeds with no
+    # network while `git remote get-url origin` still reports the raw URL.
+    git(repo, env, "config", "url.%s.insteadOf" % bare, CRED_URL)
+
+    result = run_anchor(env, repo)
+    data = anchor_json(result)
+    assert data["remote_url"] == "https://github.com/o/r.git"
+    assert FAKE_TOKEN not in result.stdout
+    assert FAKE_TOKEN not in result.stderr
+    # github.com remote + stubbed `gh` answering isPrivate=true.
+    assert data["visibility"] == "private"
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+def test_credential_never_leaks_on_fetch_failure(tmp_path):
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+    git(repo, env, "remote", "add", "origin", CRED_URL)
+    git(
+        repo,
+        env,
+        "config",
+        "url.%s.insteadOf" % (tmp_path / "no-such-remote"),
+        CRED_URL,
+    )
+
+    result = run_anchor(env, repo)
+    assert result.returncode == 2
+    assert "error" in json.loads(result.stdout.strip())
+    assert FAKE_TOKEN not in result.stdout
+    assert FAKE_TOKEN not in result.stderr
+    assert worktree_count(repo, env) == 1
+
+
+# --- visibility fallback -----------------------------------------------------
+def test_visibility_public_via_gh(tmp_path):
+    env_home = tmp_path / "home"
+    stub = stub_gh(env_home, "echo false")
+    env = make_env(env_home, path_prepend=stub)
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+    bare = tmp_path / "bare.git"
+    subprocess.run(
+        ["git", "init", "-q", "--bare", str(bare)],
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+    git(repo, env, "push", "-q", str(bare), "main")
+    git(repo, env, "remote", "add", "origin", "https://github.com/o/r.git")
+    git(repo, env, "config", "url.%s.insteadOf" % bare, "https://github.com/o/r.git")
+
+    data = anchor_json(run_anchor(env, repo))
+    assert data["visibility"] == "public"
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+def test_visibility_unknown_when_gh_fails(tmp_path):
+    env_home = tmp_path / "home"
+    stub = stub_gh(env_home, "exit 1")
+    env = make_env(env_home, path_prepend=stub)
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+    bare = tmp_path / "bare.git"
+    subprocess.run(
+        ["git", "init", "-q", "--bare", str(bare)],
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+    git(repo, env, "push", "-q", str(bare), "main")
+    git(repo, env, "remote", "add", "origin", "https://github.com/o/r.git")
+    git(repo, env, "config", "url.%s.insteadOf" % bare, "https://github.com/o/r.git")
+
+    result = run_anchor(env, repo)
+    data = anchor_json(result)
+    # gh failure is never fatal: the run succeeds with visibility unknown.
+    assert data["visibility"] == "unknown"
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+# --- output dir (security R4) ------------------------------------------------
+def test_output_dir_created_chmod_700(tmp_path):
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+    data = anchor_json(run_anchor(env, repo))
+    out_dir = tmp_path / "home" / "code" / "orrery" / "repo"
+    assert out_dir.is_dir()
+    assert stat.S_IMODE(out_dir.stat().st_mode) == 0o700
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+# --- teardown contract (plan 3.1 stage 6) ------------------------------------
+def test_teardown_idempotent_and_never_fatal(tmp_path):
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+    data = anchor_json(run_anchor(env, repo))
+    wt = data["worktree"]
+
+    assert run_anchor(env, "--teardown", repo, wt).returncode == 0
+    # Second teardown of the same worktree: idempotent.
+    assert run_anchor(env, "--teardown", repo, wt).returncode == 0
+    # Teardown against a repo path that does not exist: never fatal.
+    assert (
+        run_anchor(env, "--teardown", tmp_path / "gone", tmp_path / "gone-wt").returncode
+        == 0
+    )
+    assert worktree_count(repo, env) == 1
+
+
+def test_mid_run_failure_tears_down_worktree(tmp_path):
+    """Simulated mid-run failure AFTER the worktree exists: make the output
+    dir uncreatable so the run fails late, then assert the error path called
+    teardown and `git worktree list` is clean."""
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+    # ~/code exists as a FILE, so mkdir -p ~/code/orrery/{slug} must fail.
+    (tmp_path / "home" / "code").write_text("not a directory\n")
+
+    result = run_anchor(env, repo)
+    assert result.returncode == 2
+    assert "error" in json.loads(result.stdout.strip())
+    assert worktree_count(repo, env) == 1
+
+
+def test_stale_worktree_metadata_pruned_first(tmp_path):
+    """A prior run killed before teardown leaves stale metadata; the prune-
+    first rule means the next anchor still succeeds."""
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+    stale = tmp_path / "stale-wt"
+    git(repo, env, "worktree", "add", "--detach", str(stale))
+    shutil.rmtree(stale)
+
+    data = anchor_json(run_anchor(env, repo))
+    assert Path(data["worktree"]).is_dir()
+    run_anchor(env, "--teardown", repo, data["worktree"])
+    assert worktree_count(repo, env) == 1

--- a/modules/orrery/tests/unit/test_anchor_repo.py
+++ b/modules/orrery/tests/unit/test_anchor_repo.py
@@ -68,8 +68,11 @@ def make_repo(path, env, origin=None):
     git(path, env, "add", "hello.txt")
     git(path, env, "commit", "-q", "-m", "c1")
     if origin is not None:
+        # -b main: a bare init without it leaves HEAD dangling at
+        # refs/heads/master, and a dangling remote HEAD makes
+        # `remote set-head --auto` unable to resolve anything.
         subprocess.run(
-            ["git", "init", "-q", "--bare", str(origin)],
+            ["git", "init", "-q", "--bare", "-b", "main", str(origin)],
             env=env,
             check=True,
             capture_output=True,
@@ -180,6 +183,39 @@ def test_behind_counts_commits(tmp_path):
     run_anchor(env, "--teardown", repo, data["worktree"])
 
 
+def test_stale_origin_head_refreshed_after_default_branch_rename(tmp_path):
+    """Review finding 1 / probe P5: the remote renamed its default branch
+    (main -> trunk with one extra commit, old branch deleted) after the local
+    clone recorded origin/HEAD. The anchor must refresh the symref after the
+    fetch and pin the NEW default's tip - never the dead branch's old tip."""
+    env = make_env(tmp_path / "home")
+    origin = tmp_path / "origin.git"
+    repo = make_repo(tmp_path / "repo", env, origin=origin)
+    git(repo, env, "fetch", "-q", "origin")
+    git(repo, env, "remote", "set-head", "origin", "--auto")
+    assert (
+        git(repo, env, "symbolic-ref", "refs/remotes/origin/HEAD").strip()
+        == "refs/remotes/origin/main"
+    )
+
+    # Remote-side rename: trunk continues from main plus one commit; main dies.
+    (repo / "second.txt").write_text("second\n")
+    git(repo, env, "add", "second.txt")
+    git(repo, env, "commit", "-q", "-m", "c2")
+    git(repo, env, "push", "-q", "origin", "HEAD:refs/heads/trunk")
+    new_tip = git(repo, env, "rev-parse", "HEAD").strip()
+    old_tip = git(repo, env, "rev-parse", "HEAD~1").strip()
+    git(repo, env, "reset", "-q", "--hard", "HEAD~1")
+    git(origin, env, "symbolic-ref", "HEAD", "refs/heads/trunk")
+    git(origin, env, "branch", "-D", "main")
+
+    data = anchor_json(run_anchor(env, repo))
+    assert data["default_ref"] == "origin/trunk"
+    assert data["anchor_sha"] == new_tip
+    assert data["anchor_sha"] != old_tip
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
 def test_no_remote_supported_and_flagged(tmp_path):
     env = make_env(tmp_path / "home")
     repo = make_repo(tmp_path / "repo", env, origin=None)
@@ -208,6 +244,20 @@ def test_non_repo_dir_exits_2_with_json_error(tmp_path):
     result = run_anchor(env, plain)
     assert result.returncode == 2
     assert "error" in json.loads(result.stdout.strip())
+
+
+def test_control_char_repo_path_exits_2_with_valid_json(tmp_path):
+    """Review finding 2 / probe P1: a repo dir with an embedded newline must
+    never produce invalid JSON with exit 0. It is rejected up front, and the
+    error object stays parseable because the offending path is not echoed."""
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "bad\nname", env, origin=None)
+
+    result = run_anchor(env, repo)
+    assert result.returncode == 2
+    data = json.loads(result.stdout.strip())
+    assert "error" in data
+    assert worktree_count(repo, env) == 1
 
 
 # --- slug rule (security C7) -------------------------------------------------
@@ -287,6 +337,33 @@ def test_credentialed_remote_url_stripped_in_output(tmp_path):
     assert FAKE_TOKEN not in result.stderr
     # github.com remote + stubbed `gh` answering isPrivate=true.
     assert data["visibility"] == "private"
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+def test_uppercase_scheme_credential_stripped(tmp_path):
+    """Review finding 3 / probe P2: URL schemes are case-insensitive per RFC
+    3986, so HTTPS:// userinfo must strip exactly like https://."""
+    cred_upper = "HTTPS://x-token:ghp_fake@github.com/o/r.git"
+    env_home = tmp_path / "home"
+    stub = stub_gh(env_home, "exit 1")
+    env = make_env(env_home, path_prepend=stub)
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+    bare = tmp_path / "bare.git"
+    subprocess.run(
+        ["git", "init", "-q", "--bare", str(bare)],
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+    git(repo, env, "push", "-q", str(bare), "main")
+    git(repo, env, "remote", "add", "origin", cred_upper)
+    git(repo, env, "config", "url.%s.insteadOf" % bare, cred_upper)
+
+    result = run_anchor(env, repo)
+    data = anchor_json(result)
+    assert data["remote_url"] == "HTTPS://github.com/o/r.git"
+    assert FAKE_TOKEN not in result.stdout
+    assert FAKE_TOKEN not in result.stderr
     run_anchor(env, "--teardown", repo, data["worktree"])
 
 

--- a/modules/orrery/tests/unit/test_enumerate_repo.py
+++ b/modules/orrery/tests/unit/test_enumerate_repo.py
@@ -1,0 +1,457 @@
+"""Unit tests for enumerate_repo.py (plan Epic 2, section 3.5a).
+
+Hermetic: fixture-repo files are materialized into throwaway temp git repos.
+Materialization reads the fixture from the ccgm repo's git INDEX (git ls-files
+plus git cat-file), never the checkout: the fixture tracks both web/ and Web/,
+which a case-insensitive filesystem collapses into one on-disk directory. For
+the same reason the temp repos are built with git index plumbing
+(update-index --index-info), so both cases exist as distinct tracked paths on
+every platform.
+"""
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+MODULE_DIR = Path(__file__).resolve().parents[2]
+SCRIPT = MODULE_DIR / "skills" / "orrery" / "scripts" / "enumerate_repo.py"
+CCGM_ROOT = MODULE_DIR.parents[1]
+FIXTURE_PREFIX = "modules/orrery/tests/fixtures/fixture-repo/"
+
+AREA_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+# Import the script as a module: proves the Epic 5 import contract
+# (diff_since.py imports MANIFEST_TABLE from here) and exposes the sanitizer.
+_spec = importlib.util.spec_from_file_location("enumerate_repo", SCRIPT)
+er = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(er)
+
+
+# --- helpers -----------------------------------------------------------------
+def git_env(tmp_path):
+    env = dict(os.environ)
+    env.update(
+        {
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": str(tmp_path / "gitconfig-does-not-exist"),
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_AUTHOR_NAME": "Fixture",
+            "GIT_AUTHOR_EMAIL": "fixture@example.com",
+            "GIT_COMMITTER_NAME": "Fixture",
+            "GIT_COMMITTER_EMAIL": "fixture@example.com",
+        }
+    )
+    return env
+
+
+def _fixture_files():
+    """{relative path: bytes} for every fixture-repo file, from the ccgm
+    index (the checkout is case-folded on macOS and cannot be trusted)."""
+    raw = subprocess.run(
+        ["git", "-C", str(CCGM_ROOT), "ls-files", "-z", "--", FIXTURE_PREFIX.rstrip("/")],
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+    files = {}
+    for entry in raw.split(b"\0"):
+        if not entry:
+            continue
+        path = entry.decode("utf-8")
+        content = subprocess.run(
+            ["git", "-C", str(CCGM_ROOT), "cat-file", "blob", ":0:%s" % path],
+            check=True,
+            stdout=subprocess.PIPE,
+        ).stdout
+        files[path[len(FIXTURE_PREFIX):]] = content
+    assert files, "fixture-repo is empty - materialization is broken"
+    return files
+
+
+_FIXTURE_CACHE = None
+
+
+def fixture_files():
+    global _FIXTURE_CACHE
+    if _FIXTURE_CACHE is None:
+        _FIXTURE_CACHE = _fixture_files()
+    return dict(_FIXTURE_CACHE)
+
+
+def commit_tree(repo, files, env):
+    """Create a git repo whose ONE commit tracks exactly `files`, via index
+    plumbing so case-colliding paths (web/ + Web/) survive any filesystem."""
+    repo.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(repo)],
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+    oid_by_content = {}
+    for content in set(files.values()):
+        oid = subprocess.run(
+            ["git", "-C", str(repo), "hash-object", "-w", "--stdin"],
+            input=content,
+            env=env,
+            check=True,
+            stdout=subprocess.PIPE,
+        ).stdout.decode("ascii").strip()
+        oid_by_content[content] = oid
+    index_info = b"".join(
+        b"100644 %s 0\t%s\n"
+        % (oid_by_content[content].encode("ascii"), path.encode("utf-8"))
+        for path, content in sorted(files.items())
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "update-index", "--add", "--index-info"],
+        input=index_info,
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "fixture"],
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+    return repo
+
+
+def run_census(tmp_path, files, name="repo"):
+    env = git_env(tmp_path)
+    repo = commit_tree(tmp_path / name, files, env)
+    out = tmp_path / ("%s-census.json" % name)
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--worktree", str(repo), "--out", str(out)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    census = json.loads(out.read_bytes())
+    # Blanket acceptance criterion: EVERY emitted area id is element-id-legal.
+    for area in census["areas"]:
+        assert AREA_ID_RE.match(area["id"]), "illegal area id %r" % area["id"]
+    assert census["id_namespace"]["area_ids"] == sorted(a["id"] for a in census["areas"])
+    return census, out
+
+
+def synth(dirs, root_files=None):
+    """{path: content} with `count` distinct small files per directory."""
+    files = {}
+    for d, count in dirs.items():
+        for i in range(count):
+            files["%s/f%03d.js" % (d, i)] = b"// synthetic\n"
+    for f in root_files or []:
+        files[f] = b"# root\n"
+    return files
+
+
+def area_by_id(census, area_id):
+    matches = [a for a in census["areas"] if a["id"] == area_id]
+    assert len(matches) == 1, "expected exactly one area %r" % area_id
+    return matches[0]
+
+
+def id_of_root_path(census, path):
+    matches = [a for a in census["areas"] if a["root_paths"] == [path]]
+    assert len(matches) == 1, "expected exactly one area rooted at %r" % path
+    return matches[0]["id"]
+
+
+# --- fixture census ----------------------------------------------------------
+def test_fixture_census_areas(tmp_path):
+    files = fixture_files()
+    # The materialized index must carry BOTH cases distinctly.
+    assert any(p.startswith("web/") for p in files)
+    assert any(p.startswith("Web/") for p in files)
+
+    census, _ = run_census(tmp_path, files)
+
+    # Candidates: many (32) and web (12) survive; .github, 2fa, api, db,
+    # my-app, Web are under 5 files and merge into misc with the root files.
+    assert census["id_namespace"]["area_ids"] == ["many", "misc", "web"]
+    assert census["bucketing"] == {
+        "applied": False,
+        "bucket_count": 0,
+        "candidate_count": 2,
+    }
+
+    web = area_by_id(census, "web")
+    assert web["bucketed"] is False
+    assert web["root_paths"] == ["web"]
+    assert web["file_count"] == sum(1 for p in files if p.startswith("web/"))
+
+    many = area_by_id(census, "many")
+    assert many["file_count"] == sum(1 for p in files if p.startswith("many/"))
+
+    misc = area_by_id(census, "misc")
+    misc_paths = {m["path"] for m in misc["members"]}
+    assert {".github", "2fa", "Web", "api", "db", "my-app"} <= misc_paths
+    assert {".env.example", "README.md", "package.json"} <= misc_paths
+
+    assert census["tree"]["tracked_files"] == len(files)
+    assert census["id_namespace"]["reserved_ids"] == ["misc", "system", "users"]
+    assert census["id_namespace"]["reserved_bucket_ids"][0] == "bucket_01"
+    assert census["id_namespace"]["reserved_bucket_ids"][-1] == "bucket_24"
+    assert census["id_namespace"]["wave0_owned_kinds"] == [
+        "actor",
+        "container",
+        "external",
+    ]
+
+
+def test_fixture_census_manifests_entrypoints_languages(tmp_path):
+    files = fixture_files()
+    census, _ = run_census(tmp_path, files)
+
+    hits = {(m["kind"], m["path"]) for m in census["manifests"]}
+    assert ("wrangler", "api/wrangler.toml") in hits
+    assert ("env-example", ".env.example") in hits
+    assert ("github-workflow", ".github/workflows/deploy.yml") in hits
+    assert ("migrations", "db/migrations") in hits
+    assert ("package.json", "package.json") in hits
+
+    pkg = [m for m in census["manifests"] if m["kind"] == "package.json"][0]
+    assert "stripe" in pkg["dependencies"]
+
+    assert "api/src/worker.js" in census["entrypoints"]
+    assert "web/src/main.ts" in census["entrypoints"]
+
+    assert census["languages"]["js"] >= 1
+    assert census["languages"]["ts"] >= 1
+
+
+def test_census_byte_identical_across_two_runs(tmp_path):
+    files = fixture_files()
+    _, out1 = run_census(tmp_path, files, name="run1")
+    _, out2 = run_census(tmp_path, files, name="run2")
+    assert out1.read_bytes() == out2.read_bytes()
+
+
+# --- bucketing (section 3.5a step 3, arch C2) --------------------------------
+def test_many_tree_buckets_balanced(tmp_path):
+    # The fixture's many/ tree carries 16 sibling dirs of 2 files each. Padded
+    # to 5 files per sibling (the merge threshold would otherwise fold all 16
+    # into misc), the tree alone makes many/ hold >60% of tracked files, so it
+    # expands into 16 sibling candidates and bucketing engages.
+    files = {p: c for p, c in fixture_files().items() if p.startswith("many/")}
+    siblings = sorted({p.split("/")[1] for p in files})
+    assert len(siblings) == 16
+    for sub in siblings:
+        for i in range(3):
+            files["many/%s/pad%d.js" % (sub, i)] = b"// pad\n"
+
+    census, _ = run_census(tmp_path, files)
+
+    assert census["bucketing"]["applied"] is True
+    assert census["bucketing"]["candidate_count"] == 16
+    buckets = census["areas"]
+    assert 0 < len(buckets) <= 24
+    assert census["bucketing"]["bucket_count"] == len(buckets)
+    # Target-12 rule: 16 candidates pack into 12 buckets.
+    assert len(buckets) == 12
+    assert [b["id"] for b in buckets] == ["bucket_%02d" % i for i in range(1, 13)]
+    for b in buckets:
+        assert b["bucketed"] is True
+        assert b["members"], "bucket without members"
+        assert b["root_paths"] == [m["path"] for m in b["members"]]
+
+    # Membership: every candidate appears exactly once, and concatenating the
+    # buckets in id order reproduces alphabetical sibling order (adjacency).
+    concat = [m["path"] for b in buckets for m in b["members"]]
+    assert concat == ["many/%s" % s for s in siblings]
+
+    # Balance: 16 candidates of 5 files into 12 buckets has an optimal max of
+    # 10 files (4 buckets of two siblings, 8 of one).
+    sizes = [b["file_count"] for b in buckets]
+    assert max(sizes) == 10
+    assert min(sizes) == 5
+
+
+# --- expansion (section 3.5a step 1) -----------------------------------------
+def test_expansion_over_60_percent(tmp_path):
+    dirs = {"big/sub%02d" % i: 6 for i in range(10)}
+    dirs["api"] = 6
+    files = synth(dirs, root_files=["README.md", "notes.txt"])
+    census, _ = run_census(tmp_path, files)
+
+    ids = census["id_namespace"]["area_ids"]
+    assert "big_sub00" in ids
+    assert "big_sub09" in ids
+    assert "api" in ids
+    assert "big" not in ids  # expanded away
+    assert "misc" in ids  # the two root files
+    assert census["bucketing"]["applied"] is False
+
+
+def test_no_expansion_at_exactly_60_percent(tmp_path):
+    # 60 of 100 files is not >60%: strict inequality, no expansion.
+    files = synth({"big/inner": 60, "other": 40})
+    census, _ = run_census(tmp_path, files)
+    assert "big" in census["id_namespace"]["area_ids"]
+    assert "big_inner" not in census["id_namespace"]["area_ids"]
+
+
+# --- split (section 3.5a step 2) ---------------------------------------------
+def test_split_over_400_files(tmp_path):
+    files = synth({"big/sub1": 300, "big/sub2": 150, "other": 400})
+    census, _ = run_census(tmp_path, files)
+
+    ids = census["id_namespace"]["area_ids"]
+    # big (450) splits by subdirectory; other (exactly 400) does not.
+    assert "big_sub1" in ids
+    assert "big_sub2" in ids
+    assert "big" not in ids
+    assert "other" in ids
+
+
+# --- merge (section 3.5a step 2) ---------------------------------------------
+def test_merge_under_5_files_into_misc(tmp_path):
+    files = synth({"kept": 5, "tiny": 4})
+    census, _ = run_census(tmp_path, files)
+
+    assert census["id_namespace"]["area_ids"] == ["kept", "misc"]
+    misc = area_by_id(census, "misc")
+    assert [m["path"] for m in misc["members"]] == ["tiny"]
+    assert misc["file_count"] == 4
+
+
+# --- area-id rule (section 3.5a step 5, FROZEN) ------------------------------
+def test_area_id_adversarial_matrix(tmp_path):
+    files = synth(
+        {
+            ".github": 5,
+            "2fa": 5,
+            "Web": 5,
+            "my-app": 5,
+            "src.new": 5,
+            "web": 5,
+        }
+    )
+    census, _ = run_census(tmp_path, files)
+
+    # Candidate order is byte-sorted paths: ".github" < "2fa" < "Web" <
+    # "my-app" < "src.new" < "web", so Web claims "web" first and lowercase
+    # web/ takes the deterministic collision suffix.
+    assert id_of_root_path(census, ".github") == "a__github"
+    assert id_of_root_path(census, "2fa") == "a_2fa"
+    assert id_of_root_path(census, "Web") == "web"
+    assert id_of_root_path(census, "my-app") == "my_app"
+    assert id_of_root_path(census, "src.new") == "src_new"
+    assert id_of_root_path(census, "web") == "web_2"
+
+
+def test_fixture_web_case_collision_resolves_deterministically(tmp_path):
+    # The fixture repo itself carries both web/ and Web/. Padded above the
+    # merge threshold so both survive as areas, the collision must resolve
+    # the same way on every platform and every run.
+    files = fixture_files()
+    for i in range(3):
+        files["Web/pad%d.js" % i] = b"// pad\n"
+    census1, out1 = run_census(tmp_path, files, name="one")
+    census2, out2 = run_census(tmp_path, files, name="two")
+
+    assert id_of_root_path(census1, "Web") == "web"
+    assert id_of_root_path(census1, "web") == "web_2"
+    assert out1.read_bytes() == out2.read_bytes()
+
+
+def test_area_id_collision_my_app_my_app(tmp_path):
+    files = synth({"my-app": 5, "my_app": 5})
+    census, _ = run_census(tmp_path, files)
+    # Byte order: "my-app" (hyphen 0x2D) precedes "my_app" (underscore 0x5F).
+    assert id_of_root_path(census, "my-app") == "my_app"
+    assert id_of_root_path(census, "my_app") == "my_app_2"
+
+
+def test_area_id_long_and_unicode_names(tmp_path):
+    long_name = "x" * 200
+    files = synth({long_name: 5, "café-zone": 5})
+    census, _ = run_census(tmp_path, files)
+    assert id_of_root_path(census, long_name) == "x" * 24
+    assert id_of_root_path(census, "café-zone") == "caf_zone"
+
+
+def test_sanitize_area_id_unit_cases():
+    taken = set(er.RESERVED_IDS) | set(er.RESERVED_BUCKET_IDS)
+    assert er.sanitize_area_id("my-app", taken) == "my_app"
+    assert er.sanitize_area_id(".github", taken) == "a__github"
+    assert er.sanitize_area_id("2fa", taken) == "a_2fa"
+    assert er.sanitize_area_id("Web", taken) == "web"
+    assert er.sanitize_area_id("web", taken) == "web_2"
+    assert er.sanitize_area_id("src.new", taken) == "src_new"
+    # A reserved id is collision-suffixed, never claimed.
+    assert er.sanitize_area_id("misc", taken) == "misc_2"
+    # A name with no [a-z0-9] at all still yields a legal id.
+    assert er.sanitize_area_id("...", taken) == "a"
+    for area_id in taken:
+        if area_id.startswith("bucket_") or area_id in er.RESERVED_IDS:
+            continue
+        assert AREA_ID_RE.match(area_id)
+
+
+# --- manifest table import contract (Epic 5) ---------------------------------
+def test_manifest_table_is_importable_constant():
+    assert isinstance(er.MANIFEST_TABLE, tuple)
+    patterns = {(mtype, pattern) for _kind, mtype, pattern in er.MANIFEST_TABLE}
+    expected = {
+        ("basename", "package.json"),
+        ("basename", "pnpm-workspace.yaml"),
+        ("basename", "requirements.txt"),
+        ("basename", "pyproject.toml"),
+        ("basename", "Gemfile"),
+        ("basename", "go.mod"),
+        ("basename", "Cargo.toml"),
+        ("basename", "Package.swift"),
+        ("basename", "composer.json"),
+        ("basename", "wrangler.toml"),
+        ("basename", "vercel.json"),
+        ("basename", "netlify.toml"),
+        ("basename", "fly.toml"),
+        ("basename", "Dockerfile"),
+        ("basename", "docker-compose.yml"),
+        ("suffix", ".tf"),
+        ("glob", ".github/workflows/*.yml"),
+        ("basename", ".env.example"),
+        ("dir", "supabase"),
+        ("dir", "prisma"),
+        ("dir", "drizzle"),
+        ("dir", "migrations"),
+    }
+    assert patterns == expected
+    for row in er.MANIFEST_TABLE:
+        assert len(row) == 3
+
+
+def test_manifest_suffix_and_dir_kinds(tmp_path):
+    files = synth({"infra": 4, "supabase": 4, "app": 5})
+    files["infra/main.tf"] = b"# tf\n"
+    files["supabase/config.toml"] = b"# supabase\n"
+    census, _ = run_census(tmp_path, files)
+
+    hits = {(m["kind"], m["path"]) for m in census["manifests"]}
+    assert ("terraform", "infra/main.tf") in hits
+    assert ("supabase", "supabase") in hits
+
+
+# --- CLI error path ----------------------------------------------------------
+def test_missing_worktree_exits_2(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--worktree",
+            str(tmp_path / "nope"),
+            "--out",
+            str(tmp_path / "census.json"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "not a git worktree" in result.stderr

--- a/modules/orrery/tests/unit/test_enumerate_repo.py
+++ b/modules/orrery/tests/unit/test_enumerate_repo.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 MODULE_DIR = Path(__file__).resolve().parents[2]
 SCRIPT = MODULE_DIR / "skills" / "orrery" / "scripts" / "enumerate_repo.py"
 CCGM_ROOT = MODULE_DIR.parents[1]
@@ -32,12 +34,19 @@ _spec.loader.exec_module(er)
 
 
 # --- helpers -----------------------------------------------------------------
-def git_env(tmp_path):
-    env = dict(os.environ)
+def git_env(tmp_path=None):
+    """Scrubbed environment: every inherited GIT_* var dropped (an exported
+    GIT_DIR/GIT_INDEX_FILE/GIT_WORK_TREE would redirect every git call), then
+    the fixed hermetic set restored (review finding 9)."""
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    if tmp_path is not None:
+        config_global = str(tmp_path / "gitconfig-does-not-exist")
+    else:
+        config_global = os.devnull
     env.update(
         {
             "GIT_CONFIG_NOSYSTEM": "1",
-            "GIT_CONFIG_GLOBAL": str(tmp_path / "gitconfig-does-not-exist"),
+            "GIT_CONFIG_GLOBAL": config_global,
             "GIT_TERMINAL_PROMPT": "0",
             "GIT_AUTHOR_NAME": "Fixture",
             "GIT_AUTHOR_EMAIL": "fixture@example.com",
@@ -51,10 +60,12 @@ def git_env(tmp_path):
 def _fixture_files():
     """{relative path: bytes} for every fixture-repo file, from the ccgm
     index (the checkout is case-folded on macOS and cannot be trusted)."""
+    env = git_env()
     raw = subprocess.run(
         ["git", "-C", str(CCGM_ROOT), "ls-files", "-z", "--", FIXTURE_PREFIX.rstrip("/")],
         check=True,
         stdout=subprocess.PIPE,
+        env=env,
     ).stdout
     files = {}
     for entry in raw.split(b"\0"):
@@ -65,6 +76,7 @@ def _fixture_files():
             ["git", "-C", str(CCGM_ROOT), "cat-file", "blob", ":0:%s" % path],
             check=True,
             stdout=subprocess.PIPE,
+            env=env,
         ).stdout
         files[path[len(FIXTURE_PREFIX):]] = content
     assert files, "fixture-repo is empty - materialization is broken"
@@ -130,6 +142,7 @@ def run_census(tmp_path, files, name="repo"):
         [sys.executable, str(SCRIPT), "--worktree", str(repo), "--out", str(out)],
         capture_output=True,
         text=True,
+        env=env,
     )
     assert result.returncode == 0, result.stdout + result.stderr
     census = json.loads(out.read_bytes())
@@ -452,6 +465,19 @@ def test_missing_worktree_exits_2(tmp_path):
         ],
         capture_output=True,
         text=True,
+        env=git_env(tmp_path),
     )
     assert result.returncode == 2
     assert "not a git worktree" in result.stderr
+
+
+def test_bucket_ceiling_guard_exits_2():
+    """The sibling-group ceiling guard uses the documented CLI error shape:
+    one stderr line, exit 2 (review finding 8)."""
+    candidates = [
+        {"path": "p%02d/x" % i, "files": ["f%d" % j for j in range(5)]}
+        for i in range(25)
+    ]
+    with pytest.raises(SystemExit) as exc:
+        er._bucketize(candidates, misc_exists=False)
+    assert exc.value.code == 2


### PR DESCRIPTION
Closes #901. Refs #899.

Ships the deterministic front half of the orrery pipeline: a repo path in, a pinned, enumerated, bucketed census out, with zero LLM involvement.

## What it does

**`anchor_repo.sh <repo-path>`** (plan 3.1 stages 1 + 6)
- `git worktree prune` FIRST, so a prior crashed run's stale metadata never collides
- resolves `origin/HEAD` -> `origin/main` -> local default (no-remote supported and flagged), fetches, pins `ANCHOR_SHA`, creates a uniquely-named detached temp worktree
- STRICT slug rule (C7): basename-derived, sanitized, exit 2 when unsanitizable
- strips `user[:token]@` userinfo from the remote URL BEFORE any output (C6) - reads `remote.origin.url` from config, not `remote get-url`, which expands `insteadOf` rewrites
- `gh`-based visibility (`private`/`public`/`unknown`, never fatal), `~/code/orrery/{slug}` chmod 700 (R4)
- emits single-line JSON with all ten anchor fields; exit 2 + JSON error paths
- `--teardown <repo> <worktree>`: remove --force + prune, idempotent, never fatal - and an internal error-path trap tears down the worktree when the run itself fails after creating it

**`enumerate_repo.py --worktree --out`** (plan 3.1 stage 2, 3.5a)
- census via `git ls-files` / `git cat-file blob :0:` only - never filesystem walks (the fixture tracks both `web/` and `Web/`, which case-insensitive filesystems collapse)
- `MANIFEST_TABLE` lives here as an importable constant (Epic 5's `diff_since.py` imports it); package.json hits carry parsed dependency names
- section 3.5a exactly: >60% single-dir expansion, <5-file merge into misc, >400-file split, target-12 / ceiling-24 sibling bin-packing with `bucketed` flag + members, and the FROZEN step-5 area-id sanitization (element-id-legal by construction, collision-suffixed in candidate order)
- publishes the id namespace (area ids, reserved `misc`/`system`/`users`, `bucket_01..24`, wave-0-owned kinds)
- byte-deterministic output: sorted keys, sorted lists, ASCII, no timestamps

## Tests (35, hermetic)

Throwaway git repos with local bare origins under tempdirs; temp repos built with index plumbing so case-colliding paths survive on every platform; credentialed URLs rewritten to local paths via `url.<base>.insteadOf` (no network); `gh` stubbed on PATH.

- adversarial slugs (`../evil`, absolute-path-shaped, unicode -> exit 2, 200-char -> 64), credential-strip proof (`ghp_fake` never in any output, success AND fetch-failure paths - mutation-checked: removing the strip fails both tests), visibility private/public/unknown, chmod 700
- worktree clean after teardown on success AND after a simulated mid-run failure (error-path teardown), teardown idempotent and never fatal, stale-metadata prune-first
- byte-identical census across two runs; the fixture `many/` tree -> 16 sibling candidates -> 12 balanced buckets (max 10 / min 5 files, alphabetical adjacency preserved, membership recorded); expansion/split/merge boundary cases (exactly 60%, exactly 400, exactly 5)
- frozen area-id matrix: `my-app`->`my_app`, `.github`->`a__github`, `2fa`->`a_2fa`, `Web`->`web`, `src.new`->`src_new`, plus the fixture's real `web`/`Web` collision resolving deterministically (`Web`->`web`, `web`->`web_2` in byte-sorted candidate order) and `my-app`+`my_app`->`my_app`/`my_app_2`; every emitted id asserted against `^[a-z][a-z0-9_]*$` on every census any test produces

## Checkpoint note (Epic 4 consumes this)

The signals seed vocabulary is FROZEN as: cloudflare, vercel, netlify, fly, docker, supabase, prisma, drizzle, postgres, sqlite, redis, stripe, resend, openai, anthropic, github-actions, terraform - explicitly a SEED list; packs must report unlisted providers too.

## Verification

- `pytest modules/orrery/tests/unit -q` (venv): `35 passed`
- `ORRERY_STRICT=1 bash modules/orrery/tests/test-orrery.sh`: `layers ran: unit test-embed-browser.sh test-render-golden.sh test-validate-gate.sh` / `all layers green`
- `bash tests/test-modules.sh`: `1636 passed, 0 failed`
- `bash tests/test-no-personal-data.sh`: `PASS`
- `gen_marketplace.py --check`: `Marketplace files are up to date.` (no metadata change, no regen needed)
