### PR TITLE
#904: orrery Epic 5 — living update path (/orrery update + diff_since)

### DIFF
--- a/modules/orrery/module.json
+++ b/modules/orrery/module.json
@@ -12,6 +12,7 @@
     "skills/orrery/references/model.schema.json": { "target": "skills/orrery/references/model.schema.json", "type": "doc", "template": false },
     "skills/orrery/references/packs.md": { "target": "skills/orrery/references/packs.md", "type": "doc", "template": false },
     "skills/orrery/scripts/anchor_repo.sh": { "target": "skills/orrery/scripts/anchor_repo.sh", "type": "script", "template": false },
+    "skills/orrery/scripts/diff_since.py": { "target": "skills/orrery/scripts/diff_since.py", "type": "script", "template": false },
     "skills/orrery/scripts/emit_likec4.py": { "target": "skills/orrery/scripts/emit_likec4.py", "type": "script", "template": false },
     "skills/orrery/scripts/enumerate_repo.py": { "target": "skills/orrery/scripts/enumerate_repo.py", "type": "script", "template": false },
     "skills/orrery/scripts/likec4.sh": { "target": "skills/orrery/scripts/likec4.sh", "type": "script", "template": false },

--- a/modules/orrery/skills/orrery/SKILL.md
+++ b/modules/orrery/skills/orrery/SKILL.md
@@ -42,8 +42,8 @@ and never re-implements what a script owns.
   guidance: "run /orrery inside the repo you want mapped, or pass a path: /orrery <repo-path>".
 - **Explicit argument**: a path that exists is used as-is; a bare name tries `~/code/{name}`;
   otherwise stop with the same guidance.
-- **`update` keyword**: route to the update flow (see the labeled section at the bottom -
-  implemented in Epic 5).
+- **`update` keyword**: route to the update flow (the "Update flow" section at the
+  bottom) instead of the build steps below.
 - **`--vision <file>`**: a LOCAL file only - never fetched. If the value looks like a URL,
   stop with an error; do not download anything.
 - **`--out <dir>`**: output directory for this map. Default: `$ORRERY_HOME/{slug}` where
@@ -70,7 +70,8 @@ Capture stdout and parse the single-line JSON: `repo_path`, `remote_url`
   `private` or `unknown`, say now that the report will carry a do-not-publish-without-review
   warning.
 
-Resolve the out dir (`--out`, else `$ORRERY_HOME/{slug}`), create it `chmod 700` if needed,
+Resolve the out dir (`--out`, else `$ORRERY_HOME/{slug}` - the same root
+`anchor_repo.sh` itself honors for the dir it creates), create it `chmod 700` if needed,
 and save the anchor JSON to `$out/anchor.json`.
 
 ## Step 3 - enumerate + announce
@@ -294,10 +295,116 @@ State plainly, in this order:
   then re-dispatch ONLY the failed packs in waves of at most 4. If it trips again, halve
   the wave size and double the cooldown. Never re-launch the whole burst.
 
-## Update flow - implemented in Epic 5
+## Update flow - `/orrery update`
 
-`/orrery update [<repo>]` is not built yet. The planned shape: re-anchor, diff the recorded
-anchor against the new one (`scripts/diff_since.py` - ancestry-checked, rename-aware),
-re-investigate only the affected packs, patch-merge, and re-run the same emit -> validate ->
-render chain with the same fix loop and the same unskippable teardown. Until Epic 5 lands,
-tell the user: "the update flow is not implemented yet - run /orrery for a full rebuild."
+`/orrery update [<repo>]` refreshes an existing map incrementally. Everything the hard
+rules say about the build path holds here unchanged: every dispatch is an `orrery-scout`,
+teardown always runs (including on the "up to date" stop), and an invalid model is never
+rendered.
+
+### U1 - anchor and locate the map
+
+Resolve the target repo exactly as step 1, then run step 2 (anchor) as written - the
+update flow anchors a worktree too, so **the teardown obligation starts here** and is
+discharged on every exit path below. Resolve the out dir exactly as step 2:
+`--out` if given, else `$ORRERY_HOME/{slug}`. If `$out/state.json` does not exist, say so
+naming the resolved path - "no state.json at `$out/state.json`; a map built with a custom
+`--out` needs that same `--out` passed to update" - never silently build a second
+divergent copy without stating where the update looked.
+
+### U2 - gate + diff (deterministic)
+
+```
+python3 scripts/diff_since.py \
+  --repo <repo-path> \
+  --state $out/state.json \
+  --new-anchor <anchor_sha> \
+  --out $out/diff.json
+```
+
+`scripts/diff_since.py` owns the whole deterministic decision: the state gate (no
+state.json / unparseable / `schema_version` != 1 / `likec4_version` != the installed
+toolchain version, which it reads from `scripts/toolchain/package.json` the same way
+step 7 does), the history-rewrite check (old anchor resolvable AND an ancestor of the
+new one), the unchanged short-circuit, and the rename-aware `git diff -M`
+classification. It also updates renamed files' element anchors in place in the baseline
+`$out/model.json`, so renames preserve element continuity without re-investigation.
+A nonzero exit is an environment or contract bug: report BLOCKED with its stderr and
+run step 8.
+
+### U3 - route on diff.json (first match wins)
+
+1. **`rebuild_required` true**: announce the `rebuild_reason` verbatim (it names which
+   gate condition fired, or the clustering-material change), then run the full build -
+   steps 3 through 9 exactly as written, reusing the anchor and worktree from U1.
+2. **`history_rewritten` true**: announce "history rewritten - old anchor {sha} is
+   unresolvable or not an ancestor of {new sha}; full rebuild", then run steps 3-9 the
+   same way. Never guess-diff across rewritten history.
+3. **`unchanged` true**: report "up to date (anchor {sha})" - zero agent dispatch, **but
+   still run step 8 (teardown)**. The short-circuit skips the work, never the cleanup.
+4. Otherwise: the patch path (U4).
+
+### U4 - patch path
+
+1. **Refresh the deterministic inputs**: overwrite `$out/anchor.json` with the U1 anchor
+   JSON and re-run step 3's enumerate command to refresh `$out/census.json` (announce is
+   not repeated; the census here feeds merge meta and the state writer).
+2. **Build the re-run pack list from diff.json**: `product-vision` if
+   `product_vision_flagged`, `external-systems` if `external_systems_flagged`, and
+   `area-{area_id}` for every entry in `affected_areas` - the same load-bearing
+   `area-{area_id}` pack naming as step 5. Overwrite `$out/packs.txt` with exactly this
+   list; step U4.5 passes exactly it to `--packs`. If `affected_areas` names `misc` and
+   state.json's `areas[]` has no misc entry, dispatch `area-misc` with
+   `new_paths_routed_to_misc` as its root_paths (`misc` is a reserved, pattern-legal id).
+3. **Clear `$out/fragments/`** (delete and recreate - same hygiene as step 5), then
+   dispatch ONLY the re-run packs as `orrery-scout`, waves of at most 8, wave-0 packs
+   (if flagged) first. Briefs come from `references/packs.md` as in step 5; each area
+   pack gets its recorded `root_paths` from state.json's `areas[]`, plus
+   `new_paths_routed_to_misc` appended for the misc pack. The published-id set: resolve
+   it from re-run wave-0 replies where available, else from the baseline
+   `$out/model.json` (the `system` id, every `container` and `actor` id, and every
+   element whose `source_packs` includes `external-systems`). Persist and check
+   fragments exactly as step 5.
+4. **Failure protocol (update mode)**: one re-dispatch per failed pack, then STOP
+   retrying - do NOT split (a split's suffixed area ids would not match the baseline's
+   pack namespaces, so its output could never replace the baseline). Keep the failed
+   pack listed in `packs.txt`: `merge_fragments.py --patch` retains that pack's baseline
+   elements when no valid fragment arrives (reported as
+   `reinvestigation_failed_retained`) - the map must never silently shrink because one
+   re-investigation failed. Record the retention for the report. This applies to wave-0
+   packs too: a failed wave-0 re-run falls back to the baseline, it does not BLOCK.
+5. **Patch-merge, emit, validate** - run step 6 with the merge command replaced by patch
+   mode; everything else in step 6 (the BLOCKED dispositions for non-element errors, the
+   bounded <=3 fix loop, one fixer scout per iteration, the delete-errors.json-first
+   hygiene) applies verbatim, re-running THIS merge command each iteration:
+
+```
+python3 scripts/merge_fragments.py \
+  --fragments-dir $out/fragments \
+  --packs <comma-separated list from packs.txt> \
+  --census $out/census.json \
+  --anchor $out/anchor.json \
+  --out $out/model.json \
+  --patch --state $out/state.json --diff $out/diff.json
+```
+
+   (`--out` is both the baseline in and the patched model out. After 3 failed fix
+   iterations: BLOCKED with the errors.json path, step 8, never render.)
+6. **Render + state**: run step 7 exactly as written - render, then the atomic
+   state.json write. It reads the refreshed anchor.json/census.json and the patched
+   model.json, so the new anchor SHA and element index land atomically
+   (temp file + rename, never in place).
+7. **Teardown**: step 8, unskippable, as always.
+
+### U5 - report the delta
+
+Report the step 9 items (artifact, anchor, visibility warning, counts, embed snippet),
+plus the update delta, computed from `$out/diff.json` and the `patch` section of
+`merge-report.json`:
+
+- Elements added / updated / removed (`baseline_elements_replaced`, `orphaned_deleted`,
+  and the re-run fragments' contents).
+- Renames preserved: each `renamed_paths` entry (`from -> to`) and the
+  `elements_reanchored` ids whose anchors moved with them.
+- Any packs retained from baseline after a failed re-investigation.
+- The `open_questions` rollup from the re-run fragments.

--- a/modules/orrery/skills/orrery/SKILL.md
+++ b/modules/orrery/skills/orrery/SKILL.md
@@ -307,10 +307,14 @@ rendered.
 Resolve the target repo exactly as step 1, then run step 2 (anchor) as written - the
 update flow anchors a worktree too, so **the teardown obligation starts here** and is
 discharged on every exit path below. Resolve the out dir exactly as step 2:
-`--out` if given, else `$ORRERY_HOME/{slug}`. If `$out/state.json` does not exist, say so
-naming the resolved path - "no state.json at `$out/state.json`; a map built with a custom
-`--out` needs that same `--out` passed to update" - never silently build a second
-divergent copy without stating where the update looked.
+`--out` if given, else `$ORRERY_HOME/{slug}`. If `$out/state.json` does not exist,
+**STOP** (after step 8): report "no state.json at `$out/state.json` - a map built with a
+custom `--out` needs that same `--out` passed to update; run `/orrery` (the build path)
+to build here". An explicit update must never full-rebuild at a root it merely guessed -
+that is exactly how a second divergent copy gets created (risk adrev2-014). The other
+gate conditions (unparseable state, wrong schema_version, likec4_version mismatch -
+where the root is right but the state is unusable) DO fall back to a full rebuild; U3
+routes them.
 
 ### U2 - gate + diff (deterministic)
 
@@ -334,15 +338,18 @@ run step 8.
 
 ### U3 - route on diff.json (first match wins)
 
-1. **`rebuild_required` true**: announce the `rebuild_reason` verbatim (it names which
+1. **`state_missing` true**: report the `stop_reason` verbatim (it names the resolved
+   path that was searched and the `--out` mismatch cause), run step 8 (teardown), and
+   STOP. Never rebuild here - see U1.
+2. **`rebuild_required` true**: announce the `rebuild_reason` verbatim (it names which
    gate condition fired, or the clustering-material change), then run the full build -
    steps 3 through 9 exactly as written, reusing the anchor and worktree from U1.
-2. **`history_rewritten` true**: announce "history rewritten - old anchor {sha} is
+3. **`history_rewritten` true**: announce "history rewritten - old anchor {sha} is
    unresolvable or not an ancestor of {new sha}; full rebuild", then run steps 3-9 the
    same way. Never guess-diff across rewritten history.
-3. **`unchanged` true**: report "up to date (anchor {sha})" - zero agent dispatch, **but
+4. **`unchanged` true**: report "up to date (anchor {sha})" - zero agent dispatch, **but
    still run step 8 (teardown)**. The short-circuit skips the work, never the cleanup.
-4. Otherwise: the patch path (U4).
+5. Otherwise: the patch path (U4).
 
 ### U4 - patch path
 
@@ -356,15 +363,27 @@ run step 8.
    list; step U4.5 passes exactly it to `--packs`. If `affected_areas` names `misc` and
    state.json's `areas[]` has no misc entry, dispatch `area-misc` with
    `new_paths_routed_to_misc` as its root_paths (`misc` is a reserved, pattern-legal id).
+
+   **Empty pack list = the no-dispatch fast path, not an error.** A patchable diff can
+   legitimately affect zero packs - a pure same-area rename (continuity preserved by the
+   re-anchor alone) or an anchor advance with an identical tree. Never call
+   `merge_fragments.py` with an empty `--packs` (it exits 2 by contract). Instead: skip
+   U4.3-U4.5 entirely; if `elements_reanchored` is non-empty, run emit -> validate ->
+   render against the already re-anchored baseline `$out/model.json` (step 6 from the
+   emit command on - its dispositions apply); if it is empty, keep the existing artifact
+   untouched. Either way finish the flow - the atomic state.json advance (U4.6),
+   teardown (U4.7) - and report "no packs affected; anchor advanced" with the
+   re-anchored element count.
 3. **Clear `$out/fragments/`** (delete and recreate - same hygiene as step 5), then
    dispatch ONLY the re-run packs as `orrery-scout`, waves of at most 8, wave-0 packs
    (if flagged) first. Briefs come from `references/packs.md` as in step 5; each area
    pack gets its recorded `root_paths` from state.json's `areas[]`, plus
    `new_paths_routed_to_misc` appended for the misc pack. The published-id set: resolve
-   it from re-run wave-0 replies where available, else from the baseline
-   `$out/model.json` (the `system` id, every `container` and `actor` id, and every
-   element whose `source_packs` includes `external-systems`). Persist and check
-   fragments exactly as step 5.
+   it **per wave-0 pack** - from that pack's re-run reply where it was re-run, else from
+   the baseline `$out/model.json` (the `system` id, every `container` and `actor` id,
+   and every element whose `source_packs` includes `external-systems`) - so re-running
+   only external-systems never drops the baseline container/actor ids. Persist and
+   check fragments exactly as step 5.
 4. **Failure protocol (update mode)**: one re-dispatch per failed pack, then STOP
    retrying - do NOT split (a split's suffixed area ids would not match the baseline's
    pack namespaces, so its output could never replace the baseline). Keep the failed

--- a/modules/orrery/skills/orrery/scripts/anchor_repo.sh
+++ b/modules/orrery/skills/orrery/scripts/anchor_repo.sh
@@ -24,7 +24,9 @@ set -euo pipefail
 #   C7 - the slug must match ^[a-z0-9][a-z0-9_-]*$ after sanitization or we
 #        exit 2; it is derived from the repo directory basename only, so a
 #        path-shaped argument can never smuggle separators into the slug.
-#   R4 - the output dir ~/code/orrery/{slug} is chmod 700.
+#   R4 - the output dir ${ORRERY_HOME:-~/code/orrery}/{slug} is chmod 700.
+#        $ORRERY_HOME overrides the output root without editing this module
+#        (risk adrev2-014); unset, it defaults to ~/code/orrery.
 #
 # The run mutates the target repo in exactly two ways - `git fetch origin`
 # and `git worktree add`. The worktree is the only durable side effect, so
@@ -213,7 +215,7 @@ if [ -n "$OWNER_REPO" ] && command -v gh >/dev/null 2>&1; then
 fi
 
 # --- output dir (security R4) ------------------------------------------------
-OUT_DIR="$HOME/code/orrery/$SLUG"
+OUT_DIR="${ORRERY_HOME:-$HOME/code/orrery}/$SLUG"
 if ! mkdir -p "$OUT_DIR" 2>/dev/null; then
   emit_error "cannot create output dir $OUT_DIR" "$REPO"
 fi

--- a/modules/orrery/skills/orrery/scripts/diff_since.py
+++ b/modules/orrery/skills/orrery/scripts/diff_since.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""diff_since.py -- orrery update-path diff stage (plan Epic 5, section 3.1).
+
+Usage:
+    diff_since.py --repo <repo-path> --state <state.json> \
+        --new-anchor <sha> --out <diff.json>
+
+Deterministic, stdlib-only. Computes what changed between the recorded
+anchor (state.json's anchor_sha) and the freshly pinned one, and classifies
+the change so the update flow re-dispatches ONLY the affected packs.
+
+Decision order (each stop still writes a complete diff.json):
+
+1. State gate (business R5 / arch R5 / adrev2-009). The update flow rebuilds
+   fully, with a message naming WHICH condition fired, unless ALL of: the
+   state file exists, parses, carries anchor_sha, schema_version == 1, AND
+   likec4_version equals the installed toolchain version (read from
+   scripts/toolchain/package.json next to this script -- the same single
+   source the build path's state writer reads). Any failure ->
+   rebuild_required: true with the condition in rebuild_reason.
+2. History-rewrite safety (business C3). The old anchor must be resolvable
+   (git cat-file -e <old>^{commit}) AND an ancestor of the new one
+   (git merge-base --is-ancestor). Either failing -> history_rewritten: true
+   and stop -- never a guess-diff across rewritten history.
+3. Unchanged short-circuit. old == new -> unchanged: true, nothing else.
+4. Diff + classification: `git diff -M --name-status <old>..<new>` (explicit
+   -M so rename detection never depends on ambient config -- arch R2).
+   - Renamed files update the owning element's file anchors IN PLACE in the
+     baseline model.json (sibling of --state; temp-file + atomic rename), so
+     element continuity survives without re-investigation. A rename with
+     content edits (similarity < 100) additionally counts as a change; a
+     rename that crosses area boundaries marks both areas affected.
+   - Changed paths map to affected areas via state.json areas[].root_paths;
+     deletions map the same way, and elements whose every indexed path
+     (state.json element_index) was deleted are listed as orphaned_elements
+     for merge_fragments.py --patch to remove.
+   - Genuinely-new paths (under no recorded area) route to the existing
+     `misc` area first (arch R3). Full rebuild is reserved for
+     clustering-material changes: a new top-level directory contributing
+     >= 5 such files -> rebuild_required with the directory named.
+   - Manifest-table paths (MANIFEST_TABLE imported from enumerate_repo.py --
+     single source, never duplicated) always flag the external-systems pack;
+     README.md / CLAUDE.md / docs/ paths flag the product-vision pack.
+
+diff.json always carries every field:
+    changed_paths, affected_areas, deleted_paths, orphaned_elements,
+    new_paths_routed_to_misc, rebuild_required, rebuild_reason, unchanged,
+    history_rewritten -- plus renamed_paths ([{from,to,similarity}]),
+    elements_reanchored, external_systems_flagged, product_vision_flagged,
+    old_anchor_sha, new_anchor_sha for the update flow's pack list and
+    delta report.
+
+Exit codes: 0 = diff.json written (any outcome, including rebuild_required /
+history_rewritten / unchanged); 2 = usage or input error (unreachable repo,
+unresolvable NEW anchor, unreadable toolchain manifest) -- nothing written.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from fnmatch import fnmatchcase
+
+SCHEMA_VERSION = 1
+NEW_DIR_REBUILD_THRESHOLD = 5  # new top-level dir with >= 5 files outside all areas
+PRODUCT_VISION_BASENAMES = ("CLAUDE.md", "README.md")
+
+
+# --- single-source manifest table (imported from enumerate_repo.py) ----------
+def _load_manifest_table():
+    here = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(here, "enumerate_repo.py")
+    spec = importlib.util.spec_from_file_location("orrery_enumerate_repo", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.MANIFEST_TABLE
+
+
+MANIFEST_TABLE = _load_manifest_table()
+
+
+def _toolchain_likec4_version():
+    """The installed toolchain version -- read from scripts/toolchain/
+    package.json next to this script, the same way the build path's state
+    writer reads it (single source for the pinned version)."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(here, "toolchain", "package.json")
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)["dependencies"]["likec4"]
+
+
+# --- git plumbing ------------------------------------------------------------
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", repo] + list(args),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _is_commit(repo, sha):
+    return _git(repo, "cat-file", "-e", "%s^{commit}" % sha).returncode == 0
+
+
+def _is_ancestor(repo, old, new):
+    return _git(repo, "merge-base", "--is-ancestor", old, new).returncode == 0
+
+
+def _name_status(repo, old, new):
+    """Parse `git diff -M --name-status -z old..new` into
+    (status_code, similarity, old_path, new_path) rows. For non-renames
+    old_path == new_path and similarity is None."""
+    proc = _git(repo, "diff", "-M", "--name-status", "-z", "%s..%s" % (old, new))
+    if proc.returncode != 0:
+        raise RuntimeError("git diff -M --name-status failed between %s and %s" % (old, new))
+    tokens = proc.stdout.decode("utf-8", "replace").split("\0")
+    rows = []
+    i = 0
+    while i < len(tokens):
+        status = tokens[i]
+        if not status:
+            i += 1
+            continue
+        code = status[0]
+        if code in ("R", "C"):
+            if i + 2 >= len(tokens):
+                break
+            try:
+                similarity = int(status[1:]) if status[1:] else 100
+            except ValueError:
+                similarity = 100
+            rows.append((code, similarity, tokens[i + 1], tokens[i + 2]))
+            i += 3
+        else:
+            if i + 1 >= len(tokens):
+                break
+            rows.append((code, None, tokens[i + 1], tokens[i + 1]))
+            i += 2
+    return rows
+
+
+# --- classification helpers --------------------------------------------------
+def path_matches_manifest(path):
+    """Mirror of enumerate_repo.detect_manifests match semantics, driven by
+    the imported MANIFEST_TABLE."""
+    base = path.rsplit("/", 1)[-1]
+    for _kind, match_type, pattern in MANIFEST_TABLE:
+        if match_type == "basename":
+            if base == pattern:
+                return True
+        elif match_type == "suffix":
+            if path.endswith(pattern):
+                return True
+        elif match_type == "glob":
+            if fnmatchcase(path, pattern):
+                return True
+        elif match_type == "dir":
+            if pattern in path.split("/")[:-1]:
+                return True
+    return False
+
+
+def path_flags_product_vision(path):
+    base = path.rsplit("/", 1)[-1]
+    if base in PRODUCT_VISION_BASENAMES:
+        return True
+    return path == "docs" or path.startswith("docs/")
+
+
+def areas_of(path, areas):
+    """Area ids whose root_paths cover `path` (exact or prefix match)."""
+    hits = set()
+    for area in areas:
+        area_id = area.get("id")
+        if not area_id:
+            continue
+        for rp in area.get("root_paths") or []:
+            if path == rp or path.startswith(rp + "/"):
+                hits.add(area_id)
+                break
+    return hits
+
+
+# --- state gate --------------------------------------------------------------
+def state_gate(state_path, installed_version):
+    """Returns (reason, state). A non-None reason means the update flow must
+    fall back to a full rebuild; the reason names WHICH condition fired."""
+    if not os.path.isfile(state_path):
+        return (
+            "no state.json at %s - if this map was built with a custom --out, "
+            "pass the same --out to /orrery update; otherwise a full rebuild "
+            "is required" % state_path,
+            None,
+        )
+    try:
+        with open(state_path, "r", encoding="utf-8") as fh:
+            state = json.load(fh)
+    except ValueError:
+        return ("state.json at %s is unparseable - full rebuild required" % state_path, None)
+    if not isinstance(state, dict):
+        return ("state.json at %s is not a JSON object - full rebuild required" % state_path, None)
+    sv = state.get("schema_version")
+    if sv != SCHEMA_VERSION:
+        return (
+            "state.json schema_version is %r, expected %d - full rebuild required"
+            % (sv, SCHEMA_VERSION),
+            None,
+        )
+    recorded = state.get("likec4_version")
+    if recorded != installed_version:
+        return (
+            "state.json likec4_version %r != installed toolchain %r - full rebuild "
+            "required (a pinned-version bump changes emitted-DSL semantics; "
+            "patch-merging across it corrupts the map)" % (recorded, installed_version),
+            None,
+        )
+    if not state.get("anchor_sha"):
+        return ("state.json at %s has no anchor_sha - full rebuild required" % state_path, None)
+    return None, state
+
+
+# --- output ------------------------------------------------------------------
+def make_diff(new_anchor, old_anchor=None):
+    return {
+        "affected_areas": [],
+        "changed_paths": [],
+        "deleted_paths": [],
+        "elements_reanchored": [],
+        "external_systems_flagged": False,
+        "history_rewritten": False,
+        "new_anchor_sha": new_anchor,
+        "new_paths_routed_to_misc": [],
+        "old_anchor_sha": old_anchor,
+        "orphaned_elements": [],
+        "product_vision_flagged": False,
+        "rebuild_required": False,
+        "rebuild_reason": None,
+        "renamed_paths": [],
+        "unchanged": False,
+    }
+
+
+def _atomic_write(path, text):
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="ascii") as fh:
+        fh.write(text)
+    os.replace(tmp, path)
+
+
+def write_diff(out_path, diff):
+    _atomic_write(out_path, json.dumps(diff, sort_keys=True, indent=2, ensure_ascii=True) + "\n")
+
+
+# --- main --------------------------------------------------------------------
+def run(argv=None):
+    ap = argparse.ArgumentParser(prog="diff_since.py")
+    ap.add_argument("--repo", required=True, help="target repo path")
+    ap.add_argument("--state", required=True, help="state.json from the previous build")
+    ap.add_argument("--new-anchor", required=True, help="freshly pinned anchor SHA")
+    ap.add_argument("--out", required=True, help="diff.json output path")
+    args = ap.parse_args(argv)
+
+    try:
+        installed = _toolchain_likec4_version()
+    except (OSError, ValueError, KeyError) as exc:
+        print("diff_since.py: cannot read toolchain package.json: %s" % exc, file=sys.stderr)
+        return 2
+
+    # 1. State gate -> full rebuild with the condition named.
+    reason, state = state_gate(args.state, installed)
+    if reason is not None:
+        diff = make_diff(args.new_anchor)
+        diff["rebuild_required"] = True
+        diff["rebuild_reason"] = reason
+        write_diff(args.out, diff)
+        print("diff_since.py: diff written: %s (rebuild required: %s)" % (args.out, reason))
+        return 0
+
+    old = state["anchor_sha"]
+    diff = make_diff(args.new_anchor, old_anchor=old)
+
+    if _git(args.repo, "rev-parse", "--git-dir").returncode != 0:
+        print("diff_since.py: %s is not a git repository" % args.repo, file=sys.stderr)
+        return 2
+    if not _is_commit(args.repo, args.new_anchor):
+        print(
+            "diff_since.py: new anchor %s is not a resolvable commit in %s"
+            % (args.new_anchor, args.repo),
+            file=sys.stderr,
+        )
+        return 2
+
+    # 2. History-rewrite safety: old anchor resolvable AND ancestor of new.
+    if not _is_commit(args.repo, old) or not _is_ancestor(args.repo, old, args.new_anchor):
+        diff["history_rewritten"] = True
+        write_diff(args.out, diff)
+        print("diff_since.py: diff written: %s (history rewritten - old anchor %s "
+              "unresolvable or not an ancestor of %s)" % (args.out, old, args.new_anchor))
+        return 0
+
+    # 3. Unchanged short-circuit.
+    if old == args.new_anchor:
+        diff["unchanged"] = True
+        write_diff(args.out, diff)
+        print("diff_since.py: diff written: %s (unchanged - anchor %s)" % (args.out, old))
+        return 0
+
+    areas = state.get("areas") or []
+    element_index = state.get("element_index") or {}
+    if not isinstance(element_index, dict):
+        element_index = {}
+
+    # 4. Diff + classification.
+    try:
+        rows = _name_status(args.repo, old, args.new_anchor)
+    except RuntimeError as exc:
+        print("diff_since.py: %s" % exc, file=sys.stderr)
+        return 2
+
+    changed = set()
+    deleted = set()
+    renames = []          # (old_path, new_path, similarity)
+    outside_new = []      # genuinely-new paths under no recorded area
+    affected = set()
+    touched = set()       # every path the diff mentions, for the pack flags
+
+    for code, similarity, old_path, new_path in rows:
+        if code == "D":
+            deleted.add(old_path)
+            touched.add(old_path)
+            affected |= areas_of(old_path, areas)
+        elif code in ("R", "C"):
+            touched.add(old_path)
+            touched.add(new_path)
+            if code == "R":
+                renames.append((old_path, new_path, similarity))
+            old_areas = areas_of(old_path, areas)
+            new_areas = areas_of(new_path, areas)
+            if similarity is not None and similarity < 100:
+                changed.add(new_path)
+                affected |= new_areas
+            if old_areas != new_areas:
+                # The move crosses an area boundary: both sides need a look.
+                affected |= old_areas | new_areas
+        elif code == "A":
+            touched.add(new_path)
+            hit = areas_of(new_path, areas)
+            if hit:
+                changed.add(new_path)
+                affected |= hit
+            else:
+                outside_new.append(new_path)
+        else:
+            # M, T (typechange), and anything unexpected: a content change.
+            touched.add(new_path)
+            changed.add(new_path)
+            affected |= areas_of(new_path, areas)
+
+    # Genuinely-new paths route to misc first (arch R3)...
+    if outside_new:
+        affected.add("misc")
+    # ...unless the change is clustering-material: a new top-level directory
+    # contributing >= NEW_DIR_REBUILD_THRESHOLD files outside every area.
+    by_top_dir = {}
+    for p in outside_new:
+        if "/" in p:
+            top = p.split("/", 1)[0]
+            by_top_dir[top] = by_top_dir.get(top, 0) + 1
+    for top in sorted(by_top_dir):
+        if by_top_dir[top] >= NEW_DIR_REBUILD_THRESHOLD:
+            diff["rebuild_required"] = True
+            diff["rebuild_reason"] = (
+                "new directory %s/ adds %d files outside every recorded area - "
+                "clustering-material change, full rebuild required"
+                % (top, by_top_dir[top])
+            )
+            break
+
+    # Pack flags: manifest-table paths always flag external-systems; README/
+    # docs/CLAUDE.md flag product-vision.
+    for p in sorted(touched):
+        if path_matches_manifest(p):
+            diff["external_systems_flagged"] = True
+        if path_flags_product_vision(p):
+            diff["product_vision_flagged"] = True
+
+    # Orphans: elements whose EVERY indexed path was deleted. Renamed paths
+    # survive (they moved), so a rename never orphans its element.
+    orphaned = []
+    for el_id in sorted(element_index):
+        paths = element_index.get(el_id)
+        if isinstance(paths, list) and paths and all(p in deleted for p in paths):
+            orphaned.append(el_id)
+
+    diff["changed_paths"] = sorted(changed)
+    diff["deleted_paths"] = sorted(deleted)
+    diff["renamed_paths"] = [
+        {"from": o, "similarity": s, "to": n}
+        for o, n, s in sorted(renames)
+    ]
+    diff["affected_areas"] = sorted(affected)
+    diff["orphaned_elements"] = orphaned
+    diff["new_paths_routed_to_misc"] = sorted(outside_new)
+
+    # 5. On the patch path the baseline model must be loadable (merge --patch
+    # reads it as its baseline); renamed files get their element anchors
+    # updated IN PLACE there so continuity survives without re-investigation.
+    if not diff["rebuild_required"]:
+        model_path = os.path.join(
+            os.path.dirname(os.path.abspath(args.state)), "model.json"
+        )
+        try:
+            with open(model_path, "r", encoding="utf-8") as fh:
+                model = json.load(fh)
+        except (OSError, ValueError):
+            diff["rebuild_required"] = True
+            diff["rebuild_reason"] = (
+                "baseline model.json missing or unparseable at %s - full "
+                "rebuild required" % model_path
+            )
+            model = None
+        if model is not None and renames:
+            rename_map = {o: n for o, n, _s in renames}
+            reanchored = []
+            for el in model.get("elements") or []:
+                hit = False
+                for f in el.get("files") or []:
+                    p = f.get("path")
+                    if p in rename_map:
+                        f["path"] = rename_map[p]
+                        hit = True
+                if hit and el.get("id"):
+                    reanchored.append(el["id"])
+            if reanchored:
+                _atomic_write(model_path, json.dumps(model, indent=2) + "\n")
+                diff["elements_reanchored"] = sorted(reanchored)
+
+    write_diff(args.out, diff)
+    if diff["rebuild_required"]:
+        print("diff_since.py: diff written: %s (rebuild required: %s)"
+              % (args.out, diff["rebuild_reason"]))
+    else:
+        print("diff_since.py: diff written: %s (%d changed, %d deleted, %d renamed; "
+              "affected areas: %s%s%s)"
+              % (args.out, len(diff["changed_paths"]), len(diff["deleted_paths"]),
+                 len(diff["renamed_paths"]),
+                 ", ".join(diff["affected_areas"]) or "none",
+                 "; external-systems flagged" if diff["external_systems_flagged"] else "",
+                 "; product-vision flagged" if diff["product_vision_flagged"] else ""))
+    return 0
+
+
+def main():
+    sys.exit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/orrery/skills/orrery/scripts/diff_since.py
+++ b/modules/orrery/skills/orrery/scripts/diff_since.py
@@ -11,25 +11,38 @@ the change so the update flow re-dispatches ONLY the affected packs.
 
 Decision order (each stop still writes a complete diff.json):
 
-1. State gate (business R5 / arch R5 / adrev2-009). The update flow rebuilds
-   fully, with a message naming WHICH condition fired, unless ALL of: the
-   state file exists, parses, carries anchor_sha, schema_version == 1, AND
-   likec4_version equals the installed toolchain version (read from
-   scripts/toolchain/package.json next to this script -- the same single
-   source the build path's state writer reads). Any failure ->
-   rebuild_required: true with the condition in rebuild_reason.
-2. History-rewrite safety (business C3). The old anchor must be resolvable
+1. Missing state.json -> STOP, never rebuild (risk adrev2-014, orchestrator
+   ruling on PR #914 stage 1). On an explicit `/orrery update`, no state at
+   the resolved root most likely means the map was built with a different
+   --out; rebuilding here would create a second divergent copy. Emits
+   state_missing: true with the loud message (resolved path + the --out
+   hint) in stop_reason; rebuild_required stays false.
+2. State gate (business R5 / arch R5 / adrev2-009). Where the root is right
+   but the state is unusable, the update flow rebuilds fully with a message
+   naming WHICH condition fired: state unparseable / not an object /
+   schema_version != 1 / likec4_version != the installed toolchain version
+   (read from scripts/toolchain/package.json next to this script -- the same
+   single source the build path's state writer reads) / no anchor_sha /
+   malformed interior shapes (areas must be a list of objects with string id
+   + root_paths list of strings; element_index a dict of str -> list of
+   str -- corrupt-but-parseable state must route to rebuild, never
+   traceback). Any failure -> rebuild_required: true + rebuild_reason.
+3. History-rewrite safety (business C3). The old anchor must be resolvable
    (git cat-file -e <old>^{commit}) AND an ancestor of the new one
    (git merge-base --is-ancestor). Either failing -> history_rewritten: true
    and stop -- never a guess-diff across rewritten history.
-3. Unchanged short-circuit. old == new -> unchanged: true, nothing else.
-4. Diff + classification: `git diff -M --name-status <old>..<new>` (explicit
+4. Unchanged short-circuit. old == new -> unchanged: true, nothing else.
+5. Diff + classification: `git diff -M --name-status <old>..<new>` (explicit
    -M so rename detection never depends on ambient config -- arch R2).
    - Renamed files update the owning element's file anchors IN PLACE in the
      baseline model.json (sibling of --state; temp-file + atomic rename), so
      element continuity survives without re-investigation. A rename with
      content edits (similarity < 100) additionally counts as a change; a
-     rename that crosses area boundaries marks both areas affected.
+     rename that crosses area boundaries marks both areas affected. A rename
+     whose DESTINATION is under no recorded area routes through the same
+     logic as an added path -- misc first, and it counts toward the rebuild
+     threshold -- so a directory move into unmapped territory can never
+     silently shrink the map (stage-2 finding 1).
    - Changed paths map to affected areas via state.json areas[].root_paths;
      deletions map the same way, and elements whose every indexed path
      (state.json element_index) was deleted are listed as orphaned_elements
@@ -37,18 +50,27 @@ Decision order (each stop still writes a complete diff.json):
    - Genuinely-new paths (under no recorded area) route to the existing
      `misc` area first (arch R3). Full rebuild is reserved for
      clustering-material changes: a new top-level directory contributing
-     >= 5 such files -> rebuild_required with the directory named.
+     >= 5 such files (added or renamed-in) -> rebuild_required with the
+     directory named.
    - Manifest-table paths (MANIFEST_TABLE imported from enumerate_repo.py --
      single source, never duplicated) always flag the external-systems pack;
-     README.md / CLAUDE.md / docs/ paths flag the product-vision pack.
+     README.md / CLAUDE.md / docs/ paths flag the product-vision pack. An
+     unknown match_type in the imported table raises ValueError -- semantics
+     drift must fail loudly, never silently stop flagging.
+
+A patchable diff whose re-run pack list works out empty (both flags false,
+affected_areas empty -- e.g. a pure same-area rename, or an anchor advance
+with an identical tree) is a VALID fast path, not an error: the update flow
+skips dispatch and patch-merge, re-renders only if elements_reanchored is
+non-empty, and advances state.json (SKILL.md U4.2).
 
 diff.json always carries every field:
     changed_paths, affected_areas, deleted_paths, orphaned_elements,
     new_paths_routed_to_misc, rebuild_required, rebuild_reason, unchanged,
     history_rewritten -- plus renamed_paths ([{from,to,similarity}]),
     elements_reanchored, external_systems_flagged, product_vision_flagged,
-    old_anchor_sha, new_anchor_sha for the update flow's pack list and
-    delta report.
+    state_missing, stop_reason, old_anchor_sha, new_anchor_sha for the
+    update flow's routing and delta report.
 
 Exit codes: 0 = diff.json written (any outcome, including rebuild_required /
 history_rewritten / unchanged); 2 = usage or input error (unreachable repo,
@@ -61,6 +83,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 from fnmatch import fnmatchcase
 
 SCHEMA_VERSION = 1
@@ -88,15 +111,18 @@ def _toolchain_likec4_version():
     here = os.path.dirname(os.path.abspath(__file__))
     path = os.path.join(here, "toolchain", "package.json")
     with open(path, "r", encoding="utf-8") as fh:
-        return json.load(fh)["dependencies"]["likec4"]
+        version = json.load(fh)["dependencies"]["likec4"]
+    if not isinstance(version, str):
+        raise ValueError("dependencies.likec4 is not a string")
+    return version
 
 
 # --- git plumbing ------------------------------------------------------------
-def _git(repo, *args):
+def _git(repo, *args, capture_stderr=False):
     return subprocess.run(
         ["git", "-C", repo] + list(args),
         stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
+        stderr=subprocess.PIPE if capture_stderr else subprocess.DEVNULL,
     )
 
 
@@ -112,9 +138,13 @@ def _name_status(repo, old, new):
     """Parse `git diff -M --name-status -z old..new` into
     (status_code, similarity, old_path, new_path) rows. For non-renames
     old_path == new_path and similarity is None."""
-    proc = _git(repo, "diff", "-M", "--name-status", "-z", "%s..%s" % (old, new))
+    proc = _git(repo, "diff", "-M", "--name-status", "-z", "%s..%s" % (old, new),
+                capture_stderr=True)
     if proc.returncode != 0:
-        raise RuntimeError("git diff -M --name-status failed between %s and %s" % (old, new))
+        raise RuntimeError(
+            "git diff -M --name-status failed between %s and %s: %s"
+            % (old, new, (proc.stderr or b"").decode("utf-8", "replace").strip())
+        )
     tokens = proc.stdout.decode("utf-8", "replace").split("\0")
     rows = []
     i = 0
@@ -144,7 +174,10 @@ def _name_status(repo, old, new):
 # --- classification helpers --------------------------------------------------
 def path_matches_manifest(path):
     """Mirror of enumerate_repo.detect_manifests match semantics, driven by
-    the imported MANIFEST_TABLE."""
+    the imported MANIFEST_TABLE. An unknown match_type raises: the TABLE is
+    single-sourced but the semantics are mirrored here, so a new row class in
+    enumerate_repo must fail this module's tests loudly instead of silently
+    ceasing to flag external-systems (stage-2 finding 5)."""
     base = path.rsplit("/", 1)[-1]
     for _kind, match_type, pattern in MANIFEST_TABLE:
         if match_type == "basename":
@@ -159,6 +192,12 @@ def path_matches_manifest(path):
         elif match_type == "dir":
             if pattern in path.split("/")[:-1]:
                 return True
+        else:
+            raise ValueError(
+                "diff_since.py: unknown MANIFEST_TABLE match_type %r - "
+                "enumerate_repo.py added a row class this mirror does not "
+                "implement" % (match_type,)
+            )
     return False
 
 
@@ -184,26 +223,64 @@ def areas_of(path, areas):
 
 
 # --- state gate --------------------------------------------------------------
+def _state_shape_error(state):
+    """Shape check for the interior types classification consumes (stage-2
+    finding 3): corrupt-but-parseable state must route to rebuild with a
+    stated reason, never traceback mid-classification."""
+    areas = state.get("areas")
+    if not isinstance(areas, list):
+        return "areas is not a list"
+    for i, area in enumerate(areas):
+        if not isinstance(area, dict):
+            return "areas[%d] is not an object" % i
+        if not isinstance(area.get("id"), str) or not area["id"]:
+            return "areas[%d] has no string id" % i
+        rp = area.get("root_paths")
+        if not isinstance(rp, list) or not all(isinstance(p, str) for p in rp):
+            return "areas[%d].root_paths is not a list of strings" % i
+    index = state.get("element_index")
+    if not isinstance(index, dict):
+        return "element_index is not an object"
+    for key in index:
+        paths = index[key]
+        if not isinstance(key, str) or not isinstance(paths, list) \
+                or not all(isinstance(p, str) for p in paths):
+            return "element_index[%r] is not a list of strings" % (key,)
+    return None
+
+
 def state_gate(state_path, installed_version):
-    """Returns (reason, state). A non-None reason means the update flow must
-    fall back to a full rebuild; the reason names WHICH condition fired."""
+    """Returns (disposition, reason, state):
+    - ("stop", reason, None): no state.json at the resolved root. An explicit
+      update STOPS here (adrev2-014 orchestrator ruling) - rebuilding at a
+      possibly-wrong root would create a second divergent copy.
+    - ("rebuild", reason, None): the root is right but the state is unusable;
+      full rebuild with the condition named.
+    - (None, None, state): gate passed."""
     if not os.path.isfile(state_path):
         return (
-            "no state.json at %s - if this map was built with a custom --out, "
-            "pass the same --out to /orrery update; otherwise a full rebuild "
-            "is required" % state_path,
+            "stop",
+            "no state.json at %s - a map built with a custom --out needs that "
+            "same --out passed to /orrery update; stopping rather than "
+            "rebuilding at a possibly-wrong root (risk adrev2-014). To build "
+            "here anyway, run /orrery (the build path) explicitly." % state_path,
             None,
         )
     try:
         with open(state_path, "r", encoding="utf-8") as fh:
             state = json.load(fh)
     except ValueError:
-        return ("state.json at %s is unparseable - full rebuild required" % state_path, None)
+        return ("rebuild",
+                "state.json at %s is unparseable - full rebuild required" % state_path,
+                None)
     if not isinstance(state, dict):
-        return ("state.json at %s is not a JSON object - full rebuild required" % state_path, None)
+        return ("rebuild",
+                "state.json at %s is not a JSON object - full rebuild required" % state_path,
+                None)
     sv = state.get("schema_version")
     if sv != SCHEMA_VERSION:
         return (
+            "rebuild",
             "state.json schema_version is %r, expected %d - full rebuild required"
             % (sv, SCHEMA_VERSION),
             None,
@@ -211,14 +288,22 @@ def state_gate(state_path, installed_version):
     recorded = state.get("likec4_version")
     if recorded != installed_version:
         return (
+            "rebuild",
             "state.json likec4_version %r != installed toolchain %r - full rebuild "
             "required (a pinned-version bump changes emitted-DSL semantics; "
             "patch-merging across it corrupts the map)" % (recorded, installed_version),
             None,
         )
     if not state.get("anchor_sha"):
-        return ("state.json at %s has no anchor_sha - full rebuild required" % state_path, None)
-    return None, state
+        return ("rebuild",
+                "state.json at %s has no anchor_sha - full rebuild required" % state_path,
+                None)
+    shape_error = _state_shape_error(state)
+    if shape_error is not None:
+        return ("rebuild",
+                "state.json is malformed (%s) - full rebuild required" % shape_error,
+                None)
+    return None, None, state
 
 
 # --- output ------------------------------------------------------------------
@@ -238,15 +323,26 @@ def make_diff(new_anchor, old_anchor=None):
         "rebuild_required": False,
         "rebuild_reason": None,
         "renamed_paths": [],
+        "state_missing": False,
+        "stop_reason": None,
         "unchanged": False,
     }
 
 
 def _atomic_write(path, text):
-    tmp = path + ".tmp"
-    with open(tmp, "w", encoding="ascii") as fh:
-        fh.write(text)
-    os.replace(tmp, path)
+    # mkstemp + cleanup-on-failure, the same convention as merge_fragments.py:
+    # a fixed tmp name can interleave between two runs on one slug and a
+    # failed write must never strand a temp file (stage-2 finding 4).
+    directory = os.path.dirname(os.path.abspath(path))
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".diff-since-tmp-")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
 
 
 def write_diff(out_path, diff):
@@ -264,13 +360,21 @@ def run(argv=None):
 
     try:
         installed = _toolchain_likec4_version()
-    except (OSError, ValueError, KeyError) as exc:
+    except (OSError, ValueError, KeyError, TypeError) as exc:
         print("diff_since.py: cannot read toolchain package.json: %s" % exc, file=sys.stderr)
         return 2
 
-    # 1. State gate -> full rebuild with the condition named.
-    reason, state = state_gate(args.state, installed)
-    if reason is not None:
+    # 1. Missing state -> STOP (adrev2-014 ruling); 2. unusable state ->
+    # full rebuild with the condition named.
+    disposition, reason, state = state_gate(args.state, installed)
+    if disposition == "stop":
+        diff = make_diff(args.new_anchor)
+        diff["state_missing"] = True
+        diff["stop_reason"] = reason
+        write_diff(args.out, diff)
+        print("diff_since.py: diff written: %s (stopping: %s)" % (args.out, reason))
+        return 0
+    if disposition == "rebuild":
         diff = make_diff(args.new_anchor)
         diff["rebuild_required"] = True
         diff["rebuild_reason"] = reason
@@ -307,10 +411,9 @@ def run(argv=None):
         print("diff_since.py: diff written: %s (unchanged - anchor %s)" % (args.out, old))
         return 0
 
-    areas = state.get("areas") or []
-    element_index = state.get("element_index") or {}
-    if not isinstance(element_index, dict):
-        element_index = {}
+    # Shapes were validated by the state gate; consume them directly.
+    areas = state["areas"]
+    element_index = state["element_index"]
 
     # 4. Diff + classification.
     try:
@@ -338,7 +441,16 @@ def run(argv=None):
                 renames.append((old_path, new_path, similarity))
             old_areas = areas_of(old_path, areas)
             new_areas = areas_of(new_path, areas)
-            if similarity is not None and similarity < 100:
+            if not new_areas:
+                # Stage-2 finding 1: a rename whose destination is under no
+                # recorded area must route like an ADDED path - misc first,
+                # and counted toward the rebuild threshold - or a directory
+                # move into unmapped territory silently shrinks the map (the
+                # old area is re-investigated without the moved files while
+                # nothing investigates the destination). The re-anchor below
+                # still runs, preserving continuity when no rebuild fires.
+                outside_new.append(new_path)
+            elif similarity is not None and similarity < 100:
                 changed.add(new_path)
                 affected |= new_areas
             if old_areas != new_areas:
@@ -358,11 +470,12 @@ def run(argv=None):
             changed.add(new_path)
             affected |= areas_of(new_path, areas)
 
-    # Genuinely-new paths route to misc first (arch R3)...
+    # Paths landing under no recorded area - genuinely-new adds AND rename
+    # destinations (finding 1) - route to misc first (arch R3)...
     if outside_new:
         affected.add("misc")
     # ...unless the change is clustering-material: a new top-level directory
-    # contributing >= NEW_DIR_REBUILD_THRESHOLD files outside every area.
+    # contributing >= NEW_DIR_REBUILD_THRESHOLD such files.
     by_top_dir = {}
     for p in outside_new:
         if "/" in p:

--- a/modules/orrery/tests/e2e/test-update-fixture.sh
+++ b/modules/orrery/tests/e2e/test-update-fixture.sh
@@ -1,0 +1,453 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Update E2E (plan Epic 5): fixture-repo v1 -> full deterministic chain
+# (anchor -> census -> merge -> emit -> validate -> render -> state.json) ->
+# commit v2 changes (modify one api/ file, delete one web/ file, rename one
+# db/ file) -> re-anchor -> diff_since -> patch-merge with canned updated
+# fragments -> emit -> validate -> render -> assert:
+#   - the new element's title is present in the artifact
+#   - the deleted element's content is absent from artifact and model
+#   - the renamed element is retained with its anchor updated to the new path
+#   - state.json's anchor advanced atomically (no temp file left behind)
+#
+# The whole run exercises the $ORRERY_HOME override (risk adrev2-014): the
+# output root is redirected under this test's tempdir, asserted honored, and
+# the real ~/code/orrery is never touched.
+#
+# Fixture materialization uses INDEX PLUMBING, never cp -R + git add: the
+# fixture commits BOTH web/ and Web/, which case-insensitive filesystems fold
+# into one physical dir, so a copy-based repo diverges per OS (same technique
+# as test-ingest-fixture.sh / test-pipeline-fixture.sh). The v2 delta is also
+# committed via index plumbing for the same reason.
+#
+# Injected-failure teardown probe: run with
+#   ORRERY_UPDATE_TEST_INJECT_FAIL=post-anchor bash test-update-fixture.sh
+# to simulate a mid-run crash right after the v2 anchor; the cleanup trap
+# must still tear the anchor worktree down and remove every temp dir.
+#
+# Portable: macOS bash 3.2 + BSD tools.
+
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKILL_DIR="$MODULE_DIR/skills/orrery"
+SCRIPTS="$SKILL_DIR/scripts"
+FRAGSRC="$MODULE_DIR/tests/fixtures/fragments"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+for s in anchor_repo.sh enumerate_repo.py diff_since.py merge_fragments.py emit_likec4.py validate_map.py render_map.sh; do
+  [ -f "$SCRIPTS/$s" ] || fail "required script missing: scripts/$s"
+done
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/orrery-update.XXXXXX")"
+# Redirect the output root under the tempdir (912: the override must be
+# honored end-to-end) so the real default root is never written.
+export ORRERY_HOME="$WORK/orrery-home"
+SLUG="orrery_update_fixture"
+OUT="$ORRERY_HOME/$SLUG"
+REPO=""
+WORKTREE=""
+DEFAULT_ROOT_PREEXISTS=0
+[ -d "$HOME/code/orrery/$SLUG" ] && DEFAULT_ROOT_PREEXISTS=1
+
+cleanup() {
+  # Teardown FIRST (guarded, idempotent, never fatal): the anchor worktree
+  # lives under anchor_repo.sh's own mktemp base in TMPDIR - OUTSIDE $WORK -
+  # so an intermediate failure would otherwise strand a full checkout there.
+  if [ -n "$WORKTREE" ] && [ -n "$REPO" ] && [ -d "$REPO" ]; then
+    bash "$SCRIPTS/anchor_repo.sh" --teardown "$REPO" "$WORKTREE" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# --- materialize the fixture repo (index plumbing) + local bare origin -------
+REPO="$WORK/orrery-update-fixture"   # basename must keep matching $SLUG above
+mkdir -p "$REPO"
+GITC="git -C $REPO -c user.name=orrery -c user.email=orrery@example.invalid -c core.hooksPath=/dev/null"
+$GITC init -q
+CCGM_ROOT="$(cd "$MODULE_DIR/../.." && pwd)"
+FIXPREFIX="modules/orrery/tests/fixtures/fixture-repo"
+SRC_COUNT="$(git -C "$CCGM_ROOT" ls-files -- "$FIXPREFIX" | wc -l | tr -d ' ')"
+[ "$SRC_COUNT" -gt 0 ] || fail "no fixture-repo entries in the ccgm index (this test must run from a ccgm checkout)"
+TAB="$(printf '\t')"
+git -C "$CCGM_ROOT" ls-files -s -- "$FIXPREFIX" | while IFS= read -r line; do
+  # ls-files -s line shape: <mode> <sha> <stage><TAB><path>
+  mode="${line%% *}"
+  path="${line#*$TAB}"
+  rel="${path#$FIXPREFIX/}"
+  sha="$(git -C "$CCGM_ROOT" cat-file blob ":$path" | $GITC hash-object -w --stdin)"
+  $GITC update-index --add --cacheinfo "$mode,$sha,$rel"
+done
+$GITC commit -qm "v1" --no-verify
+$GITC branch -M main
+git init -q --bare "$WORK/origin.git"
+$GITC remote add origin "$WORK/origin.git"
+$GITC push -q -u origin main
+git -C "$WORK/origin.git" symbolic-ref HEAD refs/heads/main
+echo "ok: fixture repo materialized case-exactly with local bare origin"
+
+# --- helper: run anchor_repo.sh and persist the parsed JSON ------------------
+# Writes the anchor JSON to $OUT/anchor.json and prints "slug<TAB>sha<TAB>wt".
+parse_anchor() {
+  python3 - "$1" "$OUT/anchor.json" <<'PYEOF'
+import json
+import sys
+
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+obj = None
+for ln in reversed(lines):
+    ln = ln.strip()
+    if not ln.startswith("{"):
+        continue
+    try:
+        obj = json.loads(ln)
+        break
+    except ValueError:
+        continue
+if obj is None:
+    sys.exit("no JSON object found in anchor_repo.sh stdout")
+for key in ("slug", "anchor_sha", "worktree"):
+    if not obj.get(key):
+        sys.exit("anchor JSON missing required field: %s" % key)
+with open(sys.argv[2], "w", encoding="utf-8") as fh:
+    json.dump(obj, fh)
+print("%s\t%s\t%s" % (obj["slug"], obj["anchor_sha"], obj["worktree"]))
+PYEOF
+}
+
+# --- v1: anchor --------------------------------------------------------------
+bash "$SCRIPTS/anchor_repo.sh" "$REPO" >"$WORK/anchor1.txt" || fail "v1 anchor_repo.sh failed"
+[ -d "$OUT" ] || fail "anchor did not create the out dir under \$ORRERY_HOME ($OUT)"
+if [ "$DEFAULT_ROOT_PREEXISTS" = "0" ] && [ -d "$HOME/code/orrery/$SLUG" ]; then
+  fail "anchor created the default root despite the \$ORRERY_HOME override"
+fi
+PARSED="$(parse_anchor "$WORK/anchor1.txt")" || fail "could not parse v1 anchor JSON"
+ANCHOR_SLUG="$(printf '%s\n' "$PARSED" | cut -f1)"
+V1_SHA="$(printf '%s\n' "$PARSED" | cut -f2)"
+WORKTREE="$(printf '%s\n' "$PARSED" | cut -f3)"
+[ "$ANCHOR_SLUG" = "$SLUG" ] || fail "anchor reported slug $ANCHOR_SLUG, expected $SLUG"
+echo "ok: v1 anchored at $V1_SHA (out dir under \$ORRERY_HOME honored)"
+
+# --- v1: enumerate + fragments -----------------------------------------------
+python3 "$SCRIPTS/enumerate_repo.py" --worktree "$WORKTREE" --out "$OUT/census.json" \
+  || fail "v1 enumerate_repo.py failed"
+python3 - "$OUT/census.json" <<'PYEOF' || fail "v1 census area ids drifted from the many/misc/web expectation"
+import json
+import sys
+
+census = json.load(open(sys.argv[1], encoding="utf-8"))
+ids = sorted(a["id"] for a in census.get("areas", []))
+if ids != ["many", "misc", "web"]:
+    sys.exit("expected areas [many, misc, web], got %s" % ids)
+PYEOF
+
+mkdir -p "$OUT/fragments"
+rm -rf "$OUT/fragments"
+mkdir -p "$OUT/fragments"
+cp "$FRAGSRC/product-vision.json" "$FRAGSRC/external-systems.json" "$OUT/fragments/"
+# Area templates materialized with the census-verified area ids: web keeps the
+# storefront paths, misc carries the api/ paths, many carries the db/ paths.
+sed 's/@AREA_ID@/web/g'  "$FRAGSRC/area-alpha.json.tmpl" > "$OUT/fragments/area-web.json"
+sed 's/@AREA_ID@/misc/g' "$FRAGSRC/area-beta.json.tmpl"  > "$OUT/fragments/area-misc.json"
+sed 's/@AREA_ID@/many/g' "$FRAGSRC/area-gamma.json.tmpl" > "$OUT/fragments/area-many.json"
+PACKS="product-vision,external-systems,area-web,area-misc,area-many"
+
+# --- v1: merge -> emit -> validate -> render ---------------------------------
+python3 "$SCRIPTS/merge_fragments.py" \
+  --fragments-dir "$OUT/fragments" \
+  --packs "$PACKS" \
+  --census "$OUT/census.json" \
+  --anchor "$OUT/anchor.json" \
+  --out "$OUT/model.json" >/dev/null \
+  || fail "v1 merge_fragments.py failed"
+python3 "$SCRIPTS/emit_likec4.py" --model "$OUT/model.json" --out-dir "$OUT" \
+  || fail "v1 emit_likec4.py failed"
+python3 "$SCRIPTS/validate_map.py" \
+  --model "$OUT/model.json" --model-dir "$OUT/model" \
+  --repo "$REPO" --anchor-sha "$V1_SHA" \
+  || fail "v1 validate_map.py failed (see errors.json in $OUT)"
+bash "$SCRIPTS/render_map.sh" "$OUT" "$SLUG" >/dev/null || fail "v1 render_map.sh failed"
+[ -f "$OUT/dist/$SLUG.html" ] || fail "v1 artifact missing"
+echo "ok: v1 chain green (merge -> emit -> validate -> render)"
+
+# --- v1: state.json (the same atomic writer as SKILL.md step 7) --------------
+python3 - "$OUT" "$SKILL_DIR" <<'PYEOF' || fail "v1 state.json write failed"
+import json, os, sys, time
+out, skill_dir = sys.argv[1], sys.argv[2]
+anchor = json.load(open(os.path.join(out, "anchor.json")))
+census = json.load(open(os.path.join(out, "census.json")))
+model = json.load(open(os.path.join(out, "model.json")))
+toolchain = json.load(open(os.path.join(skill_dir, "scripts/toolchain/package.json")))
+state = {
+    "schema_version": 1,
+    "slug": anchor["slug"],
+    "repo_path": anchor["repo_path"],
+    "remote_url": anchor["remote_url"],
+    "default_ref": anchor["default_ref"],
+    "anchor_sha": anchor["anchor_sha"],
+    "visibility": anchor["visibility"],
+    "built_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    "likec4_version": toolchain["dependencies"]["likec4"],
+    "areas": census["areas"],
+    "element_index": {e["id"]: [f["path"] for f in e.get("files", [])]
+                      for e in model["elements"]},
+    "artifact": "dist/%s.html" % anchor["slug"],
+}
+tmp = os.path.join(out, "state.json.tmp")
+with open(tmp, "w") as fh:
+    json.dump(state, fh, indent=2, sort_keys=True)
+os.replace(tmp, os.path.join(out, "state.json"))
+PYEOF
+V1_STATE_SHA="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["anchor_sha"])' "$OUT/state.json")"
+[ "$V1_STATE_SHA" = "$V1_SHA" ] || fail "v1 state.json anchor mismatch"
+echo "ok: v1 state.json written (anchor $V1_STATE_SHA)"
+
+# --- v1: teardown (the build path's unskippable step 8) ----------------------
+bash "$SCRIPTS/anchor_repo.sh" --teardown "$REPO" "$WORKTREE" || fail "v1 teardown failed"
+WORKTREE=""
+
+# --- v2: commit the update delta (index plumbing) ----------------------------
+# modify one api/ file
+NEW_WORKER="$( { $GITC cat-file blob :api/src/worker.js; printf '// v2: refunds endpoint added\n'; } | $GITC hash-object -w --stdin )"
+$GITC update-index --add --cacheinfo "100644,$NEW_WORKER,api/src/worker.js"
+# delete one web/ file (the sole anchor of the baseline web__cart element)
+$GITC update-index --force-remove web/src/components/Cart.tsx
+# rename one file, blob unchanged, so `git diff -M` reports R100
+OLD_SQL="$($GITC rev-parse :db/migrations/0002_orders.sql)"
+$GITC update-index --force-remove db/migrations/0002_orders.sql
+$GITC update-index --add --cacheinfo "100644,$OLD_SQL,db/migrations/0002_orders_table.sql"
+$GITC commit -qm "v2: modify worker, delete Cart, rename orders migration" --no-verify
+$GITC push -q origin main
+echo "ok: v2 delta committed and pushed"
+
+# --- v2: re-anchor -----------------------------------------------------------
+bash "$SCRIPTS/anchor_repo.sh" "$REPO" >"$WORK/anchor2.txt" || fail "v2 anchor_repo.sh failed"
+PARSED="$(parse_anchor "$WORK/anchor2.txt")" || fail "could not parse v2 anchor JSON"
+V2_SHA="$(printf '%s\n' "$PARSED" | cut -f2)"
+WORKTREE="$(printf '%s\n' "$PARSED" | cut -f3)"
+[ "$V2_SHA" != "$V1_SHA" ] || fail "v2 anchor did not advance"
+
+if [ "${ORRERY_UPDATE_TEST_INJECT_FAIL:-}" = "post-anchor" ]; then
+  echo "INJECTED FAILURE: simulating a mid-run crash after the v2 anchor (teardown probe)" >&2
+  exit 1
+fi
+echo "ok: v2 anchored at $V2_SHA"
+
+# --- v2: diff_since ----------------------------------------------------------
+python3 "$SCRIPTS/diff_since.py" \
+  --repo "$REPO" \
+  --state "$OUT/state.json" \
+  --new-anchor "$V2_SHA" \
+  --out "$OUT/diff.json" \
+  || fail "diff_since.py failed"
+
+python3 - "$OUT/diff.json" "$OUT/model.json" "$V1_SHA" "$V2_SHA" <<'PYEOF' || fail "diff.json scoping/continuity assertions failed"
+import json
+import sys
+
+diff = json.load(open(sys.argv[1], encoding="utf-8"))
+model = json.load(open(sys.argv[2], encoding="utf-8"))
+v1, v2 = sys.argv[3], sys.argv[4]
+
+if diff["unchanged"] or diff["history_rewritten"] or diff["rebuild_required"]:
+    sys.exit("expected a patchable diff, got: %s" % {k: diff[k] for k in
+             ("unchanged", "history_rewritten", "rebuild_required", "rebuild_reason")})
+if diff["old_anchor_sha"] != v1 or diff["new_anchor_sha"] != v2:
+    sys.exit("diff anchors wrong: %s..%s" % (diff["old_anchor_sha"], diff["new_anchor_sha"]))
+if "api/src/worker.js" not in diff["changed_paths"]:
+    sys.exit("modified api/ file missing from changed_paths: %s" % diff["changed_paths"])
+if diff["deleted_paths"] != ["web/src/components/Cart.tsx"]:
+    sys.exit("deleted_paths wrong: %s" % diff["deleted_paths"])
+if diff["renamed_paths"] != [{"from": "db/migrations/0002_orders.sql",
+                              "similarity": 100,
+                              "to": "db/migrations/0002_orders_table.sql"}]:
+    sys.exit("renamed_paths wrong: %s" % diff["renamed_paths"])
+# Scoping: exactly the two touched areas - many (the renamed file's element
+# owner) is NOT re-investigated; its continuity comes from the re-anchor.
+if diff["affected_areas"] != ["misc", "web"]:
+    sys.exit("affected_areas wrong (scoping broken): %s" % diff["affected_areas"])
+if diff["orphaned_elements"] != ["web__cart"]:
+    sys.exit("orphaned_elements wrong: %s" % diff["orphaned_elements"])
+# The renamed migration sits under db/migrations/ - a manifest-table dir - so
+# the external-systems pack is flagged for re-investigation.
+if diff["external_systems_flagged"] is not True:
+    sys.exit("external_systems_flagged expected true (migrations path renamed)")
+if diff["product_vision_flagged"] is not False:
+    sys.exit("product_vision_flagged expected false")
+if diff["elements_reanchored"] != ["many__orders_schema"]:
+    sys.exit("elements_reanchored wrong: %s" % diff["elements_reanchored"])
+# In-place baseline re-anchor: the retained element already cites the new path.
+schema = [e for e in model["elements"] if e["id"] == "many__orders_schema"]
+if not schema or schema[0]["files"][0]["path"] != "db/migrations/0002_orders_table.sql":
+    sys.exit("baseline model was not re-anchored in place for the rename")
+print("ok: diff.json scoping, orphan, rename-continuity and pack flags all hold")
+PYEOF
+
+# --- v2: refresh deterministic inputs (update-flow U4.1) ---------------------
+python3 "$SCRIPTS/enumerate_repo.py" --worktree "$WORKTREE" --out "$OUT/census.json" \
+  || fail "v2 enumerate_repo.py failed"
+
+# --- v2: canned updated fragments for exactly the re-run packs ---------------
+# external-systems (flagged) re-runs with the canned wave-0 fragment; the two
+# affected areas get updated fragments: area-web drops the deleted Cart
+# element and adds a NEW one, area-misc updates the worker.
+rm -rf "$OUT/fragments"
+mkdir -p "$OUT/fragments"
+cp "$FRAGSRC/external-systems.json" "$OUT/fragments/"
+cat > "$OUT/fragments/area-web.json" <<'JSONEOF'
+{
+  "pack": "area-web",
+  "elements": [
+    {
+      "id": "web__catalog",
+      "kind": "component",
+      "title": "Catalog Browser",
+      "summary": "Product listing for the storefront grid.",
+      "description": "Lists products from the catalog feed because the Shopper needs to find items before checkout.",
+      "parent": "web",
+      "files": [{ "path": "web/src/components/ProductGrid.tsx", "start_line": 1, "end_line": 7 }]
+    },
+    {
+      "id": "web__wishlist",
+      "kind": "component",
+      "title": "Wishlist Panel",
+      "summary": "Saved-items panel added in v2 of the storefront.",
+      "description": "Keeps items the Shopper saved for later because checkout now starts from saved lists too.",
+      "parent": "web",
+      "files": [{ "path": "web/src/components/Header.tsx" }]
+    }
+  ],
+  "relations": [
+    { "from": "web__catalog", "to": "web__wishlist", "kind": "uses", "summary": "saves items" }
+  ],
+  "open_questions": []
+}
+JSONEOF
+cat > "$OUT/fragments/area-misc.json" <<'JSONEOF'
+{
+  "pack": "area-misc",
+  "elements": [
+    {
+      "id": "misc__worker",
+      "kind": "component",
+      "title": "Checkout Worker",
+      "summary": "Serverless handler that charges cards, records orders, and queues refunds.",
+      "description": "Charges cards through the Stripe API and writes orders because the storefront never touches card data; v2 adds a refunds endpoint.",
+      "technology": "Cloudflare Worker",
+      "parent": "api",
+      "files": [{ "path": "api/src/worker.js", "start_line": 1, "end_line": 17 }]
+    }
+  ],
+  "relations": [
+    { "from": "misc__worker", "to": "stripe", "kind": "calls", "summary": "charges cards" }
+  ],
+  "open_questions": []
+}
+JSONEOF
+RERUN_PACKS="external-systems,area-misc,area-web"
+
+# --- v2: patch-merge -> emit -> validate -> render ---------------------------
+python3 "$SCRIPTS/merge_fragments.py" \
+  --fragments-dir "$OUT/fragments" \
+  --packs "$RERUN_PACKS" \
+  --census "$OUT/census.json" \
+  --anchor "$OUT/anchor.json" \
+  --out "$OUT/model.json" \
+  --patch --state "$OUT/state.json" --diff "$OUT/diff.json" >/dev/null \
+  || fail "patch-mode merge_fragments.py failed"
+python3 "$SCRIPTS/emit_likec4.py" --model "$OUT/model.json" --out-dir "$OUT" \
+  || fail "v2 emit_likec4.py failed"
+python3 "$SCRIPTS/validate_map.py" \
+  --model "$OUT/model.json" --model-dir "$OUT/model" \
+  --repo "$REPO" --anchor-sha "$V2_SHA" \
+  || fail "v2 validate_map.py failed (see errors.json in $OUT)"
+bash "$SCRIPTS/render_map.sh" "$OUT" "$SLUG" >/dev/null || fail "v2 render_map.sh failed"
+ARTIFACT="$OUT/dist/$SLUG.html"
+[ -f "$ARTIFACT" ] || fail "v2 artifact missing"
+echo "ok: v2 patch chain green (patch-merge -> emit -> validate -> render)"
+
+# --- v2: state.json rewrite (atomic advance) ---------------------------------
+python3 - "$OUT" "$SKILL_DIR" <<'PYEOF' || fail "v2 state.json write failed"
+import json, os, sys, time
+out, skill_dir = sys.argv[1], sys.argv[2]
+anchor = json.load(open(os.path.join(out, "anchor.json")))
+census = json.load(open(os.path.join(out, "census.json")))
+model = json.load(open(os.path.join(out, "model.json")))
+toolchain = json.load(open(os.path.join(skill_dir, "scripts/toolchain/package.json")))
+state = {
+    "schema_version": 1,
+    "slug": anchor["slug"],
+    "repo_path": anchor["repo_path"],
+    "remote_url": anchor["remote_url"],
+    "default_ref": anchor["default_ref"],
+    "anchor_sha": anchor["anchor_sha"],
+    "visibility": anchor["visibility"],
+    "built_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    "likec4_version": toolchain["dependencies"]["likec4"],
+    "areas": census["areas"],
+    "element_index": {e["id"]: [f["path"] for f in e.get("files", [])]
+                      for e in model["elements"]},
+    "artifact": "dist/%s.html" % anchor["slug"],
+}
+tmp = os.path.join(out, "state.json.tmp")
+with open(tmp, "w") as fh:
+    json.dump(state, fh, indent=2, sort_keys=True)
+os.replace(tmp, os.path.join(out, "state.json"))
+PYEOF
+
+# --- v2: assertions ----------------------------------------------------------
+python3 - "$OUT" "$V1_SHA" "$V2_SHA" <<'PYEOF' || fail "v2 model/state assertions failed"
+import json, os, sys
+out, v1, v2 = sys.argv[1], sys.argv[2], sys.argv[3]
+model = json.load(open(os.path.join(out, "model.json"), encoding="utf-8"))
+ids = {e["id"] for e in model["elements"]}
+if "web__wishlist" not in ids:
+    sys.exit("new element web__wishlist missing from the patched model")
+if "web__cart" in ids:
+    sys.exit("deleted element web__cart survived the patch")
+if "many__orders_schema" not in ids:
+    sys.exit("renamed element many__orders_schema was not retained")
+schema = [e for e in model["elements"] if e["id"] == "many__orders_schema"][0]
+if schema["files"][0]["path"] != "db/migrations/0002_orders_table.sql":
+    sys.exit("renamed element retained but anchor not updated: %s" % schema["files"])
+state = json.load(open(os.path.join(out, "state.json"), encoding="utf-8"))
+if state["anchor_sha"] != v2:
+    sys.exit("state.json anchor did not advance: %s (expected %s)" % (state["anchor_sha"], v2))
+if state["anchor_sha"] == v1:
+    sys.exit("state.json anchor still at v1")
+if os.path.exists(os.path.join(out, "state.json.tmp")):
+    sys.exit("state.json.tmp left behind - the state write was not atomic")
+report = json.load(open(os.path.join(out, "merge-report.json"), encoding="utf-8"))
+patch = report.get("patch") or {}
+if "web__cart" not in patch.get("baseline_elements_replaced", []):
+    sys.exit("merge-report patch section did not record the area-web replacement")
+if patch.get("reinvestigation_failed_retained"):
+    sys.exit("unexpected reinvestigation failures: %s" % patch["reinvestigation_failed_retained"])
+print("ok: patched model + advanced state assertions hold")
+PYEOF
+
+# (Anchor paths appear in the artifact only as GitHub links, and this fixture's
+# remote is a local bare repo - so the rename-continuity assertion lives on the
+# patched model above, while titles are asserted in the rendered artifact.)
+grep -q "Wishlist Panel" "$ARTIFACT" || fail "new element title missing from the artifact"
+if grep -qF "Client-side cart state." "$ARTIFACT"; then
+  fail "deleted element's content still present in the artifact"
+fi
+echo "ok: artifact carries the new title; deleted element's content absent"
+
+# --- v2: teardown + worktree-clean assertion ---------------------------------
+bash "$SCRIPTS/anchor_repo.sh" --teardown "$REPO" "$WORKTREE" || fail "v2 teardown failed"
+WORKTREE=""
+WT_LIST="$(git -C "$REPO" worktree list)"
+WT_COUNT="$(printf '%s\n' "$WT_LIST" | wc -l | tr -d ' ')"
+if [ "$WT_COUNT" != "1" ]; then
+  echo "$WT_LIST" >&2
+  fail "git worktree list not clean after teardown ($WT_COUNT entries)"
+fi
+echo "ok: teardown left the target repo clean"
+
+echo "test-update-fixture.sh: PASS"

--- a/modules/orrery/tests/e2e/test-update-fixture.sh
+++ b/modules/orrery/tests/e2e/test-update-fixture.sh
@@ -10,6 +10,11 @@ set -euo pipefail
 #   - the deleted element's content is absent from artifact and model
 #   - the renamed element is retained with its anchor updated to the new path
 #   - state.json's anchor advanced atomically (no temp file left behind)
+# Then two more cycles pin the empty-re-run-pack fast path (stage-2 finding 2):
+#   v3 - pure same-area rename: zero packs to dispatch, NO merge call, render
+#        from the re-anchored baseline, state advances
+#   v4 - identical-tree anchor advance (allow-empty commit): zero packs, zero
+#        re-anchors, artifact byte-identical, only state.json advances
 #
 # The whole run exercises the $ORRERY_HOME override (risk adrev2-014): the
 # output root is redirected under this test's tempdir, asserted honored, and
@@ -439,8 +444,168 @@ if grep -qF "Client-side cart state." "$ARTIFACT"; then
 fi
 echo "ok: artifact carries the new title; deleted element's content absent"
 
-# --- v2: teardown + worktree-clean assertion ---------------------------------
+# --- v2: teardown ------------------------------------------------------------
 bash "$SCRIPTS/anchor_repo.sh" --teardown "$REPO" "$WORKTREE" || fail "v2 teardown failed"
+WORKTREE=""
+
+# --- v3: pure same-area rename -> the empty-re-run-pack fast path ------------
+# Stage-2 finding 2, shape (a): a same-area rename touching no manifest or
+# vision path affects ZERO packs. The flow must NOT call merge (empty --packs
+# exits 2); it re-renders from the baseline model diff_since re-anchored in
+# place, then advances state.
+OLD_GRID="$($GITC rev-parse :web/src/components/ProductGrid.tsx)"
+$GITC update-index --force-remove web/src/components/ProductGrid.tsx
+$GITC update-index --add --cacheinfo "100644,$OLD_GRID,web/src/components/Grid.tsx"
+$GITC commit -qm "v3: rename ProductGrid within the web area" --no-verify
+$GITC push -q origin main
+
+bash "$SCRIPTS/anchor_repo.sh" "$REPO" >"$WORK/anchor3.txt" || fail "v3 anchor_repo.sh failed"
+PARSED="$(parse_anchor "$WORK/anchor3.txt")" || fail "could not parse v3 anchor JSON"
+V3_SHA="$(printf '%s\n' "$PARSED" | cut -f2)"
+WORKTREE="$(printf '%s\n' "$PARSED" | cut -f3)"
+[ "$V3_SHA" != "$V2_SHA" ] || fail "v3 anchor did not advance"
+
+python3 "$SCRIPTS/diff_since.py" \
+  --repo "$REPO" --state "$OUT/state.json" \
+  --new-anchor "$V3_SHA" --out "$OUT/diff.json" \
+  || fail "v3 diff_since.py failed"
+python3 - "$OUT/diff.json" "$OUT/model.json" <<'PYEOF' || fail "v3 empty-pack fast-path diff assertions failed"
+import json
+import sys
+
+diff = json.load(open(sys.argv[1], encoding="utf-8"))
+model = json.load(open(sys.argv[2], encoding="utf-8"))
+if diff["unchanged"] or diff["history_rewritten"] or diff["rebuild_required"] or diff["state_missing"]:
+    sys.exit("expected a patchable diff, got routing flags set")
+# The empty re-run pack list: no areas affected, neither wave-0 pack flagged.
+if diff["affected_areas"] != [] or diff["external_systems_flagged"] or diff["product_vision_flagged"]:
+    sys.exit("expected ZERO re-run packs, got areas=%s flags=%s/%s" % (
+        diff["affected_areas"], diff["external_systems_flagged"], diff["product_vision_flagged"]))
+if diff["elements_reanchored"] != ["web__catalog"]:
+    sys.exit("elements_reanchored wrong: %s" % diff["elements_reanchored"])
+cat = [e for e in model["elements"] if e["id"] == "web__catalog"][0]
+if cat["files"][0]["path"] != "web/src/components/Grid.tsx":
+    sys.exit("baseline model not re-anchored to the renamed path")
+print("ok: v3 diff affects zero packs; baseline re-anchored in place")
+PYEOF
+
+# Fast path (SKILL U4.2): refresh inputs, SKIP dispatch + merge entirely,
+# re-render from the re-anchored baseline because elements_reanchored != [].
+python3 "$SCRIPTS/enumerate_repo.py" --worktree "$WORKTREE" --out "$OUT/census.json" \
+  || fail "v3 enumerate_repo.py failed"
+python3 "$SCRIPTS/emit_likec4.py" --model "$OUT/model.json" --out-dir "$OUT" \
+  || fail "v3 emit_likec4.py failed"
+python3 "$SCRIPTS/validate_map.py" \
+  --model "$OUT/model.json" --model-dir "$OUT/model" \
+  --repo "$REPO" --anchor-sha "$V3_SHA" \
+  || fail "v3 validate_map.py failed - the re-anchored baseline must be valid at v3"
+bash "$SCRIPTS/render_map.sh" "$OUT" "$SLUG" >/dev/null || fail "v3 render_map.sh failed"
+grep -q "Catalog Browser" "$ARTIFACT" || fail "renamed element's title missing after fast-path re-render"
+
+python3 - "$OUT" "$SKILL_DIR" <<'PYEOF' || fail "v3 state.json write failed"
+import json, os, sys, time
+out, skill_dir = sys.argv[1], sys.argv[2]
+anchor = json.load(open(os.path.join(out, "anchor.json")))
+census = json.load(open(os.path.join(out, "census.json")))
+model = json.load(open(os.path.join(out, "model.json")))
+toolchain = json.load(open(os.path.join(skill_dir, "scripts/toolchain/package.json")))
+state = {
+    "schema_version": 1,
+    "slug": anchor["slug"],
+    "repo_path": anchor["repo_path"],
+    "remote_url": anchor["remote_url"],
+    "default_ref": anchor["default_ref"],
+    "anchor_sha": anchor["anchor_sha"],
+    "visibility": anchor["visibility"],
+    "built_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    "likec4_version": toolchain["dependencies"]["likec4"],
+    "areas": census["areas"],
+    "element_index": {e["id"]: [f["path"] for f in e.get("files", [])]
+                      for e in model["elements"]},
+    "artifact": "dist/%s.html" % anchor["slug"],
+}
+tmp = os.path.join(out, "state.json.tmp")
+with open(tmp, "w") as fh:
+    json.dump(state, fh, indent=2, sort_keys=True)
+os.replace(tmp, os.path.join(out, "state.json"))
+PYEOF
+V3_STATE_SHA="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["anchor_sha"])' "$OUT/state.json")"
+[ "$V3_STATE_SHA" = "$V3_SHA" ] || fail "v3 state.json anchor did not advance"
+echo "ok: v3 fast path green - zero dispatch, re-anchored render, state advanced"
+
+bash "$SCRIPTS/anchor_repo.sh" --teardown "$REPO" "$WORKTREE" || fail "v3 teardown failed"
+WORKTREE=""
+
+# --- v4: identical-tree anchor advance -> fast path with nothing to do -------
+# Stage-2 finding 2, shape (b): the anchor advances but the tree is byte-
+# identical. Zero packs, zero re-anchors: the artifact stays untouched and
+# only state.json advances.
+ART_SUM_BEFORE="$(cksum "$ARTIFACT" | cut -d' ' -f1-2)"
+$GITC commit -q --allow-empty -m "v4: no tree change" --no-verify
+$GITC push -q origin main
+
+bash "$SCRIPTS/anchor_repo.sh" "$REPO" >"$WORK/anchor4.txt" || fail "v4 anchor_repo.sh failed"
+PARSED="$(parse_anchor "$WORK/anchor4.txt")" || fail "could not parse v4 anchor JSON"
+V4_SHA="$(printf '%s\n' "$PARSED" | cut -f2)"
+WORKTREE="$(printf '%s\n' "$PARSED" | cut -f3)"
+[ "$V4_SHA" != "$V3_SHA" ] || fail "v4 anchor did not advance"
+
+python3 "$SCRIPTS/diff_since.py" \
+  --repo "$REPO" --state "$OUT/state.json" \
+  --new-anchor "$V4_SHA" --out "$OUT/diff.json" \
+  || fail "v4 diff_since.py failed"
+python3 - "$OUT/diff.json" <<'PYEOF' || fail "v4 identical-tree diff assertions failed"
+import json
+import sys
+
+diff = json.load(open(sys.argv[1], encoding="utf-8"))
+if diff["unchanged"] or diff["history_rewritten"] or diff["rebuild_required"] or diff["state_missing"]:
+    sys.exit("expected a patchable diff, got routing flags set")
+for key in ("affected_areas", "changed_paths", "deleted_paths", "renamed_paths",
+            "orphaned_elements", "new_paths_routed_to_misc", "elements_reanchored"):
+    if diff[key]:
+        sys.exit("%s expected empty, got %s" % (key, diff[key]))
+if diff["external_systems_flagged"] or diff["product_vision_flagged"]:
+    sys.exit("no pack flags expected on an identical tree")
+print("ok: v4 diff is the all-empty patchable shape")
+PYEOF
+
+# Fast path with elements_reanchored empty: keep the artifact, advance state.
+python3 - "$OUT" "$SKILL_DIR" <<'PYEOF' || fail "v4 state.json write failed"
+import json, os, sys, time
+out, skill_dir = sys.argv[1], sys.argv[2]
+anchor = json.load(open(os.path.join(out, "anchor.json")))
+census = json.load(open(os.path.join(out, "census.json")))
+model = json.load(open(os.path.join(out, "model.json")))
+toolchain = json.load(open(os.path.join(skill_dir, "scripts/toolchain/package.json")))
+state = {
+    "schema_version": 1,
+    "slug": anchor["slug"],
+    "repo_path": anchor["repo_path"],
+    "remote_url": anchor["remote_url"],
+    "default_ref": anchor["default_ref"],
+    "anchor_sha": anchor["anchor_sha"],
+    "visibility": anchor["visibility"],
+    "built_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    "likec4_version": toolchain["dependencies"]["likec4"],
+    "areas": census["areas"],
+    "element_index": {e["id"]: [f["path"] for f in e.get("files", [])]
+                      for e in model["elements"]},
+    "artifact": "dist/%s.html" % anchor["slug"],
+}
+tmp = os.path.join(out, "state.json.tmp")
+with open(tmp, "w") as fh:
+    json.dump(state, fh, indent=2, sort_keys=True)
+os.replace(tmp, os.path.join(out, "state.json"))
+PYEOF
+V4_STATE_SHA="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["anchor_sha"])' "$OUT/state.json")"
+[ "$V4_STATE_SHA" = "$V4_SHA" ] || fail "v4 state.json anchor did not advance"
+ART_SUM_AFTER="$(cksum "$ARTIFACT" | cut -d' ' -f1-2)"
+[ "$ART_SUM_BEFORE" = "$ART_SUM_AFTER" ] || fail "artifact changed on the nothing-to-do fast path"
+echo "ok: v4 fast path green - artifact untouched, state advanced to $V4_SHA"
+
+# --- final teardown + worktree-clean assertion -------------------------------
+bash "$SCRIPTS/anchor_repo.sh" --teardown "$REPO" "$WORKTREE" || fail "v4 teardown failed"
 WORKTREE=""
 WT_LIST="$(git -C "$REPO" worktree list)"
 WT_COUNT="$(printf '%s\n' "$WT_LIST" | wc -l | tr -d ' ')"

--- a/modules/orrery/tests/unit/test_anchor_repo.py
+++ b/modules/orrery/tests/unit/test_anchor_repo.py
@@ -27,6 +27,9 @@ FAKE_TOKEN = "ghp_fake"
 def make_env(home, path_prepend=None):
     home.mkdir(parents=True, exist_ok=True)
     env = dict(os.environ)
+    # Hermeticity: an ambient $ORRERY_HOME must not redirect the default-root
+    # assertions; the override test sets it explicitly.
+    env.pop("ORRERY_HOME", None)
     env.update(
         {
             "HOME": str(home),
@@ -440,6 +443,23 @@ def test_output_dir_created_chmod_700(tmp_path):
     out_dir = tmp_path / "home" / "code" / "orrery" / "repo"
     assert out_dir.is_dir()
     assert stat.S_IMODE(out_dir.stat().st_mode) == 0o700
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+def test_output_dir_honors_orrery_home_override(tmp_path):
+    """Risk adrev2-014: $ORRERY_HOME overrides the output root without editing
+    the module. The dir is created under the override (chmod 700) and the
+    default ~/code/orrery root is NOT created."""
+    env = make_env(tmp_path / "home")
+    custom = tmp_path / "custom-root"
+    env["ORRERY_HOME"] = str(custom)
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+
+    data = anchor_json(run_anchor(env, repo))
+    out_dir = custom / "repo"
+    assert out_dir.is_dir()
+    assert stat.S_IMODE(out_dir.stat().st_mode) == 0o700
+    assert not (tmp_path / "home" / "code" / "orrery" / "repo").exists()
     run_anchor(env, "--teardown", repo, data["worktree"])
 
 

--- a/modules/orrery/tests/unit/test_diff_since.py
+++ b/modules/orrery/tests/unit/test_diff_since.py
@@ -160,7 +160,7 @@ ALL_FIELDS = {
     "external_systems_flagged", "history_rewritten", "new_anchor_sha",
     "new_paths_routed_to_misc", "old_anchor_sha", "orphaned_elements",
     "product_vision_flagged", "rebuild_required", "rebuild_reason",
-    "renamed_paths", "unchanged",
+    "renamed_paths", "state_missing", "stop_reason", "unchanged",
 }
 
 
@@ -193,6 +193,8 @@ def test_changed_path_maps_to_area(diff_mod, installed_likec4, tmp_path):
     assert diff["unchanged"] is False
     assert diff["history_rewritten"] is False
     assert diff["rebuild_required"] is False
+    assert diff["state_missing"] is False
+    assert diff["stop_reason"] is None
     assert diff["external_systems_flagged"] is False
     assert diff["product_vision_flagged"] is False
     assert diff["old_anchor_sha"] == v1
@@ -404,18 +406,21 @@ def test_readme_change_flags_product_vision(diff_mod, installed_likec4, tmp_path
 
 
 # --- the deterministic state gate (adrev2-009 / business R5) -----------------
-def test_gate_missing_state_names_the_searched_path(diff_mod, installed_likec4, tmp_path):
+def test_gate_missing_state_stops_never_rebuilds(diff_mod, installed_likec4, tmp_path):
+    """adrev2-014 orchestrator ruling: on an explicit update, no state.json at
+    the resolved root means STOP with the loud message (resolved path + --out
+    hint) - never a full rebuild at a possibly-wrong root."""
     repo = make_repo(tmp_path, V1_FILES)
     v1 = head(repo)
     out = make_out(tmp_path, v1, installed_likec4, write_state=False)
 
     code, diff = run_diff(diff_mod, repo, out, v1)
     assert code == 0
-    assert diff["rebuild_required"] is True
-    # adrev2-014: the message names the resolved path that was searched and
-    # points at the --out mismatch cause.
-    assert os.path.join(out, "state.json") in diff["rebuild_reason"]
-    assert "--out" in diff["rebuild_reason"]
+    assert diff["state_missing"] is True
+    assert diff["rebuild_required"] is False
+    assert diff["rebuild_reason"] is None
+    assert os.path.join(out, "state.json") in diff["stop_reason"]
+    assert "--out" in diff["stop_reason"]
     assert diff["unchanged"] is False
     assert diff["history_rewritten"] is False
 
@@ -487,6 +492,179 @@ def test_missing_baseline_model_forces_rebuild(diff_mod, installed_likec4, tmp_p
     assert code == 0
     assert diff["rebuild_required"] is True
     assert "model.json" in diff["rebuild_reason"]
+
+
+def test_gate_corrupt_element_index_routes_to_rebuild(diff_mod, installed_likec4, tmp_path):
+    """Stage-2 finding 3 repro: an element_index value that is a nested list
+    (unhashable) used to traceback at the orphan loop; corrupt-but-parseable
+    state must route to rebuild with a stated reason."""
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    write_files(repo, {"web/src/app.ts": "export const app = 2;\n"})
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4,
+                   element_index={"web__app": [["web/src/app.ts"]]})
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["rebuild_required"] is True
+    assert "element_index" in diff["rebuild_reason"]
+    assert "malformed" in diff["rebuild_reason"]
+
+
+def test_gate_corrupt_areas_routes_to_rebuild(diff_mod, installed_likec4, tmp_path):
+    """Stage-2 finding 3 repro: areas as a dict used to traceback at
+    areas_of; it must route to rebuild with a stated reason instead."""
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    write_files(repo, {"web/src/app.ts": "export const app = 2;\n"})
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4,
+                   areas={"web": {"root_paths": ["web"]}})
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["rebuild_required"] is True
+    assert "areas" in diff["rebuild_reason"]
+    assert "malformed" in diff["rebuild_reason"]
+
+
+# --- rename routing: unmapped destinations and edited/cross-area renames -----
+def test_rename_to_unmapped_dir_routes_to_misc(diff_mod, installed_likec4, tmp_path):
+    """Stage-2 finding 1 repro (few-file shape): moving both web/src files
+    into a new shared/ top dir must route the destinations to misc - the old
+    area's re-run no longer covers them, so something must investigate the
+    destination or the map silently shrinks."""
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    os.makedirs(os.path.join(repo, "shared"), exist_ok=True)
+    git(repo, "mv", "web/src/app.ts", "shared/app.ts")
+    git(repo, "mv", "web/src/cart.ts", "shared/cart.ts")
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["new_paths_routed_to_misc"] == ["shared/app.ts", "shared/cart.ts"]
+    # misc investigates the destination; the old area is re-investigated too.
+    assert diff["affected_areas"] == ["misc", "web"]
+    assert diff["rebuild_required"] is False
+    assert len(diff["renamed_paths"]) == 2
+    assert sorted(diff["elements_reanchored"]) == ["web__app", "web__cart"]
+
+
+def test_whole_dir_move_to_unmapped_territory_triggers_rebuild(diff_mod, installed_likec4, tmp_path):
+    """Stage-2 finding 1 repro (mass-move shape): a whole-directory move of a
+    5-file area to a new top-level dir is a clustering-material change and
+    must trigger rebuild_required, exactly as 5 ADDED files would - renames
+    must never silently delete an area."""
+    files = {
+        "web/src/a.ts": "export const a = 1;\n",
+        "web/src/b.ts": "export const b = 1;\n",
+        "web/src/c.ts": "export const c = 1;\n",
+        "web/src/d.ts": "export const d = 1;\n",
+        "web/src/e.ts": "export const e = 1;\n",
+        "api/worker.js": "export default {};\n",
+    }
+    repo = make_repo(tmp_path, files)
+    v1 = head(repo)
+    git(repo, "mv", "web", "lib")
+    v2 = commit_all(repo)
+    out = make_out(
+        tmp_path, v1, installed_likec4,
+        areas=[{"id": "web", "root_paths": ["web"]},
+               {"id": "misc", "root_paths": ["api"]}],
+        element_index={"web__a": ["web/src/a.ts"], "web__b": ["web/src/b.ts"]},
+    )
+    before = open(os.path.join(out, "model.json"), encoding="utf-8").read()
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["rebuild_required"] is True
+    assert "lib" in diff["rebuild_reason"]
+    assert len(diff["renamed_paths"]) == 5
+    # The rebuild path never mutates the baseline.
+    assert open(os.path.join(out, "model.json"), encoding="utf-8").read() == before
+
+
+def test_rename_with_edits_counts_as_change(diff_mod, installed_likec4, tmp_path):
+    """R<100: the rename is recorded, the new path counts as a change, the
+    area is affected, and the element is still re-anchored."""
+    body = "".join("export const line%d = %d;\n" % (i, i) for i in range(12))
+    files = dict(V1_FILES)
+    files["web/src/big.ts"] = body
+    repo = make_repo(tmp_path, files)
+    v1 = head(repo)
+    os.remove(os.path.join(repo, "web/src/big.ts"))
+    write_files(repo, {"web/src/bigger.ts": body + "export const extra = 99;\n"})
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4,
+                   element_index=dict(ELEMENT_INDEX, web__big=["web/src/big.ts"]))
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert len(diff["renamed_paths"]) == 1
+    rename = diff["renamed_paths"][0]
+    assert rename["from"] == "web/src/big.ts"
+    assert rename["to"] == "web/src/bigger.ts"
+    assert rename["similarity"] < 100
+    assert "web/src/bigger.ts" in diff["changed_paths"]
+    assert diff["affected_areas"] == ["web"]
+    assert diff["elements_reanchored"] == ["web__big"]
+
+
+def test_cross_area_rename_marks_both_areas(diff_mod, installed_likec4, tmp_path):
+    """A pure rename crossing area boundaries (misc -> web) marks BOTH areas
+    affected and re-anchors every owning element."""
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    git(repo, "mv", "api/worker.js", "web/src/worker.js")
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["affected_areas"] == ["misc", "web"]
+    assert diff["new_paths_routed_to_misc"] == []
+    assert sorted(diff["elements_reanchored"]) == ["misc__multi", "misc__worker"]
+
+
+# --- the empty-re-run-pack fast path (stage-2 finding 2, shape b) ------------
+def test_identical_tree_anchor_advance_is_empty_patchable_diff(diff_mod, installed_likec4, tmp_path):
+    """An anchor advance with an identical tree (allow-empty commit) yields a
+    patchable diff affecting ZERO packs - both flags false, no areas, nothing
+    re-anchored, unchanged false. The SKILL's U4.2 fast path consumes this
+    shape without ever calling merge (which exits 2 on an empty pack list)."""
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    git(repo, "commit", "-q", "--allow-empty", "-m", "no tree change", "--no-verify")
+    v2 = head(repo)
+    assert v2 != v1
+    out = make_out(tmp_path, v1, installed_likec4)
+    before = open(os.path.join(out, "model.json"), encoding="utf-8").read()
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["unchanged"] is False
+    assert diff["rebuild_required"] is False
+    assert diff["history_rewritten"] is False
+    assert diff["affected_areas"] == []
+    assert diff["external_systems_flagged"] is False
+    assert diff["product_vision_flagged"] is False
+    assert diff["changed_paths"] == []
+    assert diff["deleted_paths"] == []
+    assert diff["renamed_paths"] == []
+    assert diff["elements_reanchored"] == []
+    assert open(os.path.join(out, "model.json"), encoding="utf-8").read() == before
+
+
+# --- manifest-table semantics drift must fail loudly (stage-2 finding 5) -----
+def test_unknown_manifest_match_type_raises(diff_mod, monkeypatch):
+    monkeypatch.setattr(diff_mod, "MANIFEST_TABLE",
+                        (("mystery", "content-hash", "whatever"),))
+    with pytest.raises(ValueError) as exc:
+        diff_mod.path_matches_manifest("any/path.txt")
+    assert "content-hash" in str(exc.value)
 
 
 # --- input errors exit 2, never a silent diff --------------------------------

--- a/modules/orrery/tests/unit/test_diff_since.py
+++ b/modules/orrery/tests/unit/test_diff_since.py
@@ -1,0 +1,510 @@
+"""Unit tests for diff_since.py (plan Epic 5).
+
+Every case runs against a real two-commit throwaway git repo (hermetic,
+hooks bypassed via core.hooksPath) plus a scratch orrery output dir carrying
+state.json and a baseline model.json - the same layout the update flow
+resolves under $ORRERY_HOME/{slug}.
+
+Covered per the plan: path -> element/area mapping; delete/orphan; rename
+with -M (anchor updated in place); unchanged short-circuit; misc routing;
+rebuild_required on a new 5-file directory; history rewrite via reset --hard
+divergence; manifest-path -> external-systems flag; README -> product-vision
+flag; and the deterministic state gate diff_since encodes for the SKILL's
+update flow (missing/unparseable state, schema_version != 1,
+likec4_version != installed toolchain) - each with its own message.
+"""
+
+import importlib.util
+import json
+import os
+import subprocess
+
+import pytest
+
+MODULE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SCRIPTS_DIR = os.path.join(MODULE_DIR, "skills", "orrery", "scripts")
+TOOLCHAIN_PKG = os.path.join(SCRIPTS_DIR, "toolchain", "package.json")
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(SCRIPTS_DIR, name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="session")
+def diff_mod():
+    return _load("diff_since")
+
+
+@pytest.fixture(scope="session")
+def installed_likec4():
+    with open(TOOLCHAIN_PKG, "r", encoding="utf-8") as fh:
+        return json.load(fh)["dependencies"]["likec4"]
+
+
+# --- helpers -----------------------------------------------------------------
+def git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", repo, "-c", "user.name=orrery",
+         "-c", "user.email=orrery@example.invalid",
+         "-c", "core.hooksPath=/dev/null"] + list(args),
+        check=True, capture_output=True, text=True,
+    ).stdout
+
+
+def make_repo(tmp_path, files):
+    """Throwaway repo with an initial commit of `files`. Returns repo path."""
+    repo = os.path.join(str(tmp_path), "repo")
+    os.makedirs(repo, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", repo],
+                   check=True, capture_output=True)
+    write_files(repo, files)
+    git(repo, "add", "-A")
+    git(repo, "commit", "-qm", "v1", "--no-verify")
+    return repo
+
+
+def write_files(repo, files):
+    for rel, content in files.items():
+        full = os.path.join(repo, rel)
+        parent = os.path.dirname(full)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full, "w", encoding="utf-8") as fh:
+            fh.write(content)
+
+
+def commit_all(repo, msg="v2"):
+    git(repo, "add", "-A")
+    git(repo, "commit", "-qm", msg, "--no-verify")
+    return head(repo)
+
+
+def head(repo):
+    return git(repo, "rev-parse", "HEAD").strip()
+
+
+V1_FILES = {
+    "web/src/app.ts": "export const app = 1;\n",
+    "web/src/cart.ts": "export const cart = [];\n",
+    "api/worker.js": "export default { fetch() {} };\n",
+    "db/schema.sql": "CREATE TABLE orders (id integer);\n",
+    "package.json": '{"name": "fixture", "dependencies": {}}\n',
+    "README.md": "# fixture\n",
+}
+
+AREAS = [
+    {"id": "web", "root_paths": ["web"]},
+    {"id": "misc", "root_paths": ["api", "db", "package.json", "README.md"]},
+]
+
+ELEMENT_INDEX = {
+    "web__app": ["web/src/app.ts"],
+    "web__cart": ["web/src/cart.ts"],
+    "misc__worker": ["api/worker.js"],
+    "misc__schema": ["db/schema.sql"],
+    "misc__multi": ["api/worker.js", "db/schema.sql"],
+}
+
+
+def make_out(tmp_path, anchor_sha, installed_likec4, *, schema_version=1,
+             likec4_version=None, element_index=None, areas=None,
+             write_state=True, write_model=True, model_elements=None):
+    """Scratch orrery out dir: state.json + baseline model.json."""
+    out = os.path.join(str(tmp_path), "out")
+    os.makedirs(out, exist_ok=True)
+    if write_state:
+        state = {
+            "schema_version": schema_version,
+            "slug": "fixture",
+            "anchor_sha": anchor_sha,
+            "likec4_version": likec4_version if likec4_version is not None
+            else installed_likec4,
+            "areas": areas if areas is not None else AREAS,
+            "element_index": element_index if element_index is not None
+            else ELEMENT_INDEX,
+        }
+        with open(os.path.join(out, "state.json"), "w", encoding="utf-8") as fh:
+            json.dump(state, fh, indent=2)
+    if write_model:
+        idx = element_index if element_index is not None else ELEMENT_INDEX
+        elements = model_elements if model_elements is not None else [
+            {"id": el_id, "kind": "component", "title": el_id,
+             "files": [{"path": p} for p in paths]}
+            for el_id, paths in sorted(idx.items())
+        ]
+        with open(os.path.join(out, "model.json"), "w", encoding="utf-8") as fh:
+            json.dump({"elements": elements, "relations": []}, fh, indent=2)
+    return out
+
+
+def run_diff(diff_mod, repo, out, new_anchor):
+    diff_path = os.path.join(out, "diff.json")
+    code = diff_mod.run([
+        "--repo", repo,
+        "--state", os.path.join(out, "state.json"),
+        "--new-anchor", new_anchor,
+        "--out", diff_path,
+    ])
+    diff = None
+    if os.path.exists(diff_path):
+        with open(diff_path, "r", encoding="utf-8") as fh:
+            diff = json.load(fh)
+    return code, diff
+
+
+ALL_FIELDS = {
+    "affected_areas", "changed_paths", "deleted_paths", "elements_reanchored",
+    "external_systems_flagged", "history_rewritten", "new_anchor_sha",
+    "new_paths_routed_to_misc", "old_anchor_sha", "orphaned_elements",
+    "product_vision_flagged", "rebuild_required", "rebuild_reason",
+    "renamed_paths", "unchanged",
+}
+
+
+# --- single-source manifest table --------------------------------------------
+def test_manifest_table_imported_from_enumerate_repo(diff_mod):
+    enum_mod = _load("enumerate_repo")
+    assert diff_mod.MANIFEST_TABLE == enum_mod.MANIFEST_TABLE
+    # Never duplicated: the table's rows must not be re-declared in the source.
+    src = open(os.path.join(SCRIPTS_DIR, "diff_since.py"), encoding="utf-8").read()
+    assert "pnpm-workspace.yaml" not in src, (
+        "diff_since.py re-declares manifest rows instead of importing MANIFEST_TABLE"
+    )
+
+
+# --- path -> element/area mapping --------------------------------------------
+def test_changed_path_maps_to_area(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    write_files(repo, {"web/src/app.ts": "export const app = 2;\n"})
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert set(diff) == ALL_FIELDS
+    assert diff["changed_paths"] == ["web/src/app.ts"]
+    assert diff["affected_areas"] == ["web"]
+    assert diff["deleted_paths"] == []
+    assert diff["orphaned_elements"] == []
+    assert diff["unchanged"] is False
+    assert diff["history_rewritten"] is False
+    assert diff["rebuild_required"] is False
+    assert diff["external_systems_flagged"] is False
+    assert diff["product_vision_flagged"] is False
+    assert diff["old_anchor_sha"] == v1
+    assert diff["new_anchor_sha"] == v2
+
+
+# --- delete / orphan ---------------------------------------------------------
+def test_delete_orphans_element_whose_every_path_died(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    git(repo, "rm", "-q", "web/src/cart.ts")
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["deleted_paths"] == ["web/src/cart.ts"]
+    assert diff["orphaned_elements"] == ["web__cart"]
+    assert diff["affected_areas"] == ["web"]
+
+
+def test_partial_delete_does_not_orphan(diff_mod, installed_likec4, tmp_path):
+    """misc__multi anchors two paths; deleting one leaves it alive."""
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    git(repo, "rm", "-q", "db/schema.sql")
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert "misc__multi" not in diff["orphaned_elements"]
+    # misc__schema anchored ONLY the deleted path: orphaned.
+    assert diff["orphaned_elements"] == ["misc__schema"]
+
+
+# --- rename with -M: anchor updated in place ---------------------------------
+def test_rename_updates_owning_element_anchor_in_place(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    git(repo, "mv", "web/src/cart.ts", "web/src/basket.ts")
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["renamed_paths"] == [
+        {"from": "web/src/cart.ts", "similarity": 100, "to": "web/src/basket.ts"}
+    ]
+    assert diff["elements_reanchored"] == ["web__cart"]
+    # A pure same-area rename preserves continuity: nothing to re-investigate.
+    assert diff["changed_paths"] == []
+    assert diff["affected_areas"] == []
+    assert diff["deleted_paths"] == []
+    assert diff["orphaned_elements"] == []
+    # The baseline model was rewritten IN PLACE with the new anchor path.
+    with open(os.path.join(out, "model.json"), encoding="utf-8") as fh:
+        model = json.load(fh)
+    cart = [e for e in model["elements"] if e["id"] == "web__cart"][0]
+    assert cart["files"][0]["path"] == "web/src/basket.ts"
+    assert not os.path.exists(os.path.join(out, "model.json.tmp"))
+
+
+# --- unchanged short-circuit -------------------------------------------------
+def test_unchanged_short_circuit(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+    before = open(os.path.join(out, "model.json"), encoding="utf-8").read()
+
+    code, diff = run_diff(diff_mod, repo, out, v1)
+    assert code == 0
+    assert diff["unchanged"] is True
+    assert diff["rebuild_required"] is False
+    assert diff["history_rewritten"] is False
+    assert diff["changed_paths"] == []
+    assert diff["affected_areas"] == []
+    assert open(os.path.join(out, "model.json"), encoding="utf-8").read() == before
+
+
+# --- misc routing ------------------------------------------------------------
+def test_genuinely_new_paths_route_to_misc(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    write_files(repo, {
+        "tools/lint.js": "// lint\n",
+        "tools/fmt.js": "// fmt\n",
+    })
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["new_paths_routed_to_misc"] == ["tools/fmt.js", "tools/lint.js"]
+    assert diff["affected_areas"] == ["misc"]
+    assert diff["rebuild_required"] is False
+
+
+def test_new_path_inside_existing_area_is_a_change_not_misc(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    write_files(repo, {"web/src/wishlist.ts": "export const wl = [];\n"})
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["new_paths_routed_to_misc"] == []
+    assert diff["changed_paths"] == ["web/src/wishlist.ts"]
+    assert diff["affected_areas"] == ["web"]
+
+
+# --- rebuild_required on a clustering-material change ------------------------
+def test_rebuild_required_on_new_five_file_dir(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    write_files(repo, {
+        "billing/a.js": "1\n", "billing/b.js": "2\n", "billing/c.js": "3\n",
+        "billing/d.js": "4\n", "billing/e.js": "5\n",
+    })
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+    before = open(os.path.join(out, "model.json"), encoding="utf-8").read()
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["rebuild_required"] is True
+    assert "billing" in diff["rebuild_reason"]
+    assert diff["history_rewritten"] is False
+    # A rebuild ignores the baseline: it is never mutated on this path.
+    assert open(os.path.join(out, "model.json"), encoding="utf-8").read() == before
+
+
+def test_four_new_files_stay_below_rebuild_threshold(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    write_files(repo, {
+        "billing/a.js": "1\n", "billing/b.js": "2\n",
+        "billing/c.js": "3\n", "billing/d.js": "4\n",
+    })
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["rebuild_required"] is False
+    assert len(diff["new_paths_routed_to_misc"]) == 4
+    assert diff["affected_areas"] == ["misc"]
+
+
+# --- history rewrite (business C3) -------------------------------------------
+def test_history_rewrite_via_reset_hard_divergence(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    write_files(repo, {"web/src/app.ts": "export const app = 2;\n"})
+    v2 = commit_all(repo)
+    # Rewrite: drop v2, commit a divergent tip. v2 stays resolvable (loose
+    # object) but is no longer an ancestor of the new tip.
+    git(repo, "reset", "-q", "--hard", v1)
+    write_files(repo, {"web/src/app.ts": "export const app = 3;\n"})
+    v2b = commit_all(repo, "v2-divergent")
+    assert v2b != v2
+    out = make_out(tmp_path, v2, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2b)
+    assert code == 0
+    assert diff["history_rewritten"] is True
+    assert diff["rebuild_required"] is False
+    assert diff["changed_paths"] == []
+    assert diff["affected_areas"] == []
+
+
+def test_history_rewrite_when_old_anchor_unresolvable(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    out = make_out(tmp_path, "deadbeef" * 5, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v1)
+    assert code == 0
+    assert diff["history_rewritten"] is True
+
+
+# --- pack flags --------------------------------------------------------------
+def test_manifest_path_flags_external_systems(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    write_files(repo, {"package.json": '{"name": "fixture", "dependencies": {"left-pad": "1.0.0"}}\n'})
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["external_systems_flagged"] is True
+    assert diff["product_vision_flagged"] is False
+    assert diff["affected_areas"] == ["misc"]
+
+
+def test_readme_change_flags_product_vision(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    write_files(repo, {"README.md": "# fixture, now with a vision\n"})
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["product_vision_flagged"] is True
+    assert diff["external_systems_flagged"] is False
+
+
+# --- the deterministic state gate (adrev2-009 / business R5) -----------------
+def test_gate_missing_state_names_the_searched_path(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    out = make_out(tmp_path, v1, installed_likec4, write_state=False)
+
+    code, diff = run_diff(diff_mod, repo, out, v1)
+    assert code == 0
+    assert diff["rebuild_required"] is True
+    # adrev2-014: the message names the resolved path that was searched and
+    # points at the --out mismatch cause.
+    assert os.path.join(out, "state.json") in diff["rebuild_reason"]
+    assert "--out" in diff["rebuild_reason"]
+    assert diff["unchanged"] is False
+    assert diff["history_rewritten"] is False
+
+
+def test_gate_unparseable_state(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    out = make_out(tmp_path, v1, installed_likec4, write_state=False)
+    with open(os.path.join(out, "state.json"), "w", encoding="utf-8") as fh:
+        fh.write("{not json")
+
+    code, diff = run_diff(diff_mod, repo, out, v1)
+    assert code == 0
+    assert diff["rebuild_required"] is True
+    assert "unparseable" in diff["rebuild_reason"]
+
+
+def test_gate_schema_version_mismatch_names_the_version(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    out = make_out(tmp_path, v1, installed_likec4, schema_version=2)
+
+    code, diff = run_diff(diff_mod, repo, out, v1)
+    assert code == 0
+    assert diff["rebuild_required"] is True
+    assert "schema_version" in diff["rebuild_reason"]
+    assert "2" in diff["rebuild_reason"]
+    assert "likec4_version" not in diff["rebuild_reason"]
+
+
+def test_gate_likec4_version_mismatch_names_both_versions(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    out = make_out(tmp_path, v1, installed_likec4, likec4_version="0.0.1")
+
+    code, diff = run_diff(diff_mod, repo, out, v1)
+    assert code == 0
+    assert diff["rebuild_required"] is True
+    assert "likec4_version" in diff["rebuild_reason"]
+    assert "0.0.1" in diff["rebuild_reason"]
+    assert installed_likec4 in diff["rebuild_reason"]
+    assert "schema_version" not in diff["rebuild_reason"]
+
+
+def test_gate_matching_state_passes(diff_mod, installed_likec4, tmp_path):
+    """The gate reads the REAL toolchain pin: a state recording exactly the
+    installed version passes through to the diff."""
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    write_files(repo, {"web/src/app.ts": "export const app = 2;\n"})
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["rebuild_required"] is False
+
+
+def test_missing_baseline_model_forces_rebuild(diff_mod, installed_likec4, tmp_path):
+    """merge --patch needs the baseline model; a patchable diff without one
+    must degrade to a stated full rebuild, never a mid-patch crash."""
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    write_files(repo, {"web/src/app.ts": "export const app = 2;\n"})
+    v2 = commit_all(repo)
+    out = make_out(tmp_path, v1, installed_likec4, write_model=False)
+
+    code, diff = run_diff(diff_mod, repo, out, v2)
+    assert code == 0
+    assert diff["rebuild_required"] is True
+    assert "model.json" in diff["rebuild_reason"]
+
+
+# --- input errors exit 2, never a silent diff --------------------------------
+def test_unresolvable_new_anchor_exits_2(diff_mod, installed_likec4, tmp_path):
+    repo = make_repo(tmp_path, V1_FILES)
+    v1 = head(repo)
+    out = make_out(tmp_path, v1, installed_likec4)
+
+    code, diff = run_diff(diff_mod, repo, out, "feedface" * 5)
+    assert code == 2
+    assert diff is None
+
+
+def test_non_repo_exits_2(diff_mod, installed_likec4, tmp_path):
+    plain = os.path.join(str(tmp_path), "plain")
+    os.makedirs(plain)
+    out = make_out(tmp_path, "1234567890abcdef1234567890abcdef12345678", installed_likec4)
+
+    code, diff = run_diff(diff_mod, plain, out, "1234567890abcdef1234567890abcdef12345678")
+    assert code == 2
+    assert diff is None


### PR DESCRIPTION
Closes #904. Closes #912 (folded-in ORRERY_HOME output-root override). Refs #899.

\`/orrery update\` now refreshes an existing map incrementally instead of telling the user to rebuild. A deterministic script decides everything routable; scouts are dispatched only for the packs the diff actually touched.

## What it does

- **\`scripts/diff_since.py\`** (new, stdlib-only, deterministic) — args \`--repo --state --new-anchor --out\`:
  - **State gate** (adrev2-009 / business R5): missing state.json (message names the resolved path and the \`--out\` mismatch cause, per adrev2-014), unparseable state, \`schema_version != 1\`, \`likec4_version != installed toolchain\` (read from \`scripts/toolchain/package.json\`, same single source as the build path) — each fires \`rebuild_required\` with its own message.
  - **History-rewrite safety** (business C3): \`git cat-file -e <old>^{commit}\` AND \`git merge-base --is-ancestor\` — either failing emits \`history_rewritten: true\` and stops; never a guess-diff.
  - **Unchanged short-circuit**; then \`git diff -M --name-status\` (explicit \`-M\`, arch R2). Renames update the owning element's file anchors **in place** in the baseline model.json (atomic write) so continuity survives without re-investigation. Changed/deleted paths map to affected areas via state.json \`areas[].root_paths\`; fully-deleted elements are listed as \`orphaned_elements\`; genuinely-new paths route to \`misc\` (arch R3), with full rebuild reserved for a new >=5-file directory outside every area. \`MANIFEST_TABLE\` is **imported** from enumerate_repo.py (single source, verified by test); manifest paths flag external-systems, README/docs/CLAUDE.md flag product-vision.
  - diff.json always carries every named field plus \`renamed_paths\`, \`elements_reanchored\`, and the two pack flags for the delta report.
- **SKILL.md update flow** replaces the Epic-4 stub: anchor (teardown obligation starts there), gate+diff via diff_since, route on diff.json (rebuild with the reason verbatim / history-rewritten rebuild / **"up to date" stop that still runs teardown** / patch path). Patch path re-dispatches ONLY affected packs as \`orrery-scout\` with the load-bearing \`area-{area_id}\` naming, patch-merges with \`--patch --state --diff\`, honors merge's baseline-retention-on-failed-re-investigation (no splitting — split ids cannot match baseline pack namespaces), runs the SAME <=3 fix loop invoked identically (errors.json hygiene included), renders, advances state.json atomically, and reports the delta (added/updated/removed, renames preserved).
- **#912**: \`anchor_repo.sh\` honors \`\$ORRERY_HOME\` (default \`~/code/orrery\`) for the output root it creates, chmod 700 kept — the SKILL's "root overridable" claim is now true end-to-end. Change is confined to the output-root resolution.
- **module.json**: one additive, alphabetized files entry for diff_since.py.

## Tests

- \`tests/unit/test_diff_since.py\` — 22 cases: path->element/area mapping, delete/orphan (incl. partial delete does not orphan), rename with \`-M\` updates the anchor in place, unchanged short-circuit, misc routing (and inside-area adds are changes, not misc), rebuild on a new 5-file dir (4 files stays below threshold), history rewrite via \`reset --hard\` divergence AND unresolvable old anchor, manifest-path -> external-systems flag, README -> product-vision flag, all four state-gate conditions each with its own message (schema and likec4 mismatches assert the other condition is NOT named), missing baseline model degrades to a stated rebuild, input errors exit 2.
- \`tests/unit/test_anchor_repo.py\` — new \`ORRERY_HOME\` override test (dir created under override, chmod 700, default root NOT created); \`make_env\` strips ambient \`ORRERY_HOME\` for hermeticity.
- \`tests/e2e/test-update-fixture.sh\` — fixture v1 -> full deterministic chain + state.json -> index-plumbed v2 commit (modify one api/ file, delete one web/ file, rename one db/ file) -> re-anchor -> diff_since -> patch-merge with canned updated fragments -> emit -> validate -> render. Asserts: diff scoping is exactly \`[misc, web]\` (the renamed file's area is NOT re-investigated), new title present in the artifact, deleted element absent from model and artifact, renamed element retained with the updated anchor, state.json advanced atomically (no .tmp left). Fixture materialization and the v2 delta both use **index plumbing** (web/ vs Web/ case split never touches the filesystem), the whole run executes under \`\$ORRERY_HOME\` redirected into the tempdir, and the cleanup trap runs a guarded \`anchor_repo.sh --teardown\` on every exit path, with an \`ORRERY_UPDATE_TEST_INJECT_FAIL=post-anchor\` hook for the teardown probe.

## Verification (fresh runs)

- \`pytest modules/orrery/tests/unit -q\`: **143 passed** (incl. 22 new diff_since + 1 new anchor test; test_skill_refs now extracts the whole SKILL.md since diff_since.py exists)
- \`bash modules/orrery/tests/e2e/test-update-fixture.sh\`: **PASS** standalone
- Injected-failure teardown probe (\`ORRERY_UPDATE_TEST_INJECT_FAIL=post-anchor\`): exit 1, then zero leftover \`orrery-anchor-*\`/\`orrery-update.*\` dirs in TMPDIR and the default \`~/code/orrery/<slug>\` never created
- \`ORRERY_STRICT=1 bash modules/orrery/tests/test-orrery.sh\`: **all layers green** (unit + all 6 e2e chains incl. the new one)
- \`bash tests/test-modules.sh\`: 1641 passed, 0 failed
- \`bash tests/test-frontmatter-yaml.sh\`: all frontmatter valid
- \`bash tests/test-no-personal-data.sh\`: PASS
- \`python3 modules/plugin-marketplace/lib/gen_marketplace.py --check\`: up to date (no regen needed — descriptions unchanged)