### PR TITLE
#943: avoid SIGPIPE in the manifest membership test under pipefail

### DIFF
--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -267,7 +267,12 @@ for mod_dir in "$REPO_ROOT"/modules/*/; do
       rel_path="${abs_path#"$mod_dir"}"
       rel_path="${rel_path#/}"
       shipped_count=$((shipped_count + 1))
-      if printf '%s\n' "$declared" | grep -qxF "$rel_path"; then
+      # Herestring, not a pipe: under `set -o pipefail`, `producer | grep -q`
+      # can die with SIGPIPE if grep exits on its first match before the
+      # producer finishes writing, turning a successful match into a
+      # pipeline failure (see #943). A herestring has no second process to
+      # race against, so there is no pipe to break.
+      if grep -qxF "$rel_path" <<< "$declared"; then
         :
       else
         fail "$mod_name: shipped '$rel_path' is not in module.json files[] (will never install)"

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -347,7 +347,13 @@ WORKFLOW_FILE="$REPO_ROOT/.github/workflows/test.yml"
 if [ ! -f "$WORKFLOW_FILE" ]; then
   fail "workflow file missing: .github/workflows/test.yml"
 else
-  jobs_line=$(grep -n '^jobs:[[:space:]]*$' "$WORKFLOW_FILE" | head -1 | cut -d: -f1)
+  # No pipe: `grep -n ... | head -1 | cut -d: -f1` races `head -1` closing
+  # its read end against `grep` still writing (same SIGPIPE hazard as #943).
+  # `-m1` makes grep itself stop after the first match instead, and the
+  # `:1` field split is plain bash parameter expansion - no second process
+  # is ever reading from another live process's stdout.
+  jobs_match=$(grep -m1 -n '^jobs:[[:space:]]*$' "$WORKFLOW_FILE" || true)
+  jobs_line="${jobs_match%%:*}"
   if [ -z "$jobs_line" ]; then
     fail "test.yml: could not locate top-level 'jobs:' key"
   else
@@ -413,7 +419,14 @@ else
           start="${range%%:*}"
           end="${range##*:}"
           job_label=$(sed -n "${start}p" "$WORKFLOW_FILE" | sed 's/^[[:space:]]*//; s/:.*$//')
-          if sed -n "${start},${end}p" "$WORKFLOW_FILE" | grep -qF "tests/$suite_name"; then
+          # Capture the job's slice first, then match against the variable
+          # with a herestring instead of piping sed straight into
+          # `grep -qF`. Same SIGPIPE hazard as #943: `grep -q` can exit on
+          # its first match before `sed` finishes writing the range, and
+          # under pipefail that turns a real match into a false "missing"
+          # report - here, for every job after the first suite line found.
+          job_slice=$(sed -n "${start},${end}p" "$WORKFLOW_FILE")
+          if grep -qF "tests/$suite_name" <<< "$job_slice"; then
             :
           else
             missing_in="$missing_in $job_label"


### PR DESCRIPTION
Closes #943

## What broke

`tests/test-modules.sh` runs under `set -euo pipefail`. Its manifest-completeness check tested membership with `printf '%s\n' "$declared" | grep -qxF "$rel_path"`. `grep -q` exits the instant it finds a match and closes its read end; if `printf` still had output buffered at that moment it died with SIGPIPE, and under `pipefail` the pipeline's exit status became `printf`'s non-zero status — turning a successful match into a false "file not declared" failure.

## Fix

Three instances of the same `producer | consumer-that-exits-early` shape existed in `tests/test-modules.sh`, all now fixed:

- **Line ~270** (the original bug): `printf '%s\n' "$declared" | grep -qxF "$rel_path"` → `grep -qxF "$rel_path" <<< "$declared"`. A herestring has no second process to race against.
- **Line ~350**: `jobs_line=$(grep -n '^jobs:[[:space:]]*$' "$WORKFLOW_FILE" | head -1 | cut -d: -f1)` — an unguarded bare assignment. `head -1` racing `grep` is the same SIGPIPE hazard, and because this is a plain `var=$(...)` assignment (not inside an `if`), a failing pipeline here crashes the whole script under `set -e` rather than reaching the intended "could not locate jobs:" failure message. Replaced with `grep -m1` (grep stops itself; no downstream process ever races it) plus plain bash parameter expansion (`${jobs_match%%:*}`) for the field split — no pipe at all.
- **Line ~422**: `sed -n "${start},${end}p" "$WORKFLOW_FILE" | grep -qF "tests/$suite_name"` — structurally identical to the bug this PR exists to fix, in the CI-enumeration guard #937 (merged as `8abf4f1`) added. `grep -q` can exit on its first match before `sed` finishes writing the job's line range, turning a real "suite is wired in" match into a false "missing from CI job" report. Fixed by capturing the job's slice into a variable first (`job_slice=$(sed -n ...)`), then matching against it with a herestring — the same pattern as the first fix.

Bash-3.2 compatible (`<<<` and `grep -m1` are both supported well before 3.2; confirmed against the actual system `/bin/bash` 3.2.57 on this machine).

## Audit

Every `|` in `tests/test-modules.sh` was checked for a downstream consumer that can exit before its producer finishes writing (`grep -q`, `grep -m`, `head`, `grep -l`, and equivalents). All three instances above are fixed; every remaining pipe in the file is one of: a `jq '... | ...'` internal filter (single process, not two racing processes), or a consumer that reads its input to EOF (`tr`, `cut`, a second `sed` with no `q` command, `grep -c`/`grep -nE` without `-m`, `while read` loops) — none of those can race their producer.

The same shape in two other files — `tests/test-doc-counts.sh` (2 sites) and `tests/test-installer.sh` (3 sites) — is tracked separately in #945 (read-only findings, not touched here; one of them, `test-doc-counts.sh:136`, is the same "can abort the whole run" class as this PR's `:350` fix). `tests/test-backup.sh` has no instances.

## Verification

- `/bin/bash -n tests/test-modules.sh` — syntax OK (system bash is 3.2.57, confirmed via `/bin/bash --version`).
- `bash tests/test-modules.sh` x 20 (Homebrew bash) — 20/20 green, zero "Broken pipe" in output.
- `/bin/bash tests/test-modules.sh` x 20 (system bash 3.2.57) — 20/20 green, zero "Broken pipe" in output.
- `bash tests/test-no-personal-data.sh` — pass.
- CI-enumeration guard's own red-then-green proof, run against a scratch mirror (the real `.github/workflows/test.yml` was never edited): removed the `test-backup.sh` step from only the `test-macos` job → guard correctly failed, naming `test-backup.sh: missing from CI job(s): test-macos`; restored the file → guard passed clean (1702 passed, 0 failed).
- Reproduction attempt (original `:270` bug only, per the earlier review round): reverted to the `printf | grep -q` form in a scratch copy and ran it 100x — 0/100 reproduced, corroborated by the reviewer's independent 0/500. Reported honestly rather than manufactured: the race window is narrow on a quiet machine (the largest manifest's `$declared` is a few KB, well under a pipe buffer's capacity, so `printf`'s single `write()` almost always completes before `grep` can match and close) and only opens under CI-load scheduler jitter. Mechanism is established from the CI log (run `30760628493`) plus documented `pipefail`/SIGPIPE semantics, not from a local repro.

