### PR TITLE
#919: derive the interactive preset menu from presets/

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ The interactive installer handles everything from here.
 
 ### 2. Choose a preset (or pick modules individually)
 
-Five presets exist. The interactive menu currently offers four of them; **cloud-agent** is available via `./start.sh --preset cloud-agent` (see #919). You can also select modules one by one:
+Five presets exist, and the interactive menu offers all of them. You can also select modules one by one:
 
 | Preset | What you get | Best for |
 |--------|-------------|----------|

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -42,7 +42,7 @@ Choose where to install:
 
 ### Step 5: Module selection
 
-Choose a preset (minimal, standard, full, team) or select individual modules from a checkbox menu. The menu lists stable modules first, with beta modules (labelled `[BETA]`) at the end.
+Choose a preset (the menu lists every file under `presets/`: minimal, standard, full, team, cloud-agent) or select individual modules from a checkbox menu. The menu lists stable modules first, with beta modules (labelled `[BETA]`) at the end.
 
 ### Step 6: Dependency resolution
 
@@ -168,6 +168,9 @@ The installer is split into library files in `lib/`:
 | `lib/template.sh` | Template variable expansion via `sed`. Handles macOS and Linux `sed` differences. |
 | `lib/merge.sh` | Deep JSON merge for `settings.json` using `jq`. Special handling for arrays and hook objects. |
 | `lib/backup.sh` | Timestamped backup and restore of `~/.claude/` contents. |
+| `lib/mcp-migrate.sh` | Migrates a legacy `~/.claude/mcp.json` (unread by current Claude Code) to `~/.claude.json` via `claude mcp add-json --scope user`. Idempotent; backs up the legacy file with a `.migrated.bak` suffix on success. |
+| `lib/repair.sh` | Prunes dangling symlinks left under `~/.claude/` by module renames or moved files, so a stale link at an old target doesn't break commands like `/startup`. |
+| `lib/statusline.sh` | Claude Code status line script: model, directory + branch, context usage, and 5h/7d rate limits on one line. |
 
 ## Non-interactive mode
 

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -42,7 +42,7 @@ Choose where to install:
 
 ### Step 5: Module selection
 
-Choose a preset (the menu lists every file under `presets/`: minimal, standard, full, team, cloud-agent) or select individual modules from a checkbox menu. The menu lists stable modules first, with beta modules (labelled `[BETA]`) at the end.
+Choose a preset (the menu lists every file under `presets/`, alphabetically: cloud-agent, full, minimal, standard, team) or select individual modules from a checkbox menu. The menu lists stable modules first, with beta modules (labelled `[BETA]`) at the end.
 
 ### Step 6: Dependency resolution
 

--- a/lib/modules.sh
+++ b/lib/modules.sh
@@ -345,6 +345,37 @@ load_preset() {
   fi
 }
 
+# --- List preset names ---
+# Usage: while IFS= read -r name; do ...; done < <(list_preset_names)
+#
+# Prints every presets/*.json basename, one per line, in the glob's own
+# order (alphabetical on a normal filesystem). This is the single source
+# for "what presets exist" - the interactive menu, --help's preset list,
+# the printed preset details, and the installer test suite's expected
+# list all call this function so they cannot drift from each other (#919
+# and its follow-up: two independently-glob-ing copies is the same bug
+# class the issue was filed for).
+#
+# Prints an error to stderr and returns 1 if presets/ contains no *.json
+# files. Does not exit - callers that require at least one preset to
+# proceed must check for an empty result themselves (see start.sh's
+# --help and interactive-menu call sites, which both treat "no presets"
+# as fatal).
+list_preset_names() {
+  local pf pname
+  local found=false
+  for pf in "${CCGM_ROOT}"/presets/*.json; do
+    [ -e "$pf" ] || continue # glob matched nothing; skip the literal pattern
+    found=true
+    pname=$(basename "$pf" .json)
+    echo "$pname"
+  done
+  if [ "$found" = false ]; then
+    echo "No presets found in ${CCGM_ROOT}/presets/" >&2
+    return 1
+  fi
+}
+
 # --- List presets ---
 list_presets() {
   local preset

--- a/start.sh
+++ b/start.sh
@@ -395,13 +395,26 @@ main() {
         shift 2
         ;;
       --help|-h)
+        # Derived from presets/*.json (same glob the interactive menu uses,
+        # #919) so this line can never drift out of sync with the actual
+        # preset files again.
+        local help_preset_names="" help_pf help_pname
+        for help_pf in "${CCGM_ROOT}"/presets/*.json; do
+          [ -e "$help_pf" ] || continue
+          help_pname=$(basename "$help_pf" .json)
+          if [ -z "$help_preset_names" ]; then
+            help_preset_names="$help_pname"
+          else
+            help_preset_names="${help_preset_names}, ${help_pname}"
+          fi
+        done
         echo "CCGM - Claude Code God Mode"
         echo ""
         echo "Usage: ./start.sh [OPTIONS]"
         echo ""
         echo "Options:"
         echo "  --link              Create symlinks instead of copies"
-        echo "  --preset <name>     Use preset (minimal, standard, full, team)"
+        echo "  --preset <name>     Use preset (${help_preset_names:-none found in presets/})"
         echo "  --scope <scope>     Installation scope (global, project, both)"
         echo "  --add <module>      Add a module to an existing install (repeatable);"
         echo "                      inherits link-mode and scope from the manifest"

--- a/start.sh
+++ b/start.sh
@@ -741,10 +741,15 @@ main() {
       ui_info "Available presets:"
       echo ""
 
-      # Show preset details
+      # Show preset details. preset_names accumulates in the same order the
+      # list is printed, so the ui_choose menu below can never drift out of
+      # sync with what was just shown (#919).
       local pf pname pcount pmods
+      local preset_names=()
       for pf in "${CCGM_ROOT}"/presets/*.json; do
+        [ -e "$pf" ] || continue # glob matched nothing; skip the literal pattern
         pname=$(basename "$pf" .json)
+        preset_names+=("$pname")
         if [ "$has_jq" = true ]; then
           pcount=$(jq -r 'length' "$pf")
           pmods=$(jq -r 'join(", ")' "$pf")
@@ -756,7 +761,12 @@ main() {
       done
       echo ""
 
-      PRESET_NAME=$(ui_choose "Select preset" "minimal" "standard" "full" "team")
+      if [ ${#preset_names[@]} -eq 0 ]; then
+        ui_error "No presets found in ${CCGM_ROOT}/presets/"
+        exit 1
+      fi
+
+      PRESET_NAME=$(ui_choose "Select preset" "${preset_names[@]}")
       while IFS= read -r mod; do
         [ -n "$mod" ] && SELECTED_MODULES+=("$mod")
       done < <(load_preset "$PRESET_NAME")

--- a/start.sh
+++ b/start.sh
@@ -395,26 +395,33 @@ main() {
         shift 2
         ;;
       --help|-h)
-        # Derived from presets/*.json (same glob the interactive menu uses,
-        # #919) so this line can never drift out of sync with the actual
-        # preset files again.
-        local help_preset_names="" help_pf help_pname
-        for help_pf in "${CCGM_ROOT}"/presets/*.json; do
-          [ -e "$help_pf" ] || continue
-          help_pname=$(basename "$help_pf" .json)
+        # Derived from list_preset_names() (lib/modules.sh) - the same
+        # source the interactive menu's preset list (below, in the
+        # "Choose a preset" branch) and the printed preset details use, so
+        # this line can never drift out of sync with the actual preset
+        # files, or with the menu, again (#919).
+        local help_preset_names="" help_pname
+        while IFS= read -r help_pname; do
+          [ -z "$help_pname" ] && continue
           if [ -z "$help_preset_names" ]; then
             help_preset_names="$help_pname"
           else
             help_preset_names="${help_preset_names}, ${help_pname}"
           fi
-        done
+        done < <(list_preset_names)
+        if [ -z "$help_preset_names" ]; then
+          # list_preset_names() already printed why (no presets/*.json
+          # found) to stderr; matches the interactive menu's fatal
+          # treatment of the same condition (below).
+          exit 1
+        fi
         echo "CCGM - Claude Code God Mode"
         echo ""
         echo "Usage: ./start.sh [OPTIONS]"
         echo ""
         echo "Options:"
         echo "  --link              Create symlinks instead of copies"
-        echo "  --preset <name>     Use preset (${help_preset_names:-none found in presets/})"
+        echo "  --preset <name>     Use preset (${help_preset_names})"
         echo "  --scope <scope>     Installation scope (global, project, both)"
         echo "  --add <module>      Add a module to an existing install (repeatable);"
         echo "                      inherits link-mode and scope from the manifest"
@@ -754,15 +761,17 @@ main() {
       ui_info "Available presets:"
       echo ""
 
-      # Show preset details. preset_names accumulates in the same order the
-      # list is printed, so the ui_choose menu below can never drift out of
-      # sync with what was just shown (#919).
-      local pf pname pcount pmods
+      # Show preset details. preset_names is built from list_preset_names()
+      # (lib/modules.sh) - the same source --help's preset list uses - in
+      # the same order it is printed here, so the ui_choose menu below can
+      # never drift out of sync with what was just shown, or with --help,
+      # again (#919).
+      local pname pf pcount pmods
       local preset_names=()
-      for pf in "${CCGM_ROOT}"/presets/*.json; do
-        [ -e "$pf" ] || continue # glob matched nothing; skip the literal pattern
-        pname=$(basename "$pf" .json)
+      while IFS= read -r pname; do
+        [ -z "$pname" ] && continue
         preset_names+=("$pname")
+        pf="${CCGM_ROOT}/presets/${pname}.json"
         if [ "$has_jq" = true ]; then
           pcount=$(jq -r 'length' "$pf")
           pmods=$(jq -r 'join(", ")' "$pf")
@@ -771,11 +780,13 @@ main() {
           pmods=$(tr -d '[]"' < "$pf" | tr ',' ' ')
         fi
         ui_list_item "$pname" "($pcount modules) $pmods"
-      done
+      done < <(list_preset_names)
       echo ""
 
       if [ ${#preset_names[@]} -eq 0 ]; then
-        ui_error "No presets found in ${CCGM_ROOT}/presets/"
+        # list_preset_names() already printed why (no presets/*.json
+        # found) to stderr; matches --help's fatal treatment of the same
+        # condition (above).
         exit 1
       fi
 

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -11,6 +11,9 @@ PASS=0
 FAIL=0
 ERRORS=()
 TMPDIR=""
+# Set only while Test 8's scratch preset file exists, so cleanup() below
+# removes it even if the test fails before reaching its own removal.
+SCRATCH_PRESET_FILE=""
 
 # --- Helpers ---
 pass() {
@@ -27,6 +30,9 @@ fail() {
 cleanup() {
   if [ -n "$TMPDIR" ] && [ -d "$TMPDIR" ]; then
     rm -rf "$TMPDIR"
+  fi
+  if [ -n "$SCRATCH_PRESET_FILE" ] && [ -f "$SCRATCH_PRESET_FILE" ]; then
+    rm -f "$SCRATCH_PRESET_FILE"
   fi
 }
 trap cleanup EXIT
@@ -655,6 +661,177 @@ if grep -q "ERROR:" "$arity_stderr"; then
 else
   fail "ui_choose --default with no value did not print an 'ERROR:'-prefixed message: $(cat "$arity_stderr")"
 fi
+echo ""
+
+# ============================================================
+# Test 10: interactive preset menu and --help preset list are both
+# derived from presets/*.json (#919)
+#
+# Before the fix, start.sh printed every presets/*.json file but then
+# hardcoded both the ui_choose "Select preset" menu AND the --help
+# "--preset <name>" line to "minimal standard full team" - cloud-agent
+# was advertised in the printed list but unreachable from either. This
+# proves both derived lists come from the same glob that prints the
+# list (so neither can diverge again), and covers the degenerate case
+# of a preset filename containing a space (the glob must not
+# word-split it into multiple entries).
+# ============================================================
+echo "--- Test 10: interactive preset menu and --help match presets/*.json ---"
+
+TEST10_HOME="$TMPDIR/test10"
+mkdir -p "$TEST10_HOME/.claude"
+export HOME="$TEST10_HOME"
+export CCGM_CODE_DIR="$TEST10_HOME/code"
+export CCGM_USERNAME=testuser
+export CCGM_TIMEZONE=UTC
+export CCGM_DEFAULT_MODE=ask
+
+# Add a scratch preset with a space in its filename for the duration of
+# this test, so the menu-vs-presets comparison also exercises the
+# space-handling requirement. SCRATCH_PRESET_FILE is removed by the
+# script-wide cleanup() trap even if this test fails before reaching
+# its own removal below.
+scratch_preset="$REPO_ROOT/presets/zz scratch test.json"
+echo '["autonomy"]' > "$scratch_preset"
+SCRATCH_PRESET_FILE="$scratch_preset"
+
+# Expected menu = every presets/*.json basename, in the same glob order
+# start.sh iterates them in when it prints the list.
+expected10_presets=()
+for pf in "$REPO_ROOT"/presets/*.json; do
+  [ -e "$pf" ] || continue
+  expected10_presets+=("$(basename "$pf" .json)")
+done
+
+# Capture the exact arguments start.sh passes to `ui_choose "Select
+# preset" ...` via xtrace. CCGM_NON_INTERACTIVE makes ui_choose a
+# pass-through that returns options[0] without touching a tty, so this
+# is safe to run headlessly - we only need the trace to see the FULL
+# menu it was offered, not what it happened to auto-pick. (The
+# auto-picked preset, whichever one sorts first, may go on to fail
+# later in this same run for unrelated reasons - e.g. a preset that
+# includes a module with a required, unseeded placeholder - so this
+# test does not assert on the installer's overall exit code.)
+trace10="$TMPDIR/test10-trace.log"
+bash -x "$REPO_ROOT/start.sh" --scope global </dev/null >/dev/null 2>"$trace10" || true
+
+menu10_line=$(grep -m1 "ui_choose 'Select preset'" "$trace10" || true)
+if [ -n "$menu10_line" ]; then
+  pass "Captured the 'Select preset' ui_choose invocation"
+else
+  fail "Did not find a 'Select preset' ui_choose invocation in the trace"
+fi
+
+menu10_presets=()
+if [ -n "$menu10_line" ]; then
+  menu10_args_src="${menu10_line#*ui_choose }"
+  menu10_opts=()
+  eval "menu10_opts=($menu10_args_src)"
+  # First element is the prompt string ("Select preset"); the rest are
+  # the actual menu options.
+  menu10_presets=("${menu10_opts[@]:1}")
+fi
+
+if [ "${#menu10_presets[@]}" -eq "${#expected10_presets[@]}" ]; then
+  pass "Preset menu offers ${#menu10_presets[@]} options (matches presets/*.json count)"
+else
+  fail "Preset menu offers ${#menu10_presets[@]} options, expected ${#expected10_presets[@]} (${expected10_presets[*]})"
+fi
+
+menu10_match=true
+for i in "${!expected10_presets[@]}"; do
+  if [ "${menu10_presets[$i]:-}" != "${expected10_presets[$i]}" ]; then
+    menu10_match=false
+  fi
+done
+if [ "$menu10_match" = true ]; then
+  pass "Preset menu options exactly match presets/*.json basenames, in glob order (${expected10_presets[*]})"
+else
+  fail "Preset menu options (${menu10_presets[*]:-none}) do not match presets/*.json (${expected10_presets[*]})"
+fi
+
+# The exact bug #919 reported: cloud-agent is printed but not selectable.
+menu10_cloud_agent_present=false
+for opt in "${menu10_presets[@]}"; do
+  [ "$opt" = "cloud-agent" ] && menu10_cloud_agent_present=true
+done
+if [ "$menu10_cloud_agent_present" = true ]; then
+  pass "cloud-agent is present in the interactive preset menu"
+else
+  fail "cloud-agent is missing from the interactive preset menu (#919 regression)"
+fi
+
+# The scratch preset's space-bearing name must survive intact as a
+# single menu option, not get word-split.
+scratch_present=false
+for opt in "${menu10_presets[@]}"; do
+  [ "$opt" = "zz scratch test" ] && scratch_present=true
+done
+if [ "$scratch_present" = true ]; then
+  pass "A preset filename containing a space appears intact as a single menu option"
+else
+  fail "A preset filename containing a space did not appear intact in the menu (${menu10_presets[*]:-none})"
+fi
+
+# --help's preset list is a second surface with the exact same class of
+# bug (#919 follow-up): it must also be derived from presets/*.json, not
+# a second hand-maintained list. Reuses the scratch preset still in
+# place above.
+help10_out=$("$REPO_ROOT/start.sh" --help 2>&1)
+help10_line=$(echo "$help10_out" | grep -F -- "--preset <name>" || true)
+
+help10_presets=()
+if [ -n "$help10_line" ]; then
+  # Extract the parenthesized, comma-separated list, e.g.
+  # "  --preset <name>     Use preset (cloud-agent, full, minimal, ...)"
+  help10_inner="${help10_line#*\(}"
+  help10_inner="${help10_inner%\)*}"
+  help10_raw=()
+  IFS=',' read -ra help10_raw <<< "$help10_inner"
+  for help10_item in "${help10_raw[@]}"; do
+    # Trim leading/trailing whitespace left by the ", " separator.
+    help10_item="${help10_item#"${help10_item%%[![:space:]]*}"}"
+    help10_item="${help10_item%"${help10_item##*[![:space:]]}"}"
+    help10_presets+=("$help10_item")
+  done
+fi
+
+if [ -n "$help10_line" ]; then
+  pass "Found the --help '--preset <name>' line"
+else
+  fail "Did not find a '--preset <name>' line in --help output"
+fi
+
+if [ "${#help10_presets[@]}" -eq "${#expected10_presets[@]}" ]; then
+  pass "--help lists ${#help10_presets[@]} presets (matches presets/*.json count)"
+else
+  fail "--help lists ${#help10_presets[@]} presets, expected ${#expected10_presets[@]} (${expected10_presets[*]})"
+fi
+
+help10_match=true
+for i in "${!expected10_presets[@]}"; do
+  if [ "${help10_presets[$i]:-}" != "${expected10_presets[$i]}" ]; then
+    help10_match=false
+  fi
+done
+if [ "$help10_match" = true ]; then
+  pass "--help preset list exactly matches presets/*.json basenames, in glob order (${expected10_presets[*]})"
+else
+  fail "--help preset list (${help10_presets[*]:-none}) does not match presets/*.json (${expected10_presets[*]})"
+fi
+
+help10_cloud_agent_present=false
+for opt in "${help10_presets[@]}"; do
+  [ "$opt" = "cloud-agent" ] && help10_cloud_agent_present=true
+done
+if [ "$help10_cloud_agent_present" = true ]; then
+  pass "cloud-agent is present in the --help preset list"
+else
+  fail "cloud-agent is missing from the --help preset list (#919 regression)"
+fi
+
+rm -f "$scratch_preset"
+SCRATCH_PRESET_FILE=""
 echo ""
 
 # Restore HOME

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -11,9 +11,6 @@ PASS=0
 FAIL=0
 ERRORS=()
 TMPDIR=""
-# Set only while Test 8's scratch preset file exists, so cleanup() below
-# removes it even if the test fails before reaching its own removal.
-SCRATCH_PRESET_FILE=""
 
 # --- Helpers ---
 pass() {
@@ -30,9 +27,6 @@ fail() {
 cleanup() {
   if [ -n "$TMPDIR" ] && [ -d "$TMPDIR" ]; then
     rm -rf "$TMPDIR"
-  fi
-  if [ -n "$SCRATCH_PRESET_FILE" ] && [ -f "$SCRATCH_PRESET_FILE" ]; then
-    rm -f "$SCRATCH_PRESET_FILE"
   fi
 }
 trap cleanup EXIT
@@ -665,16 +659,27 @@ echo ""
 
 # ============================================================
 # Test 10: interactive preset menu and --help preset list are both
-# derived from presets/*.json (#919)
+# derived from presets/*.json via the shared list_preset_names() helper
+# (lib/modules.sh) (#919)
 #
 # Before the fix, start.sh printed every presets/*.json file but then
 # hardcoded both the ui_choose "Select preset" menu AND the --help
 # "--preset <name>" line to "minimal standard full team" - cloud-agent
 # was advertised in the printed list but unreachable from either. This
-# proves both derived lists come from the same glob that prints the
+# proves both derived lists come from the same function that prints the
 # list (so neither can diverge again), and covers the degenerate case
 # of a preset filename containing a space (the glob must not
 # word-split it into multiple entries).
+#
+# The whole test runs against an isolated scratch CCGM_ROOT under
+# $TMPDIR, not the repo's real presets/ directory: it symlinks start.sh,
+# lib/, and modules/, then builds its own presets/ (symlinks to the real
+# preset files, plus a scratch preset with a space in its name). This
+# means two concurrent runs of this suite cannot collide over the
+# scratch file, and a mid-test abort cannot leave a stray *.json in the
+# repo's committed presets/ - the scratch root is removed by the
+# existing TMPDIR cleanup() trap like everything else under $TMPDIR,
+# with no separate bookkeeping needed.
 # ============================================================
 echo "--- Test 10: interactive preset menu and --help match presets/*.json ---"
 
@@ -686,22 +691,32 @@ export CCGM_USERNAME=testuser
 export CCGM_TIMEZONE=UTC
 export CCGM_DEFAULT_MODE=ask
 
-# Add a scratch preset with a space in its filename for the duration of
-# this test, so the menu-vs-presets comparison also exercises the
-# space-handling requirement. SCRATCH_PRESET_FILE is removed by the
-# script-wide cleanup() trap even if this test fails before reaching
-# its own removal below.
-scratch_preset="$REPO_ROOT/presets/zz scratch test.json"
-echo '["autonomy"]' > "$scratch_preset"
-SCRATCH_PRESET_FILE="$scratch_preset"
-
-# Expected menu = every presets/*.json basename, in the same glob order
-# start.sh iterates them in when it prints the list.
-expected10_presets=()
+scratch_root="$TMPDIR/test10-root"
+mkdir -p "$scratch_root/presets"
+ln -s "$REPO_ROOT/start.sh" "$scratch_root/start.sh"
+ln -s "$REPO_ROOT/lib" "$scratch_root/lib"
+ln -s "$REPO_ROOT/modules" "$scratch_root/modules"
 for pf in "$REPO_ROOT"/presets/*.json; do
   [ -e "$pf" ] || continue
-  expected10_presets+=("$(basename "$pf" .json)")
+  ln -s "$pf" "$scratch_root/presets/$(basename "$pf")"
 done
+# A preset filename containing a space, present only in this test's
+# isolated presets/ - never written to the real, shared directory.
+echo '["autonomy"]' > "$scratch_root/presets/zz scratch test.json"
+
+# Expected menu = list_preset_names()'s output for the scratch root - the
+# exact same function start.sh itself calls, just pointed at the
+# isolated presets/ built above instead of the real one.
+expected10_presets=()
+(
+  CCGM_ROOT="$scratch_root"
+  # shellcheck source=../lib/modules.sh
+  source "$REPO_ROOT/lib/modules.sh"
+  list_preset_names
+) > "$TMPDIR/test10-expected.txt"
+while IFS= read -r pname; do
+  [ -n "$pname" ] && expected10_presets+=("$pname")
+done < "$TMPDIR/test10-expected.txt"
 
 # Capture the exact arguments start.sh passes to `ui_choose "Select
 # preset" ...` via xtrace. CCGM_NON_INTERACTIVE makes ui_choose a
@@ -713,7 +728,7 @@ done
 # includes a module with a required, unseeded placeholder - so this
 # test does not assert on the installer's overall exit code.)
 trace10="$TMPDIR/test10-trace.log"
-bash -x "$REPO_ROOT/start.sh" --scope global </dev/null >/dev/null 2>"$trace10" || true
+bash -x "$scratch_root/start.sh" --scope global </dev/null >/dev/null 2>"$trace10" || true
 
 menu10_line=$(grep -m1 "ui_choose 'Select preset'" "$trace10" || true)
 if [ -n "$menu10_line" ]; then
@@ -774,10 +789,10 @@ else
 fi
 
 # --help's preset list is a second surface with the exact same class of
-# bug (#919 follow-up): it must also be derived from presets/*.json, not
-# a second hand-maintained list. Reuses the scratch preset still in
-# place above.
-help10_out=$("$REPO_ROOT/start.sh" --help 2>&1)
+# bug (#919 follow-up): it must also be derived from presets/*.json (via
+# the same list_preset_names() helper), not a second hand-maintained
+# list. Reuses the isolated scratch root built above.
+help10_out=$("$scratch_root/start.sh" --help 2>&1)
 help10_line=$(echo "$help10_out" | grep -F -- "--preset <name>" || true)
 
 help10_presets=()
@@ -830,8 +845,6 @@ else
   fail "cloud-agent is missing from the --help preset list (#919 regression)"
 fi
 
-rm -f "$scratch_preset"
-SCRATCH_PRESET_FILE=""
 echo ""
 
 # Restore HOME


### PR DESCRIPTION
Closes #919

## Problem

`start.sh`'s interactive installer prints every `presets/*.json` file (all five, including `cloud-agent`) but then offered a hardcoded `ui_choose "Select preset" "minimal" "standard" "full" "team"` menu. `cloud-agent` was advertised in the printed list and unreachable from the menu - the only way to use it was `--preset cloud-agent` on the CLI. The `--help` text had the identical hardcoded list on a second surface.

## Fix (round 2: single shared source, per Stage 2 review)

The first round of this PR fixed both surfaces by giving each its own independent `presets/*.json` glob. Stage 2 review caught that this reintroduced the exact defect class #919 was filed for: two copies of "the list of presets" (menu, `--help`, and the test's own expected-list computation - three copies total) that had already started disagreeing about what an empty `presets/` means (menu: hard error; `--help`: silent fallback text).

Extracted `list_preset_names()` into `lib/modules.sh` (next to the existing `load_preset()`/`list_presets()`): prints every `presets/*.json` basename, one per line, in glob order. All three sites - the interactive menu, `--help`'s preset list, and the test suite's expected-list computation - now call this one function, so they cannot drift from each other again.

**Empty-`presets/` behavior, decided consistently**: both the menu and `--help` now treat zero presets as fatal (`exit 1`). The menu already did this; `--help`'s silent "none found in presets/" fallback is gone. This was a deliberate choice: a repo with no `presets/*.json` at all is a broken install, and `--help` silently reporting "none found" instead of erroring would mask that state rather than surface it - inconsistent with treating the identical condition as fatal one code path away. `list_preset_names()` itself prints the diagnostic to stderr and returns 1 (does not call `exit`, matching `load_preset()`'s existing convention); both call sites check for an empty result and exit.

**One shared helper serves all three sites** - no exceptions needed for this issue's own two LOW items (see below).

## Test fixture isolation (Stage 2 review, item 2)

Test 10's scratch preset (a filename with a space, used to pin the space-handling requirement) previously lived inside the repo's real, shared `presets/` directory - two concurrent suite runs could collide over the same file, and a mid-test abort could leave it behind in a committed directory.

Rebuilt around an isolated scratch `CCGM_ROOT` under `$TMPDIR`: symlinks to `start.sh`, `lib/`, `modules/`, plus its own `presets/` (symlinks to the five real preset files, plus the scratch one). The scratch root is removed by the suite's existing `TMPDIR` `cleanup()` trap along with everything else under `$TMPDIR` - no separate bookkeeping needed, so the previous `SCRATCH_PRESET_FILE` mechanism is gone too.

Verified directly: two **fully concurrent** runs of the suite (backgrounded, not just sequential) both pass cleanly at 76/0, and `ls presets/` on the real repo directory shows only the five real files throughout - both during a passing run and during a run reverted to pre-fix `start.sh` (7 failures). Also confirmed `git status` and file counts for `lib/` (8) and `modules/` (78) are unchanged after every run, to make sure the scratch root's directory *symlinks* never caused `rm -rf $TMPDIR` to touch the real directories they point at.

## Doc ordering fix (Stage 2 review, item 3)

`docs/installer.md` Step 5's illustrative preset list was in the stale curated order (`minimal, standard, full, team, cloud-agent`). Fixed to the actual alphabetical runtime order (`cloud-agent, full, minimal, standard, team`).

## Left alone (per review instruction)

- **LOW #4** - a directory literally named `*.json` under `presets/` crashes the print loop. Pre-existing, not introduced by this PR, requires a degenerate filesystem state. Out of scope.
- **LOW #5** - a preset filename containing a literal newline or comma renders wrong in `--help`'s parenthesized list. `presets/` is committed with five ordinary names; this cannot occur in a real checkout. The shared helper does not happen to fix this for free, so no special-casing was added.

## Test: red-then-green proof (re-run against the final, fully-rebased tree)

`tests/test-installer.sh` Test 10 runs the installer non-interactively against the isolated scratch root with no `--preset` flag (so it takes the "choose a preset" branch), captures the exact arguments passed to `ui_choose "Select preset" ...` via `bash -x` xtrace, and separately captures `--help`'s `--preset <name>` line. Both are asserted to exactly equal `list_preset_names()`'s output for the scratch root, computed by calling the same function - not a second glob.

**Red** (`start.sh` reverted to the merge-base with `origin/main`, before any of this PR's commits):

```
--- Test 10: interactive preset menu and --help match presets/*.json ---
  PASS: Captured the 'Select preset' ui_choose invocation
  FAIL: Preset menu offers 4 options, expected 6 (cloud-agent full minimal standard team zz scratch test)
  FAIL: Preset menu options (minimal standard full team) do not match presets/*.json (cloud-agent full minimal standard team zz scratch test)
  FAIL: cloud-agent is missing from the interactive preset menu (#919 regression)
  FAIL: A preset filename containing a space did not appear intact in the menu (minimal standard full team)
  PASS: Found the --help '--preset <name>' line
  FAIL: --help lists 4 presets, expected 6 (cloud-agent full minimal standard team zz scratch test)
  FAIL: --help preset list (minimal standard full team) does not match presets/*.json (cloud-agent full minimal standard team zz scratch test)
  FAIL: cloud-agent is missing from the --help preset list (#919 regression)

===================================
  Results: 69 passed, 7 failed
===================================
```

**Green** (fix restored):

```
--- Test 10: interactive preset menu and --help match presets/*.json ---
  PASS: Captured the 'Select preset' ui_choose invocation
  PASS: Preset menu offers 6 options (matches presets/*.json count)
  PASS: Preset menu options exactly match presets/*.json basenames, in glob order (cloud-agent full minimal standard team zz scratch test)
  PASS: cloud-agent is present in the interactive preset menu
  PASS: A preset filename containing a space appears intact as a single menu option
  PASS: Found the --help '--preset <name>' line
  PASS: --help lists 6 presets (matches presets/*.json count)
  PASS: --help preset list exactly matches presets/*.json basenames, in glob order (cloud-agent full minimal standard team zz scratch test)
  PASS: cloud-agent is present in the --help preset list

===================================
  Results: 76 passed, 0 failed
===================================
```

## Rebase history

Rebased onto `origin/main` five times across this PR's review as unrelated PRs merged mid-review: `#936` (`--default` flag - the PR this issue's original round had to coexist with), `#934` (orrery module), `#942` (code-quality module), and most recently `#937` (CI enumeration coverage for `tests/test-modules.sh` and `.github/workflows/test.yml`, neither of which this PR touches). Every rebase after the first was a clean, no-conflict fast-forward-style replay; verified each time via `git diff origin/main --stat` (exactly the intended files) and a `grep` for conflict markers and stale variable names across every touched file.

## Gates (fresh, post-rebase, run twice for the collision case)

```
$ bash tests/test-installer.sh 2>&1 | tail -5   # run 1
  PASS: cloud-agent is present in the --help preset list
===================================
  Results: 76 passed, 0 failed
===================================

$ bash tests/test-installer.sh 2>&1 | tail -5   # run 2, same tree
  PASS: cloud-agent is present in the --help preset list
===================================
  Results: 76 passed, 0 failed
===================================

$ bash tests/test-modules.sh 2>&1 | tail -5
--- Checking CI enumeration coverage (test.yml) ---
===================================
  Results: 1702 passed, 0 failed
===================================

$ bash tests/test-no-personal-data.sh 2>&1 | tail -3
PASS: No personal data or secret/PII shapes found

$ bash tests/test-doc-counts.sh 2>&1 | tail -3
test-doc-counts.sh: all checks passed

$ /bin/bash -n start.sh && echo OK
OK
```

Note on #943: a separate, known-intermittent `printf | grep -q` EPIPE flake in `tests/test-modules.sh` under `pipefail` is being fixed in another PR. Not observed in any of the runs above; if it appears on a CI retry, it is not from this PR.