### PR TITLE
#917: derive the installer backup set from module manifests

### DIFF
--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -1,6 +1,97 @@
 #!/usr/bin/env bash
 # CCGM - Backup and restore
 
+# --- Legacy hardcoded backup targets ---
+# Pre-dynamic-derivation coverage. Kept as a fallback (modules dir missing)
+# and unioned into the derived set so no prior coverage ever regresses.
+_backup_legacy_paths() {
+  printf '%s\n' \
+    "settings.json" \
+    "CLAUDE.md" \
+    "rules" \
+    "commands" \
+    "hooks" \
+    "multi-agent-system.md" \
+    "github-repo-protocols.md"
+}
+
+# --- Resolve the CCGM modules directory ---
+# Prefers CCGM_ROOT (set by start.sh/uninstall.sh) when it points at a real
+# modules dir; falls back to deriving the repo root from this file's own
+# location so backup.sh works correctly even when CCGM_ROOT is unset (e.g.
+# sourced directly by a test). Prints nothing and returns 1 if neither
+# resolves to an existing modules/ directory.
+_backup_modules_dir() {
+  if [ -n "${CCGM_ROOT:-}" ] && [ -d "${CCGM_ROOT}/modules" ]; then
+    echo "${CCGM_ROOT}/modules"
+    return 0
+  fi
+
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [ -d "${script_dir}/../modules" ]; then
+    (cd "${script_dir}/../modules" && pwd)
+    return 0
+  fi
+
+  return 1
+}
+
+# --- Derive the set of CCGM-managed top-level backup paths ---
+# Usage: managed_backup_paths
+# Prints one deduped, sorted top-level path per line, derived from the first
+# path segment of every module.json's files[].target (e.g.
+# "skills/orrery/SKILL.md" -> "skills"), unioned with the legacy hardcoded
+# list so no previously-covered path ever regresses. Falls back to the
+# legacy list alone if the modules directory cannot be found -- failing
+# closed to "back up less" would silently lose user data, so on any doubt
+# we fail open to the known-safe legacy set instead.
+managed_backup_paths() {
+  local modules_dir
+  if ! modules_dir="$(_backup_modules_dir)"; then
+    _backup_legacy_paths
+    return 0
+  fi
+
+  local have_jq=false
+  if command -v jq &>/dev/null; then
+    have_jq=true
+  fi
+
+  local manifest
+  local -a targets=()
+  local t
+
+  for manifest in "${modules_dir}"/*/module.json; do
+    [ -f "$manifest" ] || continue
+
+    if [ "$have_jq" = true ]; then
+      while IFS= read -r t; do
+        [ -n "$t" ] && targets+=("$t")
+      done < <(jq -r '.files // {} | to_entries[]? | .value.target // empty' "$manifest" 2>/dev/null)
+    else
+      # Minimal fallback: module.json's only "target" keys are file-entry
+      # targets, so a plain extraction is safe without a full JSON parser.
+      while IFS= read -r t; do
+        [ -n "$t" ] && targets+=("$t")
+      done < <(grep -o '"target"[[:space:]]*:[[:space:]]*"[^"]*"' "$manifest" | sed 's/^"target"[[:space:]]*:[[:space:]]*"//; s/"$//')
+    fi
+  done
+
+  # Union with the legacy list so removal/renaming of a module never
+  # silently drops backup coverage for a path it used to own.
+  while IFS= read -r t; do
+    [ -n "$t" ] && targets+=("$t")
+  done < <(_backup_legacy_paths)
+
+  local -a tops=()
+  for t in "${targets[@]}"; do
+    tops+=("${t%%/*}")
+  done
+
+  printf '%s\n' "${tops[@]}" | sort -u
+}
+
 # --- Resolve the backup base for a given install target ---
 # Backups are scoped to the install target so a project-scope (.claude/) install
 # never writes to or restores from the global ~/.claude/backups (and vice-versa).
@@ -64,17 +155,16 @@ create_backup() {
     return 0
   fi
 
-  # Check for existing CCGM-managed files
+  # Check for existing CCGM-managed files. The set of paths is derived from
+  # every installed module's manifest (see managed_backup_paths), so newer
+  # module targets like skills/, lib/, agents/, bin/ are covered without
+  # needing a hardcoded list update per module.
   local has_files=false
-  local check_paths=(
-    "settings.json"
-    "CLAUDE.md"
-    "rules"
-    "commands"
-    "hooks"
-    "multi-agent-system.md"
-    "github-repo-protocols.md"
-  )
+  local -a check_paths=()
+  local p
+  while IFS= read -r p; do
+    [ -n "$p" ] && check_paths+=("$p")
+  done < <(managed_backup_paths)
 
   for p in "${check_paths[@]}"; do
     if [ -e "${target_dir}/${p}" ]; then

--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -37,6 +37,69 @@ _backup_modules_dir() {
   return 1
 }
 
+# --- Validate a derived top-level backup path segment ---
+# Usage: _backup_safe_segment "segment"; returns 0 (safe) or 1 (reject).
+# This is the guard against a manifest target that reduces to something
+# dangerous once only its first path segment is kept. A target authored as
+# "./skills/foo.md" reduces via "${t%%/*}" to the literal segment ".", and
+# "../skills/foo.md" reduces to "..". Both would otherwise reach
+# create_backup's copy loop as a real check_paths entry: "." resolves to
+# target_dir itself, and since backup_dir lives *inside* target_dir, `cp -r`
+# would copy the (in-progress) backup directory into itself; ".." resolves
+# to target_dir's parent, a directory create_backup has no business ever
+# touching. Rejects empty, ".", "..", anything containing "/" (defensive --
+# %%/* should already prevent this), and anything outside a conservative
+# [A-Za-z0-9._-] charset that does not start with a letter or digit (so a
+# leading "." or "-" is also refused, even outside the "." / ".." cases).
+_backup_safe_segment() {
+  local seg="$1"
+  case "$seg" in
+    ""|.|..) return 1 ;;
+    */*) return 1 ;;
+    [A-Za-z0-9]*) : ;;
+    *) return 1 ;;
+  esac
+  case "$seg" in
+    *[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  return 0
+}
+
+# --- Extract only the "files" object's text from a module.json (no jq) ---
+# Usage: _backup_files_block "/path/to/module.json"
+# Scans for the "files": { key and prints from its opening brace through the
+# matching closing brace (tracking nesting depth across lines), so a later
+# grep for "target" cannot pick up an unrelated "target" key that happens to
+# live elsewhere in the manifest (e.g. a future configPrompts entry). This
+# assumes "files" appears once, as a real top-level object key -- true for
+# every manifest in this repo -- and is not a general JSON parser; jq is
+# used whenever available and this fallback only runs without it.
+_backup_files_block() {
+  awk '
+    BEGIN { in_files = 0; depth = 0; done = 0 }
+    !in_files && !done {
+      if (match($0, /"files"[ \t]*:[ \t]*\{/)) {
+        in_files = 1
+        rest = substr($0, RSTART + RLENGTH - 1)
+        o = gsub(/\{/, "{", rest)
+        c = gsub(/\}/, "}", rest)
+        depth = o - c
+        print rest
+        if (depth <= 0) { in_files = 0; done = 1 }
+        next
+      }
+      next
+    }
+    in_files {
+      o = gsub(/\{/, "{", $0)
+      c = gsub(/\}/, "}", $0)
+      depth += (o - c)
+      print $0
+      if (depth <= 0) { in_files = 0; done = 1 }
+    }
+  ' "$1" 2>/dev/null
+}
+
 # --- Derive the set of CCGM-managed top-level backup paths ---
 # Usage: managed_backup_paths
 # Prints one deduped, sorted top-level path per line, derived from the first
@@ -45,7 +108,11 @@ _backup_modules_dir() {
 # list so no previously-covered path ever regresses. Falls back to the
 # legacy list alone if the modules directory cannot be found -- failing
 # closed to "back up less" would silently lose user data, so on any doubt
-# we fail open to the known-safe legacy set instead.
+# we fail open to the known-safe legacy set instead. Every derived segment
+# is additionally checked by _backup_safe_segment before it can reach the
+# caller; a segment that fails the check is dropped (never included, never
+# aborts the install) and reported to stderr so a malformed manifest target
+# is visible without ever becoming a filesystem hazard.
 managed_backup_paths() {
   local modules_dir
   if ! modules_dir="$(_backup_modules_dir)"; then
@@ -70,11 +137,12 @@ managed_backup_paths() {
         [ -n "$t" ] && targets+=("$t")
       done < <(jq -r '.files // {} | to_entries[]? | .value.target // empty' "$manifest" 2>/dev/null)
     else
-      # Minimal fallback: module.json's only "target" keys are file-entry
-      # targets, so a plain extraction is safe without a full JSON parser.
+      # Minimal fallback: scope the extraction to the "files" object first
+      # (see _backup_files_block) so a "target" key anywhere else in the
+      # manifest can never be mistaken for a file-entry target.
       while IFS= read -r t; do
         [ -n "$t" ] && targets+=("$t")
-      done < <(grep -o '"target"[[:space:]]*:[[:space:]]*"[^"]*"' "$manifest" | sed 's/^"target"[[:space:]]*:[[:space:]]*"//; s/"$//')
+      done < <(_backup_files_block "$manifest" | grep -o '"target"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/^"target"[[:space:]]*:[[:space:]]*"//; s/"$//')
     fi
   done
 
@@ -85,8 +153,14 @@ managed_backup_paths() {
   done < <(_backup_legacy_paths)
 
   local -a tops=()
+  local top
   for t in "${targets[@]}"; do
-    tops+=("${t%%/*}")
+    top="${t%%/*}"
+    if _backup_safe_segment "$top"; then
+      tops+=("$top")
+    else
+      echo "WARNING: ignoring unsafe backup path segment '${top}' derived from manifest target '${t}'" >&2
+    fi
   done
 
   printf '%s\n' "${tops[@]}" | sort -u

--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -51,7 +51,19 @@ _backup_modules_dir() {
 # %%/* should already prevent this), and anything outside a conservative
 # [A-Za-z0-9._-] charset that does not start with a letter or digit (so a
 # leading "." or "-" is also refused, even outside the "." / ".." cases).
+#
+# `local LC_ALL=C` forces byte-wise, ASCII-only matching for the charset
+# check regardless of the caller's ambient locale. Without it, /bin/bash
+# 3.2.57 (this repo's minimum-supported bash, and macOS's stock /bin/bash)
+# combined with a UTF-8 locale (e.g. LC_ALL=en_US.UTF-8, a common ambient
+# default) lets libc's fnmatch() collate accented Latin characters as
+# "close enough" to the A-Z/a-z range, so a segment like "resume" is
+# correctly rejected but "résumé" is not -- a discrepancy from bash 5.x,
+# which rejects it under every locale. Scoping the assignment with `local`
+# means the C locale applies only for the duration of this function; the
+# caller's locale is restored the instant it returns.
 _backup_safe_segment() {
+  local LC_ALL=C
   local seg="$1"
   case "$seg" in
     ""|.|..) return 1 ;;
@@ -65,15 +77,40 @@ _backup_safe_segment() {
   return 0
 }
 
-# --- Extract only the "files" object's text from a module.json (no jq) ---
+# --- Extract (an over-approximation of) the "files" object's text (no jq) ---
 # Usage: _backup_files_block "/path/to/module.json"
 # Scans for the "files": { key and prints from its opening brace through the
 # matching closing brace (tracking nesting depth across lines), so a later
-# grep for "target" cannot pick up an unrelated "target" key that happens to
-# live elsewhere in the manifest (e.g. a future configPrompts entry). This
-# assumes "files" appears once, as a real top-level object key -- true for
-# every manifest in this repo -- and is not a general JSON parser; jq is
-# used whenever available and this fallback only runs without it.
+# grep for "target" is scoped to (approximately) the files object instead of
+# the whole manifest. This is a brace-depth counter, not a JSON parser, and
+# it is NOT guaranteed to end exactly where the "files" object ends. Two
+# known ways it can run past the true end (both verified against real
+# input, neither fixed on purpose -- see below):
+#   (a) a "target" key nested deeper inside a files-entry sub-object (e.g.
+#       files.a.meta.target) is included, where jq's `.value.target` reads
+#       only the direct child and would not see it;
+#   (b) an unmatched "{" or "}" inside a JSON string value desyncs the
+#       depth counter, so the scanned block can run past the real closing
+#       brace and swallow a following key (e.g. a configPrompts entry).
+# Both failure shapes only ADD a spurious "target" match; neither can ever
+# drop a real one, because the scanner starts at the correct opening brace
+# and only ever includes more text, never less. A spurious match is made
+# harmless downstream by two independent layers: _backup_safe_segment
+# rejects anything that is not a plausible bare path segment, and
+# create_backup's `[ -e "${target_dir}/${p}" ]` check silently skips any
+# segment that does not name something that actually exists on disk. So
+# the practical blast radius of over-approximation is zero for any target
+# dir that does not happen to contain a directory matching the spurious
+# name.
+#
+# Writing a real string-aware JSON parser in awk to close (a) and (b)
+# exactly was deliberately not done: this function exists only as the
+# fallback for users without `jq` (the normal path, and the one verified
+# byte-identical to jq's output across all 78 real module.json files in
+# this repo), and a hand-rolled parser is disproportionate complexity --
+# and a new source of bugs -- for code that decides what gets backed up.
+# Bounding the failure to "may over-include a segment that is then
+# filtered out or found to not exist" is the deliberate tradeoff.
 _backup_files_block() {
   awk '
     BEGIN { in_files = 0; depth = 0; done = 0 }

--- a/tests/test-backup.sh
+++ b/tests/test-backup.sh
@@ -728,6 +728,32 @@ else
 fi
 echo ""
 
+# --- Test 21: charset guard rejects non-ASCII segments regardless of locale ---
+# Regression test for a delta-review finding: under /bin/bash 3.2.57 (this
+# repo's minimum-supported bash, and macOS's stock /bin/bash) combined with
+# a UTF-8 locale (e.g. LC_ALL=en_US.UTF-8, a common ambient default), libc's
+# fnmatch() let accented Latin characters collate as "close enough" to the
+# [A-Za-z0-9._-] range, so "resume" was correctly rejected but "résumé" was
+# not. _backup_safe_segment now forces `local LC_ALL=C` for byte-wise
+# matching, independent of the caller's ambient locale -- so this assertion
+# passes under any invocation, but would have failed pre-fix specifically
+# under `LC_ALL=en_US.UTF-8 /bin/bash tests/test-backup.sh` (part of this
+# repo's gate suite precisely so this class of regression is caught).
+echo "--- Test 21: charset guard rejects non-ASCII segments (locale-invariant) ---"
+
+if _backup_safe_segment "résumé"; then
+  fail "_backup_safe_segment allowed a non-ASCII segment ('résumé')"
+else
+  pass "_backup_safe_segment rejects a non-ASCII segment ('résumé')"
+fi
+
+if _backup_safe_segment "skills"; then
+  pass "_backup_safe_segment still allows a legitimate ASCII segment ('skills')"
+else
+  fail "_backup_safe_segment incorrectly rejected a legitimate ASCII segment ('skills')"
+fi
+echo ""
+
 # --- Summary ---
 echo "==================================="
 echo "  Results: $PASS passed, $FAIL failed"

--- a/tests/test-backup.sh
+++ b/tests/test-backup.sh
@@ -565,6 +565,169 @@ else
 fi
 echo ""
 
+# --- Test 17: unsafe manifest targets never reach the copy loop ---
+# Regression test for the Stage 2 HIGH finding on issue #917: a manifest
+# target like "./skills/foo.md" reduces via "${t%%/*}" to the literal
+# segment ".", which -- unguarded -- would reach create_backup's copy loop
+# and `cp -r` the in-progress backup directory into itself (backup_dir
+# lives inside target_dir). "../x" reduces to "..", and "/abs/x" reduces to
+# an empty segment. _backup_safe_segment must reject all three while still
+# letting a legitimate sibling target through.
+echo "--- Test 17: unsafe manifest targets (., .., empty, abs) are rejected ---"
+
+FIXTURE_ROOT="$TMPDIR/fixture-root"
+mkdir -p "$FIXTURE_ROOT/modules/weirdmod"
+cat > "$FIXTURE_ROOT/modules/weirdmod/module.json" <<'JSON'
+{
+  "name": "weirdmod",
+  "files": {
+    "a": { "target": "./weird/file.md", "type": "doc" },
+    "b": { "target": "../also-weird/file.md", "type": "doc" },
+    "c": { "target": "/abs/weird/file.md", "type": "doc" },
+    "d": { "target": "", "type": "doc" },
+    "e": { "target": "skills/real/thing.md", "type": "doc" }
+  }
+}
+JSON
+
+fixture_paths=$(CCGM_ROOT="$FIXTURE_ROOT" managed_backup_paths 2>/dev/null)
+
+if ! echo "$fixture_paths" | grep -qx '\.'; then
+  pass "Derived path list does not contain a literal '.' segment"
+else
+  fail "Derived path list contains a dangerous literal '.' segment"
+fi
+
+if ! echo "$fixture_paths" | grep -qx '\.\.'; then
+  pass "Derived path list does not contain a literal '..' segment"
+else
+  fail "Derived path list contains a dangerous literal '..' segment"
+fi
+
+if ! echo "$fixture_paths" | grep -qx ''; then
+  pass "Derived path list does not contain an empty segment"
+else
+  fail "Derived path list contains an empty segment"
+fi
+
+if echo "$fixture_paths" | grep -qx 'skills'; then
+  pass "Legitimate sibling target (skills/) still passes through"
+else
+  fail "Legitimate sibling target (skills/) was dropped by the safety filter"
+fi
+echo ""
+
+# --- Test 18: create_backup survives a manifest with a "./..." target ---
+# Proves the fix against the concrete crash, not just the filtered list:
+# with the same weirdmod fixture as the manifest source, create_backup
+# must complete with exit 0 and must not leave a nested
+# backups/ccgm-*/backups/ccgm-*/... directory behind (the original crash
+# signature -- cp -r recursing into the in-progress backup).
+echo "--- Test 18: create_backup survives a manifest with a './...' target ---"
+
+WEIRD_TARGET="$TMPDIR/weird-claude"
+mkdir -p "$WEIRD_TARGET/skills"
+echo '{"key": "value"}' > "$WEIRD_TARGET/settings.json"
+echo "real skill" > "$WEIRD_TARGET/skills/thing.md"
+
+# Run in a subshell with set -euo pipefail, matching exactly how start.sh
+# sources lib/backup.sh and calls create_backup. The subshell inherits the
+# already-sourced functions from this script. set +e/-e brackets the call
+# (same pattern as Test 6) so a regression here fails this assertion
+# instead of aborting the whole suite.
+set +e
+( set -euo pipefail; CCGM_ROOT="$FIXTURE_ROOT" create_backup "$WEIRD_TARGET" >/dev/null )
+weird_exit=$?
+set -e
+
+if [ "$weird_exit" -eq 0 ]; then
+  pass "create_backup exits 0 with a manifest containing a './...' target"
+else
+  fail "create_backup exited $weird_exit with a manifest containing a './...' target"
+fi
+
+if [ -d "$WEIRD_TARGET/backups" ]; then
+  nested_count=$(find "$WEIRD_TARGET/backups" -mindepth 1 -type d -name backups 2>/dev/null | wc -l | tr -d ' ')
+else
+  nested_count=0
+fi
+
+if [ "$nested_count" -eq 0 ]; then
+  pass "No nested backups/ directory created inside the backup"
+else
+  fail "Found $nested_count nested backups/ directory(ies) -- the original crash signature"
+fi
+echo ""
+
+# --- Test 19: no-jq fallback is scoped to the "files" object only ---
+# Regression test for the Stage 2 MEDIUM finding: the grep-based fallback
+# must not pick up a "target" key that lives outside files (e.g. a future
+# configPrompts entry), unlike a bare `grep -o '"target"...'` over the
+# whole manifest. _backup_files_block is what scopes it.
+echo "--- Test 19: _backup_files_block excludes a decoy target outside files ---"
+
+SCOPE_FIXTURE="$TMPDIR/scope-fixture.module.json"
+cat > "$SCOPE_FIXTURE" <<'JSON'
+{
+  "name": "scopetest",
+  "files": {
+    "a": { "target": "real/path.md", "type": "doc" }
+  },
+  "configPrompts": [
+    { "key": "x", "prompt": "p", "target": "unrelated-decoy" }
+  ]
+}
+JSON
+
+scope_targets=$(_backup_files_block "$SCOPE_FIXTURE" | grep -o '"target"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/^"target"[[:space:]]*:[[:space:]]*"//; s/"$//')
+
+if echo "$scope_targets" | grep -qx 'real/path.md'; then
+  pass "_backup_files_block includes the real files[].target"
+else
+  fail "_backup_files_block missed the real files[].target"
+fi
+
+if ! echo "$scope_targets" | grep -qx 'unrelated-decoy'; then
+  pass "_backup_files_block excludes a decoy 'target' key outside files"
+else
+  fail "_backup_files_block leaked a decoy 'target' key outside files"
+fi
+echo ""
+
+# --- Test 20: managed_backup_paths dedupes shared top-level segments ---
+# Mutation-check regression for the Stage 2 LOW finding: changing
+# `sort -u` to plain `sort` in managed_backup_paths must fail this test.
+echo "--- Test 20: managed_backup_paths dedupes shared top-level segments ---"
+
+DEDUPE_ROOT="$TMPDIR/dedupe-root"
+mkdir -p "$DEDUPE_ROOT/modules/mod-a" "$DEDUPE_ROOT/modules/mod-b"
+cat > "$DEDUPE_ROOT/modules/mod-a/module.json" <<'JSON'
+{
+  "name": "mod-a",
+  "files": {
+    "a": { "target": "skills/mod-a/one.md", "type": "doc" }
+  }
+}
+JSON
+cat > "$DEDUPE_ROOT/modules/mod-b/module.json" <<'JSON'
+{
+  "name": "mod-b",
+  "files": {
+    "a": { "target": "skills/mod-b/two.md", "type": "doc" }
+  }
+}
+JSON
+
+dedupe_output=$(CCGM_ROOT="$DEDUPE_ROOT" managed_backup_paths 2>/dev/null)
+skills_count=$(echo "$dedupe_output" | grep -cx 'skills')
+
+if [ "$skills_count" -eq 1 ]; then
+  pass "managed_backup_paths lists 'skills' exactly once across two modules"
+else
+  fail "managed_backup_paths listed 'skills' $skills_count times, expected exactly 1"
+fi
+echo ""
+
 # --- Summary ---
 echo "==================================="
 echo "  Results: $PASS passed, $FAIL failed"

--- a/tests/test-backup.sh
+++ b/tests/test-backup.sh
@@ -378,6 +378,193 @@ else
 fi
 echo ""
 
+# --- Test 11: Dynamic coverage backs up skills/ and agents/ (issue #917 case) ---
+echo "--- Test 11: Dynamic coverage - skills/ and agents/ ---"
+
+DYN_TARGET="$TMPDIR/dyn-claude"
+mkdir -p "$DYN_TARGET/skills/orrery"
+mkdir -p "$DYN_TARGET/agents"
+echo "# Orrery skill" > "$DYN_TARGET/skills/orrery/SKILL.md"
+echo "# Orrery scout agent" > "$DYN_TARGET/agents/orrery-scout.md"
+
+dyn_backup=$(create_backup "$DYN_TARGET")
+
+if [ -f "$dyn_backup/skills/orrery/SKILL.md" ]; then
+  pass "skills/orrery/SKILL.md backed up"
+else
+  fail "skills/orrery/SKILL.md not found in backup"
+fi
+
+if [ -f "$dyn_backup/agents/orrery-scout.md" ]; then
+  pass "agents/orrery-scout.md backed up"
+else
+  fail "agents/orrery-scout.md not found in backup"
+fi
+echo ""
+
+# --- Test 12: lib/, bin/, output-styles/ backed up when present ---
+echo "--- Test 12: lib/, bin/, output-styles/ backed up ---"
+
+LBO_TARGET="$TMPDIR/lbo-claude"
+mkdir -p "$LBO_TARGET/lib" "$LBO_TARGET/bin" "$LBO_TARGET/output-styles"
+echo "# lib file" > "$LBO_TARGET/lib/helper.sh"
+echo "# bin file" > "$LBO_TARGET/bin/tool.sh"
+echo "# style file" > "$LBO_TARGET/output-styles/custom.md"
+
+lbo_backup=$(create_backup "$LBO_TARGET")
+
+if [ -f "$lbo_backup/lib/helper.sh" ]; then
+  pass "lib/ backed up"
+else
+  fail "lib/ not found in backup"
+fi
+
+if [ -f "$lbo_backup/bin/tool.sh" ]; then
+  pass "bin/ backed up"
+else
+  fail "bin/ not found in backup"
+fi
+
+if [ -f "$lbo_backup/output-styles/custom.md" ]; then
+  pass "output-styles/ backed up"
+else
+  fail "output-styles/ not found in backup"
+fi
+echo ""
+
+# --- Test 13: restore_backup round-trips the newly-covered paths ---
+echo "--- Test 13: restore round-trips skills/, agents/, lib/, bin/ ---"
+
+RESTORE_DYN="$TMPDIR/restored-dyn"
+mkdir -p "$RESTORE_DYN"
+restore_backup "$dyn_backup" "$RESTORE_DYN"
+
+if [ -f "$RESTORE_DYN/skills/orrery/SKILL.md" ] && [ "$(cat "$RESTORE_DYN/skills/orrery/SKILL.md")" = "# Orrery skill" ]; then
+  pass "Restored skills/orrery/SKILL.md content matches original"
+else
+  fail "Restored skills/orrery/SKILL.md missing or content differs"
+fi
+
+if [ -f "$RESTORE_DYN/agents/orrery-scout.md" ] && [ "$(cat "$RESTORE_DYN/agents/orrery-scout.md")" = "# Orrery scout agent" ]; then
+  pass "Restored agents/orrery-scout.md content matches original"
+else
+  fail "Restored agents/orrery-scout.md missing or content differs"
+fi
+
+RESTORE_LBO="$TMPDIR/restored-lbo"
+mkdir -p "$RESTORE_LBO"
+restore_backup "$lbo_backup" "$RESTORE_LBO"
+
+if [ -f "$RESTORE_LBO/lib/helper.sh" ] && [ "$(cat "$RESTORE_LBO/lib/helper.sh")" = "# lib file" ]; then
+  pass "Restored lib/helper.sh content matches original"
+else
+  fail "Restored lib/helper.sh missing or content differs"
+fi
+
+if [ -f "$RESTORE_LBO/bin/tool.sh" ] && [ "$(cat "$RESTORE_LBO/bin/tool.sh")" = "# bin file" ]; then
+  pass "Restored bin/tool.sh content matches original"
+else
+  fail "Restored bin/tool.sh missing or content differs"
+fi
+echo ""
+
+# --- Test 14: retention still prunes to N with dynamic-coverage backups ---
+echo "--- Test 14: clean_backups prunes dynamic-coverage backups to N ---"
+
+RET_TARGET="$TMPDIR/ret-claude"
+RET_BASE="$RET_TARGET/backups"
+mkdir -p "$RET_BASE"
+rm -rf "$RET_BASE"/ccgm-*
+
+for i in 1 2 3 4 5 6; do
+  bdir="$RET_BASE/ccgm-2026060${i}-120000"
+  mkdir -p "$bdir/skills"
+  echo "skill snapshot $i" > "$bdir/skills/test.md"
+done
+
+ret_count_before=$(ls -1d "$RET_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ')
+if [ "$ret_count_before" -eq 6 ]; then
+  pass "Created 6 dynamic-coverage backups"
+else
+  fail "Expected 6 backups before pruning, found $ret_count_before"
+fi
+
+clean_backups 5 "$RET_TARGET"
+
+ret_count_after=$(ls -1d "$RET_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ')
+if [ "$ret_count_after" -eq 5 ]; then
+  pass "clean_backups(5) pruned dynamic-coverage backups to 5"
+else
+  fail "clean_backups(5) kept $ret_count_after backups, expected 5"
+fi
+
+if [ -d "$RET_BASE/ccgm-20260606-120000" ] && [ -f "$RET_BASE/ccgm-20260606-120000/skills/test.md" ]; then
+  pass "Newest dynamic-coverage backup (skills/) preserved after pruning"
+else
+  fail "Newest dynamic-coverage backup not preserved correctly"
+fi
+echo ""
+
+# --- Test 15: project-scope backups with dynamic coverage stay scoped ---
+echo "--- Test 15: project-scope backup isolation with dynamic coverage ---"
+
+DYN_PROJECT_DIR="$TMPDIR/dyn-project"
+DYN_PROJECT_TARGET="$DYN_PROJECT_DIR/.claude"
+mkdir -p "$DYN_PROJECT_TARGET/skills/orrery"
+echo "# project orrery skill" > "$DYN_PROJECT_TARGET/skills/orrery/SKILL.md"
+
+rm -rf "$HOME/.claude/backups"/ccgm-*
+dyn_project_backup=$(create_backup "$DYN_PROJECT_TARGET")
+
+if [[ "$dyn_project_backup" == "$DYN_PROJECT_TARGET/backups/"* ]]; then
+  pass "Dynamic-coverage project backup written under project scope"
+else
+  fail "Dynamic-coverage project backup not scoped to project target: $dyn_project_backup"
+fi
+
+if [ -f "$dyn_project_backup/skills/orrery/SKILL.md" ]; then
+  pass "Project-scope skills/orrery/SKILL.md backed up"
+else
+  fail "Project-scope skills/orrery/SKILL.md not found in backup"
+fi
+
+# find (not ls) here: the glob matches nothing in the expected case, and
+# under `set -euo pipefail` an `ls` with no matches would abort the script.
+global_backup_count=$(find "$HOME/.claude/backups" -maxdepth 1 -type d -name 'ccgm-*' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$global_backup_count" -eq 0 ]; then
+  pass "No global-scope backup created for a project-scope backup"
+else
+  fail "Project-scope backup unexpectedly created $global_backup_count global-scope backup(s)"
+fi
+echo ""
+
+# --- Test 16: non-CCGM directories are not swept into the backup ---
+# Pins the manifest-derivation design decision: the backup set comes from
+# module.json targets, not a directory listing of the target dir. This is
+# what keeps ~/.claude/projects/ (session transcripts, memory) out of backups.
+echo "--- Test 16: non-CCGM directory (projects/) is not backed up ---"
+
+NONCCGM_TARGET="$TMPDIR/nonccgm-claude"
+mkdir -p "$NONCCGM_TARGET/skills"
+mkdir -p "$NONCCGM_TARGET/projects/some-project"
+echo "# real skill" > "$NONCCGM_TARGET/skills/test.md"
+echo "session transcript data" > "$NONCCGM_TARGET/projects/some-project/session.jsonl"
+
+nonccgm_backup=$(create_backup "$NONCCGM_TARGET")
+
+if [ -f "$nonccgm_backup/skills/test.md" ]; then
+  pass "CCGM-managed skills/ backed up"
+else
+  fail "CCGM-managed skills/ not found in backup"
+fi
+
+if [ ! -e "$nonccgm_backup/projects" ]; then
+  pass "Non-CCGM projects/ directory excluded from backup"
+else
+  fail "Non-CCGM projects/ directory was unexpectedly backed up"
+fi
+echo ""
+
 # --- Summary ---
 echo "==================================="
 echo "  Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
Closes #917

## What changed

`create_backup` in `lib/backup.sh` copied a hardcoded 7-path list
(`settings.json`, `CLAUDE.md`, `rules`, `commands`, `hooks`,
`multi-agent-system.md`, `github-repo-protocols.md`). Modules now install
to 19 distinct top-level targets across 500 declared file entries; the
hardcoded list covered 7 of them, so `agents/`, `bin/`, `eval/`, `lib/`,
`output-styles/`, `scripts/`, `skills/`, and others were silently
overwritten on install/update with no backup and no restore path.

`managed_backup_paths()` now derives the backup set from every module's
`module.json`: it takes the first path segment of each `files[].target`
(e.g. `skills/orrery/SKILL.md` -> `skills`), dedupes, and unions the
result with the legacy 7-path list so no prior coverage can regress.

Design notes:

- Derives from manifests, not a directory listing of the target dir. This
  is what keeps non-CCGM content (e.g. `~/.claude/projects/`, which holds
  session transcripts and memory) structurally out of backups.
- No plan-passing parameter. One code path, always the full managed set —
  simpler and strictly safer than plumbing an install plan through for a
  marginally smaller backup.
- Works with or without `jq`, matching the installer's existing `has_jq`
  fallback pattern (grep/sed extraction when `jq` is unavailable).
- Falls back to the legacy 7-path list if the modules directory can't be
  located, rather than backing up nothing — failing closed to "back up
  less" is the one outcome that loses user data.
- `create_backup`'s signature is unchanged. `start.sh` / `uninstall.sh` /
  `update.sh` are untouched.

## Review round 1 fixes (HIGH / MEDIUM / LOW)

**HIGH — an unsafe derived path segment could reach `cp -r`.**
`managed_backup_paths` only filtered the empty string. A manifest target
shaped `./skills/foo.md` reduces via `${t%%/*}` to the literal segment
`.`, and `../skills/foo.md` reduces to `..`. Because `backup_dir` lives
inside `target_dir`, a `.` segment in `create_backup`'s copy loop makes
`cp -r` copy the in-progress backup directory into itself — and callers
run `create_backup` under `set -euo pipefail` (`start.sh`, `uninstall.sh`),
so a bad manifest target could abort the whole installer at the backup
step. `_backup_safe_segment()` validates every derived top-level segment
before it reaches `check_paths`: rejects empty, `.`, `..`, anything
containing `/`, and anything outside a conservative
`[A-Za-z0-9._-]`, alnum-leading charset. A rejected segment is dropped
(never included, never aborts the install) and reported to stderr.

**MEDIUM — the two parsers were not equivalently scoped (original repro).**
The jq path extracts targets scoped to `.files`; the no-jq grep fallback
matched `"target"` anywhere in the manifest, so a decoy `target` key
outside `files` (e.g. a `configPrompts` entry) reached the no-jq backup
set only. `_backup_files_block()` scopes the no-jq extraction to the
`"files"` object's text (brace-depth counting across lines) before the
`target` grep runs. This closed the original repro. **See the "known
limits" section below — this fix is not a complete JSON parser, and a
later review round found two narrower ways the no-jq path can still
diverge from jq. That correction is documented there rather than here,
since claiming full parity at this point in the PR history would be
inaccurate.**

**LOW — the "deduped" claim had no pinning test.** Mutation-tested:
temporarily changing `sort -u` to plain `sort` left all prior assertions
green. Added a regression test (two modules sharing a top-level segment)
that fails under that mutation and passes on the real code.

## Review round 2 fixes (locale bug + a corrected claim)

**Fixed — the charset guard was not locale-invariant under bash 3.2.**
`_backup_safe_segment`'s charset check (`*[!A-Za-z0-9._-]*`, a negated
bracket expression) is locale-sensitive. Under `/bin/bash` 3.2.57 (this
repo's minimum-supported bash, and macOS's stock `/bin/bash`) combined
with a UTF-8 locale (e.g. `LC_ALL=en_US.UTF-8`, a common ambient
default), libc's `fnmatch()` collates accented Latin characters as
"close enough" to the `A-Z`/`a-z` range — so a segment like `resume` was
correctly rejected but the same word with accents was not. bash 5.x
rejects it under every locale tested; this was specific to bash 3.2's
`fnmatch` plus a non-C locale. This does not reopen the HIGH crash (an
accented segment is never `.`/`..` and contains no `/`), but the
function's own doc comment promised a charset it did not actually
enforce on the shell this project targets, with zero regression
coverage for the gap either way.

`local LC_ALL=C` now forces byte-wise matching for the duration of
`_backup_safe_segment`, independent of the caller's ambient locale, and
reverts automatically when the function returns (verified: the caller's
locale is intact immediately after the call). Verified locale test
result:

```
LC_ALL=C /bin/bash            -> "résumé" REJECTED (was already correct)
LC_ALL=en_US.UTF-8 /bin/bash  -> "résumé" REJECTED (was ALLOWED before this fix)
```

Added a regression test (`Test 21`) asserting a non-ASCII segment is
rejected. Mutation-confirmed: removing the `local LC_ALL=C` line and
running `LC_ALL=en_US.UTF-8 /bin/bash tests/test-backup.sh` — the exact
configuration that exposed the gap — fails Test 21 (55 passed, 1 failed);
restoring the line and re-running passes (56 passed, 0 failed).

**Corrected claim — the no-jq parser is not fully equivalent to jq, and
that is a deliberate, bounded tradeoff, not a bug to chase.** An earlier
version of this PR description said the no-jq fallback and jq are
"equivalently scoped." That is not accurate as a general claim. They
agree byte-for-byte across all 78 real `module.json` files in this repo
and on the original `configPrompts`-decoy repro (round 1, above), but
`_backup_files_block` is a brace-depth counter, not a JSON parser, and a
second review round found and reproduced two narrower ways it can
over-approximate the `"files"` block:

- a `target` key nested deeper inside a files-entry sub-object (e.g.
  `files.a.meta.target`) is included, where jq's `.value.target` reads
  only the direct child and would not see it;
- an unmatched `{` or `}` inside a JSON string value desyncs the depth
  counter, letting the scanned block run past the true end of `"files"`
  and swallow a following key (e.g. a `configPrompts` entry).

Both were reproduced directly. Both only ever **add** a spurious segment
to the derived list — neither can drop a real one, because the scanner
starts at the correct opening brace and only ever includes more text,
never less. A spurious segment is made harmless downstream by two
independent layers already in place: `_backup_safe_segment` rejects
anything that is not a plausible bare path segment, and
`create_backup`'s `[ -e "${target_dir}/${p}" ]` existence check silently
skips any segment that does not name something that actually exists on
disk. So the practical blast radius of over-approximation is zero for
any real install.

**Deliberate decision:** writing a string-aware JSON parser in awk to
close these two shapes exactly was not done, and is not planned. This
function exists only as the fallback for users without `jq` — the
normal, verified-exact path — and a hand-rolled parser is disproportionate
complexity, and a new source of bugs, for code that decides what gets
backed up. `_backup_files_block`'s comment in `lib/backup.sh` now states
this precisely (over-approximation only, never under-approximation, and
why that's safe) instead of implying full parity.

## Tests

`tests/test-backup.sh`: 56 assertions across 21 sections (up from 28
before this PR):

- Concrete issue case: `agents/orrery-scout.md` and `skills/orrery/SKILL.md`
  both get backed up.
- `lib/`, `bin/`, `output-styles/` backed up when present.
- `restore_backup` round-trips the newly-covered paths.
- `clean_backups` retention still prunes to N with the larger backup set.
- Project-scope backups with dynamic-coverage content still stay scoped
  to `<project>/.claude/backups/`, never bleeding into the global dir.
- A non-CCGM directory (`projects/`) is never swept into the backup —
  pins the manifest-derivation design decision.
- Unsafe manifest targets (`.`, `..`, empty, absolute) never reach the
  derived path list, and a legitimate sibling target still does.
- `create_backup` completes with exit 0 and leaves no nested `backups/`
  directory when a manifest contains a `./...`-style target.
- The no-jq fallback (`_backup_files_block`) excludes a decoy `target`
  key that lives outside `files` (the original repro shape).
- `managed_backup_paths` dedupes a top-level segment shared by two
  modules (mutation-confirmed against `sort -u` -> `sort`).
- The charset guard rejects a non-ASCII segment regardless of locale
  (mutation-confirmed against the pre-fix code specifically under
  `LC_ALL=en_US.UTF-8 /bin/bash`).

## Verification

```
bash tests/test-backup.sh                        # 56 passed, 0 failed
/bin/bash tests/test-backup.sh                   # 56 passed, 0 failed (bash 3.2)
LC_ALL=en_US.UTF-8 /bin/bash tests/test-backup.sh # 56 passed, 0 failed (the gap-exposing config)
bash tests/test-modules.sh                       # 1689 passed, 0 failed
bash tests/test-installer.sh                     # 67 passed, 0 failed
bash tests/test-no-personal-data.sh              # PASS
/bin/bash -n lib/backup.sh                       # syntax OK
```

Rebased onto `origin/main` (`a955127`, `d905b51`) — neither touches
`lib/backup.sh` or `tests/test-backup.sh`; rebase was clean.
