### PR TITLE
#953: InstructionsLoaded measurement harness

### DIFF
--- a/modules/relevance-injection/README.md
+++ b/modules/relevance-injection/README.md
@@ -47,11 +47,14 @@ CCGM_RELEVANCE_TASKTYPES=backend,testing      # optional
 ## Manual Installation
 
 ```bash
-cp rules/relevance-injection.md   ~/.claude/rules/relevance-injection.md
-cp hooks/relevance-inject.py      ~/.claude/hooks/relevance-inject.py
-cp lib/relevance_select.py        ~/.claude/lib/relevance_select.py
-cp lib/applicability-schema.json  ~/.claude/lib/applicability-schema.json
-# then merge settings.partial.json into ~/.claude/settings.json (SessionStart hook)
+cp rules/relevance-injection.md        ~/.claude/rules/relevance-injection.md
+cp hooks/relevance-inject.py           ~/.claude/hooks/relevance-inject.py
+cp hooks/instructions-loaded-log.py    ~/.claude/hooks/instructions-loaded-log.py
+cp lib/relevance_select.py             ~/.claude/lib/relevance_select.py
+cp lib/loaded_log.py                   ~/.claude/lib/loaded_log.py
+cp lib/applicability-schema.json       ~/.claude/lib/applicability-schema.json
+# then merge settings.partial.json into ~/.claude/settings.json
+# (registers the SessionStart and InstructionsLoaded hooks)
 ```
 
 ## Files
@@ -60,6 +63,8 @@ cp lib/applicability-schema.json  ~/.claude/lib/applicability-schema.json
 |------|-------------|
 | `rules/relevance-injection.md` | Tiered safety-core precedence + how the opt-in feature works |
 | `hooks/relevance-inject.py` | SessionStart hook; no-op unless the opt-in flag is set |
+| `hooks/instructions-loaded-log.py` | `InstructionsLoaded` hook; appends one JSONL record per loaded instruction file to `~/.claude/rule-loading/loaded-{date}.jsonl` |
 | `lib/relevance_select.py` | Pure, deterministic selection library (safety core + applicability matching) |
+| `lib/loaded_log.py` | Reads the rule-loading log: `parse_log()` and `assert_loaded()` |
 | `lib/applicability-schema.json` | JSON Schema for the optional `module.json` `applicability` field |
-| `settings.partial.json` | Registers the SessionStart hook |
+| `settings.partial.json` | Registers the SessionStart and InstructionsLoaded hooks |

--- a/modules/relevance-injection/hooks/instructions-loaded-log.py
+++ b/modules/relevance-injection/hooks/instructions-loaded-log.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""InstructionsLoaded hook: log which instruction files Claude Code loads.
+
+PURPOSE (plan.md Epic 7 -- `~/code/plans/ccgm-dynamic-rule-injection/plan.md`)
+------------------------------------------------------------------------------
+This is the deterministic measurement oracle for the rest of the dynamic
+rule-loading plan: it turns "did the right rule load?" from a model
+judgment into a fact recorded on disk. Registers on the `InstructionsLoaded`
+hook event with no matcher and appends one JSONL record per invocation to
+`~/.claude/rule-loading/loaded-{YYYY-MM-DD}.jsonl`.
+
+OBSERVED PAYLOAD SHAPE (confirmed live, `claude -p` 2.1.220, project-level
+settings.json, recorded in decisions.md)
+------------------------------------------------------------------------------
+Claude Code invokes this hook ONCE PER LOADED INSTRUCTION FILE (not once per
+session with a batched list). Each stdin payload is a flat JSON object:
+
+    {
+      "session_id": "...",
+      "transcript_path": "...",
+      "cwd": "...",
+      "hook_event_name": "InstructionsLoaded",
+      "file_path": "/absolute/path/to/the/loaded/file.md",
+      "memory_type": "User",          # observed value; others are plausible
+      "load_reason": "session_start"  # observed value; others are plausible
+    }
+
+This logger extracts those fields directly (so downstream parsing in
+lib/loaded_log.py is a flat-field read, not a nested-list search) AND keeps
+the full redacted raw payload under "raw" as a forward-compat safety net --
+if Anthropic adds or renames a field, the raw payload still has it even
+before the structured extraction above is updated.
+
+DESIGN CONSTRAINTS (same as every CCGM hook)
+------------------------------------------------------------------------------
+  - NEVER blocks the host action: always exits 0, even on a malformed or
+    empty stdin payload.
+  - Applies hook_utils.redact_secrets() to the raw payload BEFORE it is
+    stored, same as autoheal's event logger.
+  - Uses hook_utils.file_locked_append() so concurrent clones / concurrent
+    hook invocations within one session cannot interleave or tear a write.
+  - Log directory is overridable via $CCGM_RULE_LOADING_DIR for tests.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.expanduser("~/.claude/lib"))
+import hook_utils  # noqa: E402
+
+
+def _rule_loading_dir() -> str:
+    """Resolve the rule-loading data directory. Tests can override via env."""
+    override = os.environ.get("CCGM_RULE_LOADING_DIR")
+    if override:
+        return override
+    return os.path.expanduser("~/.claude/rule-loading")
+
+
+def _today_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).date().isoformat()
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+
+def _str_or_none(value: object) -> "str | None":
+    return value if isinstance(value, str) and value else None
+
+
+def _redacted_raw(data: dict) -> dict:
+    """Return `data` with any secret-shaped substring redacted.
+
+    Round-trips through JSON so the result is guaranteed JSON-serializable
+    even if `data` contains non-JSON-native values (defensive; hook stdin is
+    already parsed JSON so this is normally a no-op transform).
+    """
+    try:
+        raw_text = json.dumps(data, default=str)
+    except (TypeError, ValueError):
+        return {}
+    redacted_text = hook_utils.redact_secrets(raw_text)
+    try:
+        result = json.loads(redacted_text)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    return result if isinstance(result, dict) else {}
+
+
+def build_record(data: dict) -> dict:
+    """Build the JSONL record for one InstructionsLoaded invocation.
+
+    Pure function of `data` (plus wall-clock time) so it is directly
+    testable without stdin or filesystem I/O.
+    """
+    return {
+        "hook_event_name": _str_or_none(data.get("hook_event_name")) or "InstructionsLoaded",
+        "timestamp": _now_iso(),
+        "session_id": _str_or_none(data.get("session_id")),
+        "cwd": _str_or_none(data.get("cwd")),
+        "file_path": _str_or_none(data.get("file_path")),
+        "memory_type": _str_or_none(data.get("memory_type")),
+        "load_reason": _str_or_none(data.get("load_reason")),
+        "raw": _redacted_raw(data),
+    }
+
+
+def main() -> None:
+    try:
+        data = hook_utils.read_hook_input()
+        record = build_record(data)
+        target = os.path.join(_rule_loading_dir(), "loaded-" + _today_iso() + ".jsonl")
+        hook_utils.file_locked_append(target, json.dumps(record))
+    except Exception:
+        # NEVER block the session. A logger failure must be invisible to the
+        # host event, same contract as every other CCGM observability hook.
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/relevance-injection/lib/loaded_log.py
+++ b/modules/relevance-injection/lib/loaded_log.py
@@ -59,8 +59,17 @@ def parse_log(path: "str | os.PathLike") -> "list[dict]":
       valid ones written before it. With replacement, the undecodable
       bytes become U+FFFD and the line is then treated like any other:
       kept if it still parses as a JSON object, dropped if it does not.
-      A retained record cannot cause a false positive in assert_loaded()
-      because no real rule path contains U+FFFD.
+
+      A retained record is safe for assert_loaded() for two reasons, and
+      the weaker one is not sufficient alone. Exact and bare-form matches
+      compare the whole path, which cannot equal a real rule path once it
+      contains U+FFFD. The suffix branch compares only the tail, so in
+      principle a record could carry corruption in its leading directories
+      and still match a real rule -- but that record names the rule it
+      claims to name, so treating it as loaded is correct, and the hook's
+      own writes use ensure_ascii=True and can never emit invalid bytes at
+      all. Corruption reaching this path is external, and it does not
+      respect path boundaries.
     - A line that parses to a JSON object is appended to the result
       as-is.
     """

--- a/modules/relevance-injection/lib/loaded_log.py
+++ b/modules/relevance-injection/lib/loaded_log.py
@@ -1,0 +1,139 @@
+"""Parsing library for the InstructionsLoaded measurement log (Epic 7).
+
+Consumes the JSONL log written by
+`modules/relevance-injection/hooks/instructions-loaded-log.py` at
+`~/.claude/rule-loading/loaded-{YYYY-MM-DD}.jsonl` (or wherever
+`$CCGM_RULE_LOADING_DIR` points a test at).
+
+Two entry points, both pure functions of the filesystem (no hook I/O):
+
+    parse_log(path) -> list[dict]
+        Read a single JSONL log file into a list of record dicts.
+
+    assert_loaded(path, rule_path) -> None
+        Raise if `rule_path` was NOT recorded as loaded in the log at
+        `path`. Raises a DIFFERENT, distinctly named exception depending
+        on whether the log itself is missing (LogMissingError) versus
+        present but not naming the rule (RuleNotLoadedError). This
+        distinction is load-bearing for Epic 1's negative arm: a missing
+        log must never be silently read as "the rule was absent", or a
+        broken harness would masquerade as a passing negative assertion.
+
+See modules/relevance-injection/hooks/instructions-loaded-log.py for the
+observed payload shape this module parses.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+
+class LogMissingError(Exception):
+    """The InstructionsLoaded log file does not exist at all.
+
+    Distinct from RuleNotLoadedError on purpose: a missing log means the
+    assertion could not be evaluated (the hook never fired, the wrong
+    path was checked, the session never ran) -- it is not evidence that
+    the rule was absent from a session that actually ran.
+    """
+
+
+class RuleNotLoadedError(Exception):
+    """The log exists and parses, but no record names the given rule path."""
+
+
+def parse_log(path: "str | os.PathLike") -> "list[dict]":
+    """Parse a JSONL InstructionsLoaded log into a list of record dicts.
+
+    - Missing file -> raises FileNotFoundError (standard, distinctly
+      named; assert_loaded() below translates this into LogMissingError
+      for its own contract).
+    - Empty file -> returns [].
+    - A line that is not valid JSON, or that parses to something other
+      than a JSON object, is skipped -- never raised. One corrupt line
+      must not prevent every other record in the log from being read.
+    - A line that parses to a JSON object is appended to the result
+      as-is.
+    """
+    if not os.path.isfile(path):
+        raise FileNotFoundError(path)
+
+    records: "list[dict]" = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if isinstance(parsed, dict):
+                records.append(parsed)
+    return records
+
+
+def _loaded_file_paths(records: "list[dict]") -> "set[str]":
+    """Collect every `file_path` named across all records.
+
+    Reads the top-level `file_path` field the hook extracts directly, and
+    falls back to the same field inside the preserved `raw` payload -- so
+    a record written before a future field-name change (or one that hit
+    the extraction's `None` fallback for any reason) is not silently
+    invisible to this check.
+    """
+    paths: "set[str]" = set()
+    for record in records:
+        file_path = record.get("file_path")
+        if isinstance(file_path, str) and file_path:
+            paths.add(file_path)
+
+        raw = record.get("raw")
+        if isinstance(raw, dict):
+            raw_file_path = raw.get("file_path")
+            if isinstance(raw_file_path, str) and raw_file_path:
+                paths.add(raw_file_path)
+    return paths
+
+
+def _matches(loaded_path: str, rule_path: str) -> bool:
+    """True if `loaded_path` (as recorded) corresponds to `rule_path`.
+
+    Exact match covers the common case where the caller passes the same
+    absolute path the hook recorded. Suffix match on a normalized
+    "/"-separated tail covers a caller passing a shorter, module-relative
+    path such as "rules/tailwind.md" against a recorded absolute path
+    like "/Users/x/code/ccgm/modules/tailwind/rules/tailwind.md".
+    """
+    if loaded_path == rule_path:
+        return True
+    normalized_rule = rule_path.lstrip("/")
+    return loaded_path.endswith("/" + normalized_rule) or loaded_path == normalized_rule
+
+
+def assert_loaded(path: "str | os.PathLike", rule_path: str) -> None:
+    """Assert that `rule_path` was recorded as a loaded instruction file.
+
+    Raises:
+        LogMissingError: the log file at `path` does not exist. This is
+            NEVER treated as "the rule was not loaded" -- it means the
+            assertion has no evidence to evaluate at all.
+        RuleNotLoadedError: the log exists and parses, but no record
+            names `rule_path` as a loaded file.
+
+    Returns None (no exception) if at least one record names the rule.
+    """
+    try:
+        records = parse_log(path)
+    except FileNotFoundError as exc:
+        raise LogMissingError(f"InstructionsLoaded log not found: {path}") from exc
+
+    loaded_paths = _loaded_file_paths(records)
+    for loaded_path in loaded_paths:
+        if _matches(loaded_path, rule_path):
+            return
+
+    raise RuleNotLoadedError(
+        f"{rule_path!r} was not recorded as loaded in {path} "
+        f"({len(records)} record(s), {len(loaded_paths)} distinct file(s) loaded)"
+    )

--- a/modules/relevance-injection/lib/loaded_log.py
+++ b/modules/relevance-injection/lib/loaded_log.py
@@ -52,6 +52,15 @@ def parse_log(path: "str | os.PathLike") -> "list[dict]":
     - A line that is not valid JSON, or that parses to something other
       than a JSON object, is skipped -- never raised. One corrupt line
       must not prevent every other record in the log from being read.
+    - A line carrying invalid UTF-8 never raises. The decode happens in
+      the line iterator, outside any json.loads() guard, so without
+      `errors="replace"` a single corrupt byte would abort the whole
+      parse and discard every other record in the file -- including the
+      valid ones written before it. With replacement, the undecodable
+      bytes become U+FFFD and the line is then treated like any other:
+      kept if it still parses as a JSON object, dropped if it does not.
+      A retained record cannot cause a false positive in assert_loaded()
+      because no real rule path contains U+FFFD.
     - A line that parses to a JSON object is appended to the result
       as-is.
     """
@@ -59,7 +68,7 @@ def parse_log(path: "str | os.PathLike") -> "list[dict]":
         raise FileNotFoundError(path)
 
     records: "list[dict]" = []
-    with open(path, encoding="utf-8") as fh:
+    with open(path, encoding="utf-8", errors="replace") as fh:
         for line in fh:
             line = line.strip()
             if not line:

--- a/modules/relevance-injection/module.json
+++ b/modules/relevance-injection/module.json
@@ -10,7 +10,9 @@
   "files": {
     "rules/relevance-injection.md": { "target": "rules/relevance-injection.md", "type": "rule", "template": false },
     "hooks/relevance-inject.py": { "target": "hooks/relevance-inject.py", "type": "hook", "template": false },
+    "hooks/instructions-loaded-log.py": { "target": "hooks/instructions-loaded-log.py", "type": "hook", "template": false },
     "lib/relevance_select.py": { "target": "lib/relevance_select.py", "type": "lib", "template": false },
+    "lib/loaded_log.py": { "target": "lib/loaded_log.py", "type": "lib", "template": false },
     "lib/applicability-schema.json": { "target": "lib/applicability-schema.json", "type": "lib", "template": false },
     "settings.partial.json": { "target": "settings.json", "type": "settings", "merge": true, "template": false }
   },

--- a/modules/relevance-injection/settings.partial.json
+++ b/modules/relevance-injection/settings.partial.json
@@ -11,6 +11,17 @@
           }
         ]
       }
+    ],
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $HOME/.claude/hooks/instructions-loaded-log.py",
+            "timeout": 5000
+          }
+        ]
+      }
     ]
   }
 }

--- a/modules/relevance-injection/tests/test_loaded_log.py
+++ b/modules/relevance-injection/tests/test_loaded_log.py
@@ -110,8 +110,13 @@ class ParseLogTests(unittest.TestCase):
             self.assertEqual(len(records), 1)
             self.assertEqual(records[0]["file_path"], "/a/b/c.md")
 
-    def test_invalid_utf8_line_is_skipped_not_raised(self):
+    def test_invalid_utf8_line_does_not_discard_the_rest_of_the_log(self):
         """One corrupt byte must not discard the rest of the day's log.
+
+        Deliberately asserts only that the surrounding records survive,
+        not the corrupt line's own retain/drop disposition -- that is
+        data-dependent (the replaced line may or may not still parse as
+        JSON) and is not a property callers should rely on.
 
         The decode happens in the line iterator, outside the json.loads()
         guard, so without errors="replace" this raises UnicodeDecodeError

--- a/modules/relevance-injection/tests/test_loaded_log.py
+++ b/modules/relevance-injection/tests/test_loaded_log.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Unit tests for the InstructionsLoaded measurement harness (Epic 7, issue #953).
+
+Covers:
+  - parse_log(): empty file, a malformed line (skipped, not raised), a valid
+    line, and a missing file (raises FileNotFoundError -- the signal
+    assert_loaded() below translates into LogMissingError)
+  - assert_loaded(): raises a DISTINCT, NAMED error for "log absent"
+    (LogMissingError) versus "rule absent from a present log"
+    (RuleNotLoadedError) -- a missing log must never read as a passing
+    absence assertion
+  - hooks/instructions-loaded-log.py: never raises on malformed stdin
+    (always exits 0), and writes go through hook_utils.file_locked_append()
+"""
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MODULE_DIR = os.path.join(_HERE, "..")
+_LIB_DIR = os.path.join(_MODULE_DIR, "lib")
+_HOOK_UTILS_LIB = os.path.abspath(os.path.join(_MODULE_DIR, "..", "hooks", "lib"))
+_HOOK_PATH = os.path.join(_MODULE_DIR, "hooks", "instructions-loaded-log.py")
+
+# hook_utils.py lives in the sibling `hooks` module's lib/, not this
+# module's own lib/. Insert it BEFORE importing anything so both the
+# library under test and the hook module (imported below via
+# importlib, since its filename is hyphenated) can resolve `import
+# hook_utils` regardless of whether a real ~/.claude install exists on
+# the machine running the tests.
+sys.path.insert(0, _HOOK_UTILS_LIB)
+sys.path.insert(0, _LIB_DIR)
+
+import loaded_log  # noqa: E402
+
+
+def _load_hook_module():
+    """Import instructions-loaded-log.py as a module.
+
+    Uses importlib because the filename is hyphenated and cannot be the
+    target of a normal `import` statement.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "ccgm_test_instructions_loaded_log", _HOOK_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_jsonl(path, lines):
+    with open(path, "w", encoding="utf-8") as fh:
+        for line in lines:
+            fh.write(line + "\n")
+
+
+class ParseLogTests(unittest.TestCase):
+    def test_missing_file_raises_file_not_found(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = os.path.join(tmp, "does-not-exist.jsonl")
+            with self.assertRaises(FileNotFoundError):
+                loaded_log.parse_log(missing)
+
+    def test_empty_file_returns_empty_list(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "empty.jsonl")
+            _write_jsonl(path, [])
+            self.assertEqual(loaded_log.parse_log(path), [])
+
+    def test_malformed_line_is_skipped_not_raised(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "malformed.jsonl")
+            _write_jsonl(
+                path,
+                [
+                    "{not valid json",
+                    '{"file_path": "/a/b/c.md"}',
+                    "",  # blank line, also must not raise
+                ],
+            )
+            records = loaded_log.parse_log(path)
+            self.assertEqual(len(records), 1)
+            self.assertEqual(records[0]["file_path"], "/a/b/c.md")
+
+    def test_valid_line_is_parsed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "valid.jsonl")
+            record = {
+                "hook_event_name": "InstructionsLoaded",
+                "file_path": "/Users/x/code/ccgm/modules/tailwind/rules/tailwind.md",
+                "memory_type": "User",
+                "load_reason": "session_start",
+            }
+            _write_jsonl(path, [json.dumps(record)])
+            records = loaded_log.parse_log(path)
+            self.assertEqual(records, [record])
+
+
+class AssertLoadedTests(unittest.TestCase):
+    def test_missing_log_raises_log_missing_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = os.path.join(tmp, "does-not-exist.jsonl")
+            with self.assertRaises(loaded_log.LogMissingError):
+                loaded_log.assert_loaded(missing, "rules/tailwind.md")
+
+    def test_present_log_without_rule_raises_rule_not_loaded_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "log.jsonl")
+            _write_jsonl(
+                path,
+                [json.dumps({"file_path": "/Users/x/code/ccgm/modules/supabase/rules/supabase.md"})],
+            )
+            with self.assertRaises(loaded_log.RuleNotLoadedError):
+                loaded_log.assert_loaded(path, "rules/tailwind.md")
+
+    def test_log_missing_error_and_rule_not_loaded_error_are_distinct(self):
+        # The two failure modes must never be conflatable: a caller that
+        # only catches one must not accidentally swallow the other.
+        self.assertFalse(issubclass(loaded_log.LogMissingError, loaded_log.RuleNotLoadedError))
+        self.assertFalse(issubclass(loaded_log.RuleNotLoadedError, loaded_log.LogMissingError))
+        self.assertTrue(issubclass(loaded_log.LogMissingError, Exception))
+        self.assertTrue(issubclass(loaded_log.RuleNotLoadedError, Exception))
+
+    def test_present_log_with_exact_rule_path_passes_silently(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "log.jsonl")
+            rule_path = "/Users/x/code/ccgm/modules/tailwind/rules/tailwind.md"
+            _write_jsonl(path, [json.dumps({"file_path": rule_path})])
+            # Must not raise.
+            loaded_log.assert_loaded(path, rule_path)
+
+    def test_present_log_matches_module_relative_suffix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "log.jsonl")
+            absolute = "/Users/x/code/ccgm/modules/tailwind/rules/tailwind.md"
+            _write_jsonl(path, [json.dumps({"file_path": absolute})])
+            # Caller passes a shorter, module-relative path -- still a match.
+            loaded_log.assert_loaded(path, "rules/tailwind.md")
+
+    def test_malformed_lines_do_not_prevent_matching_a_later_valid_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "log.jsonl")
+            rule_path = "/Users/x/code/ccgm/modules/tailwind/rules/tailwind.md"
+            _write_jsonl(path, ["not json at all", json.dumps({"file_path": rule_path})])
+            loaded_log.assert_loaded(path, rule_path)
+
+
+class BuildRecordTests(unittest.TestCase):
+    """Pure-function tests on the hook's build_record(), imported in-process."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.hook = _load_hook_module()
+
+    def test_extracts_known_fields(self):
+        payload = {
+            "session_id": "abc-123",
+            "transcript_path": "/Users/x/.claude/projects/p/abc-123.jsonl",
+            "cwd": "/Users/x/scratch",
+            "hook_event_name": "InstructionsLoaded",
+            "file_path": "/Users/x/code/ccgm/modules/tailwind/rules/tailwind.md",
+            "memory_type": "User",
+            "load_reason": "session_start",
+        }
+        record = self.hook.build_record(payload)
+        self.assertEqual(record["session_id"], "abc-123")
+        self.assertEqual(record["cwd"], "/Users/x/scratch")
+        self.assertEqual(record["file_path"], payload["file_path"])
+        self.assertEqual(record["memory_type"], "User")
+        self.assertEqual(record["load_reason"], "session_start")
+        self.assertEqual(record["hook_event_name"], "InstructionsLoaded")
+        self.assertIn("timestamp", record)
+        self.assertEqual(record["raw"]["file_path"], payload["file_path"])
+
+    def test_missing_fields_become_none_not_raised(self):
+        record = self.hook.build_record({})
+        self.assertIsNone(record["session_id"])
+        self.assertIsNone(record["cwd"])
+        self.assertIsNone(record["file_path"])
+        self.assertIsNone(record["memory_type"])
+        self.assertIsNone(record["load_reason"])
+        # hook_event_name defaults rather than going None, since the log's
+        # own purpose is naming which event produced the record.
+        self.assertEqual(record["hook_event_name"], "InstructionsLoaded")
+
+    def test_raw_payload_is_passed_through_redact_secrets(self):
+        # Proves the raw payload goes through hook_utils.redact_secrets()
+        # before being stored, without embedding a real-secret-shaped
+        # fixture in the repo (which a secret scanner would flag even
+        # though it is synthetic test data).
+        payload = {"cwd": "some-marker-value"}
+        with mock.patch.object(
+            self.hook.hook_utils, "redact_secrets", wraps=self.hook.hook_utils.redact_secrets
+        ) as spy:
+            record = self.hook.build_record(payload)
+        self.assertTrue(spy.called)
+        self.assertEqual(record["raw"]["cwd"], "some-marker-value")
+
+
+class HookProcessTests(unittest.TestCase):
+    """Black-box (subprocess) and in-process behavior of the hook itself."""
+
+    def _run_hook(self, stdin_text, rule_loading_dir):
+        env = dict(os.environ)
+        env["CCGM_RULE_LOADING_DIR"] = rule_loading_dir
+        env["PYTHONPATH"] = _HOOK_UTILS_LIB + os.pathsep + env.get("PYTHONPATH", "")
+        return subprocess.run(
+            [sys.executable, _HOOK_PATH],
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def test_never_raises_on_malformed_stdin_exits_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run_hook("{not valid json at all", tmp)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_exits_zero_on_minimal_valid_input(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run_hook("{}", tmp)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_exits_zero_on_empty_stdin(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._run_hook("", tmp)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+    def test_appends_expected_record_to_target_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = {
+                "session_id": "sess-1",
+                "cwd": "/Users/x/scratch",
+                "hook_event_name": "InstructionsLoaded",
+                "file_path": "/Users/x/code/ccgm/modules/tailwind/rules/tailwind.md",
+                "memory_type": "User",
+                "load_reason": "session_start",
+            }
+            result = self._run_hook(json.dumps(payload), tmp)
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+            files = os.listdir(tmp)
+            self.assertEqual(len(files), 1)
+            log_path = os.path.join(tmp, files[0])
+            records = loaded_log.parse_log(log_path)
+            self.assertEqual(len(records), 1)
+            self.assertEqual(records[0]["file_path"], payload["file_path"])
+            self.assertEqual(records[0]["session_id"], "sess-1")
+
+    def test_writes_go_through_file_locked_append(self):
+        """Proves the hook's write path is hook_utils.file_locked_append(),
+        not a raw open()/write(), by patching it and asserting the call."""
+        hook_module = _load_hook_module()
+        calls = []
+
+        def _recording_append(path, data):
+            calls.append((path, data))
+
+        stdin_payload = json.dumps({"file_path": "/x/y/z.md"})
+
+        with mock.patch.object(
+            hook_module.hook_utils, "file_locked_append", side_effect=_recording_append
+        ):
+            with mock.patch.object(sys, "stdin", io.StringIO(stdin_payload)):
+                with tempfile.TemporaryDirectory() as tmp:
+                    with mock.patch.dict(os.environ, {"CCGM_RULE_LOADING_DIR": tmp}):
+                        with self.assertRaises(SystemExit) as ctx:
+                            hook_module.main()
+                        self.assertEqual(ctx.exception.code, 0)
+
+        self.assertEqual(len(calls), 1)
+        called_path, called_data = calls[0]
+        self.assertTrue(called_path.startswith(tmp))
+        self.assertIn("/x/y/z.md", called_data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/relevance-injection/tests/test_loaded_log.py
+++ b/modules/relevance-injection/tests/test_loaded_log.py
@@ -88,6 +88,47 @@ class ParseLogTests(unittest.TestCase):
             self.assertEqual(len(records), 1)
             self.assertEqual(records[0]["file_path"], "/a/b/c.md")
 
+    def test_valid_json_that_is_not_an_object_is_skipped(self):
+        """A bare list, string, number or null must be dropped, not returned.
+
+        parse_log() promises a list of record dicts; a caller iterating the
+        result and doing record["file_path"] would raise on a bare scalar.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "non-object.jsonl")
+            _write_jsonl(
+                path,
+                [
+                    "[1, 2, 3]",
+                    '"a bare string"',
+                    "42",
+                    "null",
+                    '{"file_path": "/a/b/c.md"}',
+                ],
+            )
+            records = loaded_log.parse_log(path)
+            self.assertEqual(len(records), 1)
+            self.assertEqual(records[0]["file_path"], "/a/b/c.md")
+
+    def test_invalid_utf8_line_is_skipped_not_raised(self):
+        """One corrupt byte must not discard the rest of the day's log.
+
+        The decode happens in the line iterator, outside the json.loads()
+        guard, so without errors="replace" this raises UnicodeDecodeError
+        and every record in the file is lost -- including the valid ones
+        written before the corruption.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "bad-utf8.jsonl")
+            with open(path, "wb") as fh:
+                fh.write(b'{"file_path": "/a/b/before.md"}\n')
+                fh.write(b'{"file_path": "\xff\xfe not utf8"}\n')
+                fh.write(b'{"file_path": "/a/b/after.md"}\n')
+            records = loaded_log.parse_log(path)
+            paths = [r["file_path"] for r in records]
+            self.assertIn("/a/b/before.md", paths)
+            self.assertIn("/a/b/after.md", paths)
+
     def test_valid_line_is_parsed(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "valid.jsonl")


### PR DESCRIPTION
Closes #953

Adds the deterministic oracle Epic 1 of the dynamic-rule-loading plan needs: a way to assert which rule files Claude Code actually loaded, instead of trusting the model's verbal report.

## What changed

- `modules/relevance-injection/hooks/instructions-loaded-log.py` registers on `InstructionsLoaded` (no matcher) and appends one redacted JSONL record per invocation to `~/.claude/rule-loading/loaded-{date}.jsonl`, via `hook_utils.file_locked_append()`. Never raises; always exits 0.
- `modules/relevance-injection/lib/loaded_log.py`: `parse_log()` reads the JSONL, skipping malformed lines without raising. `assert_loaded()` raises `LogMissingError` when the log itself is absent and a distinct `RuleNotLoadedError` when the log exists but doesn't name the rule — a missing log can never read as a passing absence check.
- `modules/relevance-injection/tests/test_loaded_log.py` covers both library functions plus the hook process itself (malformed/empty stdin still exits 0, writes go through `file_locked_append`).
- `module.json` / `settings.partial.json` updated to declare and register the new hook.

## Payload shape (verified live)

The plan's execution constraint forbade `bash start.sh` or writing to `~/.claude/settings.json` (other sessions were live on the machine). Per the epic's fallback order, the hook was registered at **project level** instead — a scratch repo's own `.claude/settings.json` — and `claude -p` was run inside it. The event fired without touching any shared machine state.

Claude Code invokes the hook once per loaded file with a flat object:

```json
{"session_id": "...", "cwd": "...", "hook_event_name": "InstructionsLoaded", "file_path": "/abs/path/to/rule.md", "memory_type": "User", "load_reason": "session_start"}
```

Directly usable by a flat-field parser — no nested-list search needed. Full details, including what's not yet confirmed (load_reason for a Tier-B mid-session load, other memory_type values), are recorded in `~/code/plans/ccgm-dynamic-rule-injection/decisions.md` under "Epic 7 — observed InstructionsLoaded payload schema".

## Verification

```
python3 -m pytest modules/relevance-injection/tests/test_loaded_log.py -q
..................
18 passed in 0.11s

echo '{}' | python3 modules/relevance-injection/hooks/instructions-loaded-log.py; echo "exit=$?"
exit=0

bash tests/test-modules.sh
Results: 1704 passed, 0 failed

python3 modules/plugin-marketplace/lib/gen_marketplace.py --check
Marketplace files are up to date.

bash tests/test-no-personal-data.sh
PASS: No personal data or secret/PII shapes found
```