### PR TITLE
#918: honor declared prompt defaults under CCGM_NON_INTERACTIVE

### DIFF
--- a/docs/installer.md
+++ b/docs/installer.md
@@ -188,7 +188,7 @@ CCGM_NON_INTERACTIVE=1 \
 | `CCGM_CODE_DIR` | Code workspace directory | `~/code` |
 | `CCGM_TIMEZONE` | Timezone | auto-detected |
 
-In non-interactive mode, text and yes/no prompts use their default values. Choice prompts currently resolve to their first option, not their declared default (see #918).
+In non-interactive mode, all prompts use their declared default value: text and yes/no prompts return their default, and choice prompts (module `configPrompts` entries with an `options` list) return their declared `default` when it names one of the options. A choice prompt with no declared default, or a declared default that isn't one of its options, falls back to the first option (the latter also prints a warning naming the mismatch).
 
 ## Adding a module to an existing install
 

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -143,13 +143,39 @@ _read_key() {
 
 # --- Single select ---
 # Usage: result=$(ui_choose "Pick one" "option1" "option2" "option3")
+#        result=$(ui_choose --default "option2" "Pick one" "option1" "option2" "option3")
+#
+# Optional leading "--default <value>" flag: under CCGM_NON_INTERACTIVE=1,
+# returns that value instead of options[0], as long as it is one of the
+# options. Ignored entirely in interactive mode - it never preselects or
+# reorders the menu. If the default is empty, or is not one of the options,
+# non-interactive mode falls back to options[0] (silently for an empty
+# default, with a warning to stderr for a non-empty one that doesn't match -
+# that shape means a manifest typo, not "no default declared").
 ui_choose() {
+  local non_interactive_default=""
+  if [ "$1" = "--default" ]; then
+    non_interactive_default="$2"
+    shift 2
+  fi
+
   local prompt="$1"
   shift
   local options=("$@")
 
   if _is_non_interactive; then
-    # Return first option in non-interactive mode
+    if [ -n "$non_interactive_default" ]; then
+      local opt
+      for opt in "${options[@]}"; do
+        if [ "$opt" = "$non_interactive_default" ]; then
+          echo "$opt"
+          return 0
+        fi
+      done
+      echo -e "${UI_YELLOW}  Warning: declared default '$non_interactive_default' for '$prompt' is not among its options; using '${options[0]}'${UI_RESET}" >&2
+    fi
+    # No default declared, or declared default didn't match any option:
+    # fall back to the first option.
     echo "${options[0]}"
     return 0
   fi

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -152,9 +152,18 @@ _read_key() {
 # non-interactive mode falls back to options[0] (silently for an empty
 # default, with a warning to stderr for a non-empty one that doesn't match -
 # that shape means a manifest typo, not "no default declared").
+#
+# --default with no value following it (i.e. "--default" is the entire
+# argument list) is a caller error, not "no default" - it fails loudly
+# (stderr message, return 1) instead of silently returning an empty string
+# with exit 0, and does so the same way whether or not the caller has -u set.
 ui_choose() {
   local non_interactive_default=""
   if [ "$1" = "--default" ]; then
+    if [ "$#" -lt 2 ]; then
+      echo -e "${UI_RED}  ERROR: ui_choose --default requires a value${UI_RESET}" >&2
+      return 1
+    fi
     non_interactive_default="$2"
     shift 2
   fi
@@ -172,7 +181,7 @@ ui_choose() {
           return 0
         fi
       done
-      echo -e "${UI_YELLOW}  Warning: declared default '$non_interactive_default' for '$prompt' is not among its options; using '${options[0]}'${UI_RESET}" >&2
+      echo -e "${UI_YELLOW}  WARNING: declared default '$non_interactive_default' for '$prompt' is not among its options; using '${options[0]}'${UI_RESET}" >&2
     fi
     # No default declared, or declared default didn't match any option:
     # fall back to the first option.

--- a/start.sh
+++ b/start.sh
@@ -910,7 +910,7 @@ main() {
           if [ -n "$options" ]; then
             local opt_arr
             IFS=',' read -ra opt_arr <<< "$options"
-            value=$(ui_choose "$prompt" "${opt_arr[@]}")
+            value=$(ui_choose --default "$default" "$prompt" "${opt_arr[@]}")
           else
             case "$key" in
               __LOG_REPO__)

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -514,6 +514,123 @@ else
 fi
 echo ""
 
+# ============================================================
+# Test 8: CCGM_NON_INTERACTIVE honors declared configPrompt defaults
+# (#918 regression pin: identity's personalizeIdentity declares
+# default "no" with options ["yes","no"] - options[0] is "yes". Before
+# the fix, non-interactive mode silently ran the identity
+# personalization block with unchosen answers.)
+# ============================================================
+echo "--- Test 8: non-interactive mode honors declared defaults (identity) ---"
+
+TEST8_HOME="$TMPDIR/test8"
+mkdir -p "$TEST8_HOME/.claude"
+export HOME="$TEST8_HOME"
+export CCGM_CODE_DIR="$TEST8_HOME/code"
+
+set +e
+"$REPO_ROOT/start.sh" --preset standard --scope global </dev/null >/dev/null 2>&1
+install8_exit=$?
+set -e
+if [ $install8_exit -eq 0 ]; then
+  pass "Installer exited successfully (standard preset, test 8)"
+else
+  fail "Installer exited with code $install8_exit (standard preset, test 8)"
+fi
+
+env8="$TEST8_HOME/.claude/.ccgm.env"
+if [ -f "$env8" ]; then
+  # The declared default ("no") must win, not options[0] ("yes").
+  if grep -q "^CCGM_MODULE_identity__personalizeIdentity=no$" "$env8"; then
+    pass "identity__personalizeIdentity resolved to declared default 'no', not options[0] 'yes'"
+  else
+    fail "identity__personalizeIdentity did not resolve to 'no' (options[0] leaked through)"
+  fi
+
+  # Because personalizeIdentity correctly resolved to "no", the
+  # personalization follow-up block must never have run, so none of its
+  # invented answers should be present.
+  if grep -qE "^CCGM_MODULE_identity__(role|expertise|communication|building|values)=" "$env8"; then
+    fail "Identity personalization block ran under non-interactive mode with unchosen answers"
+  else
+    pass "Identity personalization block did not run (no invented role/communication/values)"
+  fi
+else
+  fail ".ccgm.env not found for test 8"
+fi
+echo ""
+
+# ============================================================
+# Test 9: ui_choose --default edge cases (unit-level, direct)
+#
+# Sourced directly rather than run through the full installer -
+# Test 8 above already pins the end-to-end identity case (a
+# non-options[0] default winning). These cover the remaining
+# ui_choose contract points from #918 that don't need a full
+# installer run to exercise.
+# ============================================================
+echo "--- Test 9: ui_choose --default edge cases ---"
+
+# shellcheck source=../lib/ui.sh
+source "$REPO_ROOT/lib/ui.sh"
+export CCGM_NON_INTERACTIVE=1
+
+# No declared default -> falls back to options[0] (regression guard: the
+# five call sites that never pass --default must be unaffected).
+result=$(ui_choose "Where to install?" "global" "project" "both")
+if [ "$result" = "global" ]; then
+  pass "ui_choose with no --default returns options[0] ('global')"
+else
+  fail "ui_choose with no --default returned '$result', expected 'global'"
+fi
+
+# Declared default is options[0] -> unaffected (regression guard for the
+# common case, where a manifest's default happens to match options[0]).
+result=$(ui_choose --default "minimal" "Select preset" "minimal" "standard" "full" "team")
+if [ "$result" = "minimal" ]; then
+  pass "ui_choose --default matching options[0] returns 'minimal'"
+else
+  fail "ui_choose --default matching options[0] returned '$result', expected 'minimal'"
+fi
+
+# Declared default is an empty string -> treated as "no default declared",
+# falls back to options[0] silently (no warning; an empty default is not a
+# manifest typo).
+default_stderr="$TMPDIR/test9-empty-default-stderr.log"
+result=$(ui_choose --default "" "Pick one" "first" "second" 2>"$default_stderr")
+if [ "$result" = "first" ]; then
+  pass "ui_choose --default '' (empty) returns options[0] ('first')"
+else
+  fail "ui_choose --default '' (empty) returned '$result', expected 'first'"
+fi
+if [ -s "$default_stderr" ]; then
+  fail "ui_choose --default '' (empty) unexpectedly printed a warning"
+else
+  pass "ui_choose --default '' (empty) printed no warning"
+fi
+
+# Declared default is not among the options -> falls back to options[0]
+# AND warns to stderr (a manifest typo must not silently pick an
+# unrelated value).
+mismatch_stderr="$TMPDIR/test9-mismatch-stderr.log"
+result=$(ui_choose --default "nonexistent" "Pick one" "first" "second" 2>"$mismatch_stderr")
+if [ "$result" = "first" ]; then
+  pass "ui_choose --default with an unmatched value returns options[0] ('first')"
+else
+  fail "ui_choose --default with an unmatched value returned '$result', expected 'first'"
+fi
+if grep -qi "warning" "$mismatch_stderr"; then
+  pass "ui_choose --default with an unmatched value warns to stderr"
+else
+  fail "ui_choose --default with an unmatched value printed no warning"
+fi
+if echo "$result" | grep -qi "warning"; then
+  fail "Warning text leaked into ui_choose's returned value"
+else
+  pass "Warning text did not leak into ui_choose's returned value"
+fi
+echo ""
+
 # Restore HOME
 export HOME="$TMPDIR/home"
 

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -619,15 +619,41 @@ if [ "$result" = "first" ]; then
 else
   fail "ui_choose --default with an unmatched value returned '$result', expected 'first'"
 fi
-if grep -qi "warning" "$mismatch_stderr"; then
-  pass "ui_choose --default with an unmatched value warns to stderr"
+if grep -q "WARNING:" "$mismatch_stderr"; then
+  pass "ui_choose --default with an unmatched value warns to stderr with 'WARNING:' (matches lib/*.sh sibling casing)"
 else
-  fail "ui_choose --default with an unmatched value printed no warning"
+  fail "ui_choose --default with an unmatched value did not print a 'WARNING:'-prefixed message: $(cat "$mismatch_stderr")"
 fi
 if echo "$result" | grep -qi "warning"; then
   fail "Warning text leaked into ui_choose's returned value"
 else
   pass "Warning text did not leak into ui_choose's returned value"
+fi
+
+# --default with no value following it (the flag as the entire argument
+# list) is a caller error, not "no default" - it must fail loudly (stderr
+# message, non-zero exit), never silently return an empty string with
+# exit 0. This holds under both -u (unbound $2) and non -u (silently
+# empty $2) - the guard is arity-based, not reliant on shell options.
+arity_stderr="$TMPDIR/test9-arity-stderr.log"
+set +e
+result=$(ui_choose --default 2>"$arity_stderr")
+arity_exit=$?
+set -e
+if [ $arity_exit -ne 0 ]; then
+  pass "ui_choose --default with no value exits non-zero (arity guard)"
+else
+  fail "ui_choose --default with no value exited 0 (expected non-zero)"
+fi
+if [ -z "$result" ]; then
+  pass "ui_choose --default with no value returns empty stdout"
+else
+  fail "ui_choose --default with no value returned '$result' on stdout"
+fi
+if grep -q "ERROR:" "$arity_stderr"; then
+  pass "ui_choose --default with no value prints an 'ERROR:'-prefixed message to stderr"
+else
+  fail "ui_choose --default with no value did not print an 'ERROR:'-prefixed message: $(cat "$arity_stderr")"
 fi
 echo ""
 


### PR DESCRIPTION
Closes #918

## Problem

Under `CCGM_NON_INTERACTIVE=1`, `ui_choose` always returned `options[0]`, ignoring a configPrompt's declared `default`. `start.sh`'s configPrompts loop already parsed the default (`IFS='|' read -r key prompt default options`) but never passed it through - the value was parsed and discarded.

Concretely: identity's `personalizeIdentity` prompt declares `"default": "no"` with `"options": ["yes", "no"]`. `options[0]` is `"yes"`, so `CCGM_NON_INTERACTIVE=1 ./start.sh --preset standard` - the exact command the docs give CI/agent users - silently ran the identity personalization block with invented answers nobody chose.

## Fix

`ui_choose` accepts an optional leading `--default <value>` flag (`lib/ui.sh`). Under non-interactive mode:
- If a default is supplied and matches one of the options, it wins.
- If no default is supplied, or it's an empty string, falls back to `options[0]` (unchanged behavior, no warning - not a manifest problem).
- If a non-empty default doesn't match any option, falls back to `options[0]` and prints a warning to stderr (a manifest typo shouldn't silently pick an unrelated value).

Interactive mode is untouched - the default is parsed and then ignored entirely once past the non-interactive branch; it never preselects or reorders the menu.

`start.sh`'s configPrompts loop (~line 913) now passes `--default "$default"` through to `ui_choose`.

## Call-site audit (required by the issue)

Six `ui_choose` call sites total, all confirmed:

| Site | Passes `--default`? | Effect of this change |
|---|---|---|
| `start.sh:702` (install scope) | No | None - still resolves to `options[0]` (`global`) |
| `start.sh:738` (installation mode) | No | None - still resolves to `options[0]` (`Choose a preset`) |
| `start.sh:759` (select preset) | No | None - still resolves to `options[0]` (`minimal`) |
| `start.sh:913` (configPrompts loop) | **Yes (new)** | Now honors the module's declared default instead of always `options[0]` |
| `start.sh:958` (identity communication) | No | None - hardcoded prompt, no manifest default to honor |
| `start.sh:964` (identity values) | No | None - hardcoded prompt, no manifest default to honor |

None of the five untouched sites relied on `options[0]` in any way this change alters - they simply never pass `--default`, so the non-interactive branch takes the same "no default supplied" path it always did.

## Tests

Added to `tests/test-installer.sh` (kept in the file CI already runs per-step by name, rather than a new sibling `test-*.sh` that `.github/workflows/test.yml`'s explicit step list would never execute):

- **Test 8** (pinned regression): `CCGM_NON_INTERACTIVE=1` + `--preset standard` resolves `identity__personalizeIdentity` to the declared default `no`, and none of the personalization block's invented answers (`role`/`expertise`/`communication`/`building`/`values`) land in `.ccgm.env`. Verified this fails against unpatched `origin/main` (reproduced via `git archive origin/main` into a scratch dir: `personalizeIdentity=yes`, `communication=Concise and direct`, `values=Simplicity and readability` - all unchosen).
- **Test 9** (direct `ui_choose` unit checks): no `--default` still resolves to `options[0]`; a default equal to `options[0]` is unaffected; an empty-string default falls back to `options[0]` with no warning; a default matching no option falls back to `options[0]` and warns to stderr without the warning leaking into the returned value.

## Docs

`docs/installer.md`'s non-interactive section rewritten to describe the fixed behavior (declared default wins; fallback + warning on a bad/absent default) and drops the stale `(see #918)` pointer.

## Gate output

```
$ bash tests/test-installer.sh
===================================
  Results: 64 passed, 0 failed
===================================

$ bash tests/test-modules.sh
===================================
  Results: 1657 passed, 0 failed
===================================

$ bash tests/test-no-personal-data.sh
PASS: No personal data or secret/PII shapes found

$ bash tests/test-doc-counts.sh
test-doc-counts.sh: all checks passed

$ /bin/bash -n lib/ui.sh start.sh
(no output - both files parse clean under bash 3.2's -n)
```

## Out of scope (left alone per spec)

- `lib/ui.sh:77`'s `${answer,,}` (bash 4-only lowercasing, breaks on macOS's bash 3.2) is a separate pre-existing bug in `ui_confirm`, tracked as #931. Not touched here.
