### PR TITLE
orrery: anchor_repo.sh deferred review LOWs — error-contract consistency and loud degradations

### DIFF
--- a/modules/orrery/skills/orrery/SKILL.md
+++ b/modules/orrery/skills/orrery/SKILL.md
@@ -57,15 +57,17 @@ bash scripts/anchor_repo.sh <repo-path>
 ```
 
 Capture stdout and parse the single-line JSON: `repo_path`, `remote_url`
-(credential-stripped), `default_ref`, `anchor_sha`, `worktree`, `slug`, `behind`, `dirty`,
-`no_remote`, `visibility`.
+(credential-stripped), `default_ref`, `anchor_sha`, `worktree`, `slug`, `behind` (an integer,
+or `null` when the commit count could not be determined), `dirty`, `no_remote`, `visibility`.
 
 - **Exit 2** (unreachable repo, fetch failure, unsanitizable slug): stop and report the
   script's error. Nothing was created, so no teardown is owed yet.
 - **Success**: from this moment the teardown obligation exists - record `<repo-path>` and
   `<worktree>` so step 8 can always run, even if a later step fails.
-- **`dirty` or `behind` true**: proceed - the build runs against the pinned anchor, not the
-  working tree - and state the fact in the report (step 9).
+- **`dirty` true, or `behind` a positive count**: proceed - the build runs against the pinned
+  anchor, not the working tree - and state the fact in the report (step 9).
+- **`behind` is `null`**: proceed the same way, but never treat this as "not behind" - the
+  count is undetermined, not zero. Report it as such in step 9.
 - **Surface `visibility` immediately** to the user (`public` / `private` / `unknown`). For
   `private` or `unknown`, say now that the report will carry a do-not-publish-without-review
   warning.
@@ -259,8 +261,9 @@ never fatal; run it even if you believe a partial cleanup already happened.
 State plainly, in this order:
 
 - Artifact path (`$out/dist/{slug}.html`) and its byte size.
-- Anchor SHA and default ref; whether the source repo was `dirty` or `behind` at anchor time
-  (the map reflects the anchor, not the working tree).
+- Anchor SHA and default ref; whether the source repo was `dirty` or `behind` at anchor time,
+  or - if `behind` was `null` - that the behind-count could not be determined (the map
+  reflects the anchor, not the working tree).
 - Repo visibility. For `private` or `unknown`: **"do not publish this artifact without
   review - the source repo is not public"** - place the warning directly beside the embed
   snippet below.

--- a/modules/orrery/skills/orrery/scripts/anchor_repo.sh
+++ b/modules/orrery/skills/orrery/scripts/anchor_repo.sh
@@ -28,9 +28,11 @@ set -euo pipefail
 #        $ORRERY_HOME overrides the output root without editing this module
 #        (risk adrev2-014); unset, it defaults to ~/code/orrery.
 #
-# The run mutates the target repo in exactly two ways - `git fetch origin`
-# and `git worktree add`. The worktree is the only durable side effect, so
-# any failure after it is created triggers teardown from the error path.
+# The run mutates the target repo in three ways - `git fetch origin`,
+# `git remote set-head origin --auto` (refreshes the stale origin/HEAD
+# symref after the fetch), and `git worktree add`. The worktree is the only
+# durable side effect, so any failure after it is created triggers teardown
+# from the error path.
 #
 # Portable: macOS bash 3.2 + BSD tools. Deterministic: no LLM or tool calls.
 
@@ -101,7 +103,12 @@ esac
 if [ ! -d "$REPO_ARG" ]; then
   emit_error "repo path does not exist or is not a directory" "$REPO_ARG"
 fi
-REPO="$(cd "$REPO_ARG" && pwd -P)"
+# `cd --` so a repo dir name starting with `-` is never parsed as an option,
+# and an unreadable dir fails through emit_error instead of aborting via
+# set -e with a non-2 exit and no JSON (review finding 6).
+if ! REPO="$(cd -- "$REPO_ARG" && pwd -P)"; then
+  emit_error "repo path exists but could not be entered" "$REPO_ARG"
+fi
 case "$REPO" in
   *[[:cntrl:]]*)
     emit_error "resolved repo path contains control characters" ""
@@ -127,11 +134,18 @@ NO_REMOTE=false
 REMOTE_URL=""
 # config --get (not remote get-url): get-url expands insteadOf rewrites, and
 # the credential-bearing string to strip is the URL as configured.
-RAW_URL="$(git -C "$REPO" config --get remote.origin.url 2>/dev/null || true)"
-if [ -n "$RAW_URL" ]; then
+# `config --get` exits 1 when the key is simply not set (git-config(1)) -
+# that is a legitimate no-remote repo. Any other nonzero exit (unreadable or
+# malformed config file, etc.) is a genuine read failure and must not be
+# silently folded into the same no_remote path (review finding 7a).
+GIT_CONFIG_RC=0
+RAW_URL="$(git -C "$REPO" config --get remote.origin.url 2>/dev/null)" || GIT_CONFIG_RC=$?
+if [ "$GIT_CONFIG_RC" -eq 0 ]; then
   REMOTE_URL="$(strip_userinfo "$RAW_URL")"
-else
+elif [ "$GIT_CONFIG_RC" -eq 1 ]; then
   NO_REMOTE=true
+else
+  emit_error "cannot read remote.origin.url from git config (exit $GIT_CONFIG_RC)" "$REPO"
 fi
 RAW_URL=""
 
@@ -168,9 +182,17 @@ if [ -z "$ANCHOR_SHA" ]; then
 fi
 
 # --- behind + dirty ----------------------------------------------------------
-BEHIND="$(git -C "$REPO" rev-list --count "HEAD..$ANCHOR_SHA" 2>/dev/null | tr -cd '0-9' || true)"
-if [ -z "$BEHIND" ]; then
-  BEHIND=0
+# Never fabricate a 0: a rev-list failure (e.g. an orphan local branch with a
+# remote configured) must be distinguishable from a legitimate zero-commits-
+# behind result (review finding 7b). BEHIND holds the bare JSON token to
+# emit - either a decimal count or the literal `null`.
+if REV_COUNT="$(git -C "$REPO" rev-list --count "HEAD..$ANCHOR_SHA" 2>/dev/null)"; then
+  BEHIND="$(printf '%s' "$REV_COUNT" | tr -cd '0-9')"
+  if [ -z "$BEHIND" ]; then
+    BEHIND=null
+  fi
+else
+  BEHIND=null
 fi
 DIRTY=false
 if [ -n "$(git -C "$REPO" status --porcelain 2>/dev/null)" ]; then
@@ -188,8 +210,21 @@ on_exit() {
 }
 trap on_exit EXIT
 
-WT_BASE="$(mktemp -d "${TMPDIR:-/tmp}/orrery-anchor-${SLUG}.XXXXXX")"
+# A mktemp failure must fail through emit_error, not abort via set -e with a
+# non-2 exit and no JSON (review finding 6).
+if ! WT_BASE="$(mktemp -d "${TMPDIR:-/tmp}/orrery-anchor-${SLUG}.XXXXXX" 2>/dev/null)"; then
+  emit_error "mktemp failed to create a temp worktree directory" "$REPO"
+fi
 WT="$WT_BASE/wt"
+# TMPDIR is caller-controlled and flows straight into WT; a control character
+# there reproduces the exit-0-with-invalid-JSON shape the repo-path guard
+# above closed (delta re-review residual). Reject before mutating anything.
+case "$WT" in
+  *[[:cntrl:]]*)
+    rmdir "$WT_BASE" >/dev/null 2>&1 || true
+    emit_error "resolved worktree path contains control characters" "$REPO"
+    ;;
+esac
 if ! git -C "$REPO" worktree add --detach "$WT" "$ANCHOR_SHA" >/dev/null 2>&1; then
   rmdir "$WT_BASE" >/dev/null 2>&1 || true
   emit_error "git worktree add failed" "$REPO"

--- a/modules/orrery/tests/unit/test_anchor_repo.py
+++ b/modules/orrery/tests/unit/test_anchor_repo.py
@@ -123,17 +123,24 @@ def stub_gh(home, body):
 
 def stub_git_subcommand_failure(home, subcommand, exit_code):
     """Install a git stub on a PATH-prepend dir that exits `exit_code` when
-    invoked as `git -C <repo> <subcommand> ...` and execs the real git for
-    every other invocation. Returns the stub dir. Used to force a specific
-    git subcommand to fail without corrupting repo state (reviews finding
-    7a/7b need a failure the real git binary won't otherwise produce)."""
+    invoked as exactly `git -C <repo> <subcommand> ...` and execs the real
+    git for every other invocation. Returns the stub dir. Used to force a
+    specific git subcommand to fail without corrupting repo state (review
+    finding 7a/7b need a failure the real git binary won't otherwise
+    produce).
+
+    The `$1 = -C` check is load-bearing, not decorative: matching on `$3`
+    alone would also catch worktree_count()'s own
+    `git -C <repo> worktree list --porcelain` the moment a future test
+    stubs "worktree" - breaking the assertion helper instead of cleanly
+    failing the code under test."""
     stub_dir = home / "stub-bin"
     stub_dir.mkdir(parents=True, exist_ok=True)
     real_git = shutil.which("git")
     git_stub = stub_dir / "git"
     git_stub.write_text(
         "#!/bin/sh\n"
-        'if [ "$3" = "%s" ]; then\n'
+        'if [ "$1" = "-C" ] && [ "$3" = "%s" ]; then\n'
         "  exit %d\n"
         "fi\n"
         'exec "%s" "$@"\n' % (subcommand, exit_code, real_git)

--- a/modules/orrery/tests/unit/test_anchor_repo.py
+++ b/modules/orrery/tests/unit/test_anchor_repo.py
@@ -129,11 +129,16 @@ def stub_git_subcommand_failure(home, subcommand, exit_code):
     finding 7a/7b need a failure the real git binary won't otherwise
     produce).
 
-    The `$1 = -C` check is load-bearing, not decorative: matching on `$3`
-    alone would also catch worktree_count()'s own
-    `git -C <repo> worktree list --porcelain` the moment a future test
-    stubs "worktree" - breaking the assertion helper instead of cleanly
-    failing the code under test."""
+    The `$1 = -C` check only narrows the match to `-C`-prefixed calls; it
+    does NOT disambiguate between two `-C`-prefixed calls to the same
+    subcommand with different sub-actions. Concretely: every invocation
+    this test file makes through the git() helper is `-C`-prefixed, so
+    stubbing "worktree" would still catch worktree_count()'s own
+    `git -C <repo> worktree list --porcelain` alongside the script's
+    `worktree add` - that would need a `$4` check ("list" vs "add"), which
+    this helper does not have. Safe for the subcommands actually stubbed
+    today (config, rev-list): neither appears in any git() call this file
+    makes outside of anchor_repo.sh's own invocations."""
     stub_dir = home / "stub-bin"
     stub_dir.mkdir(parents=True, exist_ok=True)
     real_git = shutil.which("git")

--- a/modules/orrery/tests/unit/test_anchor_repo.py
+++ b/modules/orrery/tests/unit/test_anchor_repo.py
@@ -26,7 +26,11 @@ FAKE_TOKEN = "ghp_fake"
 # --- helpers -----------------------------------------------------------------
 def make_env(home, path_prepend=None):
     home.mkdir(parents=True, exist_ok=True)
-    env = dict(os.environ)
+    # Scrubbed environment: every inherited GIT_* var dropped (an exported
+    # GIT_DIR/GIT_INDEX_FILE/GIT_WORK_TREE would redirect every git call the
+    # script makes), then the fixed hermetic set restored below - mirrors the
+    # enumerate-side git_env() fix (review finding 9).
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
     # Hermeticity: an ambient $ORRERY_HOME must not redirect the default-root
     # assertions; the override test sets it explicitly.
     env.pop("ORRERY_HOME", None)
@@ -114,6 +118,27 @@ def stub_gh(home, body):
     gh = stub_dir / "gh"
     gh.write_text("#!/bin/sh\n" + body + "\n")
     gh.chmod(0o755)
+    return stub_dir
+
+
+def stub_git_subcommand_failure(home, subcommand, exit_code):
+    """Install a git stub on a PATH-prepend dir that exits `exit_code` when
+    invoked as `git -C <repo> <subcommand> ...` and execs the real git for
+    every other invocation. Returns the stub dir. Used to force a specific
+    git subcommand to fail without corrupting repo state (reviews finding
+    7a/7b need a failure the real git binary won't otherwise produce)."""
+    stub_dir = home / "stub-bin"
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    real_git = shutil.which("git")
+    git_stub = stub_dir / "git"
+    git_stub.write_text(
+        "#!/bin/sh\n"
+        'if [ "$3" = "%s" ]; then\n'
+        "  exit %d\n"
+        "fi\n"
+        'exec "%s" "$@"\n' % (subcommand, exit_code, real_git)
+    )
+    git_stub.chmod(0o755)
     return stub_dir
 
 
@@ -261,6 +286,101 @@ def test_control_char_repo_path_exits_2_with_valid_json(tmp_path):
     data = json.loads(result.stdout.strip())
     assert "error" in data
     assert worktree_count(repo, env) == 1
+
+
+def test_control_char_tmpdir_worktree_path_exits_2_with_valid_json(tmp_path):
+    """Delta re-review residual: a TMPDIR containing a control character
+    flows into the worktree path via mktemp and must not reproduce the
+    exit-0-with-invalid-JSON shape the repo-path guard closed (finding 2)."""
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+    bad_tmpdir = tmp_path / "bad\ntmp"
+    bad_tmpdir.mkdir(parents=True, exist_ok=True)
+    env["TMPDIR"] = str(bad_tmpdir)
+
+    result = run_anchor(env, repo)
+    assert result.returncode == 2
+    data = json.loads(result.stdout.strip())
+    assert "error" in data
+    assert worktree_count(repo, env) == 1
+
+
+def test_unreadable_repo_dir_exits_2_with_json_error(tmp_path):
+    """Review finding 6: cd into a repo dir with no read/execute permission
+    must fail through emit_error (exit 2 + JSON), not abort via set -e with a
+    bare non-2 exit and no JSON."""
+    env = make_env(tmp_path / "home")
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o000)
+    try:
+        result = run_anchor(env, locked)
+        assert result.returncode == 2
+        data = json.loads(result.stdout.strip())
+        assert "error" in data
+    finally:
+        locked.chmod(0o755)
+
+
+def test_dash_prefixed_repo_arg_not_parsed_as_cd_option(tmp_path):
+    """Review finding 6: a repo dir name starting with `-` must not be read
+    by `cd` as an option flag; `cd --` fixes this."""
+    env = make_env(tmp_path / "home")
+    workdir = tmp_path / "somewhere"
+    workdir.mkdir()
+    repo = make_repo(workdir / "-dashrepo", env, origin=None)
+
+    result = run_anchor(env, "-dashrepo", cwd=workdir)
+    data = anchor_json(result)
+    assert data["repo_path"] == str(repo.resolve())
+    run_anchor(env, "--teardown", repo, data["worktree"])
+
+
+def test_mktemp_failure_exits_2_with_json_error(tmp_path):
+    """Review finding 6: an unwritable TMPDIR makes mktemp fail; the run must
+    fail through emit_error, not abort via set -e with a bare non-2 exit."""
+    env = make_env(tmp_path / "home")
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+    readonly_tmp = tmp_path / "readonly-tmp"
+    readonly_tmp.mkdir()
+    readonly_tmp.chmod(0o500)
+    env["TMPDIR"] = str(readonly_tmp)
+    try:
+        result = run_anchor(env, repo)
+        assert result.returncode == 2
+        data = json.loads(result.stdout.strip())
+        assert "error" in data
+        assert worktree_count(repo, env) == 1
+    finally:
+        readonly_tmp.chmod(0o700)
+
+
+def test_git_config_read_failure_exits_2_with_json_error(tmp_path):
+    """Review finding 7a: a genuine git-config read failure (distinct from
+    "no origin configured", exit 1) must fail loudly through emit_error, not
+    silently fall into the no-remote path."""
+    env_home = tmp_path / "home"
+    stub = stub_git_subcommand_failure(env_home, "config", 3)
+    env = make_env(env_home, path_prepend=stub)
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+
+    result = run_anchor(env, repo)
+    assert result.returncode == 2
+    data = json.loads(result.stdout.strip())
+    assert "error" in data
+
+
+def test_rev_list_failure_emits_behind_null_not_fabricated_zero(tmp_path):
+    """Review finding 7b: a rev-list failure must never fabricate behind: 0 -
+    it must be reported as null so callers can tell the count is unknown."""
+    env_home = tmp_path / "home"
+    stub = stub_git_subcommand_failure(env_home, "rev-list", 128)
+    env = make_env(env_home, path_prepend=stub)
+    repo = make_repo(tmp_path / "repo", env, origin=None)
+
+    data = anchor_json(run_anchor(env, repo))
+    assert data["behind"] is None
+    run_anchor(env, "--teardown", repo, data["worktree"])
 
 
 # --- slug rule (security C7) -------------------------------------------------


### PR DESCRIPTION
Closes #929

Resolves the deferred LOW findings from the Stage-2 code-quality review of
PR #909 (orrery Epic 2), plus the three residuals its delta re-review
recorded. Evidence: `~/code/plans/codebase-system-map/reviews/etp-pr909-stage2.md`
(findings #4-#7 and the `## Delta re-review (70aacd0)` section).

All changes are in `modules/orrery/skills/orrery/scripts/anchor_repo.sh`
(the file the issue calls `lib/anchor_repo.sh`; that's its actual path in
this repo) plus its unit test file.

## What changed

**Contract-consistent failures (finding #6).** The header promises exit 2
plus a JSON error object for an unreachable repo. Three paths broke that
contract, aborting via `set -e` with a non-2 exit and no JSON:
- `cd` into an unreadable repo dir
- a repo dir name starting with `-` (bash `cd` read it as an option)
- `mktemp` failure

All three now route through `emit_error`. The `cd` fix uses `cd --` so a
dash-leading name is never parsed as a flag.

**Loud degradations (finding #7).**
- A git-config read failure is now distinguished from "no origin
  configured": `config --get`'s documented exit 1 (key not set) keeps the
  existing `no_remote` path; any other nonzero exit (corrupt/unreadable
  config file) now fails loudly through `emit_error`.
- A `rev-list` failure now emits `behind: null` instead of a fabricated `0`.

**Delta re-review residuals.**
- The header comment's stale "mutates the target repo in exactly two ways"
  is corrected to three, naming `git remote set-head origin --auto`.
- The `[[:cntrl:]]` control-character guard is extended to the resolved
  worktree path, closing the TMPDIR-derived residual left open by the
  existing repo-path guard.
- `test_anchor_repo.py`'s `make_env` now drops inherited `GIT_*` vars,
  mirroring the enumerate-side `git_env()` fix that landed in #909.

## Explicitly WONTFIX (recorded, not implemented)

- **Finding #4** — cosmetic `@`-path mangling of relative local remotes.
  Display-only; fetch uses git's own config, not the mangled display string.
- **Finding #5** — no timeout on the `gh` visibility call. Bounded by
  gh/TCP in practice; macOS ships no stock `timeout(1)`, and the reviewer's
  own recommendation was accept-as-is.

## Testing

One regression test per fixed behavior, using the reviewer's probe recipes
as templates: unreadable dir, dash-prefixed name, mktemp failure, TMPDIR
control chars in the worktree path, git-config failure vs absent origin
(both branches), rev-list failure.

```
$ python3 -m pytest modules/orrery/tests/unit/ -q
165 passed in 31.92s

$ ORRERY_STRICT=1 bash modules/orrery/tests/test-orrery.sh
layers ran: unit test-embed-browser.sh test-ingest-fixture.sh
  test-pipeline-fixture.sh test-render-golden.sh test-update-fixture.sh
  test-validate-gate.sh
test-orrery.sh: all layers green

$ bash tests/test-modules.sh
Results: 1657 passed, 0 failed

$ bash tests/test-no-personal-data.sh
PASS: No personal data or secret/PII shapes found
```