### PR TITLE
#915: orrery — drop ancestor-descendant relations at merge (implied by nesting)

### DIFF
--- a/modules/orrery/skills/orrery/scripts/merge_fragments.py
+++ b/modules/orrery/skills/orrery/scripts/merge_fragments.py
@@ -38,6 +38,10 @@ Contract highlights (plan Epic 3):
     or the reserved cross-cutting ids (system, users), merge normally:
     longest description wins, files/tags union, source_packs[] provenance.
   * Relations are deduped; dangling endpoints dropped + reported.
+  * Ancestor-descendant relations (one endpoint on the other's parent
+    chain, or equal endpoints) are dropped + reported: containment is
+    already expressed by nesting, and LikeC4 rejects such edges
+    ("Invalid parent-child relationship").
 
 Exit codes: 0 = merged (the report carries all screening findings);
 2 = usage / unreadable input.
@@ -514,6 +518,41 @@ def merge_relations(pool, valid_ids, report):
     return out
 
 
+def drop_ancestor_relations(relations, elements, report):
+    """Drop relations where one endpoint is an ancestor of the other (via
+    the elements' parent chains), or the endpoints are equal (#915).
+
+    Containment is already expressed by nesting, so the relation is
+    semantically redundant -- and LikeC4 rejects it outright ("Invalid
+    parent-child relationship"), which failed validate on the first
+    full-scale run (16 such relations on a 551-element model). The walk
+    carries a visited set so a defensive parent cycle (validate_map.py
+    check 6 catches those later) can never loop it forever.
+    """
+    parent = {e["id"]: e.get("parent") for e in elements}
+
+    def is_ancestor(anc, node):
+        seen = set()
+        cur = parent.get(node)
+        while cur is not None and cur not in seen:
+            if cur == anc:
+                return True
+            seen.add(cur)
+            cur = parent.get(cur)
+        return False
+
+    out = []
+    for rel in relations:
+        frm, to = rel["from"], rel["to"]
+        if frm == to or is_ancestor(frm, to) or is_ancestor(to, frm):
+            report["dropped_ancestor_relations"].append(
+                {"from": frm, "to": to, "reason": "implied by nesting"}
+            )
+            continue
+        out.append(rel)
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Meta (anchor + census -> model.schema.json meta)
 # ---------------------------------------------------------------------------
@@ -646,6 +685,7 @@ def new_report(mode, packs):
         "collisions": [],
         "neutralized": [],
         "dropped_relations": [],
+        "dropped_ancestor_relations": [],
         "reparented": [],
         "dropped_parent_orphans": [],
         "open_questions": {},
@@ -760,6 +800,10 @@ def run(argv=None):
     elements = cascade_parent_orphans(elements, report)
     valid_ids = {e["id"] for e in elements}
     relations = merge_relations(relation_pool, valid_ids, report)
+    # After dangling-drop, before the model is written; both modes (build
+    # and --patch) flow through here, so the patched model gets the same
+    # screen (#915).
+    relations = drop_ancestor_relations(relations, elements, report)
 
     model = {
         "meta": build_meta(anchor, census),
@@ -797,6 +841,9 @@ def run(argv=None):
     if report["dropped_relations"]:
         print("merge_fragments.py: dropped %d dangling relation(s)"
               % len(report["dropped_relations"]))
+    if report["dropped_ancestor_relations"]:
+        print("merge_fragments.py: %d ancestor relation(s) dropped: implied by nesting"
+              % len(report["dropped_ancestor_relations"]))
     if report["reparented"]:
         print("merge_fragments.py: reparented %d child(ren) of withheld element(s): %s"
               % (len(report["reparented"]),

--- a/modules/orrery/tests/unit/test_merge_fragments.py
+++ b/modules/orrery/tests/unit/test_merge_fragments.py
@@ -467,6 +467,168 @@ def test_never_defined_parent_still_cascades(merge_mod, tmp_path):
     assert [d["id"] for d in report["dropped_parent_orphans"]] == ["child_of_ghost"]
 
 
+# --- ancestor-descendant relations (#915) ----------------------------------
+
+def test_parent_child_relation_dropped(merge_mod, tmp_path):
+    # Direct parent -> child: containment is already expressed by nesting;
+    # LikeC4 rejects the edge ("Invalid parent-child relationship").
+    box = element("box", kind="container")
+    item = element("box_item", parent="box")
+    code, model, report = run_merge(
+        merge_mod, tmp_path, packs=["one"],
+        fragments={"one.json": frag(
+            "one", [box, item],
+            relations=[{"from": "box", "to": "box_item", "summary": "contains"}],
+        )},
+    )
+    assert code == 0
+    assert model["relations"] == []
+    assert report["dropped_ancestor_relations"] == [
+        {"from": "box", "to": "box_item", "reason": "implied by nesting"}
+    ]
+
+
+def test_grandparent_grandchild_relation_dropped(merge_mod, tmp_path):
+    # The walk follows the whole parent chain, not just one hop.
+    top = element("top", kind="container")
+    mid = element("mid", kind="container", parent="top")
+    leaf = element("leaf", parent="mid")
+    code, model, report = run_merge(
+        merge_mod, tmp_path, packs=["one"],
+        fragments={"one.json": frag(
+            "one", [top, mid, leaf],
+            relations=[{"from": "top", "to": "leaf", "summary": "reaches down two levels"}],
+        )},
+    )
+    assert model["relations"] == []
+    assert report["dropped_ancestor_relations"] == [
+        {"from": "top", "to": "leaf", "reason": "implied by nesting"}
+    ]
+
+
+def test_child_parent_reverse_relation_dropped(merge_mod, tmp_path):
+    # The descendant -> ancestor direction is the same class.
+    box = element("box", kind="container")
+    item = element("box_item", parent="box")
+    code, model, report = run_merge(
+        merge_mod, tmp_path, packs=["one"],
+        fragments={"one.json": frag(
+            "one", [box, item],
+            relations=[{"from": "box_item", "to": "box", "summary": "calls up"}],
+        )},
+    )
+    assert model["relations"] == []
+    assert report["dropped_ancestor_relations"] == [
+        {"from": "box_item", "to": "box", "reason": "implied by nesting"}
+    ]
+
+
+def test_self_relation_dropped(merge_mod, tmp_path):
+    # Equal endpoints are treated as the same class.
+    code, model, report = run_merge(
+        merge_mod, tmp_path, packs=["one"],
+        fragments={"one.json": frag(
+            "one", [element("alpha")],
+            relations=[{"from": "alpha", "to": "alpha", "summary": "self loop"}],
+        )},
+    )
+    assert model["relations"] == []
+    assert report["dropped_ancestor_relations"] == [
+        {"from": "alpha", "to": "alpha", "reason": "implied by nesting"}
+    ]
+
+
+def test_sibling_and_unrelated_relations_untouched(merge_mod, tmp_path, capsys):
+    box = element("box", kind="container")
+    sib_a = element("sib_a", parent="box")
+    sib_b = element("sib_b", parent="box")
+    other = element("other")
+    code, model, report = run_merge(
+        merge_mod, tmp_path, packs=["one"],
+        fragments={"one.json": frag(
+            "one", [box, sib_a, sib_b, other],
+            relations=[
+                {"from": "sib_a", "to": "sib_b", "summary": "sibling edge"},
+                {"from": "other", "to": "sib_a", "summary": "unrelated edge"},
+            ],
+        )},
+    )
+    assert len(model["relations"]) == 2
+    assert report["dropped_ancestor_relations"] == []
+    assert "ancestor relation(s) dropped" not in capsys.readouterr().out
+
+
+def test_ancestor_drop_count_reported(merge_mod, tmp_path, capsys):
+    # The count line matches the existing report-line pattern, and the
+    # report carries one entry per dropped relation.
+    box = element("box", kind="container")
+    item = element("box_item", parent="box")
+    sib = element("sib", parent="box")
+    code, model, report = run_merge(
+        merge_mod, tmp_path, packs=["one"],
+        fragments={"one.json": frag(
+            "one", [box, item, sib],
+            relations=[
+                {"from": "box", "to": "box_item", "summary": "contains"},
+                {"from": "box_item", "to": "box_item", "summary": "self loop"},
+                {"from": "box_item", "to": "sib", "summary": "sibling edge kept"},
+            ],
+        )},
+    )
+    assert "2 ancestor relation(s) dropped: implied by nesting" in capsys.readouterr().out
+    assert len(report["dropped_ancestor_relations"]) == 2
+    assert [(r["from"], r["to"]) for r in model["relations"]] == [("box_item", "sib")]
+
+
+def test_parent_cycle_walk_terminates(merge_mod, tmp_path):
+    # Defensive: a cycle in the parent chains (validate_map.py flags it
+    # later) must not hang the ancestor walk. The edge between the two
+    # cycle members is classified ancestor (each is on the other's chain);
+    # the edge from the unrelated element survives.
+    a = element("cyc_a", kind="container", parent="cyc_b")
+    b = element("cyc_b", kind="container", parent="cyc_a")
+    c = element("outside")
+    code, model, report = run_merge(
+        merge_mod, tmp_path, packs=["one"],
+        fragments={"one.json": frag(
+            "one", [a, b, c],
+            relations=[
+                {"from": "cyc_a", "to": "cyc_b", "summary": "inside the cycle"},
+                {"from": "outside", "to": "cyc_a", "summary": "into the cycle"},
+            ],
+        )},
+    )
+    assert code == 0
+    assert [(r["from"], r["to"]) for r in model["relations"]] == [("outside", "cyc_a")]
+    assert report["dropped_ancestor_relations"] == [
+        {"from": "cyc_a", "to": "cyc_b", "reason": "implied by nesting"}
+    ]
+
+
+def test_patch_mode_drops_ancestor_relation(merge_mod, tmp_path):
+    # The patched model gets the same screen: --patch flows through the
+    # same post-merge drop as build mode.
+    box = element("box", kind="container")
+    item = element("box_item", parent="box")
+    code, baseline, _ = run_merge(
+        merge_mod, tmp_path, packs=["one"],
+        fragments={"one.json": frag("one", [box, item])},
+    )
+    assert {e["id"] for e in baseline["elements"]} == {"box", "box_item"}
+    frag_dir = os.path.join(str(tmp_path), "fragments")
+    write_json(os.path.join(frag_dir, "one.json"),
+               frag("one", [box, item],
+                    relations=[{"from": "box", "to": "box_item", "summary": "contains"}]))
+    code, patched, report = run_merge(
+        merge_mod, tmp_path, packs=["one"], extra_args=["--patch"],
+    )
+    assert code == 0
+    assert patched["relations"] == []
+    assert report["dropped_ancestor_relations"] == [
+        {"from": "box", "to": "box_item", "reason": "implied by nesting"}
+    ]
+
+
 # --- meta ------------------------------------------------------------------
 
 def test_meta_source_links_github(merge_mod, tmp_path):


### PR DESCRIPTION
Closes #915. Refs #899.

A fresh /orrery run on ccgm (551 elements) produced a model LikeC4 rejects: 16 relations had one endpoint on the other endpoint's parent chain (e.g. `installer -> bucket_06__module_manifest_json`, whose chain reaches `installer`). LikeC4 refuses these ("Invalid parent-child relationship") because containment is already expressed by nesting.

## What changed

`merge_fragments.py`: after relation resolution (dangling-drop) and before the model is written, drop every relation where one endpoint is an ancestor of the other, walking each endpoint's `parent` chain through the merged element set. Equal endpoints (self-relations) are treated as the same class. The walk carries a visited set so a defensive parent cycle cannot loop it (validate_map.py still flags the cycle itself later). Both build and `--patch` modes flow through the same post-merge screen, so a patched model gets the same treatment.

Reporting follows the existing pattern: a `dropped_ancestor_relations` list (one `{from, to, reason: "implied by nesting"}` entry per drop) in merge-report.json, and a count line — `N ancestor relation(s) dropped: implied by nesting` — in the run output, printed only when non-zero, like the dangling-relation line.

## Tests

Extended `tests/unit/test_merge_fragments.py` with 8 tests: direct parent->child dropped; grandparent->grandchild (2-level chain) dropped; child->parent (reverse) dropped; self-relation dropped; sibling + unrelated relations untouched (and no count line printed); count line + report count asserted on a mixed case; parent-cycle walk terminates (edge inside the cycle classified ancestor, edge into the cycle kept); `--patch` mode applies the same drop.

No fixture or golden updates needed: verified the golden-emitted model contains zero ancestor-class relations, so the drop is a no-op on all checked-in fixtures.

## Verification

- `python3 -m pytest modules/orrery/tests/unit -q` — 128 passed
- `ORRERY_STRICT=1 bash modules/orrery/tests/test-orrery.sh` — all layers green (unit, embed-browser, ingest-fixture, pipeline-fixture, render-golden, validate-gate)
- `bash tests/test-modules.sh` — 1640 passed, 0 failed
