### PR TITLE
#931: replace the bash-4 lowercase expansion in ui_confirm and relax the documented bash floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For blocks pre-selecting a specific preset, and for how to dry-run this safely, 
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`npm install -g @anthropic-ai/claude-code`)
 - macOS or Linux
-- bash 3.2+ or zsh
+- bash 3.2+ (the installer scripts always run under bash via their shebang, regardless of your login shell)
 - git
 - python3
 - jq

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For blocks pre-selecting a specific preset, and for how to dry-run this safely, 
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`npm install -g @anthropic-ai/claude-code`)
 - macOS or Linux
-- bash 4+ or zsh
+- bash 3.2+ or zsh
 - git
 - python3
 - jq

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ CCGM requires:
 
 - **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** - the CLI tool from Anthropic (`npm install -g @anthropic-ai/claude-code`)
 - **macOS or Linux** - Windows is not supported
-- **bash 3.2+** or **zsh**
+- **bash 3.2+** - the installer scripts always run under bash via their shebang; your login shell can be zsh, that only affects which rc file the alias-installer feature touches
 - **git** - for cloning and version tracking
 - **Python 3** - hooks are written in Python
 - **jq** - for JSON manipulation during settings merge

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ CCGM requires:
 
 - **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** - the CLI tool from Anthropic (`npm install -g @anthropic-ai/claude-code`)
 - **macOS or Linux** - Windows is not supported
-- **bash 4+** or **zsh**
+- **bash 3.2+** or **zsh**
 - **git** - for cloning and version tracking
 - **Python 3** - hooks are written in Python
 - **jq** - for JSON manipulation during settings merge
@@ -66,7 +66,7 @@ CCGM can install to either or both of two locations:
 |-------|------|--------|
 | **Global** | `~/.claude/` | Applies to all projects and all Claude Code environments |
 | **Project** | `.claude/` in current directory | Applies only to the current project |
-| **Both** | Both paths above | Installs to both locations |
+| **Both** | Both paths above | Applies everywhere, plus a project-level copy in the current repo |
 
 ```bash
 ./start.sh                    # Interactive scope selection

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -48,7 +48,7 @@ Choose a preset (the menu lists every file under `presets/`, alphabetically: clo
 
 Automatically adds any modules required by your selection. Uses a depth-first topological sort with cycle detection. Reports any automatically added dependencies.
 
-For example, selecting `xplan` automatically adds its dependencies `multi-agent` and `adversarial-review`, which in turn add `startup-dashboard` (multi-agent's dependency) and `subagent-patterns` (adversarial-review's dependency), and `startup-dashboard` in turn adds `session-history`.
+For example, selecting `xplan` automatically adds its dependencies `multi-agent` and `adversarial-review`, which in turn add `startup-dashboard` (multi-agent's dependency) and `subagent-patterns` (adversarial-review's dependency). `startup-dashboard` then adds `session-history`.
 
 ### Step 7: Module config prompts
 

--- a/docs/project-story.md
+++ b/docs/project-story.md
@@ -301,7 +301,7 @@ Every one of these produced a durable control, not just a fix:
 
 ## Third-Party Tools & Integrations
 
-**Hard requirements**: Claude Code, git, bash 3.2+/zsh, python3 (stdlib only — no pip dependencies anywhere in the hook/lib layer), jq.
+**Hard requirements**: Claude Code, git, bash 3.2+ (the installer scripts always run under bash via their shebang, regardless of login shell), python3 (stdlib only — no pip dependencies anywhere in the hook/lib layer), jq.
 
 **Optional, per-module**: `gh` (GitHub CLI), launchd (macOS scheduling for autoheal/dreaming), tmux (agent panes), yt-dlp (transcripts), Resend (email digests), Hetzner Cloud + Terraform + Packer (cloud dispatch), Go + Bubble Tea (the deprecated agent-manager TUI), Playwright + a Chrome extension MCP + WebMCP (browser automation tiers), Exa MCP (semantic research), Docker + Ollama + SearXNG (the separate deep-research companion), and the Anthropic Messages API (background analyzers, via curl).
 

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -71,10 +71,12 @@ ui_confirm() {
   else
     yn_hint="[y/N]"
   fi
+  local answer_lower
   while true; do
     echo -en "${UI_CYAN}? ${UI_RESET}${UI_BOLD}$prompt${UI_RESET} $yn_hint "
     read -r answer
-    case "${answer,,}" in
+    answer_lower=$(echo "$answer" | tr '[:upper:]' '[:lower:]')
+    case "$answer_lower" in
       y|yes) return 0 ;;
       n|no) return 1 ;;
       "")

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -71,14 +71,18 @@ ui_confirm() {
   else
     yn_hint="[y/N]"
   fi
-  local answer_lower
   while true; do
     echo -en "${UI_CYAN}? ${UI_RESET}${UI_BOLD}$prompt${UI_RESET} $yn_hint "
     read -r answer
-    answer_lower=$(echo "$answer" | tr '[:upper:]' '[:lower:]')
-    case "$answer_lower" in
-      y|yes) return 0 ;;
-      n|no) return 1 ;;
+    # Case-insensitive match via bracket expressions per character, not
+    # ${answer,,} (bash 4+) or a `tr`/subshell round-trip - the latter
+    # runs the answer through bash's builtin `echo`, which flag-parses a
+    # literal "-n" or "-e" answer into empty output, silently taking the
+    # default instead of rejecting the input. This form forks nothing
+    # (ui_confirm runs in a prompt loop) and needs no bash-4 feature.
+    case "$answer" in
+      [Yy]|[Yy][Ee][Ss]) return 0 ;;
+      [Nn]|[Nn][Oo]) return 1 ;;
       "")
         if [ "$default" = "yes" ]; then return 0; else return 1; fi
         ;;

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -898,6 +898,43 @@ if [ -x /bin/bash ]; then
     fail "ui_confirm under /bin/bash did not confirm mixed-case 'YES': $mixed_out"
   fi
 
+  # A literal "-n" or "-e" answer must be REJECTED (re-prompt), not
+  # silently accepted as empty input -> the default. Piping the invalid
+  # answer followed by a real one, with a default that would produce a
+  # DIFFERENT result than the real answer, distinguishes "took the
+  # default on the first read" (bug) from "re-prompted, then read the
+  # real answer" (correct): if the bug were present, the invalid answer
+  # would resolve to the default before the second line is ever read.
+  set +e
+  dashn_out=$(printf -- '-n\nyes\n' | /bin/bash -c \
+    "source '$REPO_ROOT/lib/ui.sh'; ui_confirm 'Proceed?' 'no' && echo CONFIRMED || echo DECLINED" 2>&1)
+  set -e
+  if echo "$dashn_out" | grep -q "Please answer yes or no"; then
+    pass "ui_confirm under /bin/bash re-prompts on a literal '-n' answer instead of silently taking the default"
+  else
+    fail "ui_confirm under /bin/bash did not re-prompt on '-n' (silently took the default): $dashn_out"
+  fi
+  if echo "$dashn_out" | grep -q "CONFIRMED"; then
+    pass "ui_confirm under /bin/bash accepts the real answer ('yes') after rejecting '-n'"
+  else
+    fail "ui_confirm under /bin/bash did not resolve to the real answer after '-n': $dashn_out"
+  fi
+
+  set +e
+  dashe_out=$(printf -- '-e\nno\n' | /bin/bash -c \
+    "source '$REPO_ROOT/lib/ui.sh'; ui_confirm 'Proceed?' 'yes' && echo CONFIRMED || echo DECLINED" 2>&1)
+  set -e
+  if echo "$dashe_out" | grep -q "Please answer yes or no"; then
+    pass "ui_confirm under /bin/bash re-prompts on a literal '-e' answer instead of silently taking the default"
+  else
+    fail "ui_confirm under /bin/bash did not re-prompt on '-e' (silently took the default): $dashe_out"
+  fi
+  if echo "$dashe_out" | grep -q "DECLINED"; then
+    pass "ui_confirm under /bin/bash accepts the real answer ('no') after rejecting '-e'"
+  else
+    fail "ui_confirm under /bin/bash did not resolve to the real answer after '-e': $dashe_out"
+  fi
+
   export CCGM_NON_INTERACTIVE=1
 else
   echo "  SKIP: /bin/bash not present on this system"
@@ -912,10 +949,12 @@ echo ""
 # and missing-files arrays into _install_missing. Namerefs are bash
 # 4.3+; under bash 3.2 `local -n` is a hard "invalid option" abort. The
 # fix shares script-scope globals between _check_installed_drift and
-# _install_missing instead (the same convention start.sh already uses
-# for SELECTED_MODULES). update.sh now guards its `main "$@"` call with
-# a BASH_SOURCE-vs-$0 check so this test can source it directly (no
-# live git fetch, no interactive flow) and drive the real code path.
+# _install_missing instead - _install_missing only ever reads these
+# arrays, never writes them back, so a plain global is simpler than any
+# form of indirection would be. update.sh now guards its `main "$@"`
+# call with a BASH_SOURCE-vs-$0 check so this test can source it
+# directly (no live git fetch, no interactive flow) and drive the real
+# code path.
 # ============================================================
 echo "--- Test 12: update.sh _install_missing under real /bin/bash (#931 nameref regression) ---"
 

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -847,6 +847,140 @@ fi
 
 echo ""
 
+# ============================================================
+# Test 11: ui_confirm under real /bin/bash (#931 regression)
+#
+# ${answer,,} is a bash-4 parameter expansion; under bash 3.2 (macOS's
+# system /bin/bash) it is a hard abort ("bad substitution") mid-function,
+# so ui_confirm never returns and NEITHER branch of a
+# `ui_confirm ... && ... || ...` caller runs - `bash -n` does not catch
+# this, because the expansion parses fine and only fails at expansion
+# time. This drives the real interactive path (CCGM_NON_INTERACTIVE
+# unset) under /bin/bash explicitly - not whatever bash resolves to on
+# $PATH, which may be a newer Homebrew bash on a dev machine.
+# ============================================================
+echo "--- Test 11: ui_confirm under real /bin/bash (#931 regression) ---"
+
+if [ -x /bin/bash ]; then
+  unset CCGM_NON_INTERACTIVE
+
+  set +e
+  confirm_out=$(printf 'yes\n' | /bin/bash -c \
+    "source '$REPO_ROOT/lib/ui.sh'; ui_confirm 'Proceed?' && echo CONFIRMED || echo DECLINED" 2>&1)
+  set -e
+  if echo "$confirm_out" | grep -q "bad substitution"; then
+    fail "ui_confirm under /bin/bash hit a bash-4 'bad substitution' abort (answer: yes): $confirm_out"
+  elif echo "$confirm_out" | grep -q "CONFIRMED"; then
+    pass "ui_confirm under /bin/bash returns confirmed for 'yes'"
+  else
+    fail "ui_confirm under /bin/bash did not confirm 'yes': $confirm_out"
+  fi
+
+  set +e
+  decline_out=$(printf 'no\n' | /bin/bash -c \
+    "source '$REPO_ROOT/lib/ui.sh'; ui_confirm 'Proceed?' && echo CONFIRMED || echo DECLINED" 2>&1)
+  set -e
+  if echo "$decline_out" | grep -q "bad substitution"; then
+    fail "ui_confirm under /bin/bash hit a bash-4 'bad substitution' abort (answer: no): $decline_out"
+  elif echo "$decline_out" | grep -q "DECLINED"; then
+    pass "ui_confirm under /bin/bash returns declined for 'no'"
+  else
+    fail "ui_confirm under /bin/bash did not decline 'no': $decline_out"
+  fi
+
+  set +e
+  mixed_out=$(printf 'YES\n' | /bin/bash -c \
+    "source '$REPO_ROOT/lib/ui.sh'; ui_confirm 'Proceed?' && echo CONFIRMED || echo DECLINED" 2>&1)
+  set -e
+  if echo "$mixed_out" | grep -q "CONFIRMED"; then
+    pass "ui_confirm under /bin/bash lowercases mixed-case 'YES' before matching"
+  else
+    fail "ui_confirm under /bin/bash did not confirm mixed-case 'YES': $mixed_out"
+  fi
+
+  export CCGM_NON_INTERACTIVE=1
+else
+  echo "  SKIP: /bin/bash not present on this system"
+fi
+echo ""
+
+# ============================================================
+# Test 12: update.sh's _install_missing under real /bin/bash (#931
+# nameref regression)
+#
+# update.sh:132-133 used `local -n` namerefs to pass the missing-modules
+# and missing-files arrays into _install_missing. Namerefs are bash
+# 4.3+; under bash 3.2 `local -n` is a hard "invalid option" abort. The
+# fix shares script-scope globals between _check_installed_drift and
+# _install_missing instead (the same convention start.sh already uses
+# for SELECTED_MODULES). update.sh now guards its `main "$@"` call with
+# a BASH_SOURCE-vs-$0 check so this test can source it directly (no
+# live git fetch, no interactive flow) and drive the real code path.
+# ============================================================
+echo "--- Test 12: update.sh _install_missing under real /bin/bash (#931 nameref regression) ---"
+
+if [ -x /bin/bash ]; then
+  UPDATE_TEST_HOME="$TMPDIR/test12-update-home"
+  mkdir -p "$UPDATE_TEST_HOME/.claude"
+  cat > "$UPDATE_TEST_HOME/.claude/.ccgm-manifest.json" <<'MANIFEST_EOF'
+{
+  "preset": "minimal",
+  "scope": "global",
+  "linkMode": false,
+  "modules": ["global-claude-md", "autonomy"],
+  "files": []
+}
+MANIFEST_EOF
+
+  set +e
+  update_out=$(HOME="$UPDATE_TEST_HOME" CCGM_NON_INTERACTIVE=1 /bin/bash -c \
+    "source '$REPO_ROOT/update.sh'; _check_installed_drift" 2>&1)
+  update_exit=$?
+  set -e
+
+  if echo "$update_out" | grep -qE "invalid option|bad substitution"; then
+    fail "update.sh's _install_missing hit a bash-4-only construct under /bin/bash: $update_out"
+  elif [ $update_exit -ne 0 ]; then
+    fail "update.sh's _check_installed_drift/_install_missing exited $update_exit under /bin/bash: $update_out"
+  else
+    pass "update.sh's _check_installed_drift/_install_missing ran clean under /bin/bash"
+  fi
+
+  # "minimal" preset (presets/minimal.json) is ["global-claude-md",
+  # "autonomy", "git-workflow"]; the manifest above installs the first
+  # two, so git-workflow is the missing module _install_missing must
+  # pull in - exercising the "install files from missing modules" loop.
+  if [ -f "$UPDATE_TEST_HOME/.claude/rules/git-workflow.md" ]; then
+    pass "missing module (git-workflow) installed by _install_missing"
+  else
+    fail "missing module (git-workflow) was not installed"
+  fi
+
+  # global-claude-md and autonomy are already "installed" per the
+  # manifest but have no files on disk in this fresh fake HOME, so their
+  # files are detected as missing too - exercising the "fix missing
+  # files in already-installed modules" loop.
+  if [ -f "$UPDATE_TEST_HOME/.claude/CLAUDE.md" ] && \
+     [ -f "$UPDATE_TEST_HOME/.claude/rules/autonomy.md" ] && \
+     [ -f "$UPDATE_TEST_HOME/.claude/rules/confusion-protocol.md" ]; then
+    pass "missing files in already-installed modules installed by _install_missing"
+  else
+    fail "missing files in already-installed modules were not all installed"
+  fi
+
+  if command -v jq &>/dev/null; then
+    manifest_modules=$(jq -c '.modules | sort' "$UPDATE_TEST_HOME/.claude/.ccgm-manifest.json" 2>/dev/null)
+    if [ "$manifest_modules" = '["autonomy","git-workflow","global-claude-md"]' ]; then
+      pass "manifest updated with the newly installed module (git-workflow)"
+    else
+      fail "manifest modules after install were '$manifest_modules', expected git-workflow added"
+    fi
+  fi
+else
+  echo "  SKIP: /bin/bash not present on this system"
+fi
+echo ""
+
 # Restore HOME
 export HOME="$TMPDIR/home"
 

--- a/update.sh
+++ b/update.sh
@@ -36,9 +36,11 @@ _check_installed_drift() {
 
   # --- Check 1: Missing modules (in preset but not installed) ---
   # missing_modules/missing_files are intentionally NOT `local`: bash 3.2 has
-  # no namerefs (local -n / declare -n are bash 4.3+), so they are shared
-  # script-scope globals that _install_missing reads directly below - the
-  # same convention start.sh already uses for SELECTED_MODULES.
+  # no namerefs (local -n / declare -n are bash 4.3+). _install_missing below
+  # only ever READS these arrays - it never writes them back - so there is
+  # nothing for a nameref to buy here; a plain script-scope global shared
+  # between this function and _install_missing is simpler than any form of
+  # indirection would be.
   missing_modules=()
   if [ "$preset" != "custom" ] && [ -f "${CCGM_ROOT}/presets/${preset}.json" ]; then
     local preset_modules installed_modules
@@ -132,10 +134,11 @@ _check_installed_drift() {
 # Helper: Install missing modules and files
 #
 # Reads the missing_modules/missing_files arrays set by
-# _check_installed_drift above. No indirection (local -n / declare -n)
-# is used here - namerefs are bash 4.3+, and this installer's floor is
-# bash 3.2. Sharing script-scope globals between these two helpers is
-# the same convention start.sh uses for SELECTED_MODULES.
+# _check_installed_drift above (script-scope globals, not `local` -
+# see the comment there). No indirection (local -n / declare -n) is
+# used here - namerefs are bash 4.3+, and this installer's floor is
+# bash 3.2. This function only reads missing_modules/missing_files, so
+# a plain shared global is simpler than any indirection would be.
 # ============================================================
 _install_missing() {
   local link_mode="$1"

--- a/update.sh
+++ b/update.sh
@@ -35,7 +35,11 @@ _check_installed_drift() {
   local drift_count=0
 
   # --- Check 1: Missing modules (in preset but not installed) ---
-  local missing_modules=()
+  # missing_modules/missing_files are intentionally NOT `local`: bash 3.2 has
+  # no namerefs (local -n / declare -n are bash 4.3+), so they are shared
+  # script-scope globals that _install_missing reads directly below - the
+  # same convention start.sh already uses for SELECTED_MODULES.
+  missing_modules=()
   if [ "$preset" != "custom" ] && [ -f "${CCGM_ROOT}/presets/${preset}.json" ]; then
     local preset_modules installed_modules
     preset_modules=$(jq -r '.[]' "${CCGM_ROOT}/presets/${preset}.json" 2>/dev/null | sort)
@@ -60,7 +64,7 @@ _check_installed_drift() {
   # --- Check 2: Missing files in installed modules ---
   local installed_modules
   installed_modules=$(jq -r '.modules[]?' "$manifest" 2>/dev/null)
-  local missing_files=()
+  missing_files=()
 
   while IFS= read -r mod; do
     [ -z "$mod" ] && continue
@@ -117,7 +121,7 @@ _check_installed_drift() {
   if [ ${#missing_modules[@]} -gt 0 ] || [ ${#missing_files[@]} -gt 0 ]; then
     echo ""
     if ui_confirm "Install missing modules/files now?"; then
-      _install_missing "$link_mode" missing_modules missing_files
+      _install_missing "$link_mode"
     else
       ui_info "Run ./start.sh to do a full reinstall"
     fi
@@ -126,15 +130,19 @@ _check_installed_drift() {
 
 # ============================================================
 # Helper: Install missing modules and files
+#
+# Reads the missing_modules/missing_files arrays set by
+# _check_installed_drift above. No indirection (local -n / declare -n)
+# is used here - namerefs are bash 4.3+, and this installer's floor is
+# bash 3.2. Sharing script-scope globals between these two helpers is
+# the same convention start.sh uses for SELECTED_MODULES.
 # ============================================================
 _install_missing() {
   local link_mode="$1"
-  local -n _missing_mods=$2
-  local -n _missing_files=$3
   local installed_count=0
 
   # Install files from missing modules
-  for mod in ${_missing_mods[@]+"${_missing_mods[@]}"}; do
+  for mod in ${missing_modules[@]+"${missing_modules[@]}"}; do
     ui_info "Installing module: $mod"
     while IFS='|' read -r src target type template merge; do
       local full_src="${CCGM_ROOT}/modules/${mod}/${src}"
@@ -162,13 +170,13 @@ _install_missing() {
   done
 
   # Fix missing/unsymlinked files in already-installed modules
-  for entry in ${_missing_files[@]+"${_missing_files[@]}"}; do
+  for entry in ${missing_files[@]+"${missing_files[@]}"}; do
     local mod="${entry%%:*}"
     local target="${entry#*:}"
 
     # Skip if this module was just fully installed above
     local already_done=false
-    for m in ${_missing_mods[@]+"${_missing_mods[@]}"}; do
+    for m in ${missing_modules[@]+"${missing_modules[@]}"}; do
       [ "$m" = "$mod" ] && already_done=true
     done
     [ "$already_done" = true ] && continue
@@ -194,18 +202,18 @@ _install_missing() {
   done
 
   # Update manifest with newly installed modules
-  if [ ${#_missing_mods[@]} -gt 0 ]; then
+  if [ ${#missing_modules[@]} -gt 0 ]; then
     local manifest="${HOME}/.claude/.ccgm-manifest.json"
     local tmp_manifest
     tmp_manifest=$(mktemp)
 
     # Add missing modules to the modules array
     local new_modules_json
-    new_modules_json=$(printf '%s\n' "${_missing_mods[@]}" | jq -R . | jq -s .)
+    new_modules_json=$(printf '%s\n' "${missing_modules[@]}" | jq -R . | jq -s .)
     jq --argjson new "$new_modules_json" '.modules = (.modules + $new | unique)' "$manifest" > "$tmp_manifest"
 
     # Add new file paths to the files array
-    for mod in "${_missing_mods[@]}"; do
+    for mod in "${missing_modules[@]}"; do
       while IFS='|' read -r src target type template merge; do
         [ "$merge" = "true" ] && continue
         local full_target="${HOME}/.claude/${target}"
@@ -215,7 +223,7 @@ _install_missing() {
     done
 
     mv "$tmp_manifest" "$manifest"
-    ui_success "Updated manifest with ${#_missing_mods[@]} new module(s)"
+    ui_success "Updated manifest with ${#missing_modules[@]} new module(s)"
   fi
 
   echo ""
@@ -403,4 +411,10 @@ main() {
   _offer_reinstall
 }
 
-main "$@"
+# Only run main when executed directly (./update.sh, bash update.sh) - not
+# when sourced (tests/test-installer.sh sources this file to drive
+# _check_installed_drift/_install_missing directly, bash-3.2-only, without
+# triggering a live git fetch or the rest of the interactive flow).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi


### PR DESCRIPTION
Closes #931

## The bug (Part 1)

`lib/ui.sh:77` lowercased the user's answer with `${answer,,}`, a bash-4 parameter expansion. Under macOS's system `/bin/bash` (3.2.57) that expansion is a fatal error, and the failure kills `ui_confirm` mid-function - neither branch of its caller runs. `ui_confirm` has 13 call sites across `start.sh`, `update.sh`, `uninstall.sh`, including `start.sh:1035` ("Proceed with installation?"), on the default interactive path. `bash -n` does not catch it; the expansion parses fine and only fails at expansion time.

## Stage-1 finding: a second bash-4 construct in update.sh (Part 2)

`update.sh:132-133`'s `_install_missing` used `local -n` namerefs (bash 4.3+) to receive arrays from `_check_installed_drift`; under real `/bin/bash` 3.2.57 that's a hard `local: -n: invalid option` abort, on `update.sh`'s default interactive path. Fixed by sharing script-scope globals between the two functions instead (they're only ever read by `_install_missing`, never written back, so no indirection is needed). `update.sh`'s trailing `main "$@"` is now guarded (`BASH_SOURCE` vs `$0`) so a test can source the file and drive the real code path without a live git fetch.

## Stage-2 findings, this round (3 CONFIRMED, all closed)

**1. `lib/ui.sh` - the `tr` fix silently ate a literal `-n`/`-e` answer.** `echo "$answer" | tr ...` runs the answer through bash's builtin `echo`, which flag-parses `-n`/`-e` into empty output - confirmed with a hex dump under real `/bin/bash` 3.2.57. A user typing `-n` at a prompt got an empty lowercased answer, which `ui_confirm`'s `case` treated as empty input -> the default, instead of an invalid answer that re-prompts.

Fixed by dropping the `tr`/subshell round-trip entirely: `ui_confirm` now matches case-insensitively via bracket-expression patterns (`[Yy]|[Yy][Ee][Ss]`, `[Nn]|[Nn][Oo]`) directly in the `case` statement - no external `tr`/`echo`, no subshell fork per prompt-loop iteration, no bash-4 feature. Verified under real `/bin/bash` 3.2.57 that `-n` and `-e` are now rejected and re-prompt, and the subsequent real answer is read correctly. Added test cases to `tests/test-installer.sh` Test 11.

Grepped the repo for the same `echo "$var" | tr` shape outside this fix's scope - **not fixed here, reporting for a follow-up**:

| File | Line(s) | Variable |
|---|---|---|
| `modules/cloud-dispatch/lib/workspace-setup-all.sh` | 204-205 | issue title |
| `modules/cloud-dispatch/lib/workspace-assign.sh` | 82-83 | issue title |
| `modules/cloud-dispatch/lib/workspace-setup-all.sh` | 132, 171 | issue number (`tr -d` variant) |
| `modules/cloud-dispatch/lib/budget-track.sh` | 81 | `$1` |
| `modules/brand-naming/lib/brand-check-gather.sh` | 13 | brand name |
| `modules/commands-extra/commands/checkpoint.md` | 55 | checkpoint title |
| `modules/commands-extra/skills/audit/tests/test-diff-mode.sh` | 223 | paths list (`tr '\n' '|'` variant) |

Checked and **not vulnerable in practice** (already `printf`-based, or the input can't start with `-`): `modules/agent-manager/postInstall.sh:19` (`uname -s | tr`, no `echo` at all), `modules/youtube-transcripts/lib/grab-transcript.sh:169-170` and `modules/orrery/skills/orrery/scripts/anchor_repo.sh:63-64` (both already `printf '%s' "$1"`), `modules/cloud-dispatch/lib/agent-status.sh:120` (ssh output piped through `tr`, not `echo` of a variable).

**2. `update.sh` - the `SELECTED_MODULES` precedent comment was inaccurate.** My comments cited `start.sh`'s `SELECTED_MODULES` as precedent for the cross-function global. Verified: `SELECTED_MODULES` is set and read entirely within `start.sh`'s single `main()` function (grep confirms every reference is inside that one function) - not an instance of the cross-function pattern I was citing it to justify. Reworded both comments (`update.sh` and the matching `tests/test-installer.sh` Test 12 comment) to justify the choice on its own terms: `_install_missing` only ever reads `missing_modules`/`missing_files`, so a plain global is simpler than any indirection - no precedent claim needed.

**3. `README.md`/`docs/getting-started.md` - the "or zsh" half of the floor claim was false.** Every entry point (`start.sh`, `update.sh`, `uninstall.sh`) carries a `#!/usr/bin/env bash` shebang, so bash is always the interpreter and zsh never is - a machine with zsh and no bash could not run `./start.sh` at all. Fixed both files to say what's true: the scripts always run under bash via their shebang, and a zsh login shell only affects which rc file the optional alias-installer feature touches. Grepped `docs/` for the same claim and found a third occurrence in `docs/project-story.md`'s "Hard requirements" line (pre-existing, untouched by this PR's earlier commits) - fixed it the same way. The one remaining zsh reference (`docs/installer.md:98`, the alias-installer's `~/.zshrc`/`~/.bashrc` choice) is genuinely about the user's login shell, not the interpreter, and is correct as written.

## Broadened bash-4+ construct scan

Re-scanned `start.sh`, `update.sh`, `uninstall.sh`, `lib/*.sh`:

| Construct | Result |
|---|---|
| `local -n` / `declare -n` (namerefs) | Fixed (this PR) |
| `declare -A` / `typeset -A` | None |
| `mapfile` / `readarray` | None |
| `${var,,}` / `${var^^}` / `${var@Q}` | Fixed (this PR) |
| `&>>`, `wait -n`, `printf '%()T'`, `coproc`, globstar/`**`, `;;&`/`;&`, `declare -g`, `EPOCHSECONDS`/`SRANDOM` | None |
| `[[ ... =~ ... ]]` with `BASH_REMATCH` | Two `=~` matches in `lib/modules.sh` (no `BASH_REMATCH` consumption); verified working under real bash 3.2.57 |

`lib/template.sh:24` already carries an explicit bash-3.2 workaround.

## Verification (real `/bin/bash` 3.2.57, not `bash -n` alone)

```
/bin/bash -n start.sh update.sh uninstall.sh lib/*.sh   # exit 0
bash tests/test-installer.sh                              # 87 passed, 0 failed
/bin/bash tests/test-installer.sh                         # 87 passed, 0 failed
/bin/bash tests/test-merge.sh                              # 16 passed, 0 failed
/bin/bash tests/test-templates.sh                          # 22 passed, 0 failed
/bin/bash tests/test-backup.sh                              # 28 passed, 0 failed
bash tests/test-modules.sh                                 # 1702 passed, 0 failed
bash tests/test-no-personal-data.sh                        # PASS
bash tests/test-doc-counts.sh                              # all checks passed
```

`ui_choose`'s arrow-key path reads `/dev/tty` directly and can't be driven headlessly; covered by the static scan instead. No interactive terminal session was opened at any point.

**Floor relaxed: yes**, on the evidence above. `README.md` and `docs/getting-started.md` state the floor accurately (bash 3.2+, always the interpreter regardless of login shell).

## Prose nits (PR #921 Stage-2 review)

- `docs/installer.md` Step 6 - fixed the doubled "in turn" in the dependency-chain sentence.
- `docs/getting-started.md` scopes table - the `Both` row's Effect cell now informs instead of restating "both" three times.

## Aging issue references

| Issue | State | Doc reference | Action |
|-------|-------|----------------|--------|
| #917 | OPEN | `docs/installer.md:67` | Left alone |
| #919 | CLOSED (by #939, after this PR flagged it as open) | `docs/getting-started.md` | #939's own commit removed this reference as part of its fix |
| #918 | CLOSED | none found | Nothing to remove - already cleaned up by #936 |
| #930 | CLOSED | none found | Nothing to remove - already cleaned up by #933 |

## Rebase note

Rebased twice onto `origin/main`: once through #935/#937 (CI-enumeration guard) and #941, and again through #939 (`#919: derive the interactive preset menu from presets/`), which landed its own Test 10 in `tests/test-installer.sh`. This branch's tests are renumbered to Test 11 and Test 12 to follow it - the whole file was re-read end to end after both rebases to confirm no duplicated, orphaned, or misnumbered block survived (one such collision was caught and fixed mid-round: a stray "Test 11" label left on the `update.sh` block after the first renumbering pass).

`start.sh` is untouched by this PR - the broadened bash-4 scan found nothing there.

## Scope

Did not touch `lib/backup.sh`, `tests/test-backup.sh`, `tests/test-modules.sh`, `modules/**`, or `.github/workflows/**` - ran their tests, didn't edit them. The `echo | tr` sites found elsewhere in the repo (table above) are reported, not fixed, per this round's explicit scope instruction.
