### PR TITLE
#947: describe the manifest-derived backup set in Step 10

### DIFF
--- a/docs/installer.md
+++ b/docs/installer.md
@@ -68,7 +68,7 @@ Creates a timestamped backup at `<target>/backups/ccgm-YYYYMMDD-HHMMSS/` - `~/.c
 
 The set of items copied is derived from the modules themselves: every `modules/*/module.json` file target contributes its first path segment, so `skills/`, `agents/`, `lib/`, `bin/`, `scripts/`, `output-styles/`, and the rest are all covered. That set is unioned with the seven legacy paths (`settings.json`, `CLAUDE.md`, `rules/`, `commands/`, `hooks/`, `multi-agent-system.md`, `github-repo-protocols.md`), so coverage only ever grows. Any `.ccgm*` files are copied too. Deriving from the manifests is what keeps non-CCGM content - `projects/`, holding session transcripts and memory - out of the backup.
 
-A derived segment is skipped, with a warning on stderr, if it is empty, `.`, `..`, contains a `/`, or falls outside a conservative ASCII character set. If the modules directory cannot be located at all, the backup falls back to the seven legacy paths rather than backing up nothing.
+A derived segment is skipped, with a warning on stderr, unless it clears two separate checks: every character must be in `[A-Za-z0-9._-]`, and the first character must be a letter or digit. So `.`, `..`, an empty segment, and anything containing a `/` are refused - and so is a leading `.` or `-` (`.hidden`, `-foo`), even though those characters are themselves allowed later in a name. If the modules directory cannot be located at all, the backup falls back to the seven legacy paths rather than backing up nothing.
 
 The 5 most recent backups are kept; older ones are deleted.
 

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -64,7 +64,13 @@ A single yes/no gate. Answering no exits without making changes.
 
 ### Step 10: Backup
 
-Creates a timestamped backup at `<target>/backups/ccgm-YYYYMMDD-HHMMSS/` - `~/.claude/backups/` for a global install, `<project>/.claude/backups/` for a project install. It copies a fixed list of top-level items if they exist: `settings.json`, `CLAUDE.md`, `rules/`, `commands/`, `hooks/`, `multi-agent-system.md`, `github-repo-protocols.md`, and any `.ccgm*` files. The 5 most recent backups are kept; older ones are deleted. Module targets outside that list (`skills/`, `agents/`, `lib/`, `bin/`, ...) are not currently backed up (see #917).
+Creates a timestamped backup at `<target>/backups/ccgm-YYYYMMDD-HHMMSS/` - `~/.claude/backups/` for a global install, `<project>/.claude/backups/` for a project install.
+
+The set of items copied is derived from the modules themselves: every `modules/*/module.json` file target contributes its first path segment, so `skills/`, `agents/`, `lib/`, `bin/`, `scripts/`, `output-styles/`, and the rest are all covered. That set is unioned with the seven legacy paths (`settings.json`, `CLAUDE.md`, `rules/`, `commands/`, `hooks/`, `multi-agent-system.md`, `github-repo-protocols.md`), so coverage only ever grows. Any `.ccgm*` files are copied too. Deriving from the manifests is what keeps non-CCGM content - `projects/`, holding session transcripts and memory - out of the backup.
+
+A derived segment is skipped, with a warning on stderr, if it is empty, `.`, `..`, contains a `/`, or falls outside a conservative ASCII character set. If the modules directory cannot be located at all, the backup falls back to the seven legacy paths rather than backing up nothing.
+
+The 5 most recent backups are kept; older ones are deleted.
 
 ### Step 11: Install
 


### PR DESCRIPTION
Closes #947.

`docs/installer.md` Step 10 still described the fixed 7-path backup list that #917 replaced, and
pointed at #917 as an open limitation. #917 closed with PR #932 (`c2139e6`).

The rewritten paragraph states what `create_backup` actually does now:

- The set is derived from every `modules/*/module.json` file target (first path segment), so
  `skills/`, `agents/`, `lib/`, `bin/`, `scripts/`, `output-styles/` and the rest are covered.
- It is unioned with the seven legacy paths, so coverage only grows.
- Deriving from manifests is what keeps non-CCGM content out of the backup — notably `projects/`,
  which holds session transcripts and memory.
- Unsafe derived segments (empty, `.`, `..`, containing `/`, or outside a conservative ASCII set)
  are skipped with a stderr warning.
- If the modules directory cannot be located, it falls back to the legacy seven rather than backing
  up nothing.

Retention, per-scope location, and `.ccgm*` copying are unchanged and still described.

This was the last stale issue reference in the docs — `grep -rnoE '#(917|918|919|929|930|931|935|943)\b' docs/ README.md CLAUDE.md` now returns nothing.

## Verification

```
bash tests/test-doc-counts.sh      -> all checks passed
bash tests/test-no-personal-data.sh -> PASS
bash tests/test-modules.sh          -> 1702 passed, 0 failed
```