### PR TITLE
#930: install the three unwired code-quality rules; gate manifest file existence

### DIFF
--- a/modules/code-quality/README.md
+++ b/modules/code-quality/README.md
@@ -21,14 +21,22 @@ Copy `rules/code-quality.md` into your Claude configuration:
 # Global (all projects)
 cp rules/code-quality.md ~/.claude/rules/code-quality.md
 cp rules/change-philosophy.md ~/.claude/rules/change-philosophy.md
+cp rules/latent-vs-deterministic.md ~/.claude/rules/latent-vs-deterministic.md
 cp rules/completeness.md ~/.claude/rules/completeness.md
 cp rules/receiving-code-review.md ~/.claude/rules/receiving-code-review.md
+cp rules/in-the-circuits.md ~/.claude/rules/in-the-circuits.md
+cp rules/spec-is-the-artifact.md ~/.claude/rules/spec-is-the-artifact.md
+cp rules/menu-gen-test.md ~/.claude/rules/menu-gen-test.md
 
 # Project-level
 cp rules/code-quality.md .claude/rules/code-quality.md
 cp rules/change-philosophy.md .claude/rules/change-philosophy.md
+cp rules/latent-vs-deterministic.md .claude/rules/latent-vs-deterministic.md
 cp rules/completeness.md .claude/rules/completeness.md
 cp rules/receiving-code-review.md .claude/rules/receiving-code-review.md
+cp rules/in-the-circuits.md .claude/rules/in-the-circuits.md
+cp rules/spec-is-the-artifact.md .claude/rules/spec-is-the-artifact.md
+cp rules/menu-gen-test.md .claude/rules/menu-gen-test.md
 ```
 
 ## Files
@@ -40,3 +48,6 @@ cp rules/receiving-code-review.md .claude/rules/receiving-code-review.md
 | `rules/latent-vs-deterministic.md` | Rule file on classifying work as latent (judgment) vs deterministic (scripts) and pushing deterministic steps into code |
 | `rules/completeness.md` | Rule file on the Boil-the-Lake completeness principle and scoring rubric |
 | `rules/receiving-code-review.md` | Rule file on receiving code review feedback: verify before implementing, push back with evidence, no sycophantic agreement |
+| `rules/in-the-circuits.md` | Rule file on classifying tasks as in-circuit (dense RL training, trust output) vs out-of-circuit (no verifier, slow down) before proceeding |
+| `rules/spec-is-the-artifact.md` | Rule file on treating the spec as the durable artifact and code as regenerable output; write and review the spec before the code runs |
+| `rules/menu-gen-test.md` | Rule file on the Menu-Gen Test: before building an app/script/feature, ask whether a single prompt or multimodal call could replace it |

--- a/modules/code-quality/module.json
+++ b/modules/code-quality/module.json
@@ -10,7 +10,10 @@
     "rules/change-philosophy.md": { "target": "rules/change-philosophy.md", "type": "rule", "template": false },
     "rules/latent-vs-deterministic.md": { "target": "rules/latent-vs-deterministic.md", "type": "rule", "template": false },
     "rules/completeness.md": { "target": "rules/completeness.md", "type": "rule", "template": false },
-    "rules/receiving-code-review.md": { "target": "rules/receiving-code-review.md", "type": "rule", "template": false }
+    "rules/receiving-code-review.md": { "target": "rules/receiving-code-review.md", "type": "rule", "template": false },
+    "rules/in-the-circuits.md": { "target": "rules/in-the-circuits.md", "type": "rule", "template": false },
+    "rules/spec-is-the-artifact.md": { "target": "rules/spec-is-the-artifact.md", "type": "rule", "template": false },
+    "rules/menu-gen-test.md": { "target": "rules/menu-gen-test.md", "type": "rule", "template": false }
   },
   "tags": ["code-quality", "testing", "security", "standards"],
   "configPrompts": []

--- a/modules/systematic-debugging/README.md
+++ b/modules/systematic-debugging/README.md
@@ -13,11 +13,12 @@ Installs a rules file that enforces structured debugging instead of random fix a
 
 Includes a three-strike rule: after 3 failed fix attempts, stop and question the architecture.
 
-The parent rule is backed by three focused sub-rules that give agents named moves during Phase 1-2:
+The parent rule is backed by four focused sub-rules that give agents named moves during Phase 1-2:
 
 - **Root Cause Tracing** - trace errors backward up the call chain to the originating trigger, not the surface symptom
 - **Defense-in-Depth Validation** - once the origin is found, add validation at every layer the bad value passed through so the same class of bug is structurally impossible
 - **Condition-Based Waiting** - replace arbitrary `sleep(N)` with `waitFor(condition)` to eliminate timing-based flaky tests
+- **Animals vs Ghosts** - name which RL circuit a task falls in before diagnosing a stuck agent, so degraded output reads as a distribution gap, not defiance
 
 ## Manual Installation
 

--- a/modules/systematic-debugging/README.md
+++ b/modules/systematic-debugging/README.md
@@ -28,6 +28,7 @@ cp rules/debugging.md ~/.claude/rules/debugging.md
 cp rules/root-cause-tracing.md ~/.claude/rules/root-cause-tracing.md
 cp rules/defense-in-depth.md ~/.claude/rules/defense-in-depth.md
 cp rules/condition-based-waiting.md ~/.claude/rules/condition-based-waiting.md
+cp rules/animals-vs-ghosts.md ~/.claude/rules/animals-vs-ghosts.md
 
 # Project-level
 cp rules/systematic-debugging.md .claude/rules/systematic-debugging.md
@@ -35,6 +36,7 @@ cp rules/debugging.md .claude/rules/debugging.md
 cp rules/root-cause-tracing.md .claude/rules/root-cause-tracing.md
 cp rules/defense-in-depth.md .claude/rules/defense-in-depth.md
 cp rules/condition-based-waiting.md .claude/rules/condition-based-waiting.md
+cp rules/animals-vs-ghosts.md .claude/rules/animals-vs-ghosts.md
 ```
 
 ## Files
@@ -46,3 +48,4 @@ cp rules/condition-based-waiting.md .claude/rules/condition-based-waiting.md
 | `rules/root-cause-tracing.md` | Trace errors backward up the call chain to the originating trigger |
 | `rules/defense-in-depth.md` | Layered validation that makes a fixed bug structurally impossible to reintroduce |
 | `rules/condition-based-waiting.md` | Replace arbitrary sleeps with condition polling to kill flaky tests |
+| `rules/animals-vs-ghosts.md` | Mental model: LLMs are statistical simulators, not animal intelligences - diagnose which RL circuit you're in instead of anthropomorphizing failure |

--- a/modules/systematic-debugging/module.json
+++ b/modules/systematic-debugging/module.json
@@ -10,7 +10,8 @@
     "rules/debugging.md": { "target": "rules/debugging.md", "type": "rule", "template": false },
     "rules/root-cause-tracing.md": { "target": "rules/root-cause-tracing.md", "type": "rule", "template": false },
     "rules/defense-in-depth.md": { "target": "rules/defense-in-depth.md", "type": "rule", "template": false },
-    "rules/condition-based-waiting.md": { "target": "rules/condition-based-waiting.md", "type": "rule", "template": false }
+    "rules/condition-based-waiting.md": { "target": "rules/condition-based-waiting.md", "type": "rule", "template": false },
+    "rules/animals-vs-ghosts.md": { "target": "rules/animals-vs-ghosts.md", "type": "rule", "template": false }
   },
   "tags": ["debugging", "root-cause", "methodology", "troubleshooting"],
   "configPrompts": []

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -223,11 +223,14 @@ echo ""
 echo "  Checked $declared_entries declared files[] entries across $module_count modules"
 echo ""
 
-# --- Test: Manifest completeness - every shipped lib/command is installed ---
-# Reverse of the check above: ensure no lib/*.sh or commands/*.md sits on disk
-# without a files[] entry, or it silently never installs. Other file types
+# --- Test: Manifest completeness - every shipped lib/command/rule is installed ---
+# Reverse of the check above: ensure no lib/*.sh, commands/*.md, or rules/*.md
+# sits on disk without a files[] entry, or it silently never installs. This is
+# the direction that actually catches #930's bug class (a shipped file with no
+# manifest entry at all) - the forward check above only catches the opposite
+# (a manifest entry pointing at a file that isn't there). Other file types
 # (README.md, terraform/, packer/, tests/) are intentionally not installed.
-echo "--- Checking manifest completeness (lib + commands coverage) ---"
+echo "--- Checking manifest completeness (lib + commands + rules coverage) ---"
 for mod_dir in "$REPO_ROOT"/modules/*/; do
   [ ! -d "$mod_dir" ] && continue
   mod_name=$(basename "$mod_dir")
@@ -240,9 +243,9 @@ for mod_dir in "$REPO_ROOT"/modules/*/; do
 
   shipped_count=0
   missing_count=0
-  for subdir in lib commands; do
+  for subdir in lib commands rules; do
     [ -d "$mod_dir/$subdir" ] || continue
-    # Match shell scripts in lib/, markdown in commands/.
+    # Match shell scripts in lib/, markdown in commands/ and rules/.
     if [ "$subdir" = "lib" ]; then
       pattern="*.sh"
     else
@@ -263,7 +266,7 @@ for mod_dir in "$REPO_ROOT"/modules/*/; do
   done
 
   if [ "$shipped_count" -gt 0 ] && [ "$missing_count" -eq 0 ]; then
-    pass "$mod_name: all $shipped_count shipped lib/command file(s) declared in manifest"
+    pass "$mod_name: all $shipped_count shipped lib/command/rule file(s) declared in manifest"
   fi
 done
 echo ""

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -190,8 +190,17 @@ for mod_dir in "$REPO_ROOT"/modules/*/; do
 done
 echo ""
 
-# --- Test: All file paths in files map point to existing files ---
-echo "--- Checking file references ---"
+# --- Test: manifest-existence gate - every files map entry resolves on disk ---
+# For every module.json files[] key, assert the source path exists. Uses
+# [ -e ], not [ -f ], so a symlink to a file or a directory both count as
+# present - only a missing path (including a broken symlink) fails. This
+# guards the declared -> disk direction (a stale or mistyped manifest entry
+# pointing at a deleted/renamed file). It is the companion, not the fix, for
+# #930's actual bug class - three code-quality rules shipped on disk with no
+# files[] entry at all - which the disk -> declared "manifest completeness"
+# check below catches, but only for lib/*.sh and commands/*.md today.
+echo "--- Checking manifest-existence gate (files map -> source exists) ---"
+declared_entries=0
 for mod_dir in "$REPO_ROOT"/modules/*/; do
   [ ! -d "$mod_dir" ] && continue
   mod_name=$(basename "$mod_dir")
@@ -200,14 +209,18 @@ for mod_dir in "$REPO_ROOT"/modules/*/; do
   jq empty "$manifest" 2>/dev/null || continue
 
   while IFS= read -r src_path; do
+    [ -z "$src_path" ] && continue
+    declared_entries=$((declared_entries + 1))
     full_path="$mod_dir/$src_path"
-    if [ -f "$full_path" ]; then
+    if [ -e "$full_path" ]; then
       pass "$mod_name: file exists '$src_path'"
     else
       fail "$mod_name: referenced file missing '$src_path' (expected at $full_path)"
     fi
   done < <(jq -r '.files | keys[]' "$manifest" 2>/dev/null)
 done
+echo ""
+echo "  Checked $declared_entries declared files[] entries across $module_count modules"
 echo ""
 
 # --- Test: Manifest completeness - every shipped lib/command is installed ---

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -228,8 +228,19 @@ echo ""
 # sits on disk without a files[] entry, or it silently never installs. This is
 # the direction that actually catches #930's bug class (a shipped file with no
 # manifest entry at all) - the forward check above only catches the opposite
-# (a manifest entry pointing at a file that isn't there). Other file types
-# (README.md, terraform/, packer/, tests/) are intentionally not installed.
+# (a manifest entry pointing at a file that isn't there).
+#
+# Two different kinds of file types are NOT scanned here, and they are not
+# the same kind of "not scanned":
+#   - Genuinely never installed: README.md, terraform/, packer/, tests/.
+#     These have no files[] entry by design; a scan would just be noise.
+#   - Installed, but not yet covered by this gate: hooks/*.py, skills/*,
+#     agents/*, bin/*. Install location is driven purely by a files[]
+#     entry's `target` (type is advisory metadata only - see
+#     lib/modules.sh:189-190), so an undeclared hook or skill file fails to
+#     install exactly as silently as an undeclared rule did before this PR.
+#     Extending the scan to those subdirs is deliberately out of scope here;
+#     rules were the demonstrated gap for #930.
 echo "--- Checking manifest completeness (lib + commands + rules coverage) ---"
 for mod_dir in "$REPO_ROOT"/modules/*/; do
   [ ! -d "$mod_dir" ] && continue


### PR DESCRIPTION
Closes #930

## What changed

**Part 1 — wire the three code-quality rules.** `modules/code-quality/rules/`
held eight rule files; `module.json` declared five. `in-the-circuits.md`,
`spec-is-the-artifact.md`, and `menu-gen-test.md` were on disk but never
installed. They ship — each landed through its own issue and merged PR
(#436/#445, #437/#447, #438/#448), and five other modules' already-shipping
content already points readers at them (`animals-vs-ghosts.md` calls
`in-the-circuits.md` "the sister rule"; `research.md` and `xplan.md` both
send readers to `menu-gen-test.md`; `launch`'s README/SKILL.md and
`ideate`'s SKILL.md reference `spec-is-the-artifact.md`).

Added all three to `module.json`'s `files` map and to `README.md` — the
`cp` block and the `Files` table. Also fixed the `cp` block, which was
already missing `latent-vs-deterministic.md` despite it being listed in
the Files table — same defect class, fixed while in the file.

**Part 2 — the gate that actually catches this bug class.**
`tests/test-modules.sh` already had a forward check (declared `files[]`
entry -> source exists on disk); hardened it from `[ -f ]` to `[ -e ]` and
added a summary count. But that check only catches a stale manifest entry
pointing at a missing file — the opposite direction from the bug in Part 1
(a file shipped on disk with no manifest entry at all).

The check that catches *that* direction is the separate manifest-completeness
scan further down, and it only looked at `lib/*.sh` and `commands/*.md` —
never `rules/*.md`. Extended it to scan `rules/` too. That immediately
surfaced a fourth unwired rule repo-wide:
`modules/systematic-debugging/rules/animals-vs-ghosts.md` — same defect,
same May-2 philosophy-wave provenance (issue #440, merged PR #450), and the
file that calls `in-the-circuits.md` "the sister rule" three times, so both
halves of that pair were failing to install. Wired it into
`modules/systematic-debugging/module.json` and `README.md` (cp block +
Files table), matching that module's existing five-entry shape.

An independent Python scan of every module's `rules/` directory against its
`module.json` `files[]` map confirms no other module has an unwired rule.
Did not extend the reverse check to any other file type (skills, agents,
hooks, bin) — rules were the demonstrated gap for this issue.

**Part 3 — non-finding.** `modules/commands-utility/statusline-command.sh`
was flagged elsewhere as a possible ghost manifest entry. It is not: it's a
symlink to `../../lib/statusline.sh` and resolves under both `-f` and `-e`.
The scout that raised it runs with Read/Grep/Glob and no Bash, so it could
not see the symlink resolve. No change made in `modules/commands-utility/`.

## Verification

```
$ bash tests/test-modules.sh
  Checked 504 declared files[] entries across 78 modules
  Results: 1689 passed, 0 failed

$ bash tests/test-doc-counts.sh
test-doc-counts.sh: all checks passed

$ bash tests/test-no-personal-data.sh
PASS: No personal data or secret/PII shapes found

$ python3 modules/plugin-marketplace/lib/gen_marketplace.py --check
Marketplace files are up to date.

$ /bin/bash -n tests/test-modules.sh
(syntax OK)
```

Ran under both the macOS system bash (3.2.57) and Homebrew bash (5.3.9).
Doc counts did not move — module count is unchanged (78), only per-module
file counts grew, and neither gate tracks that.