### PR TITLE
#935: run the four unwired test suites in CI and guard against enumeration drift

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,14 +48,26 @@ jobs:
       - name: Test templates
         run: bash tests/test-templates.sh
 
+      - name: Test settings merge
+        run: bash tests/test-merge.sh
+
+      - name: Test backup/restore
+        run: bash tests/test-backup.sh
+
       - name: Test installer (minimal)
         run: bash tests/test-installer.sh
 
       - name: Test link mode
         run: bash tests/test-link-mode.sh
 
+      - name: Test uninstall settings preservation
+        run: bash tests/test-uninstall-settings.sh
+
       - name: Audit skill test suite
         run: bash tests/run-audit-suite.sh
+
+      - name: xplan-web-review smoke tests
+        run: bash tests/test-xplan-web-review.sh
 
       - name: Hooks test suites (dispatcher equivalence + precedence)
         run: |
@@ -182,14 +194,26 @@ jobs:
       - name: Test templates
         run: bash tests/test-templates.sh
 
+      - name: Test settings merge
+        run: bash tests/test-merge.sh
+
+      - name: Test backup/restore
+        run: bash tests/test-backup.sh
+
       - name: Test installer (minimal)
         run: bash tests/test-installer.sh
 
       - name: Test link mode
         run: bash tests/test-link-mode.sh
 
+      - name: Test uninstall settings preservation
+        run: bash tests/test-uninstall-settings.sh
+
       - name: Audit skill test suite
         run: bash tests/run-audit-suite.sh
+
+      - name: xplan-web-review smoke tests
+        run: bash tests/test-xplan-web-review.sh
 
       - name: Hooks test suites (dispatcher equivalence + precedence)
         run: |

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -349,12 +349,17 @@ else
     total_lines=$(wc -l < "$WORKFLOW_FILE" | tr -d ' ')
 
     # Job boundaries: lines shaped like "  <job-name>:" (exactly 2-space
-    # indent, nothing after the colon) that appear after the top-level
-    # "jobs:" key. Each one starts a new job; the next one (or EOF) ends it.
-    # This scopes the check to per-job step lists rather than treating the
-    # file as one flat blob, so a suite wired into ubuntu but not macos is
-    # caught -- not silently passed by a whole-file grep.
+    # indent, colon, then only whitespace and/or a trailing "# comment")
+    # that appear after the top-level "jobs:" key. Each one starts a new
+    # job; the next one (or EOF) ends it. This scopes the check to per-job
+    # step lists rather than treating the file as one flat blob, so a suite
+    # wired into ubuntu but not macos is caught -- not silently passed by a
+    # whole-file grep. The trailing-comment tolerance matters: without it,
+    # a routine "test-macos: # runs on macOS" edit drops a job boundary and
+    # merges two jobs' ranges into one, silently disabling the per-job
+    # check it is supposed to run (see the job-count assertion below).
     ranges=""
+    job_names=""
     prev=""
     while IFS= read -r ln; do
       if [ -n "$prev" ]; then
@@ -363,17 +368,35 @@ else
 "
       fi
       prev="$ln"
-    done < <(tail -n "+$((jobs_line + 1))" "$WORKFLOW_FILE" | grep -n '^  [A-Za-z0-9_-]*:[[:space:]]*$' | cut -d: -f1 | while IFS= read -r n; do echo $((n + jobs_line)); done)
+    done < <(tail -n "+$((jobs_line + 1))" "$WORKFLOW_FILE" | grep -nE '^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$' | cut -d: -f1 | while IFS= read -r n; do echo $((n + jobs_line)); done)
     if [ -n "$prev" ]; then
       ranges="${ranges}${prev}:${total_lines}
 "
     fi
 
+    while IFS= read -r range; do
+      [ -z "$range" ] && continue
+      start="${range%%:*}"
+      name=$(sed -n "${start}p" "$WORKFLOW_FILE" | sed 's/^[[:space:]]*//; s/:.*$//')
+      job_names="$job_names $name"
+    done < <(printf '%s' "$ranges")
+
     job_count=$(printf '%s\n' "$ranges" | grep -c ':' || true)
-    if [ "$job_count" -eq 0 ]; then
-      fail "test.yml: could not locate any job definitions under 'jobs:' (unexpected format)"
+    # Load-bearing check: assert a floor, not just "> 0". A job-boundary
+    # parsing regression (trailing comment, changed indent, a run: block
+    # that happens to contain a job-key-shaped line, ...) degrades the
+    # per-job scoping silently -- every suite present anywhere in the file
+    # then satisfies a single merged range and the guard reports all-green,
+    # exactly the whole-file-grep weakness this check exists to prevent.
+    # Failing loud here, naming what was actually detected, converts that
+    # class of regression into a red test instead of manufactured
+    # confidence. Raise MIN_EXPECTED_CI_JOBS if a legitimate third job is
+    # ever added; do not hardcode an exact-equals that would break on that.
+    MIN_EXPECTED_CI_JOBS=2
+    if [ "$job_count" -lt "$MIN_EXPECTED_CI_JOBS" ]; then
+      fail "test.yml: expected >= $MIN_EXPECTED_CI_JOBS CI job(s) under 'jobs:', found $job_count (detected:${job_names:- none}) -- job-boundary parsing may be broken (e.g. a trailing comment or unexpected indent on a job key line)"
     else
-      pass "test.yml: found $job_count job definition(s) under 'jobs:'"
+      pass "test.yml: found $job_count job definition(s) under 'jobs:' (${job_names# })"
 
       for suite_path in "$SCRIPT_DIR"/test-*.sh; do
         [ -f "$suite_path" ] || continue

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -330,6 +330,79 @@ for preset_file in "$REPO_ROOT"/presets/*.json; do
 done
 echo ""
 
+# --- Test: every tests/test-*.sh suite is wired into CI, in every job ---
+# tests/run-all.sh discovers suites by globbing "$SCRIPT_DIR"/test-*.sh, but
+# .github/workflows/test.yml enumerates each suite by hand as its own step,
+# once per job. The two lists drift silently (issue #935): a suite can exist
+# on disk, run green under run-all.sh, and never once gate a PR because no
+# one added its step to the workflow -- or added it to one job and not the
+# other, which is the same bug in miniature.
+echo "--- Checking CI enumeration coverage (test.yml) ---"
+WORKFLOW_FILE="$REPO_ROOT/.github/workflows/test.yml"
+if [ ! -f "$WORKFLOW_FILE" ]; then
+  fail "workflow file missing: .github/workflows/test.yml"
+else
+  jobs_line=$(grep -n '^jobs:[[:space:]]*$' "$WORKFLOW_FILE" | head -1 | cut -d: -f1)
+  if [ -z "$jobs_line" ]; then
+    fail "test.yml: could not locate top-level 'jobs:' key"
+  else
+    total_lines=$(wc -l < "$WORKFLOW_FILE" | tr -d ' ')
+
+    # Job boundaries: lines shaped like "  <job-name>:" (exactly 2-space
+    # indent, nothing after the colon) that appear after the top-level
+    # "jobs:" key. Each one starts a new job; the next one (or EOF) ends it.
+    # This scopes the check to per-job step lists rather than treating the
+    # file as one flat blob, so a suite wired into ubuntu but not macos is
+    # caught -- not silently passed by a whole-file grep.
+    ranges=""
+    prev=""
+    while IFS= read -r ln; do
+      if [ -n "$prev" ]; then
+        end=$((ln - 1))
+        ranges="${ranges}${prev}:${end}
+"
+      fi
+      prev="$ln"
+    done < <(tail -n "+$((jobs_line + 1))" "$WORKFLOW_FILE" | grep -n '^  [A-Za-z0-9_-]*:[[:space:]]*$' | cut -d: -f1 | while IFS= read -r n; do echo $((n + jobs_line)); done)
+    if [ -n "$prev" ]; then
+      ranges="${ranges}${prev}:${total_lines}
+"
+    fi
+
+    job_count=$(printf '%s\n' "$ranges" | grep -c ':' || true)
+    if [ "$job_count" -eq 0 ]; then
+      fail "test.yml: could not locate any job definitions under 'jobs:' (unexpected format)"
+    else
+      pass "test.yml: found $job_count job definition(s) under 'jobs:'"
+
+      for suite_path in "$SCRIPT_DIR"/test-*.sh; do
+        [ -f "$suite_path" ] || continue
+        suite_name=$(basename "$suite_path")
+        missing_in=""
+
+        while IFS= read -r range; do
+          [ -z "$range" ] && continue
+          start="${range%%:*}"
+          end="${range##*:}"
+          job_label=$(sed -n "${start}p" "$WORKFLOW_FILE" | sed 's/^[[:space:]]*//; s/:.*$//')
+          if sed -n "${start},${end}p" "$WORKFLOW_FILE" | grep -qF "tests/$suite_name"; then
+            :
+          else
+            missing_in="$missing_in $job_label"
+          fi
+        done < <(printf '%s' "$ranges")
+
+        if [ -z "$missing_in" ]; then
+          pass "$suite_name: wired into all $job_count CI job(s)"
+        else
+          fail "$suite_name: missing from CI job(s):$missing_in (add 'run: bash tests/$suite_name' to .github/workflows/test.yml)"
+        fi
+      done
+    fi
+  fi
+fi
+echo ""
+
 # --- Summary ---
 echo "==================================="
 echo "  Results: $PASS passed, $FAIL failed"

--- a/tests/test-xplan-web-review.sh
+++ b/tests/test-xplan-web-review.sh
@@ -14,6 +14,37 @@ FAIL=0
 pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
 
+# Poll for a server to accept a connection on 127.0.0.1:$1, up to $2
+# attempts at ~50ms apiece (default 100 attempts =~ 5s). Condition-based
+# waiting per ~/.claude/rules/condition-based-waiting.md -- replaces a
+# fixed sleep-then-curl, which is a latent flake under a loaded CI runner
+# even once the server is guaranteed to actually attempt to bind (see the
+# DISPLAY export below).
+wait_for_port() {
+  local port="$1"
+  local max_attempts="${2:-100}"
+  local attempt=0
+  while [ "$attempt" -lt "$max_attempts" ]; do
+    if curl -s -o /dev/null "http://127.0.0.1:$port/" 2>/dev/null; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.05
+  done
+  return 1
+}
+
+# On Linux, is_headless() (modules/xplan/lib/xplan-web-review.py) treats a
+# missing $DISPLAY as headless and exits 1 before argument validation or
+# port binding -- exactly what GitHub's ubuntu-latest runner has, which is
+# why every server/arg-validation test below silently never ran in CI
+# (issue #935). Exporting a fake DISPLAY makes this suite exercise the same
+# validation/serving code path on Linux that it always exercised locally on
+# macOS (where is_headless() never checks $DISPLAY at all). Every server
+# invocation below already passes --no-open, so nothing tries to launch a
+# real browser against this fake display.
+export DISPLAY="${DISPLAY:-:99}"
+
 echo "=== xplan-web-review smoke tests ==="
 
 # -- Setup: scratch plan dir
@@ -68,6 +99,25 @@ else
   fail "XPLAN_NO_WEB=1 exited $rc, expected 1"
 fi
 
+# -- Test 3b: on Linux, missing $DISPLAY yields exit 1 (headless fallback).
+# This is the exact path that let the suite go green locally on macOS while
+# rotting invisibly under CI (issue #935) -- pin it explicitly now that
+# every other invocation below forces DISPLAY to be set. Only meaningful on
+# Linux: is_headless() checks $DISPLAY only when sys.platform starts with
+# "linux", so macOS never takes this branch and asserting on it there would
+# be asserting on unrelated platform behavior.
+if [ "$(uname -s)" = "Linux" ]; then
+  env -u DISPLAY -u XPLAN_NO_WEB python3 "$LIB" "$TMPDIR" --no-open >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" = "1" ]; then
+    pass "Linux without \$DISPLAY exits 1 (headless fallback)"
+  else
+    fail "Linux without \$DISPLAY exited $rc, expected 1"
+  fi
+else
+  echo "  SKIP: Linux-without-\$DISPLAY check (not Linux; is_headless() only checks \$DISPLAY on Linux)"
+fi
+
 # -- Test 4: nonexistent dir yields exit 2
 python3 "$LIB" "$TMPDIR/does-not-exist" --no-open >/dev/null 2>&1
 rc=$?
@@ -92,13 +142,16 @@ rmdir "$EMPTY_DIR" 2>/dev/null
 PORT=47431
 python3 "$LIB" "$TMPDIR" --no-open --port "$PORT" >/tmp/xplan-web-test-stdout.$$ 2>/tmp/xplan-web-test-stderr.$$ &
 SERVER_PID=$!
-sleep 0.8
 
-code=$(curl -s -o /tmp/xplan-web-test-index.$$ -w "%{http_code}" "http://127.0.0.1:$PORT/")
-if [ "$code" = "200" ] && grep -q "xplan review" /tmp/xplan-web-test-index.$$; then
-  pass "GET / returns 200 and expected HTML"
+if wait_for_port "$PORT"; then
+  code=$(curl -s -o /tmp/xplan-web-test-index.$$ -w "%{http_code}" "http://127.0.0.1:$PORT/")
+  if [ "$code" = "200" ] && grep -q "xplan review" /tmp/xplan-web-test-index.$$; then
+    pass "GET / returns 200 and expected HTML"
+  else
+    fail "GET / returned $code (expected 200)"
+  fi
 else
-  fail "GET / returned $code (expected 200)"
+  fail "server did not bind on port $PORT within ~5s"
 fi
 
 # -- Test 7: /raw/plan.md returns markdown
@@ -168,24 +221,27 @@ rm "$TMPDIR/comments.json" 2>/dev/null
 PORT=47432
 python3 "$LIB" "$TMPDIR" --no-open --port "$PORT" >/dev/null 2>&1 &
 SERVER_PID=$!
-sleep 0.8
 
-curl -s -X POST -H 'Content-Type: application/json' \
-  -d '{"action":"accept","comments":[]}' \
-  "http://127.0.0.1:$PORT/accept" >/dev/null
+if wait_for_port "$PORT"; then
+  curl -s -X POST -H 'Content-Type: application/json' \
+    -d '{"action":"accept","comments":[]}' \
+    "http://127.0.0.1:$PORT/accept" >/dev/null
 
-wait "$SERVER_PID" 2>/dev/null
-SERVER_PID=""
+  wait "$SERVER_PID" 2>/dev/null
+  SERVER_PID=""
 
-if python3 -c "
+  if python3 -c "
 import json
 d = json.load(open('$TMPDIR/comments.json'))
 assert d['action'] == 'accept', 'action != accept'
 assert d['comments'] == [], 'comments not empty on accept'
 " 2>/dev/null; then
-  pass "POST /accept writes action=accept with empty comments"
+    pass "POST /accept writes action=accept with empty comments"
+  else
+    fail "/accept did not write expected payload"
+  fi
 else
-  fail "/accept did not write expected payload"
+  fail "server did not bind on port $PORT within ~5s"
 fi
 
 # -- Cleanup scratch files

--- a/tests/test-xplan-web-review.sh
+++ b/tests/test-xplan-web-review.sh
@@ -15,17 +15,37 @@ pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
 
 # Poll for a server to accept a connection on 127.0.0.1:$1, up to $2
-# attempts at ~50ms apiece (default 100 attempts =~ 5s). Condition-based
-# waiting per ~/.claude/rules/condition-based-waiting.md -- replaces a
-# fixed sleep-then-curl, which is a latent flake under a loaded CI runner
-# even once the server is guaranteed to actually attempt to bind (see the
+# attempts (default 60). Condition-based waiting per
+# ~/.claude/rules/condition-based-waiting.md -- replaces a fixed
+# sleep-then-curl, which is a latent flake under a loaded CI runner even
+# once the server is guaranteed to actually attempt to bind (see the
 # DISPLAY export below).
+#
+# Each attempt is bounded to 1s via curl's --max-time. Without a per-call
+# bound, a single curl invocation has no time limit of its own, and the
+# loop's real wall-clock time is set by however long that one call happens
+# to block -- not by attempt-count * sleep arithmetic. That gap is not
+# theoretical here: on the macOS CI runner this workflow targets, two
+# independent green runs of this exact call site (PR #937, runs
+# 30760298565 and 30759895061) measured 35.16-36.40s to succeed, ~7x what
+# a naive 100 * 50ms reading implies. Likely cause: Python's
+# http.server.HTTPServer.server_bind() calls socket.getfqdn(host) -- a
+# reverse-DNS lookup -- between bind() and listen(); PlanHandler already
+# overrides log_message as a no-op, so this is not per-request log
+# resolution, it is the one-time bind-time lookup. That is server
+# behavior in modules/xplan/lib/xplan-web-review.py -- out of scope here,
+# and not fixed by this suite.
+#
+# 60 attempts * (1s curl bound + 0.05s sleep) ~= 63s worst case: about
+# 1.7x the highest of the four observed real values (36.40s), enough
+# margin for ordinary CI variance without leaving a genuinely dead server
+# to poll for ~100s before this suite reports it.
 wait_for_port() {
   local port="$1"
-  local max_attempts="${2:-100}"
+  local max_attempts="${2:-60}"
   local attempt=0
   while [ "$attempt" -lt "$max_attempts" ]; do
-    if curl -s -o /dev/null "http://127.0.0.1:$port/" 2>/dev/null; then
+    if curl -s -o /dev/null --max-time 1 "http://127.0.0.1:$port/" 2>/dev/null; then
       return 0
     fi
     attempt=$((attempt + 1))
@@ -151,7 +171,7 @@ if wait_for_port "$PORT"; then
     fail "GET / returned $code (expected 200)"
   fi
 else
-  fail "server did not bind on port $PORT within ~5s"
+  fail "server did not bind on port $PORT within ~63s (60 attempts x ~1.05s)"
 fi
 
 # -- Test 7: /raw/plan.md returns markdown
@@ -241,7 +261,7 @@ assert d['comments'] == [], 'comments not empty on accept'
     fail "/accept did not write expected payload"
   fi
 else
-  fail "server did not bind on port $PORT within ~5s"
+  fail "server did not bind on port $PORT within ~63s (60 attempts x ~1.05s)"
 fi
 
 # -- Cleanup scratch files


### PR DESCRIPTION
Closes #935

## The gap

`tests/run-all.sh` discovers suites by globbing `tests/test-*.sh`; `.github/workflows/test.yml`
enumerates each suite by hand, once per job (`test` on ubuntu, `test-macos` on macos). The two
lists drifted: four suites on disk ran green under `run-all.sh` and never once gated a PR in CI.

## Fix

**1. Wired the four missing suites into both CI jobs** in `.github/workflows/test.yml`, placed near
related steps rather than appended at the end (settings-merge/backup next to the other `lib/`-level
tests, uninstall next to install/link-mode, xplan-web-review next to the other skill-test steps).

Confirmed each is green on `main` before wiring it:

```
$ bash tests/test-backup.sh
  Results: 28 passed, 0 failed

$ bash tests/test-merge.sh
  Results: 16 passed, 0 failed

$ bash tests/test-uninstall-settings.sh
  Results: 16 passed, 0 failed

$ bash tests/test-xplan-web-review.sh
  Results: 13 passed, 0 failed
```

**2. Added a drift guard** to `tests/test-modules.sh` (already wired into both CI jobs — no new
unwired file). It enumerates `tests/test-*.sh` from disk, locates each job's step range under the
top-level `jobs:` key in `test.yml`, and asserts every suite's basename appears **within every
job's own range**, not just somewhere in the file. This checks both jobs individually — a suite
wired into `test` but missing from `test-macos` fails the guard naming the specific missing job,
which a whole-file `grep` would have silently passed. That was exactly the shape of this bug.

## Fixed after review 1: ubuntu CI was red (headless Linux)

Wiring `test-xplan-web-review.sh` into the ubuntu job (this PR's own point) surfaced a suite that
had rotted invisibly: `modules/xplan/lib/xplan-web-review.py`'s `is_headless()` treats a missing
`$DISPLAY` as headless on Linux and exits 1 before argument validation or port binding.
`ubuntu-latest` has no `$DISPLAY`; macOS never takes that branch, which is why the suite passed
locally and in `test-macos` but failed 3/13 in `test`. **`modules/xplan/lib/xplan-web-review.py` is
unchanged** — it behaves exactly as its own docstring documents; the suite's environment assumption
was wrong, not the lib.

Fix, in `tests/test-xplan-web-review.sh` only:
- Export a fake `DISPLAY` so the suite exercises the same validation/serving path on Linux that it
  always exercised on macOS. Every server test already passes `--no-open`, so nothing tries to
  launch a real browser.
- Added a Linux-only test that pins the missing-`$DISPLAY` fallback itself (`exits 1`), since that
  is the exact behavior that just bit us and nothing asserted on it before. Skipped (not
  pass/fail-counted) on macOS, where `is_headless()` never checks `$DISPLAY`.
- Replaced the two fixed `sleep 0.8` calls before each server's first `curl` with a bounded poll
  for the port to accept a connection (condition-based waiting) — a fixed sleep is a latent flake
  under a loaded CI runner even with `DISPLAY` set correctly.
- Re-checked `test-backup.sh`, `test-merge.sh`, `test-uninstall-settings.sh` for the same class of
  assumption (`$DISPLAY`, GUI, macOS-only binaries, fixed sleeps): none found. `test-backup.sh` has
  one `sleep 1`, but it's a commented, condition-anchored wait for a distinct `HHMMSS` backup
  timestamp (1s wall-clock resolution), not a readiness poll — out of scope for this fix.

## Fixed after review 2: the guard itself was fragile

An independent probe found that the drift guard's job-boundary regex (`^  name:[[:space:]]*$`)
silently broke on a routine edit: appending `# runs on macOS` after `test-macos:` drops that
boundary, merges both jobs' ranges into one, and every suite then vacuously "passes" — job count
silently 2 → 1, guard reports all-green. A guard that stops guarding without saying so manufactures
false confidence, which is the same failure shape issue #935 was filed for.

Fix, in `tests/test-modules.sh` only:
- Extended the boundary regex to tolerate a trailing `# comment` after the job key.
- Added a floor assertion (`>= 2` detected CI jobs) that fails loud, naming what was actually
  detected, whenever job-boundary parsing degrades for any reason.

Re-ran both probes against the fixed guard (Probe A — trailing comment, the silent-degradation
case; Probe B — delete one suite's step from only one job, must still fail named):

```
Probe A after fix:  PASS: test.yml: found 2 job definition(s) under 'jobs:' (test test-macos)
                     Results: 1702 passed, 0 failed
Probe B:             FAIL: test-backup.sh: missing from CI job(s): test-macos (add 'run: bash
                      tests/test-backup.sh' to .github/workflows/test.yml)
                      Results: 1701 passed, 1 failed  ->  restored -> 1702 passed, 0 failed
```

A third, milder mode the reviewer also found (a `run: |` block containing a job-key-shaped line)
already fails loud with a named suite/job, which is a maintenance annoyance rather than a
correctness hole — fixing it in full generality means writing a real YAML parser, ruled out by this
repo's stdlib/shell-only test-plumbing convention.

## Fixed after review 3: wait_for_port's documented bound was ~7x off on the target runner

`curl` was invoked with no `--max-time`/`--connect-timeout`, so a single poll iteration had no time
bound of its own — only the iteration *count* was bounded. On the macOS CI runner this workflow
targets, timestamped logs from two independent green PR runs measured this exact call site taking
35.16–36.40s to succeed, ~7x what the documented "100 attempts × 50ms ≈ 5s" figure implied, and
close enough to the 100-attempt ceiling that ordinary CI variance could flip it into a hard failure
— reintroducing the flake class this PR's own commit message says it eliminates, with a larger and
less predictable margin than the `sleep 0.8` it replaced. Likely cause:
`HTTPServer.server_bind()` calls `socket.getfqdn(host)` (a reverse-DNS lookup) between `bind()` and
`listen()`; `PlanHandler.log_message` is already a no-op, so this is not per-request log
resolution, it is the one-time bind-time lookup. **That is server behavior in
`modules/xplan/lib/xplan-web-review.py` — not fixed here, out of scope, and worth its own issue if
it ever matters in production.**

Fix, in `tests/test-xplan-web-review.sh` only:
- Added `--max-time 1` to the `curl` probe, so each poll attempt is bounded independently of the
  sleep/attempt-count arithmetic.
- Dropped the attempt ceiling from 100 to 60. Worst case is now `60 × (1s curl bound + 0.05s sleep)
  ≈ 63s` — about 1.7x the highest of the four observed real values (36.40s), enough margin for
  ordinary CI variance without leaving a genuinely dead server to poll for ~100s+ before the suite
  reports it. Chose 1.7x rather than a larger multiplier because the four observed values were
  tightly clustered (35.16–36.40s, ~1.2s spread), so a smaller margin was already comfortable.
- Corrected the fail message and comments to state the real budget (`~63s (60 attempts x ~1.05s)`)
  instead of the `~5s` figure the old arithmetic implied but the runner never honored.

Confirmed on the fix commit's own CI run (`30761219176`, `test-macos`, timestamped step log): the
two `wait_for_port` calls took 36.16s and 36.29s — consistent with the reviewer's prior
measurements, comfortably under the new 63s ceiling, suite green at 13/13 in both jobs.

## Rebase

Rebased twice onto `origin/main`: once after PR #933 merged (`a955127`), once more after #934/#936/
#941 merged (final base `ef3c3e2`). Clean rebases both times, no conflicts — non-overlapping regions
of the touched files.

**Issue #943** (an unrelated intermittent `printf | grep -q` under `pipefail` false failure in
`test-modules.sh`'s manifest-completeness check) had no fix PR open as of this push. Per the
coordinator's sequencing note, this PR will rebase over that fix once it lands and merges before
this one; the drift guard added here sits in a different section of `test-modules.sh` than that
check.

## Ordering vs #932

Wired `test-backup.sh` as it exists on `main` (28 assertions) — the issue notes this is safe
regardless of #932's outcome, since the suite passes on both versions.

## Constraints respected

- Touched only `.github/workflows/test.yml`, `tests/test-modules.sh`, and
  `tests/test-xplan-web-review.sh`. Did not touch `modules/xplan/**` or `tests/run-all.sh`.
- Bash 3.2 compatible (no `declare -A`/`mapfile`/`${var,,}`); `/bin/bash -n` passes on both edited
  test files under the system's `/bin/bash` (GNU bash 3.2.57).
- YAML validated: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` → OK.

## Final CI (this branch's tip, `c6f8412`)

`test` pass (3m40s), `test-macos` pass (4m58s), `module-tests (ubuntu-latest)` pass, `module-tests
(macos-latest)` pass. `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`.