### PR TITLE
#920: docupdate — post-orrery docs pass (installer/getting-started/README/CLAUDE.md drift)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,10 @@ ccgm/
 │   ├── template.sh     # __PLACEHOLDER__ expansion
 │   ├── merge.sh        # settings.json merge via jq
 │   ├── modules.sh      # Module discovery + deps
-│   └── backup.sh       # Backup/restore
+│   ├── backup.sh       # Backup/restore
+│   ├── mcp-migrate.sh  # Legacy mcp.json re-registration
+│   ├── repair.sh       # Stale symlink repair
+│   └── statusline.sh   # Status line script
 ├── modules/            # 77 self-contained modules
 │   └── {name}/
 │       ├── module.json # Manifest
@@ -28,7 +31,8 @@ ccgm/
 │   ├── minimal.json
 │   ├── standard.json
 │   ├── full.json
-│   └── team.json
+│   ├── team.json
+│   └── cloud-agent.json
 └── tests/              # Test scripts
 ```
 
@@ -51,7 +55,7 @@ bash tests/test-no-personal-data.sh
 
 Each module is self-contained in `modules/{name}/`:
 - `module.json` defines metadata, files, dependencies, and config prompts
-- Content files go in subdirectories matching their target location (rules/, commands/, hooks/)
+- Content files go in subdirectories matching their target location (rules/, commands/, hooks/, skills/, agents/)
 - Rule files (rules/*.md) use generic language, NOT template variables
 - Config files (hooks, settings) may use `__PLACEHOLDER__` template variables
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ For blocks pre-selecting a specific preset, and for how to dry-run this safely, 
 - macOS or Linux
 - bash 4+ or zsh
 - git
+- python3
+- jq
 
-The installer checks for Claude Code, additional tools (jq, Python 3, gh CLI), and offers to install any that are missing.
+The installer checks for these tools (plus the optional gh CLI) and offers to install any that are missing.
 
 ## Install
 
@@ -132,7 +134,7 @@ For a quick install with a preset:
 |--------|---------|----------|
 | **minimal** | global-claude-md, autonomy, git-workflow | Getting started |
 | **standard** | global-claude-md, autonomy, identity, git-workflow, hooks, branch-guard, ask-context, model-vetting, settings, commands-core, commands-utility, self-improving, output-formatting, writing-system, statusline | Most users |
-| **team** | global-claude-md, autonomy, git-workflow, hooks, branch-guard, ask-context, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification, autoheal, output-formatting, writing-system, ce-review, pr-feedback, pr-review-toolkit, document-review, compound-knowledge (+ deps) | Teams |
+| **team** | global-claude-md, autonomy, git-workflow, hooks, branch-guard, ask-context, settings, commands-core, github-protocols, code-quality, systematic-debugging, verification, autoheal, output-formatting, writing-system, ce-review, pr-feedback, pr-review-toolkit, document-review, compound-knowledge, skill-authoring, subagent-patterns (+ deps) | Teams |
 | **cloud-agent** | 55 modules | Autonomous/headless agents |
 | **full** | 73 modules | Power users |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ Optional but recommended:
 
 - **[GitHub CLI](https://cli.github.com/)** (`gh`) - enables auto-detection of your GitHub username, issue management commands, and PR workflows
 
-The installer checks for all prerequisites and offers to install missing tools using your system's package manager (Homebrew on macOS, apt/dnf/pacman on Linux).
+The installer checks for these global prerequisites and offers to install missing tools using your system's package manager (Homebrew on macOS, apt/dnf/pacman on Linux). Some modules need extra tools (Node, wrangler, etc.) - see each module's README for its specific requirements.
 
 ## Installation
 
@@ -33,7 +33,7 @@ The interactive installer handles everything from here.
 
 ### 2. Choose a preset (or pick modules individually)
 
-The installer offers five presets, or you can select modules one by one:
+Five presets exist. The interactive menu currently offers four of them; **cloud-agent** is available via `./start.sh --preset cloud-agent` (see #919). You can also select modules one by one:
 
 | Preset | What you get | Best for |
 |--------|-------------|----------|
@@ -60,17 +60,19 @@ After installation, start a new Claude Code session. Your new rules, commands, a
 
 ## Install scopes
 
-CCGM can install to two locations:
+CCGM can install to either or both of two locations:
 
 | Scope | Path | Effect |
 |-------|------|--------|
 | **Global** | `~/.claude/` | Applies to all projects and all Claude Code environments |
 | **Project** | `.claude/` in current directory | Applies only to the current project |
+| **Both** | Both paths above | Installs to both locations |
 
 ```bash
 ./start.sh                    # Interactive scope selection
 ./start.sh --scope global     # Global only
 ./start.sh --scope project    # Project only
+./start.sh --scope both       # Both locations
 ```
 
 Global installation is the most common choice. Project-level installation is useful when you want different rules for a specific repo, or when sharing configuration with a team via version control.

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -4,7 +4,7 @@ The CCGM installer (`start.sh`) is an interactive bash script that handles prere
 
 ## Installation flow
 
-The installer runs 15 sequential steps:
+The installer runs 15 sequential steps, plus a conditional Step 14b (legacy MCP migration):
 
 ### Step 1: Welcome
 
@@ -48,7 +48,7 @@ Choose a preset (minimal, standard, full, team) or select individual modules fro
 
 Automatically adds any modules required by your selection. Uses a depth-first topological sort with cycle detection. Reports any automatically added dependencies.
 
-For example, selecting `xplan` automatically adds its dependencies `multi-agent` and `adversarial-review`, which in turn add `startup-dashboard` (multi-agent's dependency) and `subagent-patterns` (adversarial-review's dependency).
+For example, selecting `xplan` automatically adds its dependencies `multi-agent` and `adversarial-review`, which in turn add `startup-dashboard` (multi-agent's dependency) and `subagent-patterns` (adversarial-review's dependency), and `startup-dashboard` in turn adds `session-history`.
 
 ### Step 7: Module config prompts
 
@@ -64,7 +64,7 @@ A single yes/no gate. Answering no exits without making changes.
 
 ### Step 10: Backup
 
-Creates a timestamped backup of existing `~/.claude/` contents to `~/.claude/backups/ccgm-YYYYMMDD-HHMMSS/`. Only backs up files that CCGM will overwrite.
+Creates a timestamped backup at `<target>/backups/ccgm-YYYYMMDD-HHMMSS/` - `~/.claude/backups/` for a global install, `<project>/.claude/backups/` for a project install. It copies a fixed list of top-level items if they exist: `settings.json`, `CLAUDE.md`, `rules/`, `commands/`, `hooks/`, `multi-agent-system.md`, `github-repo-protocols.md`, and any `.ccgm*` files. The 5 most recent backups are kept; older ones are deleted. Module targets outside that list (`skills/`, `agents/`, `lib/`, `bin/`, ...) are not currently backed up (see #917).
 
 ### Step 11: Install
 
@@ -101,6 +101,10 @@ Optionally adds two aliases to `~/.zshrc` or `~/.bashrc`:
 - `alias ccgms="claude /startup --dangerously-skip-permissions"` — launch with the startup dashboard
 
 Detects existing aliases to avoid duplicates.
+
+### Step 14b: Legacy MCP migration
+
+If a legacy `~/.claude/mcp.json` exists (unread by current Claude Code), re-registers each of its server entries via `claude mcp add-json --scope user` (`lib/mcp-migrate.sh`). Idempotent: already-registered names are skipped, and the legacy file is renamed with a `.migrated.bak` suffix on success. Note: this writes MCP registrations to `~/.claude.json`, which the manifest does not track and `uninstall.sh` does not undo.
 
 ### Step 15: Next steps
 
@@ -184,7 +188,7 @@ CCGM_NON_INTERACTIVE=1 \
 | `CCGM_CODE_DIR` | Code workspace directory | `~/code` |
 | `CCGM_TIMEZONE` | Timezone | auto-detected |
 
-All module config prompts use their default values in non-interactive mode.
+In non-interactive mode, text and yes/no prompts use their default values. Choice prompts currently resolve to their first option, not their declared default (see #918).
 
 ## Adding a module to an existing install
 


### PR DESCRIPTION
Closes #920. Refs #899, #917, #918, #919.

Docs-only pass fixing the drift found by the post-orrery /docupdate audit. Every edit describes current behavior as it is, with the issue number referenced where behavior is scheduled to change.

## Changes

**CLAUDE.md** (AGENTS.md is a symlink to it, so it follows automatically)
- Structure block: lib/ tree now lists `mcp-migrate.sh`, `repair.sh`, `statusline.sh`; presets tree now lists `cloud-agent.json`
- Module-content sentence now names `skills/` and `agents/` alongside rules/, commands/, hooks/

**README.md**
- `team` preset row: added the missing `skill-authoring` and `subagent-patterns` (presets/team.json has 22 modules; the row listed 20)
- Requirements: `python3` and `jq` are now list items, matching docs/getting-started.md — both are hard-required by start.sh's prereq checks (start.sh:525-526). `gh` stays an optional aside. "bash 4+" untouched; Node not added (scoped per-module)

**docs/getting-started.md**
- Preset section: five presets exist; the interactive menu currently offers four, `cloud-agent` installs via `--preset cloud-agent` (see #919; start.sh:759 hardcodes the four-item menu)
- Install scopes: added the third `both` scope, mirroring docs/installer.md Step 4 (start.sh:702 offers global/project/both)
- Prerequisite check claim narrowed to the global tools, pointing at each module's README for module-specific requirements

**docs/installer.md**
- Step 10 Backup: describes the actual behavior — a fixed list of top-level items (settings.json, CLAUDE.md, rules/, commands/, hooks/, multi-agent-system.md, github-repo-protocols.md, .ccgm*), 5-deep retention, project-scope backups under `<project>/.claude/backups/`; notes skills//agents//lib//bin/ are not backed up (see #917; lib/backup.sh:69-77, clean_backups 5)
- Non-interactive: choice prompts resolve to their first option, not the declared default (see #918; lib/ui.sh ui_choose returns options[0]); text/confirm prompts do use defaults
- Step 6: dependency example extended one level — startup-dashboard adds session-history (verified: modules/startup-dashboard/module.json depends on session-history, which has no deps; chain is now closed)
- Added Step 14b (Legacy MCP migration) between Steps 14 and 15, matching start.sh:1527's own "Step 14b" numbering; the "15 sequential steps" line now reads "plus a conditional Step 14b". Notes it writes to ~/.claude.json, untracked by the manifest and not undone by uninstall

## Verification

- `bash tests/test-doc-counts.sh` — all checks passed, exit 0
- `bash tests/test-no-personal-data.sh` — PASS, exit 0
- `bash tests/test-modules.sh` — 1641 passed, 0 failed
- `diff CLAUDE.md AGENTS.md` — empty (AGENTS.md is a symlink to CLAUDE.md)