### PR TITLE
#961: test cheap dismissed alternatives instead of re-reviewing them

### DIFF
--- a/modules/adversarial-review/agents/adrev-reviewer.md
+++ b/modules/adversarial-review/agents/adrev-reviewer.md
@@ -32,6 +32,28 @@ The caller passes:
 | `code` / `dir` | Read the entry points first, then trace what they depend on. Grep for callers before judging anything unused or safe to change. |
 | `concept` | The text you were handed is the entity. Ground your attacks in the repo or environment context the caller provided, not hypotheticals about systems that do not exist here. |
 
+## Run the Cheapest Decisive Experiment First
+
+**Before you argue about a claim, ask whether you can settle it.** You have `Bash`. A two-minute experiment beats a paragraph of reasoning, and it beats a second reviewer repeating the reasoning.
+
+This step exists because of a measured failure. A plan dismissed an alternative and recorded it as a risk-register row. That row survived **six reviews** - three constructive and three sequential adversarial passes at maximum effort. Two of the adversarial passes cited the row directly. None of them ran it. A canary file and three headless invocations then falsified half the dismissal and materially changed the plan. Reviewing a testable claim again is the expensive way to not answer it.
+
+Before the battery, list the target's claims that are **empirically settleable**, and run the cheapest one that would change a finding:
+
+| Claim shape | The experiment |
+|-------------|----------------|
+| "Mechanism X does / does not work here" | Run X on a canary in a scratch dir |
+| "Alternative Y was rejected because it cannot do Z" | Try Y on Z |
+| "This suite / command / hook fails" (or passes) | Execute it |
+| "This file / field / flag exists" (or does not) | Read it, grep it, `--help` it |
+| "These two things are equivalent" | Diff their actual output |
+
+**The cost gate.** A dismissal is testable when a bounded experiment settles it: **minutes, no permanent change, fully reversible.** "Would Postgres have been better" is not testable here - record it as an untested assumption and label it as such. Do not turn this step into a mandate to prototype every road not taken.
+
+**Rules for running one.** Work in a scratch directory or a temp dir. If you must touch shared state to get an answer, make the change inert by construction (scope it to a name or extension nothing else uses), remove it immediately, and **verify the removal in the report**. Never leave an artifact behind. Never run anything destructive, anything that launches an app or takes focus, or anything that spends real money without the caller asking for it.
+
+**Report what you ran.** A review that ran no experiment when a cheap one was available is a weaker review, and the report must show that. Populate `experiments_run` (below) even when the result confirmed the target - a confirmed claim with evidence outranks the same claim with an argument.
+
 ## The Attack Battery
 
 Run every test against the target. Skip a test only when it is structurally inapplicable (e.g., reversal cost on a read-only audit doc), and say so in the report.
@@ -51,6 +73,8 @@ How does this break? Walk the concrete failure classes: empty/null/malformed inp
 ### 4. Strongest opposing case
 
 Steelman the best argument against this entity existing in this form. Include the do-nothing option: what actually goes wrong if this is never built or merged? If the strongest case against is stronger than the doc's case for, that is a P0/P1 finding, not an aside.
+
+**Attack the dismissals specifically.** Every rejected alternative the target names - in prose, in a "considered and rejected" list, or parked in a risk register - is an **untested claim wearing the costume of a settled decision**. Ask of each: was it actually tried, or only argued about? Is the stated reason for rejection checkable? A dismissal that has never been run is the single most likely place a plan is wrong, because it was decided once, early, and then inherited by every later reader including you. If it clears the cost gate above, **run it** rather than assessing the argument for it.
 
 ### 5. Reversal-cost check
 
@@ -123,12 +147,23 @@ Return findings as JSON:
       "suggestion": "Reorder: drop the old table only after backfill verification, and state the rollback window explicitly"
     }
   ],
+  "experiments_run": [
+    {
+      "claim": "Plan section 1.3: 'claudeMdExcludes cannot scope user-level rules'",
+      "method": "canary rule in ~/.claude/rules/ + 3 headless `claude -p` runs (none / path-exclude / glob-exclude)",
+      "result": "FALSIFIED - excluded by both path and glob from a project-layer settings.json",
+      "cleanup": "canary removed; directory verified back to its 46-file baseline",
+      "finding": "adrev-015"
+    }
+  ],
   "survived": ["falsification: success metrics in section 5 are concrete and measurable"],
   "status": "DONE"
 }
 ```
 
 `survived` lists attacks the target genuinely withstood - this is what makes a clean verdict credible.
+
+`experiments_run` records every empirical check from the "cheapest decisive experiment" step, **including those that confirmed the target** - a confirmed claim with evidence outranks the same claim with an argument. Each entry names the claim, the method, the result, and the cleanup performed. An empty array is a valid and honest answer when nothing was cheaply settleable; it is **not** valid when the target contained a testable dismissal you chose to argue about instead. When an experiment resolves a claim, cite its `finding` id so the reasoning and the evidence stay linked.
 
 Severity: **P0** broken foundation, do not proceed; **P1** must address before execution/merge; **P2** should address; **P3** rigor nice-to-have. Confidence: **>= 0.80** you can point at the exact passage and name the exact failure; **0.60-0.79** suspected but interpretation-dependent; **< 0.60** speculative - include only in the artifact, never apply.
 

--- a/modules/code-quality/rules/latent-vs-deterministic.md
+++ b/modules/code-quality/rules/latent-vs-deterministic.md
@@ -38,6 +38,50 @@ Stop and reach for a script (or an existing tool) if you catch yourself:
 
 Each of these is a deterministic computation. If it gets the wrong answer once, it will get the wrong answer again. Push it into code where the test can pin it.
 
+## The Same Rule Applies to Claims, Not Just Computations
+
+Everything above is about arithmetic the model does in its head. The identical mistake happens one level up, with **assertions about how a system behaves** — and it is harder to see, because the output is an argument rather than a number.
+
+"Does `X` work here?" is not a judgment call. It is a question with a determinate answer that a short experiment returns exactly. Reasoning about it produces a confident paragraph; running it produces the answer.
+
+| Claim | Class | Belongs in |
+|-------|-------|-----------|
+| Is this the right architecture? | Latent | Model |
+| Which of these tradeoffs matters more to us? | Latent | Model |
+| Does this flag / mechanism / config actually work here? | **Deterministic** | An experiment |
+| Does this suite pass? | **Deterministic** | Run it |
+| Can this alternative do the thing we said it can't? | **Deterministic** | Try it |
+| Is that field / file / option really there? | **Deterministic** | Read, grep, `--help` |
+| Do these two approaches produce the same output? | **Deterministic** | Diff them |
+
+### Dismissed Alternatives Are the Worst Case
+
+A rejected alternative — in a plan, a design doc, a risk register, an "options considered" list — is an **untested claim wearing the costume of a settled decision**. It gets written once, early, under time pressure, and then every later reader inherits it as fact. Nobody re-opens it, because it looks decided.
+
+This is measured, not hypothetical: a dismissal in one plan survived **six reviews** — three constructive and three adversarial at maximum effort — with two reviewers citing it directly. None ran it. A two-minute experiment then falsified half of it and changed the plan materially. Six expensive reviews lost to one cheap test.
+
+**When a decision rests on a dismissal, run the dismissed thing before defending the decision.**
+
+### The Cost Gate
+
+This is bounded on purpose, or it becomes a mandate to prototype every road not taken. A claim is worth testing when the experiment is **minutes, needs no permanent change, and is fully reversible.**
+
+- **Testable:** does this flag scope that file, does this command accept that argument, does this suite pass, does that API return that shape.
+- **Not testable here:** would a different database have been better, will users like this, does this scale to 100x. Record these as **untested assumptions and label them as such** — an assumption that says "unverified" is still better than one that reads as settled.
+
+If you must touch shared state to get an answer: make the change inert by construction (scope it to a name nothing else uses), remove it immediately, and verify the removal.
+
+### Red Flags That a Claim Is Being Argued Instead of Tested
+
+Stop and run it if you catch yourself:
+
+- Writing a paragraph defending whether a mechanism works, with a shell available
+- Carrying a rejected alternative through a second review without anyone having run it
+- Saying "the docs don't mention it, so presumably…" when a canary would settle it in two minutes
+- Reviewing a claim again because the last review didn't resolve it
+- Treating "three reviewers agreed" as evidence about behavior — agreement is not observation
+- Writing "should work" / "shouldn't be affected" / "presumably fine" about something runnable
+
 ## Why This Rule Exists
 
 Two classes of failure disappear when deterministic work moves to scripts:

--- a/modules/xplan/commands/xplan.md
+++ b/modules/xplan/commands/xplan.md
@@ -1040,6 +1040,26 @@ Create `~/code/plans/{concept-name}/decisions.md`:
 
 Include all stack decisions from Phase 2.5 and scope decisions from Phase 2.6.
 
+### 3.7.1 Alternatives Register (MANDATORY) — and test the cheap dismissals
+
+Every alternative the plan rejects gets a row here, with the one column that matters: **what it would cost to find out.** A dismissal written once, early, is inherited as fact by every later reader — including every review agent — so it is the most likely place a plan is quietly wrong.
+
+```markdown
+## Alternatives Considered and Dismissed
+
+| # | Alternative | Why dismissed | Cost to test | Tested? | Result |
+|---|-------------|---------------|--------------|---------|--------|
+| A1 | ... | ... | minutes / hours / not bounded | yes/no | ... |
+```
+
+**Fill `Cost to test` honestly, then run every row marked `minutes`.** A dismissal is cheaply testable when the experiment takes minutes, needs no permanent change, and is fully reversible — does this flag scope that file, does this command take that argument, does that API return that shape, does the suite pass. Run it in a scratch dir; if you must touch shared state, make the change inert by construction, remove it immediately, and verify the removal.
+
+Rows that are **not** bounded ("would a different database have been better", "will users like it") are recorded as **untested assumptions and labelled as such**. That is a valid outcome. Silently presenting an untested dismissal as a settled decision is not.
+
+**Why this exists.** On one `/xplana` run, a dismissed alternative was recorded as a risk-register row and survived **six reviews** — three constructive and three sequential adversarial passes at maximum effort, two of which cited the row directly. None ran it. A two-minute experiment then falsified half the dismissal, confirmed and strengthened the other half, and added a new first-shippable epic. Reviewing a testable claim again is the expensive way to not answer it. See `latent-vs-deterministic.md` > "The Same Rule Applies to Claims".
+
+Feed this register to the Phase 4 and Phase 5.7 reviewers as a named reference file, so they attack the dismissals rather than re-deriving them.
+
 ---
 
 ## Phase 4: Plan Review
@@ -1800,6 +1820,15 @@ If any selected review file is missing, STOP. Go back to Phase 4. If Phase 5.7 w
 If the Phase 5.7 final pass left unresolved P0/P1 findings, surface them in the gate summary so the user decides to execute with eyes open — do not bury them.
 
 Also re-read plan §8.6. If it lists live-testing steps whose permission line is `NOT AUTHORIZED`, name those steps in the gate summary and state that the executor will stop on each one until the user approves it and names a runner. **Proceeding through this gate approves execution; it does not grant live-testing permission** — only an explicit Q8 answer recorded in §8.6 does that.
+
+Then re-read the **Alternatives Register** (Phase 3.7.1) and check it before gating:
+
+```bash
+# Any row whose cost-to-test is "minutes" MUST show Tested = yes.
+grep -A 40 "Alternatives Considered and Dismissed" ~/code/plans/{concept-name}/decisions.md
+```
+
+If a cheaply-testable dismissal is still untested, **run it now** — it takes minutes and this is the last point before the plan is committed to. A dismissal that survived every review without anyone executing it is the plan's most likely quiet error, and the reviews cannot have caught it, because argument is not observation. If a row is genuinely not bounded, confirm it reads as an **untested assumption** rather than a settled decision, and name it in the gate summary alongside any unresolved P0/P1 findings so the user decides with the uncertainty visible.
 
 Use AskUserQuestion:
 


### PR DESCRIPTION
Closes #961

## What this changes for you

A rejected alternative is an untested claim wearing the costume of a settled decision. Today nothing
in CCGM tells anyone to run one — so a dismissal written once, early, gets inherited as fact by every
later reader, including every review agent. After this, a cheap dismissal gets executed instead of
argued about, at three points: when a plan is authored, when it is adversarially reviewed, and at the
gate before it is committed to.

## Why

Measured, not hypothetical. On an `/xplana` run, a plan dismissed `claudeMdExcludes` and recorded it
as a risk-register row. That row survived **six reviews** — three constructive (security,
architecture, business-logic) and three sequential `adrev-reviewer` passes on Opus at max effort. Two
adversarial passes cited the row directly.

None ran it.

A canary rule and three headless `claude -p` invocations then settled it in about two minutes:
`claudeMdExcludes` **does** scope user-level `~/.claude/rules/*.md` from a project-layer
`.claude/settings.json`, including by glob — worth a measured 30,355 tokens (41.3%) on the reference
install. That falsified half the dismissal, confirmed and strengthened the other half, and added a
new first-shippable epic to the plan.

Six expensive reviews lost to one cheap test. The reviews could not have caught it: argument is not
observation.

## Changes

**`modules/adversarial-review/agents/adrev-reviewer.md`** — the agent already ships with `Bash` and a
description saying it hunts "the alternative nobody steelmanned." It had the capability and the
mandate; what it lacked was an instruction to reach for the shell on a claim. Adds a
cheapest-decisive-experiment step ahead of the attack battery, with a table of settleable claim
shapes; an `experiments_run` field in the findings JSON so a review that ran nothing is visibly
weaker than one that did; and an instruction under "strongest opposing case" to attack dismissals
specifically.

**`modules/code-quality/rules/latent-vs-deterministic.md`** — already said don't reason about what
you can compute, with red flags like *"'Eyeballing' whether a regex matches without running it."* It
stopped at arithmetic. Extends the same principle to assertions about how a system behaves, where the
mistake is harder to see because the output is an argument rather than a number, and names dismissed
alternatives as the worst case.

**`modules/xplan/commands/xplan.md`** — a mandatory Alternatives Register in `decisions.md` with a
cost-to-test column. Rows costing minutes must be run; the 6.5 gate re-checks them before the plan is
committed to, and surfaces any unbounded ones as untested assumptions rather than settled decisions.

## The cost gate

All three carry the same bound, or this becomes a mandate to prototype every road not taken:
**testable means minutes, no permanent change, fully reversible.** "Does this flag scope that file"
qualifies. "Would a different database have been better" does not — those are recorded as untested
assumptions and labelled as such, which is still better than reading as decided. Experiments that
touch shared state must be inert by construction, removed immediately, and the removal verified.

## Verification

```
tests/test-modules.sh          1702 passed, 0 failed
tests/test-no-personal-data.sh PASS
tests/test-doc-counts.sh       all checks passed
gen_marketplace.py --check     Marketplace files are up to date
```

Docs-only change across three files (+108 lines, no deletions); no `module.json` touched, so no
marketplace regen was needed and no new `test-*.sh` was added for the #935 enumeration guard to catch.