### PR TITLE
#941: code-quality — simplest-implementation principle, dependency ladder, no backward-compat shims

### DIFF
--- a/modules/code-quality/README.md
+++ b/modules/code-quality/README.md
@@ -6,6 +6,9 @@ Code standards, testing requirements, error handling patterns, security practice
 
 This module installs a rules file that instructs Claude to:
 
+- Choose the simplest implementation that fully meets the current requirements, rather than building for requirements that do not exist yet
+- Climb the dependency ladder deliberately: built-in first, then an established library, and hand-rolled code only when neither fits
+- Delete backward-compatibility shims and migrate callers instead of keeping old shapes alive
 - Follow consistent code standards (environment variables, database migrations, dependencies, component patterns, path aliases)
 - Write tests for new features, edge cases, bug fixes, and complex logic
 - Apply structured error handling patterns for both frontend and backend
@@ -43,8 +46,8 @@ cp rules/menu-gen-test.md .claude/rules/menu-gen-test.md
 
 | File | Description |
 |------|-------------|
-| `rules/code-quality.md` | Rule file covering code standards, testing, error handling, security, build verification, and living documents |
-| `rules/change-philosophy.md` | Rule file on elegant integration: redesign existing systems rather than bolting on |
+| `rules/code-quality.md` | Rule file covering the simplest-implementation principle, the dependency ladder (built-in > established library > custom implementation), code standards, testing, error handling, security, build verification, and living documents |
+| `rules/change-philosophy.md` | Rule file on elegant integration: redesign existing systems rather than bolting on, and delete backward-compatibility shims rather than preserving old shapes |
 | `rules/latent-vs-deterministic.md` | Rule file on classifying work as latent (judgment) vs deterministic (scripts) and pushing deterministic steps into code |
 | `rules/completeness.md` | Rule file on the Boil-the-Lake completeness principle and scoring rubric |
 | `rules/receiving-code-review.md` | Rule file on receiving code review feedback: verify before implementing, push back with evidence, no sycophantic agreement |

--- a/modules/code-quality/rules/change-philosophy.md
+++ b/modules/code-quality/rules/change-philosophy.md
@@ -11,12 +11,65 @@ When making changes to an existing system, do not patch, bolt on, or work around
 - Refactor toward that ideal rather than adding layers of special cases
 - The result should look like it was always designed this way
 
+## Do Not Preserve Backward Compatibility
+
+Compatibility shims are how "bolted on" happens. The shim *is* the special case: a second code path, kept alive so an old shape can coexist with the new one. Keep enough of them and the system stops having a design and starts having a history.
+
+When a change makes an old shape wrong, delete the old shape. Update every caller in the same change.
+
+Delete rather than preserve:
+
+- Deprecated aliases, wrappers, and re-exports kept "just in case"
+- Readers for a format nothing writes any more
+- Version flags with exactly one live value
+- Adapters for callers that no longer exist
+- `if (legacy)` branches nothing sets `legacy` for
+- Dead options left in a signature so an old call site would still type-check
+
+Migrate the callers instead. Compatibility is not free: it doubles the paths under test, hides which one is real, and defers a rename that costs minutes now and an archaeology session later.
+
+### Where Compatibility Is a Real Requirement
+
+Compatibility is a requirement when something outside this change depends on the old shape and cannot be updated with it:
+
+- Published APIs, packages, or CLIs with consumers you do not control
+- On-disk data, databases, or persisted state that already exists in the field
+- Wire protocols between independently deployed peers
+- Anything under a stated support or versioning commitment
+
+Where compatibility is genuinely required, treat it as a requirement, not a reflex: name it in the spec, write the migration, and version the break deliberately. What this rule forbids is preserving the old shape out of caution when nothing depends on it.
+
+### The Grep Test
+
+Before keeping any compatibility path, find its callers:
+
+```bash
+grep -rn "old_function_name" src/ tests/ scripts/
+```
+
+If the only hits are the definition and the shim, delete both. **If you cannot name the caller, there is no caller.** "Something might use it" is a guess; the grep is the answer.
+
+For a published surface, the callers are outside the repo - which is exactly why that case is a requirement instead of a reflex. Everywhere else, the repo is the whole world.
+
+### Rationalizations
+
+| You are about to say... | The reality is... |
+|-------------------------|-------------------|
+| "Something might still call the old one" | Grep. If nothing calls it, nothing calls it. Keeping it costs a permanent second code path to avoid a search that takes seconds. |
+| "I'll deprecate it now and remove it later" | Later does not come. The deprecation comment becomes the documentation, and the shim outlives everyone who understood it. |
+| "Removing it is a breaking change" | Internal code has no consumers to break. A change is only breaking if someone outside this change depends on it - name them or delete it. |
+| "Keeping the old path is the safe option" | Two live paths is the unsafe option. Tests cover one, production takes the other, and nobody knows which. |
+| "It's only a small alias" | Small aliases are what codebases fill up with. Each one is individually free and collectively the reason nothing can be renamed. |
+| "Updating every caller is out of scope" | Updating callers is the change. Half a rename leaves the codebase worse than before it started. |
+| "I'll leave the old param so existing calls still compile" | A parameter nothing reads is a lie the signature tells the next reader. Remove it and fix the call sites. |
+
 ## When to Apply
 
 - Adding new features to existing code
 - Fixing bugs that reveal a design flaw
 - Integrating a new dependency or service
 - Extending a data model
+- Renaming or reshaping anything with callers inside the repo
 
 ## When NOT to Apply
 
@@ -24,6 +77,7 @@ When making changes to an existing system, do not patch, bolt on, or work around
 - Time-critical hotfixes (patch now, redesign later)
 - Changes to code you don't own or understand fully yet
 - When the "elegant" solution would require rewriting half the codebase for a minor feature
+- Surfaces with consumers outside this change (see "Where Compatibility Is a Real Requirement")
 
 ## Examples
 
@@ -43,3 +97,14 @@ return processWithConfig(data, config)
 ```
 
 The goal is not perfection - it's coherence. Every change should make the system feel more intentional, not more accidental.
+
+## Red Flags
+
+Stop and redesign if you catch yourself:
+
+- Adding a branch, flag, or wrapper whose only job is keeping an older shape working
+- Writing "deprecated" in a comment instead of deleting the thing
+- Leaving a parameter, field, or export in place so old call sites still compile
+- Duplicating logic with slight variations rather than making the difference a parameter
+- Keeping a code path because "something might use it" without running the grep
+- Calling a half-finished rename done because the alias makes it build

--- a/modules/code-quality/rules/code-quality.md
+++ b/modules/code-quality/rules/code-quality.md
@@ -1,21 +1,54 @@
 # Code Quality Standards
 
+## Simplest Implementation That Fully Meets the Requirements
+
+Choose the simplest implementation that fully meets the current requirements. Both halves carry weight:
+
+- **Simplest** - no abstraction with one implementation, no config option nobody sets, no plugin system for a single plugin, no generic helper called from one place.
+- **Fully meets the current requirements** - simple is not the same as partial. Every stated requirement is handled, edge cases and error paths included. See `completeness.md`.
+
+The requirements that count are the ones that exist now. A requirement someone might have next quarter is a guess, and code shaped around a guess has to be unwound when the guess turns out wrong. Build the second case when the second case arrives - by then its actual shape is known.
+
+Signs the implementation outran the requirements:
+
+- An interface with exactly one implementer
+- A config option that is never set to anything but its default
+- A layer whose only job is forwarding calls to the next layer
+- Generic type parameters instantiated with the same concrete type everywhere
+- "We'll need this when we add X" where X is on no roadmap
+
 ## Minimize Dependencies and Complexity
 
-Prefer simpler, lower-level solutions over external tools and libraries. If a built-in language feature, standard library, or platform capability achieves an equal or better outcome, use it instead of adding a dependency.
+Prefer the simplest layer that fully solves the problem. If a built-in language feature, standard library, or platform capability achieves an equal or better outcome, use it instead of adding a dependency.
 
 This applies to everything: CLI tools, npm packages, frameworks, shell utilities, and any external tooling.
 
+**The ladder: built-in > established library > custom implementation > framework.**
+
 - **Before adding a dependency**, check whether the language or platform already provides what you need
-- **Built-in > library > framework** - use the simplest layer that solves the problem
+- **When the built-in does not cover it, prefer an established, well-maintained library over a custom implementation** - see below
 - **Fewer dependencies = fewer failure modes** - every dependency is a maintenance burden, a security surface, and a breaking-change risk
 - **Equal outcome = no dependency** - if the result is the same or better without the tool, don't use the tool
 
-Examples:
+Built-in wins:
 - Pure bash with ANSI escapes instead of a TUI library for simple menus
 - `fetch()` instead of axios for HTTP requests
 - CSS variables instead of a theming library
 - Shell built-ins (`read`, `printf`) instead of external CLI tools
+
+### Established Library Over Custom Implementation
+
+"Minimize dependencies" is not "write it yourself." A hand-rolled implementation is still a dependency - one with no maintainer, no security advisories, no other users finding its bugs, and no exit. When the built-in genuinely does not cover the problem, take the established library.
+
+Library wins:
+- A maintained date library instead of hand-written timezone and DST arithmetic
+- The platform crypto API or a vetted library instead of a hand-written primitive
+- A real parser for a real grammar (CSV, YAML, semver, HTML) instead of regex
+- A schema validator instead of hand-written per-field checks across every entry point
+
+"Established, well-maintained" means: released within the last year or explicitly finished, an issue tracker someone answers, a license that permits the use, and adoption wide enough that its bugs surface in public rather than in this codebase. A package failing those tests is not a safer choice than writing the code - it is the same risk with less control.
+
+The dividing line is scope, not preference. Twenty lines of obvious logic is not a library's job. Anything with a specification behind it - dates, encodings, crypto, grammars, protocols - is.
 
 ## Code Standards
 
@@ -65,6 +98,7 @@ Examples:
 
 - **Question every new dependency** - can the standard library or a built-in do this?
 - Justify new npm packages in PR description (why is this needed over a simpler approach?)
+- **A custom implementation is also a dependency.** Justify hand-rolling in the PR description the same way - why this over an established library?
 - Prefer well-maintained packages with good TypeScript support when a dependency is genuinely warranted
 
 ### Component Patterns (React/TypeScript)

--- a/modules/code-quality/rules/completeness.md
+++ b/modules/code-quality/rules/completeness.md
@@ -67,6 +67,8 @@ Completeness is not gold-plating. Do not:
 
 The rule is: **finish the job you are on**, not "expand the job to touch every file you can reach." If the task is "add input validation to the login form," finish it to 10/10 (all inputs, all error paths, tests, a11y). Do not also rewrite the auth middleware because it looked rough.
 
+Completeness governs the *depth* of the job, not the *breadth* of the design. It says handle every case the current requirements imply; it never says build for requirements that do not exist yet. The two run together: **the simplest implementation that fully meets the current requirements, finished completely, is a 10/10.** An extra abstraction layer nothing uses does not raise the score - it is unfinished work in a different direction. See `code-quality.md` > "Simplest Implementation That Fully Meets the Requirements."
+
 ## The Test
 
 Before claiming a task is complete, ask:


### PR DESCRIPTION
Closes #941

Three principles from an AGENTS.md screenshot, integrated into the `code-quality` module. One of them contradicted the module as written, so this reconciles rather than appends.

## What changes for an agent reading these rules

**It stops hand-rolling things that have libraries.** `code-quality.md` said "Prefer simpler, lower-level solutions over external tools and libraries" with the ladder `built-in > library > framework`. An agent reads that as license to write its own date math whenever `Date` falls short. The ladder now has the missing rung:

```
built-in > established library > custom implementation > framework
```

with the reason stated plainly — a hand-rolled implementation is still a dependency, just one with no maintainer, no security advisories, no other users finding its bugs, and no exit. The dividing line is scope, not taste: twenty lines of obvious logic is not a library's job; anything with a specification behind it (dates, encodings, crypto, grammars, protocols) is. "Established, well-maintained" is defined concretely so it is not a vibe check.

**It stops leaving compatibility shims behind.** `change-philosophy.md` gains a "Do Not Preserve Backward Compatibility" section. The framing ties it to the rule already there: a shim *is* the bolted-on special case — a second code path kept alive so an old shape can coexist with the new one. When a change makes an old shape wrong, delete the old shape and migrate the callers in the same change.

**It stops building for requirements that do not exist.** `code-quality.md` gains an opening section on choosing the simplest implementation that fully meets the *current* requirements, with a list of signs the implementation outran them (an interface with one implementer, a config option never set off its default, a layer that only forwards calls).

## The carve-out that keeps the compat rule safe

Stated bare, "do not preserve backward compatibility" would tell an agent to delete the learnings-store legacy shard reader and the relevance-injection compatible default. So the section names where compatibility is a genuine requirement: published APIs and CLIs with consumers you do not control, on-disk data already in the field, wire protocols between independently deployed peers, and anything under a stated support commitment. There, compatibility gets named in the spec, migrated, and versioned deliberately. What the rule forbids is preserving an old shape out of caution when nothing depends on it — and the grep test settles which case you are in: if you cannot name the caller, there is no caller.

## Reconciling "simplest" with "boil the lake"

`completeness.md` and the new section read as opposed on their face. Two sentences in `completeness.md` fix that: completeness governs the *depth* of the job, not the *breadth* of the design. The simplest implementation that fully meets the current requirements, finished completely, is a 10/10. An unused abstraction layer does not raise the score — it is unfinished work pointed sideways.

## Structure

Per `rule-authoring.md`, the backward-compat section is the one agents actively rationalize past, so it ships with a 7-row rationalizations table and red flags. `change-philosophy.md` had no red flags before; the new list covers the whole rule, not just the new section.

## Changes

| File | Change |
|---|---|
| `rules/code-quality.md` | New "Simplest Implementation That Fully Meets the Requirements" section; dependency ladder reworked with "Established Library Over Custom Implementation"; `Dependencies` checklist names custom implementations as a dependency class |
| `rules/change-philosophy.md` | New "Do Not Preserve Backward Compatibility" section (what to delete, where compat is a real requirement, the grep test, rationalizations); red flags for the whole rule; two cross-references |
| `rules/completeness.md` | Two sentences in `Boundaries` reconciling depth-vs-breadth |
| `README.md` | Capability bullets and file descriptions updated |

Rules only — no hooks, commands, or installer surface touched.

## Test Plan

- `bash tests/test-modules.sh` — 1689 passed, 0 failed
- `bash tests/test-no-personal-data.sh` — PASS, no personal data or secret/PII shapes
- Pre-commit hook: gitleaks clean, no large files, no conflict markers