### PR TITLE
#949: make uninstall alias removal portable across BSD and GNU sed

### DIFF
--- a/lib/template.sh
+++ b/lib/template.sh
@@ -2,6 +2,23 @@
 # CCGM - Template expansion
 # Replaces __PLACEHOLDER__ variables with values from .ccgm.env
 
+# --- Portable in-place sed ---
+# Usage: sed_inplace 'sed-script' file [file2 ...]
+# macOS (BSD) sed requires -i '' (empty string as its own argument for the
+# backup suffix); GNU sed (Linux) takes -i with no separate argument and
+# would otherwise misparse a bare '' as the script and the real script as a
+# filename. Centralized here so every caller picks the right form once,
+# instead of re-deriving this detection at each call site.
+sed_inplace() {
+  local script="$1"
+  shift
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "$script" "$@"
+  else
+    sed -i "$script" "$@"
+  fi
+}
+
 # --- Expand templates in a single file ---
 # Usage: expand_templates "/path/to/file" "/path/to/.ccgm.env"
 # Modifies the file in-place
@@ -77,13 +94,6 @@ expand_templates() {
 
   # Perform replacements using sed
   # Use a different delimiter (|) in case paths contain /
-  local sed_cmd="sed"
-  # macOS sed requires -i '' while GNU sed uses -i
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed_cmd="sed -i ''"
-  else
-    sed_cmd="sed -i"
-  fi
 
   # Build sed expression
   local sed_expr=""
@@ -111,11 +121,7 @@ expand_templates() {
   done
 
   # Apply sed in-place
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "$sed_expr" "$file"
-  else
-    sed -i "$sed_expr" "$file"
-  fi
+  sed_inplace "$sed_expr" "$file"
 }
 
 # --- Check if a file has unexpanded templates ---

--- a/lib/template.sh
+++ b/lib/template.sh
@@ -9,13 +9,18 @@
 # would otherwise misparse a bare '' as the script and the real script as a
 # filename. Centralized here so every caller picks the right form once,
 # instead of re-deriving this detection at each call site.
+# The -- before the script guards against a script or filename that starts
+# with a dash: GNU sed permutes option scanning across the whole argument
+# list by default, so a later "-name" argument gets misread as an unknown
+# flag even though it is positional; BSD sed does not, but -- is a no-op
+# for it. Exits non-zero (propagated to the caller) if sed itself fails.
 sed_inplace() {
   local script="$1"
   shift
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "$script" "$@"
+    sed -i '' -- "$script" "$@"
   else
-    sed -i "$script" "$@"
+    sed -i -- "$script" "$@"
   fi
 }
 

--- a/tests/test-uninstall-settings.sh
+++ b/tests/test-uninstall-settings.sh
@@ -438,6 +438,79 @@ else
 fi
 echo ""
 
+echo "--- Test 11: Alias removal reports failure (not success) when sed cannot write the rc file ---"
+
+if [ "$(id -u)" -eq 0 ]; then
+  echo "  SKIP: running as root - permission-based write failures cannot be forced"
+else
+  RO_DIR="$ALIAS_TMPDIR/readonly-dir"
+  mkdir -p "$RO_DIR"
+  RO_RC="$RO_DIR/.zshrc"
+  cat > "$RO_RC" << 'ZSHRC'
+export PATH="$PATH:/usr/local/bin"
+
+# CCGM - Claude Code launchers
+alias ccgm="claude --dangerously-skip-permissions"
+alias ccgms="claude /startup --dangerously-skip-permissions"
+ZSHRC
+
+  # sed -i writes via a temp file plus rename in the same directory, so
+  # chmod on the FILE alone does not force a write failure - the rename
+  # only needs the directory to be writable. Locking the directory does.
+  chmod 555 "$RO_DIR"
+
+  set +e
+  bash -c "source '$REPO_ROOT/uninstall.sh'; remove_ccgm_alias_lines '$RO_RC'" >/dev/null 2>&1
+  ro_exit=$?
+  set -e
+
+  chmod 755 "$RO_DIR"
+
+  if [ $ro_exit -eq 2 ]; then
+    pass "remove_ccgm_alias_lines reports failure (exit 2) instead of success when sed cannot write the file"
+  else
+    fail "Expected exit 2 (sed failure) on an unwritable directory, got $ro_exit"
+  fi
+
+  if grep -qE '^alias ccgm=' "$RO_RC"; then
+    pass "Aliases remain in the file sed could not write - the failed removal did not silently drop data"
+  else
+    fail "Aliases were removed even though the containing directory was read-only - test setup invalid"
+  fi
+fi
+echo ""
+
+echo "--- Test 12: sed_inplace does not misparse a dash-prefixed filename as an option ---"
+
+DASH_DIR="$ALIAS_TMPDIR/dash-test"
+mkdir -p "$DASH_DIR"
+DASH_FILE="$DASH_DIR/-leading-dash.txt"
+printf 'keep\nremove-me\n' > "$DASH_FILE"
+
+set +e
+dash_out=$(bash -c "cd '$DASH_DIR' && source '$REPO_ROOT/lib/template.sh' && sed_inplace '/remove-me/d' '-leading-dash.txt'" 2>&1)
+dash_exit=$?
+set -e
+
+if [ $dash_exit -eq 0 ]; then
+  pass "sed_inplace succeeds on a dash-prefixed filename instead of misparsing it as an option"
+else
+  fail "sed_inplace failed on a dash-prefixed filename (exit $dash_exit): $dash_out"
+fi
+
+if grep -qE '^remove-me$' -- "$DASH_FILE" 2>/dev/null; then
+  fail "sed_inplace did not actually remove the target line from the dash-prefixed file"
+else
+  pass "Target line removed from the dash-prefixed file"
+fi
+
+if grep -qE '^keep$' -- "$DASH_FILE" 2>/dev/null; then
+  pass "Unrelated line preserved in the dash-prefixed file"
+else
+  fail "Unrelated line lost from the dash-prefixed file"
+fi
+echo ""
+
 # NOTE (platform coverage): this suite runs on macOS, so the assertions
 # above only exercise sed_inplace's BSD (sed -i with an empty-string suffix
 # argument) branch via lib/template.sh. The GNU branch (sed -i with no

--- a/tests/test-uninstall-settings.sh
+++ b/tests/test-uninstall-settings.sh
@@ -315,6 +315,138 @@ else
 fi
 echo ""
 
+# ============================================================
+# Shell alias removal (issue #949)
+#
+# uninstall.sh used to strip ccgm/ccgms aliases with a hardcoded BSD-style
+# `sed -i ''`, which GNU sed (Linux) misparses: it reads the empty string as
+# the sed script and the real script as a filename, and errors out. These
+# tests exercise remove_ccgm_alias_lines (uninstall.sh) directly against a
+# scratch rc file, never the real ~/.zshrc or ~/.bashrc. uninstall.sh is
+# sourced rather than executed, so main() never runs - see the
+# BASH_SOURCE guard at the bottom of uninstall.sh.
+# ============================================================
+echo "--- Test 8: Alias removal strips aliases + comment header, leaves everything else untouched ---"
+
+ALIAS_TMPDIR="$TMPDIR/alias-test"
+mkdir -p "$ALIAS_TMPDIR"
+RC_FILE="$ALIAS_TMPDIR/.zshrc"
+
+# Mirrors what start.sh's alias step actually writes: unrelated content,
+# then a blank line + CCGM comment header + both alias lines, then more
+# unrelated content after.
+cat > "$RC_FILE" << 'ZSHRC'
+export PATH="$PATH:/usr/local/bin"
+alias ll="ls -la"
+
+# CCGM - Claude Code launchers
+alias ccgm="claude --dangerously-skip-permissions"
+alias ccgms="claude /startup --dangerously-skip-permissions"
+
+export EDITOR=vim
+ZSHRC
+
+# Everything that should survive removal, byte for byte, in order. The
+# blank line CCGM appended ahead of its comment header is not cleaned up
+# (out of scope for #949), so it remains here too, alongside the blank line
+# that already followed the alias block.
+cat > "$ALIAS_TMPDIR/expected.zshrc" << 'ZSHRC'
+export PATH="$PATH:/usr/local/bin"
+alias ll="ls -la"
+
+
+export EDITOR=vim
+ZSHRC
+
+set +e
+remove_out=$(bash -c "source '$REPO_ROOT/uninstall.sh'; remove_ccgm_alias_lines '$RC_FILE'" 2>&1)
+remove_exit=$?
+set -e
+
+if [ $remove_exit -eq 0 ]; then
+  pass "remove_ccgm_alias_lines reports success when aliases are present"
+else
+  fail "remove_ccgm_alias_lines failed on a file with aliases present: $remove_out"
+fi
+
+if ! grep -qE '^alias ccgm=' "$RC_FILE" && ! grep -qE '^alias ccgms=' "$RC_FILE"; then
+  pass "ccgm and ccgms alias lines removed"
+else
+  fail "alias lines still present: $(grep -E '^alias ccgm' "$RC_FILE" || true)"
+fi
+
+if ! grep -qE '^# CCGM - ' "$RC_FILE"; then
+  pass "CCGM comment header removed"
+else
+  fail "CCGM comment header still present: $(grep -E '^# CCGM - ' "$RC_FILE" || true)"
+fi
+
+if diff -q "$ALIAS_TMPDIR/expected.zshrc" "$RC_FILE" >/dev/null 2>&1; then
+  pass "Every other line in the rc file is byte-identical to before"
+else
+  fail "Unrelated rc file content was altered: $(diff "$ALIAS_TMPDIR/expected.zshrc" "$RC_FILE" || true)"
+fi
+echo ""
+
+echo "--- Test 9: Alias removal is idempotent on an already-clean file ---"
+
+# Snapshot the already-cleaned file, then run removal again.
+cp "$RC_FILE" "$ALIAS_TMPDIR/before-second-run.zshrc"
+
+set +e
+second_out=$(bash -c "source '$REPO_ROOT/uninstall.sh'; remove_ccgm_alias_lines '$RC_FILE'" 2>&1)
+second_exit=$?
+set -e
+
+if [ $second_exit -eq 1 ]; then
+  pass "Second run reports no-op (no CCGM aliases found) instead of erroring"
+else
+  fail "Second run on an already-clean file exited $second_exit (expected 1, no-op): $second_out"
+fi
+
+if diff -q "$ALIAS_TMPDIR/before-second-run.zshrc" "$RC_FILE" >/dev/null 2>&1; then
+  pass "Running removal twice does not change an already-clean file"
+else
+  fail "Second run mutated an already-clean file: $(diff "$ALIAS_TMPDIR/before-second-run.zshrc" "$RC_FILE" || true)"
+fi
+echo ""
+
+echo "--- Test 10: Alias removal is a no-op on a file with no CCGM aliases at all ---"
+
+NO_ALIAS_RC="$ALIAS_TMPDIR/no-alias.zshrc"
+cat > "$NO_ALIAS_RC" << 'ZSHRC'
+export PATH="$PATH:/usr/local/bin"
+alias ll="ls -la"
+ZSHRC
+cp "$NO_ALIAS_RC" "$ALIAS_TMPDIR/no-alias-before.zshrc"
+
+set +e
+bash -c "source '$REPO_ROOT/uninstall.sh'; remove_ccgm_alias_lines '$NO_ALIAS_RC'" >/dev/null 2>&1
+no_alias_exit=$?
+set -e
+
+if [ $no_alias_exit -eq 1 ]; then
+  pass "No-op reported for a file with no CCGM aliases"
+else
+  fail "Expected no-op (exit 1) for a file with no CCGM aliases, got $no_alias_exit"
+fi
+
+if diff -q "$ALIAS_TMPDIR/no-alias-before.zshrc" "$NO_ALIAS_RC" >/dev/null 2>&1; then
+  pass "File with no CCGM aliases left untouched"
+else
+  fail "File with no CCGM aliases was modified"
+fi
+echo ""
+
+# NOTE (platform coverage): this suite runs on macOS, so the assertions
+# above only exercise sed_inplace's BSD (sed -i with an empty-string suffix
+# argument) branch via lib/template.sh. The GNU branch (sed -i with no
+# separate suffix argument - the actual bug issue #949 fixes) is exercised
+# by CI's ubuntu-latest job, not by a local run on this machine.
+echo "NOTE: local run exercises the BSD/macOS sed_inplace branch only;"
+echo "the GNU/Linux branch is covered by CI's ubuntu-latest job."
+echo ""
+
 # --- Summary ---
 echo "==================================="
 echo "  Results: $PASS passed, $FAIL failed"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -15,19 +15,26 @@ source "${CCGM_ROOT}/lib/template.sh"
 
 # --- Remove CCGM shell aliases + comment header from a single rc file ---
 # Usage: remove_ccgm_alias_lines "/path/to/rc_file"
-# Returns 1 (no-op) when the file is missing or has no CCGM aliases.
+# Return codes:
+#   0 - CCGM aliases were present and removal succeeded
+#   1 - no-op: the file is missing or has no CCGM aliases (not an error)
+#   2 - CCGM aliases were present but sed failed to remove them (e.g. a
+#       read-only file or full disk) - the caller must surface this rather
+#       than report success
 # Only the alias step in start.sh ever writes a "# CCGM - " line to an rc
 # file, so matching the whole prefix (rather than specific trailing words)
 # is safe and also cleans up comment text left by older CCGM versions.
+# All three deletions run as one sed script/one sed_inplace call, so there
+# is a single exit status to check instead of three.
 remove_ccgm_alias_lines() {
   local rc="$1"
   if [ ! -f "$rc" ] || ! grep -qE 'alias ccgm(s)?=' "$rc" 2>/dev/null; then
     return 1
   fi
-  sed_inplace '/^# CCGM - /d' "$rc"
-  sed_inplace '/^alias ccgm=/d' "$rc"
-  sed_inplace '/^alias ccgms=/d' "$rc"
-  return 0
+  if sed_inplace '/^# CCGM - /d;/^alias ccgm=/d;/^alias ccgms=/d' "$rc"; then
+    return 0
+  fi
+  return 2
 }
 
 # ============================================================
@@ -288,11 +295,15 @@ main() {
   ui_header "Shell Aliases"
 
   local rc_files=("$HOME/.zshrc" "$HOME/.bashrc")
-  local rc alias_removed=false
+  local rc rc_status alias_removed=false
   for rc in "${rc_files[@]}"; do
-    if remove_ccgm_alias_lines "$rc"; then
+    rc_status=0
+    remove_ccgm_alias_lines "$rc" || rc_status=$?
+    if [ "$rc_status" -eq 0 ]; then
       ui_success "Removed CCGM aliases from $rc"
       alias_removed=true
+    elif [ "$rc_status" -eq 2 ]; then
+      ui_warn "Failed to remove CCGM aliases from $rc - check file permissions and remove manually"
     fi
   done
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -11,6 +11,24 @@ CCGM_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CCGM_ROOT}/lib/ui.sh"
 source "${CCGM_ROOT}/lib/backup.sh"
 source "${CCGM_ROOT}/lib/merge.sh"
+source "${CCGM_ROOT}/lib/template.sh"
+
+# --- Remove CCGM shell aliases + comment header from a single rc file ---
+# Usage: remove_ccgm_alias_lines "/path/to/rc_file"
+# Returns 1 (no-op) when the file is missing or has no CCGM aliases.
+# Only the alias step in start.sh ever writes a "# CCGM - " line to an rc
+# file, so matching the whole prefix (rather than specific trailing words)
+# is safe and also cleans up comment text left by older CCGM versions.
+remove_ccgm_alias_lines() {
+  local rc="$1"
+  if [ ! -f "$rc" ] || ! grep -qE 'alias ccgm(s)?=' "$rc" 2>/dev/null; then
+    return 1
+  fi
+  sed_inplace '/^# CCGM - /d' "$rc"
+  sed_inplace '/^alias ccgm=/d' "$rc"
+  sed_inplace '/^alias ccgms=/d' "$rc"
+  return 0
+}
 
 # ============================================================
 # Main
@@ -272,11 +290,7 @@ main() {
   local rc_files=("$HOME/.zshrc" "$HOME/.bashrc")
   local rc alias_removed=false
   for rc in "${rc_files[@]}"; do
-    if [ -f "$rc" ] && grep -qE 'alias ccgm(s)?=' "$rc" 2>/dev/null; then
-      # Remove alias lines and their CCGM comment lines
-      sed -i '' '/^# CCGM - .*session.*$/d' "$rc"
-      sed -i '' '/^alias ccgm=/d' "$rc"
-      sed -i '' '/^alias ccgms=/d' "$rc"
+    if remove_ccgm_alias_lines "$rc"; then
       ui_success "Removed CCGM aliases from $rc"
       alias_removed=true
     fi
@@ -295,4 +309,8 @@ main() {
   echo ""
 }
 
-main "$@"
+# Guard so this file can be sourced (e.g. by tests, to call
+# remove_ccgm_alias_lines directly) without triggering a live uninstall run.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi


### PR DESCRIPTION
Closes #949

## The bug

`uninstall.sh` stripped the `ccgm`/`ccgms` aliases from `~/.zshrc` and `~/.bashrc` with a hardcoded BSD-style `sed -i ''`. GNU sed (Linux) reads the empty string as the sed script (empty) and the real script as a filename instead, and exits nonzero:

```
sed: can't read /^# CCGM - .*session.*$/d: No such file or directory
```

Reproduced with real GNU sed (`brew install gnu-sed`, invoked as `gsed`) against the exact BSD-style invocation. Under `set -euo pipefail`, this aborts uninstall mid-run on Linux, after files are already removed but before the shell aliases are cleaned up.

## Approach taken

`lib/template.sh` already had this exact BSD/GNU detection (for `expand_templates`), so per the issue guidance I extracted it into a shared `sed_inplace()` helper in `lib/template.sh` rather than writing a second copy in `uninstall.sh`. Both `expand_templates()` and `uninstall.sh`'s alias-removal now call it. As a side benefit, `expand_templates()` lost a dead `sed_cmd` variable that computed the same branch and was never used, plus a second, duplicate copy of the same `OSTYPE` check right below it - three copies of this detection down to one.

I considered the temp-file-rewrite alternative (`sed ... > tmp && mv tmp file`, no `-i` at all) instead of extending the existing detection pattern. Went with the shared helper because the detection already existed, was already proven in `expand_templates()`, and this keeps one pattern for in-place sed across the whole repo rather than introducing a second style alongside it.

## A second bug found while writing the test

Writing the test ("assert the comment header is gone") surfaced a bug independent of the sed portability issue: the header-removal regex required the literal word `session` (`/^# CCGM - .*session.*$/d`), but `start.sh` has written `# CCGM - Claude Code launchers` since #561/#562 - the regex never matched it, on any platform. The comment line silently survived every uninstall, before and unrelated to the BSD/GNU issue. Fixed by broadening the pattern to the `# CCGM - ` prefix, which is the only thing CCGM ever writes to an rc file (confirmed - no other write site), so this also cleans up header text left by older CCGM versions instead of requiring an exact string match.

## Other `sed -i ''` sites

Searched `uninstall.sh`, `start.sh`, and `update.sh`. Found nothing outside the three lines this issue targets - `start.sh` and `update.sh` have zero `sed -i` invocations of any kind.

## Tests

Added Tests 8-10 to `tests/test-uninstall-settings.sh` (now wired into CI per #937, no new file to wire up):
- Test 8: alias lines + comment header removed, everything else in the rc file byte-identical (via `diff`, not a loose grep check)
- Test 9: idempotent - a second run on an already-clean file reports no-op and does not mutate the file
- Test 10: no-op on a file with no CCGM aliases at all

`uninstall.sh` gained a `remove_ccgm_alias_lines()` function (extracted from the inline loop body) plus a `BASH_SOURCE` guard around the `main "$@"` call at the bottom, matching the pattern `update.sh` already uses - tests source `uninstall.sh` and call the function directly against a scratch rc file, never `main()` and never the real `~/.zshrc`/`~/.bashrc`.

**Platform coverage, stated plainly**: this machine is macOS, so the local test run only exercises `sed_inplace`'s BSD branch (confirmed via the passing suite below). The GNU branch - the actual bug this issue fixes - is exercised by CI's `ubuntu-latest` job, not by this local run. I separately verified the GNU branch by hand: applied the exact same three patterns with real GNU sed (`gsed -i '/^# CCGM - /d' ...` etc., no separate suffix argument) against the same fixture content used in Test 8, and it produced the expected output with exit 0 on all three invocations.

## Verification

```
bash tests/test-uninstall-settings.sh   # 24 passed, 0 failed
bash tests/test-modules.sh              # 1702 passed, 0 failed
bash tests/test-installer.sh            # 87 passed, 0 failed
bash tests/test-templates.sh            # 22 passed, 0 failed
bash tests/test-no-personal-data.sh     # PASS
bash -n uninstall.sh                    # OK
```