### PR TITLE
#950: correct preset descriptions, dependency rows, and installer behavior docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Habit: always Read the workspace `modules/` path before any Edit, even if you re
 
 The `modules/autoheal/` directory holds CCGM's self-healing observability loop. It captures permission events, tool failures, and user-correction signals to a local JSONL log, runs a daily analyzer via direct Anthropic API call, and surfaces a digest of proposed configuration improvements.
 
-### Bring-up
+### Autoheal bring-up
 
 ```bash
 bash start.sh --add autoheal                         # install hooks/commands/rules/scripts
@@ -129,7 +129,7 @@ All four are **default OFF**. Autoheal stays observation-only until you opt in.
 
 Per-repo overrides live in `.autoheal/config.json` at the repo root. Both files are gitignored.
 
-### Slash commands
+### Autoheal slash commands
 
 | Command | Purpose |
 |---------|---------|
@@ -141,7 +141,7 @@ Per-repo overrides live in `.autoheal/config.json` at the repo root. Both files 
 | `/permission-fix [event-id\|latest]` | In-session root-cause sub-agent for a permission failure |
 | `/permission-audit` | Static audit of installed hooks + settings against the classification table |
 
-### Posture
+### Autoheal posture
 
 Autoheal is opt-in by design. The default install only captures events and surfaces a local digest. Nothing alerts mid-session, nothing auto-applies, no network calls leave the machine. Each opt-in is a deliberate `/autoheal-toggle` away.
 
@@ -149,7 +149,7 @@ Autoheal is opt-in by design. The default install only captures events and surfa
 
 The `modules/dreaming/` directory holds CCGM's nightly, cost-capped transcript-mining pipeline. It mines session transcripts into evidence-tagged `self-improving` learnings-store proposals. Every proposal is human-reviewed via `/dream-apply` by default; an opt-in **optimistic auto-integration** engine (`optimistic_integration.enabled`, default `false`) can integrate them instead, behind a per-op-kind posture (immediate for `verify`, a dwell window for `add`/`supersede`/`contradict`/`deprecate`), per-slug blast-radius caps, a batch-anomaly check, and a windowed circuit breaker.
 
-### Bring-up
+### Dreaming bring-up
 
 ```bash
 bash start.sh --add dreaming                          # install lib/bin/commands/rules
@@ -168,7 +168,7 @@ bash modules/self-improving/bin/memory-setup.sh       # activation prompts: read
 | `optimistic_integration.max_add_supersede_per_run` | `10` | Per-slug, per-night cap on `add` + `supersede` |
 | `optimistic_integration.max_eviction_absolute` / `max_eviction_fraction_per_run` | `3` / `0.20` | Per-slug, per-night cap on `contradict` + `deprecate` — the smaller of the two dominates |
 
-### Slash commands
+### Dreaming slash commands
 
 | Command | Purpose |
 |---------|---------|
@@ -180,7 +180,7 @@ bash modules/self-improving/bin/memory-setup.sh       # activation prompts: read
 
 Rollback for a bad auto-integrated batch is `ccgm-learnings-sync revert <sha>` (in `self-improving`) — not a raw `git revert`, which is unsound against this store's `merge=union` shard files.
 
-### Posture
+### Dreaming posture
 
 Human-gated apply (`/dream-apply`) is always on and requires no opt-in. Optimistic auto-integration is opt-in and off by default; every gate (eval regression, blast-radius caps, anomaly check, circuit breaker) is designed to hold even if the daily report is never read — only *undoing* an already-integrated row needs a read. See `modules/dreaming/rules/dreaming.md` for the full contract.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ Every module needs a `module.json` manifest. Here is the full schema:
   "category": "core",
   "scope": ["global", "project"],
   "dependencies": [],
+  "status": "stable",
   "files": {
     "rules/your-module.md": {
       "target": "rules/your-module.md",
@@ -141,6 +142,7 @@ The runner discovers these automatically, so no registration is needed.
 | `category` | string | yes | Module category (see categories below). |
 | `scope` | string[] | yes | Where the module can be installed: `"global"`, `"project"`, or both. |
 | `dependencies` | string[] | yes | Module names that must be installed first. Use `[]` for no dependencies. |
+| `status` | string | no | Gates whether the module is offered. Omit for a stable module; set to `"beta"` or `"deprecated"` otherwise. Recognized by the installer's module menu and by the preset-coverage test (a `beta`/`deprecated` module is auto-excluded from the "every stable module belongs in a preset" check). |
 | `files` | object | yes | Map of source paths to file descriptors (see below). |
 | `tags` | string[] | yes | Searchable tags for discovery. |
 | `configPrompts` | object[] | yes | Configuration questions asked during installation. Use `[]` for none. |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ CCGM places files into `~/.claude/` (global) or `.claude/` (project-level):
 |-----------|------|-------------------|
 | `rules/*.md` | Behavior rules | Loaded automatically at session start |
 | `commands/*.md` | Slash commands | Available as `/commit`, `/pr`, etc. |
+| `skills/*/SKILL.md` | Packaged capabilities | Invoked by name, e.g. `/brainstorm`, `/ce-review` |
 | `agents/*.md` | Subagent prompts | Reusable prompts invoked by commands and skills via the Task tool |
 | `hooks/*.py` | Workflow hooks | Triggered on Claude Code events |
 | `settings.json` | Permissions | Controls tool access and auto-approval |
@@ -56,7 +57,7 @@ Steps:
    Available presets and what they include:
      - minimal  : global-claude-md, autonomy, git-workflow
      - standard : the above + identity, hooks, branch-guard, ask-context, model-vetting, live-testing-guard, settings, commands-core, commands-utility, self-improving, output-formatting, writing-system, statusline
-     - team     : standard core + github-protocols, code-quality, systematic-debugging, verification
+     - team     : standard core (minus identity, commands-utility, model-vetting, live-testing-guard, self-improving, statusline) + github-protocols, code-quality, systematic-debugging, verification, autoheal, and review/compound-knowledge tooling (ce-review, pr-feedback, document-review, compound-knowledge, skill-authoring, subagent-patterns, pr-review-toolkit)
      - cloud-agent : large set for power users running autonomous agents
      - full     : every stable module
    Based on what you know about my workflow, recommend one preset. Ask me to confirm or pick a different one before continuing. (One question only — do not ask anything else.)
@@ -177,8 +178,8 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | Module | Category | Commands | Description | Dependencies |
 |--------|----------|----------|-------------|--------------|
 | **adversarial-review** | workflow | `/adrev` | Adversarial review of a plan or any entity (file, PR, issue, dir, concept). Separate reviewer agent attacks premises and failure modes; plan targets get findings incorporated automatically and four autonomous-execution tenets enforced (minimal human work, follow-up completion, decision context, comprehensive E2E coverage) unless told not to | subagent-patterns |
-| **agent-manager** | workflow | `/agents` | [DEPRECATED] Go-based terminal UI (/agents) for monitoring Claude Code agent processes via tmux. Unmaintained; not offered for new installs, kept in-repo for existing users | multi-agent |
-| **agent-native** | patterns | `/agent-native-audit` | Principles, audit skill, and a self-eval / red-team rubric for building applications where an agent is a first-class client | - |
+| **agent-manager** [DEPRECATED] | workflow | `/agents` | Go-based terminal UI (/agents) for monitoring Claude Code agent processes via tmux. Unmaintained; not offered for new installs, kept in-repo for existing users | multi-agent |
+| **agent-native** | patterns | `/agent-native-audit` | Principles, audit skill, and a self-eval / red-team rubric for building applications where an agent is a first-class client | subagent-patterns |
 | **argus** | workflow | `/argus` | Closed-loop visual-ATDD harness: deterministic gates plus a separate judge agent score UI renders against a design spec until convergence | subagent-patterns |
 | **ask-context** | core | - | Hard PreToolUse gate: no AskUserQuestion whose decision context is invisible to the user. Blocks deictic references, identical re-asks after pushback, and mid-workstream questions with no visible text | settings |
 | **atdd** | workflow | `/atdd` | Agentic Test-Driven Development. /atdd reads Playwright vision specs, iteratively builds app code until all tests pass, then ships | - |
@@ -190,16 +191,16 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | **browser-automation** | patterns | - | Browser tool selection (Chrome, Playwright, WebMCP), verification priority, UI testing workflow | - |
 | **capability-router** | commands | `/capabilities` | Decision map for CCGM's overlapping command clusters (research, review, planning, debugging, knowledge), plus a tight always-on pointer rule | - |
 | **ccgm-doctor** | workflow | - | Audit tool for Claude Code installs: dangling hook/command refs, lexical overlap between command descriptions, and a routing eval | - |
-| **ce-review** | commands | `/ce-review` | /ce-review unified code-review orchestrator. Composes scope-drift, learnings-researcher, tier-sharpener, and review-synthesizer with structured JSON findings | - |
+| **ce-review** | commands | `/ce-review` | /ce-review unified code-review orchestrator. Composes scope-drift, learnings-researcher, tier-sharpener, and review-synthesizer with structured JSON findings | compound-knowledge, pr-review-toolkit, subagent-patterns |
 | **cloud-dispatch** | workflow | `/dispatch`, `/dispatch-status`, `/dispatch-stop`, `/vm-manage` | Delegate GitHub issues to autonomous Claude Code agents on Hetzner Cloud VMs. Includes /dispatch, /dispatch-status, /dispatch-stop, /vm-manage commands | - |
 | **cloudflare** | tech-specific | - | Pages vs Workers selection, deployment methods, Git integration requirements | - |
 | **code-quality** | patterns | - | Code standards, testing requirements, error handling, security, build verification | - |
 | **commands-core** | commands | `/commit`, `/cpm`, `/ghi`, `/gs`, `/pr`, `/pr-description` | The everyday git loop: commit with an issue-prefixed message, open a PR that closes its issue, or run commit-PR-merge end to end. Plus repo status, issue creation, and a pure PR-body writer callable by other commands | - |
 | **commands-extra** | commands | `/audit`, `/checkpoint`, `/freeze`, `/guard`, `/promote-rule`, `/pwv`, `/unfreeze`, `/walkthrough` | Codebase audit, Playwright visual verification, step-by-step walkthrough mode, promoting a repo rule to global, and scope control: `/freeze` locks edits to one directory until `/unfreeze`, `/guard` pairs that with careful mode, `/checkpoint` saves and resumes work-in-progress state | - |
-| **commands-preamble** | workflow | - | [EXPERIMENTAL] UserPromptSubmit hook that injects a compact preamble of iron-law principles into every prompt | - |
+| **commands-preamble** | workflow | - | [EXPERIMENTAL] UserPromptSubmit hook that injects a compact preamble of iron-law principles into every prompt | settings, autonomy, code-quality |
 | **commands-utility** | commands | `/ccgm-sync`, `/cws-submit`, `/user-test` | Chrome Web Store submission walkthrough, syncing local config changes back to the CCGM repo, and browser-driven user testing | - |
 | **common-mistakes** | patterns | - | 8 battle-tested anti-patterns: shallow exploration, dependency blindness, ESLint Fast Refresh, more | - |
-| **compound-knowledge** | workflow | `/compound`, `/compound-refresh`, `/compound-reproject` | Team-shared learnings in `docs/solutions/`. After solving a non-trivial problem, capture the pattern in a versioned schema | - |
+| **compound-knowledge** | workflow | `/compound`, `/compound-refresh`, `/compound-reproject` | Team-shared learnings in `docs/solutions/`. After solving a non-trivial problem, capture the pattern in a versioned schema | skill-authoring |
 | **copycat** | commands | `/copycat` | Analyzes external Claude Code config repos and reports the patterns, rules, and techniques worth adopting into CCGM | - |
 | **debugging** | commands | `/debug` | Structured root-cause debugging on Opus: reproduce, hypothesize, instrument, diagnose, fix, verify, instead of guessing at a fix | - |
 | **deepresearch** | commands | `/deepresearch` | Multi-query semantic research via the Exa MCP server: parallel query fan-out synthesized into a structured research.md | - |
@@ -221,7 +222,7 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | **make-interfaces-feel-better** | patterns | `/make-interfaces-feel-better` | Design-engineering details that compound into polished interfaces. Model-invoked skill covering design direction, typography, surfaces, animations, performance | - |
 | **mcp-development** | tech-specific | - | Building MCP servers: project structure, tool design, error handling, testing, evaluation patterns | - |
 | **model-vetting** | core | - | Security vetting gate for new AI models: weights provenance, format safety, license/data terms, serving path, staged agentic access | - |
-| **multi-agent** | workflow | `/handoff`, `/mawf`, `/workspace-setup` | Multi-clone parallel agent work with issue claiming, port allocation, /mawf workflow | startup-dashboard |
+| **multi-agent** | workflow | `/handoff`, `/mawf`, `/workspace-setup` | Multi-clone parallel agent work with issue claiming, port allocation, /mawf workflow | startup-dashboard, hooks |
 | **onboarding** | commands | `/onboarding` | Analyzes a repository and generates a structured ONBOARDING.md for new contributors | - |
 | **orrery** | commands | `/orrery` | Deep-dives a codebase with parallel read-only scouts and renders an interactive, zoomable, embeddable system-design map as one self-contained HTML file: 4 zoom tiers, GitHub links pinned to an anchor SHA, per-node product prose; `/orrery update` refreshes it | - |
 | **output-formatting** | patterns | - | Copy-pasteable content goes in fenced code blocks, never blockquotes, so it pastes clean anywhere | - |
@@ -249,7 +250,7 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | **tailwind** | tech-specific | - | Tailwind CSS v4 design system: CSS-first config, design tokens, CVA variants, dark mode, responsive grids | - |
 | **test-driven-development** | patterns | - | Strict red-green-refactor TDD discipline. No production code without a failing test first | - |
 | **test-vision** | workflow | `/e2e`, `/test-vision` | Vision-driven e2e test suite generation. /test-vision for full repo analysis + parallel test suite creation. /e2e for single-feature spec generation | browser-automation, multi-agent |
-| **todos** | workflow | `/todo-create`, `/todo-resolve`, `/todo-triage` | File-based review-finding tracker. Review findings, PR nitpicks, and tech debt tracked with structured YAML | - |
+| **todos** | workflow | `/todo-create`, `/todo-resolve`, `/todo-triage` | File-based review-finding tracker. Review findings, PR nitpicks, and tech debt tracked with structured YAML | skill-authoring, subagent-patterns |
 | **verification** | patterns | - | Evidence-before-claims: fresh execution of verification commands, read full output before asserting done | - |
 | **writing-system** | patterns | `/rewrite` | Orwell's six rules as the global prose standard for docs, PR text, commits, and reports, plus /rewrite (violations list, then rewrite; mode:landing swap test) | - |
 | **xplan** | workflow | `/etp`, `/xplan`, `/xplan-resume`, `/xplan-status`, `/xplana` | Interactive planning framework: discovery interview, deep research, tech stack sign-off, constructive peer review + a 3-pass sequential adversarial review that enforces four plan-execution tenets (minimal/edge-bucketed human work, follow-up completion, autonomous decision context, comprehensive autonomous E2E test suite), parallel agent execution. Requires [/deepresearch](#companion-module-deepresearch) | multi-agent, adversarial-review |
@@ -378,7 +379,7 @@ The `docs/` directory contains comprehensive documentation:
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
 | [Install via Agent](docs/install-via-agent.md) | Per-preset paste-blocks and how to dry-run them safely |
 | [Module Catalog](docs/modules.md) | Detailed reference for all 78 modules |
-| [Commands Reference](docs/commands.md) | All 84 slash commands with usage examples |
+| [Commands Reference](docs/commands.md) | All 89 slash commands with usage examples |
 | [Hooks Reference](docs/hooks.md) | All 31 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -756,6 +756,85 @@ Synthesizes what shipped in a time window by walking the git log, surfacing hots
 
 ---
 
+## Dreaming commands
+
+Installed by the **dreaming** module. Dreaming mines session transcripts nightly into evidence-tagged proposals against the self-improving learnings store. Every proposal is human-gated by default (`/dream-apply`); an opt-in optimistic auto-integration engine can apply proposals unattended instead, behind a dwell window and blast-radius caps.
+
+---
+
+### /dream
+
+**Status overview for the dreaming pipeline.**
+
+Read-only. Shows the slash command surface, current config flags, the last-mined watermark per project slug, today's digest path, pending/accepted/rejected proposal counts, any active canary incident, whether the nightly LaunchAgent is loaded, and (when optimistic auto-integration is on) its enabled/suspended state and dwelling-row count.
+
+**Usage**:
+```
+/dream
+```
+
+**Installed by**: dreaming module
+
+---
+
+### /dream-digest
+
+**Render today's dreaming digest, or a specific past date's.**
+
+Prints the markdown digest generated from that day's mined proposals. Falls back to materializing the digest from the day's proposals file if it has not been rendered yet.
+
+**Usage**: `/dream-digest` (today) or `/dream-digest 2026-05-15`.
+
+**Installed by**: dreaming module
+
+---
+
+### /dream-apply
+
+**List, apply, or reject pending dreaming proposals.**
+
+The always-available, human-gated write path from a mined proposal into the learnings store — including the only path a `_global` proposal can ever be promoted through. `/dream-apply` (no args) lists pending proposals; `/dream-apply <id>` shows and applies one; `/dream-apply <id> reject` dismisses it without a store write.
+
+**Usage**:
+```
+/dream-apply
+/dream-apply <proposal-id>
+/dream-apply <proposal-id> reject
+```
+
+**Installed by**: dreaming module
+
+---
+
+### /dream-review
+
+**Review auto-integrated and still-dwelling rows; veto or revert.**
+
+The post-hoc control surface for opt-in optimistic auto-integration: lists rows that auto-applied on their own plus rows still inside their dwell window (written, not yet read-eligible), reverses a single bad row (`veto <id>`), or reverts an entire night's batch (`revert <batch_id|sha>`).
+
+**Usage**:
+```
+/dream-review
+/dream-review veto <id>
+/dream-review revert <batch_id>
+```
+
+**Installed by**: dreaming module
+
+---
+
+### /dream-scorecard
+
+**Weekly observability scorecard for the memory system.**
+
+Renders deterministic figures for the 7 days ending on a given date (default today): captured, injected, and reused learnings; applied proposals; optimistic-integration safety signals (auto-integrated, mid-dwell, reverted-after-review, circuit-breaker trips); and overall store health.
+
+**Usage**: `/dream-scorecard` (last 7 days) or `/dream-scorecard 2026-06-30`.
+
+**Installed by**: dreaming module
+
+---
+
 ## Autoheal commands
 
 Installed by the **autoheal** module. The autoheal pipeline observes hook events, runs a daily transcript analyzer, and surfaces actionable proposals through these commands.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ The installer asks for a few values up front, before you pick modules:
 - **Code directory** - where your projects live (default: `~/code`)
 - **Timezone** - auto-detected from system settings
 
-These three are always asked, regardless of which modules you select. After module selection, the installer asks any further questions the chosen modules define - currently just **Permission mode** (`ask` or `dontAsk`), from the **settings** module.
+These three are always asked, regardless of which modules you select. After module selection, the installer asks whatever further questions the chosen modules declare in their own `configPrompts` - the set depends entirely on what you picked. For example: permission mode (`ask` or `dontAsk`) from `settings`, protected branch names from `hooks`, or SSH connection details from `remote-server`. See [Installer - Step 7](installer.md#step-7-module-config-prompts) for how these are collected.
 
 ### 4. Restart Claude Code
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,20 +39,21 @@ Five presets exist, and the interactive menu offers all of them. You can also se
 |--------|-------------|----------|
 | **minimal** | Core autonomy + git workflow rules | Trying CCGM for the first time |
 | **standard** | Minimal + hooks, settings, core commands | Most individual developers |
-| **team** | Standard + github-protocols, code-quality, systematic-debugging, verification | Teams with shared repos |
+| **team** | Core workflow + code-quality, systematic-debugging, verification, autoheal, and PR-review/compound-knowledge tooling | Teams with shared repos |
 | **full** | 74 modules | Power users who want everything |
-| **cloud-agent** | Full minus desktop-only modules, plus agent orchestration | Headless cloud VMs dispatching parallel agents |
+| **cloud-agent** | Full minus 19 desktop/interactive-only modules (writing-system, capability-router, ccgm-doctor, skillify, todos, orrery, etc.) | Headless cloud VMs dispatching parallel agents |
 
 See [Presets](presets.md) for detailed breakdowns.
 
 ### 3. Answer configuration prompts
 
-Depending on which modules you selected, the installer may ask:
+The installer asks for a few values up front, before you pick modules:
 
-- **GitHub username** - auto-detected from `gh api user` if GitHub CLI is installed
+- **GitHub username** - auto-detected from `gh api user` if GitHub CLI is installed, otherwise prompted
 - **Code directory** - where your projects live (default: `~/code`)
 - **Timezone** - auto-detected from system settings
-- **Permission mode** - `ask` (confirm before risky actions) or `dontAsk` (full auto-approval)
+
+These three are always asked, regardless of which modules you select. After module selection, the installer asks any further questions the chosen modules define - currently just **Permission mode** (`ask` or `dontAsk`), from the **settings** module.
 
 ### 4. Restart Claude Code
 
@@ -75,7 +76,9 @@ CCGM can install to either or both of two locations:
 ./start.sh --scope both       # Both locations
 ```
 
-Global installation is the most common choice. Project-level installation is useful when you want different rules for a specific repo, or when sharing configuration with a team via version control.
+Global installation is the most common choice. Project-level installation is useful when you want different rules for a specific repo.
+
+Only 18 of the 78 modules declare `"project"` in their `scope`. A module that does not lists nothing to install at project scope: `start.sh` silently skips it and prints no message. If you install with `--scope project` alone, expect most of the modules you picked to install nothing - check each module's README for whether it supports project scope before relying on it.
 
 ## Install modes
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,7 +78,7 @@ CCGM can install to either or both of two locations:
 
 Global installation is the most common choice. Project-level installation is useful when you want different rules for a specific repo.
 
-Only 18 of the 78 modules declare `"project"` in their `scope`. A module that does not lists nothing to install at project scope: `start.sh` silently skips it and prints no message. If you install with `--scope project` alone, expect most of the modules you picked to install nothing - check each module's README for whether it supports project scope before relying on it.
+Only 18 of the 78 modules declare `"project"` in their `scope`. A module that doesn't has nothing to install there: `start.sh` silently skips it and prints no message. If you install with `--scope project` alone, expect most of the modules you picked to install nothing - check each module's README for whether it supports project scope before relying on it.
 
 ## Install modes
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -20,6 +20,8 @@ Hooks are registered in `settings.json` under the `hooks` key. Each hook specifi
 
 The **hooks** module installs 15 hooks, 6 Python libraries, and a settings partial. Seven other modules add the rest: **self-improving** 3, **subagent-patterns** 2, and one each from **branch-guard**, **ask-context**, **startup-dashboard**, **commands-preamble**, and **relevance-injection**. Total: 25 hooks across 8 modules (the **autoheal** module's 6 observational hooks are documented in their own section below, bringing the installed total to 31).
 
+This count excludes `hooks/plugin-rule-inject.py`, which brings the true `"type": "hook"` file total to 32. It is the **plugin-marketplace** module's own hook, copied into every other rules-bearing module's `hooks/` directory so each module's generated Claude Code plugin manifest can register it independently - see [plugin-marketplace](../modules/plugin-marketplace/README.md) for what it does.
+
 ---
 
 ### enforce-git-workflow.py

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -165,7 +165,7 @@ The uninstaller:
 7. Offers to restore from the safety backup if you change your mind
 8. Removes the `ccgm`/`ccgms` aliases from `~/.zshrc` and `~/.bashrc`, if present
 
-Only CCGM-installed files are removed. Personal files you created in `~/.claude/` are untouched. `settings.json` keeps any keys you added yourself - CCGM only un-merges out what it contributed, and removes the file itself if that leaves nothing behind.
+Only CCGM-installed files are removed. Personal files you created in `~/.claude/` are untouched.
 
 ## Installer library
 

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -2,6 +2,8 @@
 
 The CCGM installer (`start.sh`) is an interactive bash script that handles prerequisite checking, module selection, dependency resolution, file installation, and verification.
 
+Requires bash 3.2+ - the installer scripts always run under bash via their shebang, regardless of your login shell.
+
 ## Installation flow
 
 The installer runs 15 sequential steps, plus a conditional Step 14b (legacy MCP migration):
@@ -48,7 +50,7 @@ Choose a preset (the menu lists every file under `presets/`, alphabetically: clo
 
 Automatically adds any modules required by your selection. Uses a depth-first topological sort with cycle detection. Reports any automatically added dependencies.
 
-For example, selecting `xplan` automatically adds its dependencies `multi-agent` and `adversarial-review`, which in turn add `startup-dashboard` (multi-agent's dependency) and `subagent-patterns` (adversarial-review's dependency). `startup-dashboard` then adds `session-history`.
+For example, selecting `xplan` automatically adds its dependencies `multi-agent` and `adversarial-review`, which in turn add `startup-dashboard` and `hooks` (multi-agent's dependencies) and `subagent-patterns` (adversarial-review's dependency). `startup-dashboard` then adds `session-history`, and `hooks` adds `settings`. The full closure is 8 modules: `session-history`, `startup-dashboard`, `settings`, `hooks`, `multi-agent`, `subagent-patterns`, `adversarial-review`, `xplan`.
 
 ### Step 7: Module config prompts
 
@@ -157,11 +159,13 @@ The uninstaller:
 1. Reads `.ccgm-manifest.json` to find the exact files that were installed
 2. Creates a safety backup before removing anything
 3. Removes each file (handles both regular files and symlinks)
-4. Removes `.ccgm-manifest.json` and `.ccgm.env`
-5. Cleans up empty `rules/`, `commands/`, and `hooks/` directories
-6. Offers to restore from the safety backup if you change your mind
+4. Un-merges CCGM-contributed keys from merge targets like `settings.json`, leaving the file in place with your own keys intact - it is never deleted
+5. Removes `.ccgm-manifest.json` and `.ccgm.env`
+6. Cleans up empty `rules/`, `commands/`, and `hooks/` directories
+7. Removes the `ccgm`/`ccgms` aliases from `~/.zshrc` and `~/.bashrc`, if present
+8. Offers to restore from the safety backup if you change your mind
 
-Only CCGM-installed files are removed. Personal files you created in `~/.claude/` are untouched.
+Only CCGM-installed files are removed. Personal files you created in `~/.claude/` are untouched, and `settings.json` itself is never deleted - only the keys CCGM added are un-merged out of it.
 
 ## Installer library
 

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -159,13 +159,13 @@ The uninstaller:
 1. Reads `.ccgm-manifest.json` to find the exact files that were installed
 2. Creates a safety backup before removing anything
 3. Removes each file (handles both regular files and symlinks)
-4. Un-merges CCGM-contributed keys from merge targets like `settings.json`, leaving the file in place with your own keys intact - it is never deleted
+4. Un-merges CCGM-contributed keys from merge targets like `settings.json`. If any of your own keys remain afterward, the file stays in place with just those keys; if nothing remains (the common case if you never added your own permissions), the file itself is deleted
 5. Removes `.ccgm-manifest.json` and `.ccgm.env`
 6. Cleans up empty `rules/`, `commands/`, and `hooks/` directories
-7. Removes the `ccgm`/`ccgms` aliases from `~/.zshrc` and `~/.bashrc`, if present
-8. Offers to restore from the safety backup if you change your mind
+7. Offers to restore from the safety backup if you change your mind
+8. Removes the `ccgm`/`ccgms` aliases from `~/.zshrc` and `~/.bashrc`, if present
 
-Only CCGM-installed files are removed. Personal files you created in `~/.claude/` are untouched, and `settings.json` itself is never deleted - only the keys CCGM added are un-merged out of it.
+Only CCGM-installed files are removed. Personal files you created in `~/.claude/` are untouched. `settings.json` keeps any keys you added yourself - CCGM only un-merges out what it contributed, and removes the file itself if that leaves nothing behind.
 
 ## Installer library
 

--- a/tests/test-doc-counts.sh
+++ b/tests/test-doc-counts.sh
@@ -395,6 +395,52 @@ else
   ok "README catalog Commands column matches every module.json"
 fi
 
+# --- (f3) README catalog Dependencies column matches module.json ------------
+# Same shape as (f2): the Dependencies column is pure fact, derived from each
+# module.json's own dependencies[] array. A module whose deps change without
+# the catalog row following fails here.
+
+CATALOG_DEP_DIFF=$(python3 - <<'PYEOF'
+import json, pathlib, re, sys
+
+def declared(mod):
+    d = json.load(open(f"modules/{mod}/module.json"))
+    return list(d.get("dependencies", []))
+
+lines = pathlib.Path("README.md").read_text().split("\n")
+SEP = "|--------|----------|----------|-------------|--------------|"
+try:
+    s = lines.index(SEP)
+except ValueError:
+    print("catalog separator not found; the column layout changed")
+    sys.exit(0)
+
+e = s + 1
+problems = []
+while e < len(lines) and lines[e].startswith("| **"):
+    cells = [c.strip() for c in lines[e].strip().strip("|").split(" | ")]
+    name = re.match(r"\*\*([^*]+)\*\*", cells[0]).group(1)
+    want = ", ".join(declared(name)) or "-"
+    if len(cells) != 5:
+        # Already reported by the (f2) cell-count check above; skip here.
+        pass
+    elif cells[4] != want:
+        problems.append(f"{name}: column says [{cells[4]}], module.json declares [{want}]")
+    e += 1
+
+for p in problems:
+    print(p)
+PYEOF
+)
+
+if [ -n "$CATALOG_DEP_DIFF" ]; then
+  fail "README catalog Dependencies column disagrees with module.json:
+$CATALOG_DEP_DIFF
+  -> update the Dependencies cell so it lists every entry in the module's dependencies[] array."
+else
+  ok "README catalog Dependencies column matches every module.json"
+fi
+
 # --- (g) command + hook count claims track the reference docs ---------------
 # README advertises how many commands and hooks the reference docs cover. Derive
 # both from the docs themselves so the advertised number cannot go stale.


### PR DESCRIPTION
Closes #950

Fixes 15 doc-drift findings from the 2026-08-02 docupdate audit. Re-derived every finding from the repo before editing (jq against `presets/*.json` and `modules/*/module.json`, `grep`/`comm` against `start.sh`/`uninstall.sh`/`docs/commands.md`) rather than copying the issue's numbers on trust.

## CRITICAL

**1-2. Preset descriptions (README.md, docs/getting-started.md).** Re-ran the set-diffs: `standard - team` is exactly the 6 modules the issue named, `team - standard` (minus the 4 already covered by "standard core +") is exactly the 8 it named. Fixed the README paste block and the getting-started table to describe `team` accurately instead of "standard + 4 modules". For `cloud-agent`, confirmed `cloud-agent ⊆ full` with zero modules added (`comm -23 cloud full` is empty) - fixed getting-started's "Full minus desktop-only, plus agent orchestration" to "Full minus 19 desktop/interactive-only modules", dropping the false "plus" framing (cloud-dispatch is already in `full`, not something `cloud-agent` adds on top).

**3. Dependencies column (README.md), 6 rows.** Verified each with `jq '.dependencies' modules/<name>/module.json` - all 6 matched the issue exactly. Fixed the rows. Also extended `tests/test-doc-counts.sh` with a `(f3)` check that derives the Dependencies column from `module.json` the same way the existing `(f2)` check already does for Commands - proved it fails on a deliberately-wrong row (temporarily set agent-native's cell to a bogus value, watched the guard catch it, reverted) before leaving it in place passing.

## MISSING

**4. `docs/commands.md` missing the dreaming module's 5 commands.** Counted real commands from disk: 68 `commands/*.md` files + 24 `skills/*/SKILL.md` dirs, 89 unique names after dedup. Diffed against the 84 headings in `docs/commands.md` - the gap is exactly the 5 dreaming commands (`dream`, `dream-apply`, `dream-digest`, `dream-review`, `dream-scorecard`), confirming the issue's claim precisely. Added a "Dreaming commands" section (placed after Self-improving, since dreaming depends on it) matching the file's existing per-command format, and updated README's "All 84 slash commands" to 89.

**5. `skills/` row missing from README's "what gets installed" table.** Added it between `commands/*.md` and `agents/*.md`.

**6. `docs/installer.md` Uninstalling section.** Read `uninstall.sh` directly: lines 269-289 strip the `ccgm`/`ccgms` aliases from `.zshrc`/`.bashrc`, and lines 77-90/143-201 never delete `settings.json` - only CCGM-contributed keys are un-merged out, preserving the user's own settings. Rewrote the step list to include both behaviors.

**7. `docs/getting-started.md` config prompts ordering.** Confirmed in `start.sh`: Step 3 (username/code-dir/timezone, unconditional) runs before Step 4 (scope) and Step 5 (modules); only Permission mode is a real `configPrompts` entry, from `settings`. Rewrote the section to state the three unconditional prompts first and note Permission mode is the one module-conditional question.

**8. `docs/getting-started.md` project-scope oversell.** Confirmed via `jq`: 18 of 78 modules declare `"project"` scope; of `standard`'s 16, exactly 2 do (`autonomy`, `git-workflow`); of `team`'s 22, exactly 7 do. Confirmed the silent-skip in `start.sh:253` (`[ -z "$target_dir" ] && continue`, no message) for a module whose scope doesn't include `project`. Added a plain paragraph stating the constraint without discouraging project scope generally.

**9. `CONTRIBUTING.md` missing the `status` field.** Confirmed 4 modules use it (`agent-manager`, `dreaming`, `plugin-marketplace`, `relevance-injection`) and that `lib/modules.sh`'s `is_beta`/`is_deprecated` (called from `start.sh`'s module-menu code) read it. Added it to both the full schema example and the Top-Level Fields table.

## STALE

**10. `docs/installer.md` dependency-resolution example.** Walked the full closure for `xplan` module-by-module: 8 modules total (`session-history`, `startup-dashboard`, `settings`, `hooks`, `multi-agent`, `subagent-patterns`, `adversarial-review`, `xplan`), matching the issue exactly. The old example omitted `hooks` and `settings`. Rewrote it to name the full closure.

## MINOR

**11.** Added the bash 3.2+ floor to `docs/installer.md` (README and getting-started already had it).

**12.** Renamed CLAUDE.md's 3 colliding H3 pairs: "Bring-up" -> "Autoheal bring-up" / "Dreaming bring-up", "Slash commands" -> "Autoheal slash commands" / "Dreaming slash commands", "Posture" -> "Autoheal posture" / "Dreaming posture". Confirmed nothing links to the old anchors first.

**13.** Added a note to `docs/hooks.md` explaining why `plugin-rule-inject.py` isn't in the 31-hook count, and points at the plugin-marketplace module's README for what the file does. One correction to the issue's own evidence: it's `"type": "hook"` in exactly one module.json (plugin-marketplace's own, which is the source of the 32 vs 31 the issue correctly cites) - the file is *copied* into 39 other modules' `hooks/` directories and referenced from their `.claude-plugin/plugin.json` manifests (as a `"type": "command"` hook wrapper, Claude Code's own plugin-manifest vocabulary, not CCGM's `module.json` one), not declared `"type": "hook"` in 39 module.json files as literally stated. The note in the fix doesn't repeat that specific wording.

**14.** No content change - `docs/modules.md` is currently correct (78/78, confirmed via `grep -c '^### '`). The issue's point is that no guard checks its per-module row-set or ordering, only its top-line count claim. Left as-is per the issue's own framing (a latent guard gap, not present drift); noted here for visibility.

**15.** Moved `agent-manager`'s `[DEPRECATED]` from inside the description cell to a `**agent-manager** [DEPRECATED]` name suffix, matching the convention `dreaming`/`plugin-marketplace`/`relevance-injection` already use (3 of 4 tagged modules used the suffix style).

## Verification

```
bash tests/test-doc-counts.sh        # exit 0, all checks pass (incl. new Dependencies-column check)
bash tests/test-modules.sh           # exit 0, 1702 passed, 0 failed
bash tests/test-no-personal-data.sh  # exit 0, PASS
bash tests/test-frontmatter-yaml.sh  # exit 0, all frontmatter valid
python3 modules/plugin-marketplace/lib/gen_marketplace.py --check   # exit 0, up to date
```

Also proved the new `(f3)` Dependencies-column check actually fails on bad input: temporarily corrupted one row's Dependencies cell, re-ran the guard (`FAIL: ... agent-native: column says [wrong-dep-for-selftest], module.json declares [subagent-patterns]`), then reverted and re-ran clean.

## Not touched

`modules/*/README.md` (issue #951) and `uninstall.sh` (issue #949) - out of scope per the dispatch spec.
