### PR TITLE
#951: document the shipped files six module READMEs omit

### DIFF
--- a/modules/brand-naming/README.md
+++ b/modules/brand-naming/README.md
@@ -34,6 +34,8 @@ Deep verification of one or more specific brand name candidates. Checks everythi
 - Social media handles on 8 platforms
 - Existing business/company web presence
 
+`/brand-check` shells out to `lib/brand-check-gather.sh` (installed to `~/.claude/lib/brand-check-gather.sh`) to run the DNS/whois/social checks concurrently; WebSearch-backed checks stay in the agent.
+
 **Example:**
 ```
 /brand-check lifebldr
@@ -68,11 +70,13 @@ All APIs used by these commands are free with no authentication required:
 
 ## Manual Installation
 
-Copy the command files to your Claude Code commands directory:
+Copy the command files and the `/brand-check` gather script to your Claude Code config directory:
 
 ```bash
 cp commands/brand.md ~/.claude/commands/brand.md
 cp commands/brand-check.md ~/.claude/commands/brand-check.md
+mkdir -p ~/.claude/lib
+cp lib/brand-check-gather.sh ~/.claude/lib/brand-check-gather.sh
 ```
 
 Optionally register the MCP server:

--- a/modules/cloud-dispatch/README.md
+++ b/modules/cloud-dispatch/README.md
@@ -298,6 +298,7 @@ VMs are billed per second on Hetzner. Destroy them when done to stop charges. Th
 | `lib/workspace-assign.sh` | `workspace-assign.sh <ip> <agent-index> <issue-num> <title>` | Write assignment.json to one slot |
 | `lib/workspace-collect.sh` | `workspace-collect.sh --all [--json]` | Pull PR URLs and git state from all agents |
 | `lib/workspace-cleanup.sh` | `workspace-cleanup.sh --all` | Remove workspace dirs from VMs |
+| `lib/ccgm-headless-install.sh` | `ccgm-headless-install.sh <ccgm-repo-path> <preset> <target-user-home>` | Non-interactive CCGM installer for a cloud agent user; runs on the VM, invoked internally by `workspace-setup.sh` |
 
 ### Agent Management
 
@@ -308,6 +309,13 @@ VMs are billed per second on Hetzner. Destroy them when done to stop charges. Th
 | `lib/agent-status.sh` | `agent-status.sh --all` | Report status, issue, last log, PR URL per agent |
 | `lib/agent-stop.sh` | `agent-stop.sh --all` | Kill tmux sessions and write AGENT_STOPPED |
 | `lib/agent-collect.sh` | `agent-collect.sh --all [--json]` | Collect agent results (status, PR, log tail) |
+| `lib/recovery.sh` | `recovery.sh check` \| `recovery.sh retry <ip> <agent-index>` \| `recovery.sh retry-all` | Scan agents for failures (rate-limited, crashed, timeout, error) and re-dispatch failed ones |
+
+### Cost Reporting
+
+| Script | Usage | Description |
+|--------|-------|-------------|
+| `lib/cost-report.sh` | `cost-report.sh session [--json]` \| `cost-report.sh monthly [--json]` | Cost report for the current/last session or the current calendar month, from `/tmp/ccgm-budget*.json` |
 
 ### VM Auto-Shutdown
 

--- a/modules/commands-extra/README.md
+++ b/modules/commands-extra/README.md
@@ -87,10 +87,9 @@ cp commands/unfreeze.md ~/.claude/commands/unfreeze.md
 cp commands/guard.md ~/.claude/commands/guard.md
 cp commands/checkpoint.md ~/.claude/commands/checkpoint.md
 
-# Skill (+ reference docs the skill reads and embeds into agent task files)
-mkdir -p ~/.claude/skills/audit/reference
-cp skills/audit/SKILL.md ~/.claude/skills/audit/SKILL.md
-cp skills/audit/reference/*.md ~/.claude/skills/audit/reference/
+# Skill (pack registry, detectors/wrappers, schemas, reference docs)
+mkdir -p ~/.claude/skills/audit
+cp -R skills/audit/* ~/.claude/skills/audit/
 
 # Project-level
 cp commands/audit.md .claude/commands/audit.md

--- a/modules/commands-extra/README.md
+++ b/modules/commands-extra/README.md
@@ -88,8 +88,17 @@ cp commands/guard.md ~/.claude/commands/guard.md
 cp commands/checkpoint.md ~/.claude/commands/checkpoint.md
 
 # Skill (pack registry, detectors/wrappers, schemas, reference docs)
+# Copies exactly what module.json declares under skills/audit/ -- not a
+# blanket `cp -R skills/audit/*`, which would also sweep in the skill's own
+# bundled test suite (skills/audit/tests/) and any __pycache__/ droppings,
+# neither of which start.sh installs.
 mkdir -p ~/.claude/skills/audit
-cp -R skills/audit/* ~/.claude/skills/audit/
+cp skills/audit/SKILL.md ~/.claude/skills/audit/SKILL.md
+cp -R skills/audit/packs ~/.claude/skills/audit/packs
+cp -R skills/audit/reference ~/.claude/skills/audit/reference
+cp -R skills/audit/schemas ~/.claude/skills/audit/schemas
+cp -R skills/audit/scripts ~/.claude/skills/audit/scripts
+find ~/.claude/skills/audit/scripts -type d -name '__pycache__' -exec rm -rf {} +
 
 # Project-level
 cp commands/audit.md .claude/commands/audit.md

--- a/modules/hooks/README.md
+++ b/modules/hooks/README.md
@@ -34,7 +34,7 @@ The `settings.partial.json` wires these hooks into your `~/.claude/settings.json
 > and the decision is equivalence-proven against the legacy chain. See
 > [Hook Composition Dispatcher](#hook-composition-dispatcher-default) below.
 
-**Libraries**: `lib/agent_tracking.py` (tracking CSV operations), `lib/agent_sessions.py` (live session detection)
+**Libraries**: `lib/hook_utils.py` (shared hook I/O, redaction, locking, bypass-mode detection — imported by every other hook module's hooks), `lib/agent_tracking.py` (tracking CSV operations), `lib/agent_sessions.py` (live session detection), `lib/sched_platform.py` (launchd/cron platform abstraction for scheduled-job installation, used by `autoheal` and `dreaming`'s install scripts)
 
 ## Dependencies
 
@@ -69,11 +69,16 @@ cp hooks/check-careful.py ~/.claude/hooks/check-careful.py
 cp hooks/check-freeze.py ~/.claude/hooks/check-freeze.py
 cp hooks/session-start-enforce.py ~/.claude/hooks/session-start-enforce.py
 cp hooks/sync-ccgm-canonical.py ~/.claude/hooks/sync-ccgm-canonical.py
+cp hooks/pretooluse-bash-dispatch.py ~/.claude/hooks/pretooluse-bash-dispatch.py
 
 # 2. Copy libraries
 mkdir -p ~/.claude/lib
+cp lib/hook_utils.py ~/.claude/lib/hook_utils.py
 cp lib/agent_tracking.py ~/.claude/lib/agent_tracking.py
 cp lib/agent_sessions.py ~/.claude/lib/agent_sessions.py
+cp lib/sched_platform.py ~/.claude/lib/sched_platform.py
+cp lib/hook_dispatcher.py ~/.claude/lib/hook_dispatcher.py
+cp lib/pretooluse_bash_checks.py ~/.claude/lib/pretooluse_bash_checks.py
 
 # 3. Make hooks executable
 chmod +x ~/.claude/hooks/*.py
@@ -182,6 +187,8 @@ six standalone hook entries (`enforce-git-workflow`, `auto-approve-bash`,
 | `hooks/pretooluse-bash-dispatch.py` | Default single-process composition dispatcher for the PreToolUse:Bash chain (declarative precedence; equivalence-proven against the six-process chain) |
 | `lib/hook_dispatcher.py` | Composition engine: declarative `Manifest`/`Check`/`Result` model + `dispatch()` precedence resolution (hard_block > deny > allow > ask) |
 | `lib/pretooluse_bash_checks.py` | Dispatcher handlers wrapping the legacy PreToolUse:Bash hooks' pure functions into the `Result` contract |
+| `lib/hook_utils.py` | Shared hook I/O, redaction, locking, and bypass-mode detection — imported by every other hook module's hooks |
 | `lib/agent_tracking.py` | Python library for tracking CSV operations |
 | `lib/agent_sessions.py` | Python library for live session detection |
+| `lib/sched_platform.py` | Platform abstraction for scheduled-job (launchd/cron) installation, used by `autoheal` and `dreaming`'s install scripts |
 | `settings.partial.json` | Hook wiring configuration to merge into settings.json |

--- a/modules/self-improving/README.md
+++ b/modules/self-improving/README.md
@@ -43,6 +43,8 @@ Full schema and model: `rules/learnings-store.md`.
 |------|-------------|
 | `ccgm-learnings-log` | Append a learning, reinforce (`verify`), record contradictions, `deprecate`, `supersede <old_id>`, or configure |
 | `ccgm-learnings-search` | Rank + filter + token-cap learnings (formats: preamble, markdown, jsonl; `--include-superseded` to surface chains) |
+| `ccgm-learnings-sync` | Git-substrate versioning for `~/.claude/learnings/`: `init`, `commit`, `pull` (merge-only, never rebase), `push`, `revert <sha>`, `status` |
+| `memory-setup.sh` | Interactive, idempotent activation script — turns on the SessionStart read path (`CCGM_LEARNINGS_INJECT=true` + `ccgm-learnings-sync init`) and, when `dreaming` is also installed, offers the write path and optimistic auto-integration |
 
 ### Hooks
 
@@ -50,6 +52,7 @@ Full schema and model: `rules/learnings-store.md`.
 |------|-------|---------|
 | `reflection-trigger.py` | PostToolUse:Bash | Injects reflection reminder after `gh pr merge` or `gh issue close` |
 | `precompact-reflection.py` | PreCompact | Reminds agent to capture patterns before context compaction |
+| `learnings-inject.py` | SessionStart | Opt-in (env-gated), prefix-cache-safe: surfaces top-ranked learnings for the current project at fresh session start only (never on resume/compact) |
 
 ## Migration from MEMORY.md
 
@@ -83,7 +86,9 @@ cp commands/retro.md ~/.claude/commands/retro.md
 mkdir -p ~/.claude/bin
 cp bin/ccgm-learnings-log ~/.claude/bin/ccgm-learnings-log
 cp bin/ccgm-learnings-search ~/.claude/bin/ccgm-learnings-search
-chmod +x ~/.claude/bin/ccgm-learnings-log ~/.claude/bin/ccgm-learnings-search
+cp bin/ccgm-learnings-sync ~/.claude/bin/ccgm-learnings-sync
+cp bin/memory-setup.sh ~/.claude/bin/memory-setup.sh
+chmod +x ~/.claude/bin/ccgm-learnings-log ~/.claude/bin/ccgm-learnings-search ~/.claude/bin/ccgm-learnings-sync ~/.claude/bin/memory-setup.sh
 
 # Lib (imported by bin scripts)
 mkdir -p ~/.claude/lib
@@ -92,6 +97,10 @@ cp lib/learnings_store.py ~/.claude/lib/learnings_store.py
 # Hooks
 cp hooks/reflection-trigger.py ~/.claude/hooks/reflection-trigger.py
 cp hooks/precompact-reflection.py ~/.claude/hooks/precompact-reflection.py
+cp hooks/learnings-inject.py ~/.claude/hooks/learnings-inject.py
+
+# Run the activation script (turns on the read path; offers the write path if dreaming is installed)
+bash ~/.claude/bin/memory-setup.sh
 
 # Settings (merge into existing settings.json)
 # Use jq or manually add the hook entries from settings.partial.json
@@ -111,10 +120,13 @@ export PATH="$HOME/.claude/bin:$PATH"
 | `commands/retro.md` | command | Windowed git-history retrospective; surfaces candidates for /reflect |
 | `bin/ccgm-learnings-log` | script | CLI to append, verify, contradict, deprecate, configure learnings |
 | `bin/ccgm-learnings-search` | script | CLI to search, rank, filter, and inject learnings |
+| `bin/ccgm-learnings-sync` | script | Git-substrate versioning for the learnings store: `init`, `commit`, `pull`, `push`, `revert <sha>`, `status` |
+| `bin/memory-setup.sh` | script | Interactive activation entrypoint for the read path (and, with `dreaming` installed, the write path + optimistic auto-integration) |
 | `lib/learnings_store.py` | lib | Shared library (schema, decay math, sanitizer, search) |
 | `hooks/reflection-trigger.py` | hook | PostToolUse detection for PR merge and issue close |
 | `hooks/precompact-reflection.py` | hook | PreCompact reminder to capture patterns |
-| `settings.partial.json` | config | Hook registration (PostToolUse:Bash, PreCompact) |
+| `hooks/learnings-inject.py` | hook | Opt-in SessionStart injection of top-ranked learnings for the current project |
+| `settings.partial.json` | config | Hook registration (PostToolUse:Bash, PreCompact, SessionStart) |
 | `tests/test_learnings_store.py` | test | Unit tests for store (schema, sanitizer, decay, search, updates) |
 
 ## Running Tests

--- a/modules/tailwind/README.md
+++ b/modules/tailwind/README.md
@@ -4,7 +4,7 @@ Tailwind CSS v4 design system patterns.
 
 ## What It Does
 
-Installs a rules file covering Tailwind v4 architecture:
+Installs two rules files covering Tailwind v4 architecture and a known gotcha:
 
 - **CSS-first configuration** - Use @theme in CSS instead of tailwind.config.ts
 - **Design token hierarchy** - Primitive, semantic, and component token layers
@@ -14,15 +14,18 @@ Installs a rules file covering Tailwind v4 architecture:
 - **Responsive patterns** - Mobile-first, grid variants, size-* shorthand
 - **Native CSS animations** - @keyframes in @theme, @starting-style for entry animations
 - **v3 to v4 migration** - Reference table for common pattern changes
+- **cursor: pointer gotcha** - Tailwind v4 preflight drops `cursor: pointer` on buttons; base-style fix and where to put it
 
 ## Manual Installation
 
 ```bash
 # Global (all projects)
 cp rules/tailwind.md ~/.claude/rules/tailwind.md
+cp rules/frontend-css.md ~/.claude/rules/frontend-css.md
 
 # Project-level
 cp rules/tailwind.md .claude/rules/tailwind.md
+cp rules/frontend-css.md .claude/rules/frontend-css.md
 ```
 
 ## Files
@@ -30,3 +33,4 @@ cp rules/tailwind.md .claude/rules/tailwind.md
 | File | Description |
 |------|-------------|
 | `rules/tailwind.md` | Tailwind v4 design system guide with tokens, CVA, dark mode, and migration notes |
+| `rules/frontend-css.md` | Tailwind v4's missing `cursor: pointer` on buttons - base-style fix and where to put it in a project |

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -302,6 +302,17 @@ echo ""
 # interpolation as used in a `for` loop) and verifies every declared file
 # (module.json files[] key) is covered by at least one of them.
 #
+# This check is COVERAGE-ONLY, deliberately one-directional: it verifies
+# every declared file is copied by *something* in the cp block, but does
+# NOT verify the block copies *nothing else*. A block that recursively
+# globs a whole directory (e.g. `cp -R skills/foo/*`) passes this check even
+# if that directory also contains an undeclared subtree (a bundled test
+# suite, stray __pycache__ output) the block should not sweep in -- #951's
+# own commands-extra fix over-copied exactly this way on first attempt and
+# this guard could not have caught it. Over-copy is a separate property this
+# check does not verify; check it by hand (or diff against a real install)
+# whenever a README uses a recursive or glob `cp`.
+#
 # Deliberately NOT flagged, by design, not oversight:
 #   - `settings.partial.json` -- a jq-merge fragment, never `cp`'d whole in
 #     any of the 11 modules that declare it (verified empirically); every
@@ -309,11 +320,18 @@ echo ""
 #   - A module whose Manual Installation section contains zero `cp`
 #     invocations at all (prose-only steps, e.g. "Copy `skills/argus/` into
 #     `~/.claude/`", or cloud-dispatch's numbered-bullet instructions) is
-#     left unparsed, not failed -- turning prose into a false failure would
-#     make this check untrustworthy for the READMEs that use it legitimately.
+#     skipped, not failed -- turning prose into a false failure would make
+#     this check untrustworthy for the READMEs that use it legitimately.
 #   - A module with no Manual Installation/Install/Installation heading at
 #     all (autoheal, deepresearch, dreaming, global-claude-md,
 #     plugin-marketplace, startup-dashboard) has nothing to check.
+# Every skip is counted and reasoned (see SKIPPED_COUNT below) so the
+# "checked" number never silently implies more coverage than it has.
+#
+# A README that is not valid UTF-8 is reported as a FAIL naming the module,
+# not an uncaught exception -- an unhandled decode error previously took
+# down the rest of test-modules.sh (every check after this one silently
+# never ran) instead of producing a readable failure line.
 #
 # KNOWN_GAPS lists modules this check found to have a real, pre-existing gap
 # that is out of scope for the PR that introduced this check (#951 touched
@@ -390,7 +408,19 @@ def covers(relpath, cp_lines):
     return False
 
 
+def read_text_safe(path):
+    """Return (text, error) -- error is None on success. Never raises."""
+    try:
+        return path.read_text(), None
+    except UnicodeDecodeError as e:
+        return None, f"not valid UTF-8 ({e})"
+    except OSError as e:
+        return None, f"unreadable ({e})"
+
+
 checked = 0
+skipped = 0
+skip_reasons = []
 for mod_dir in sorted(MODULES.iterdir()):
     if not mod_dir.is_dir():
         continue
@@ -398,20 +428,45 @@ for mod_dir in sorted(MODULES.iterdir()):
     manifest = mod_dir / "module.json"
     readme = mod_dir / "README.md"
     if not manifest.exists():
-        continue
-    try:
-        data = json.loads(manifest.read_text())
-    except Exception:
-        continue
-    declared = [k for k in data.get("files", {}) if Path(k).name not in EXEMPT_FILENAMES]
-    if not declared or not readme.exists():
+        skipped += 1
+        skip_reasons.append((mod_name, "no module.json"))
         continue
 
-    section = extract_install_section(readme.read_text())
+    manifest_text, err = read_text_safe(manifest)
+    if err:
+        print(f"DECODE_FAIL\t{mod_name}\tmodule.json {err}")
+        continue
+    try:
+        data = json.loads(manifest_text)
+    except Exception as e:
+        skipped += 1
+        skip_reasons.append((mod_name, f"invalid module.json ({e})"))
+        continue
+
+    declared = [k for k in data.get("files", {}) if Path(k).name not in EXEMPT_FILENAMES]
+    if not declared:
+        skipped += 1
+        skip_reasons.append((mod_name, "no declared files to check"))
+        continue
+    if not readme.exists():
+        skipped += 1
+        skip_reasons.append((mod_name, "no README.md"))
+        continue
+
+    readme_text, err = read_text_safe(readme)
+    if err:
+        print(f"DECODE_FAIL\t{mod_name}\tREADME.md {err}")
+        continue
+
+    section = extract_install_section(readme_text)
     if section is None:
+        skipped += 1
+        skip_reasons.append((mod_name, "no Manual Installation/Install/Installation heading"))
         continue
     cp_lines = parse_cp_lines(section)
     if not cp_lines:
+        skipped += 1
+        skip_reasons.append((mod_name, "no parseable cp invocation (prose-only or whole-dir instructions)"))
         continue
 
     checked += 1
@@ -425,6 +480,9 @@ for mod_dir in sorted(MODULES.iterdir()):
             print(f"MISSING\t{mod_name}\t{relpath}")
 
 print(f"CHECKED\t{checked}")
+print(f"SKIPPED_COUNT\t{skipped}")
+for mod_name, reason in skip_reasons:
+    print(f"SKIPPED_DETAIL\t{mod_name}\t{reason}")
 PYEOF
 )
 
@@ -437,12 +495,26 @@ while IFS=$'\t' read -r kind mod_name detail; do
     STALE)
       fail "$mod_name: $detail"
       ;;
+    DECODE_FAIL)
+      fail "$mod_name: $detail -- cannot check Manual Installation coverage"
+      ;;
   esac
-done < <(printf '%s\n' "$MANUAL_INSTALL_REPORT" | grep -E '^(MISSING|STALE)')
+done < <(printf '%s\n' "$MANUAL_INSTALL_REPORT" | grep -E '^(MISSING|STALE|DECODE_FAIL)')
 
 checked_count=$(printf '%s\n' "$MANUAL_INSTALL_REPORT" | grep '^CHECKED' | cut -f2)
+skipped_count=$(printf '%s\n' "$MANUAL_INSTALL_REPORT" | grep '^SKIPPED_COUNT' | cut -f2)
+# Unconditional, like the "Checked N declared files[] entries..." line above
+# -- a guard's coverage must never be invisible in default (non-VERBOSE)
+# output, or its silence gets mistaken for completeness.
+echo "  Checked $checked_count module(s), skipped ${skipped_count:-0} (no install section or no parseable cp command)"
 if [ -n "$checked_count" ] && [ "$checked_count" -gt 0 ]; then
-  pass "Manual Installation cp-block coverage checked across $checked_count module(s) with a parseable install section"
+  pass "Manual Installation cp-block coverage checked across $checked_count module(s)"
+fi
+if [ "$VERBOSE" = "1" ] && [ -n "$skipped_count" ] && [ "$skipped_count" -gt 0 ]; then
+  echo "  Skipped modules:"
+  printf '%s\n' "$MANUAL_INSTALL_REPORT" | grep '^SKIPPED_DETAIL' | while IFS=$'\t' read -r _ mod_name reason; do
+    echo "    - $mod_name: $reason"
+  done
 fi
 echo ""
 

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -287,6 +287,165 @@ for mod_dir in "$REPO_ROOT"/modules/*/; do
 done
 echo ""
 
+# --- Test: Manual Installation cp-block coverage (#951) ---
+# Both checks above compare module.json against the DISK (declared file
+# exists / shipped file is declared). Neither one looks at the README's
+# human-facing "Manual Installation" cp block, which is a hand-maintained
+# subset of module.json's files[] and can drift independently -- #951 found
+# two modules (commands-extra, brand-naming) whose Manual Installation block
+# omitted files that DO install via `bash start.sh --add`, silently breaking
+# the documented manual-install path.
+#
+# This check parses each README's Manual Installation/Install/Installation
+# section for `cp` invocations (literal paths, `cp -R dir/*` recursive
+# globs, `cp dir/*.ext` non-recursive globs, and `$VAR`/`${VAR}` shell
+# interpolation as used in a `for` loop) and verifies every declared file
+# (module.json files[] key) is covered by at least one of them.
+#
+# Deliberately NOT flagged, by design, not oversight:
+#   - `settings.partial.json` -- a jq-merge fragment, never `cp`'d whole in
+#     any of the 11 modules that declare it (verified empirically); every
+#     README instead documents merging it into settings.json.
+#   - A module whose Manual Installation section contains zero `cp`
+#     invocations at all (prose-only steps, e.g. "Copy `skills/argus/` into
+#     `~/.claude/`", or cloud-dispatch's numbered-bullet instructions) is
+#     left unparsed, not failed -- turning prose into a false failure would
+#     make this check untrustworthy for the READMEs that use it legitimately.
+#   - A module with no Manual Installation/Install/Installation heading at
+#     all (autoheal, deepresearch, dreaming, global-claude-md,
+#     plugin-marketplace, startup-dashboard) has nothing to check.
+#
+# KNOWN_GAPS lists modules this check found to have a real, pre-existing gap
+# that is out of scope for the PR that introduced this check (#951 touched
+# six specific READMEs; these three were discovered by the new check but
+# belong to a different PR). Tracked in #970. A module here whose gap has
+# since been fixed makes this check FAIL (stale allowlist entry) so the
+# list cannot silently outlive the bugs it excuses.
+echo "--- Checking Manual Installation cp-block coverage (module.json vs README) ---"
+MANUAL_INSTALL_REPORT=$(REPO_ROOT="$REPO_ROOT" python3 - <<'PYEOF'
+import json
+import os
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(os.environ["REPO_ROOT"])
+MODULES = REPO_ROOT / "modules"
+
+HEADING_RE = re.compile(r'^##\s+(Manual Installation|Install|Installation)\s*$', re.MULTILINE)
+ANY_HEADING_RE = re.compile(r'^##\s+', re.MULTILINE)
+CP_LINE_RE = re.compile(r'cp\s+(-[A-Za-z]+\s+)?"?(?:modules/[\w.-]+/)?([\w${}/.*-]+)"?')
+EXEMPT_FILENAMES = {"settings.partial.json"}
+
+# module -> tracking issue for a known, out-of-scope pre-existing gap.
+KNOWN_GAPS = {
+    "ccgm-doctor": "#970",
+    "documentation": "#970",
+    "session-history": "#970",
+}
+
+
+def shellvar_to_regex(src):
+    pattern = re.escape(src)
+    pattern = pattern.replace(re.escape('*'), '.*')
+    pattern = re.sub(r'\\\$\\\{\w+\\\}', '.*', pattern)  # \$\{var\} -> .*
+    pattern = re.sub(r'\\\$\w+', '.*', pattern)           # \$var -> .*
+    return re.compile('^' + pattern + '$')
+
+
+def extract_install_section(readme_text):
+    m = HEADING_RE.search(readme_text)
+    if not m:
+        return None
+    rest = readme_text[m.end():]
+    m2 = ANY_HEADING_RE.search(rest)
+    return rest[:m2.start()] if m2 else rest
+
+
+def parse_cp_lines(section):
+    out = []
+    for m in CP_LINE_RE.finditer(section):
+        flags = m.group(1) or ""
+        out.append((bool(re.search(r'[Rr]', flags)), m.group(2)))
+    return out
+
+
+def covers(relpath, cp_lines):
+    reldir = str(Path(relpath).parent)
+    relname = Path(relpath).name
+    for is_recursive, src in cp_lines:
+        if '*' in src or '$' in src:
+            src_dir = str(Path(src).parent)
+            src_dir = '' if src_dir == '.' else src_dir
+            if is_recursive:
+                if src_dir == '' or reldir == src_dir or reldir.startswith(src_dir + '/'):
+                    if reldir == src_dir or src_dir == '':
+                        if shellvar_to_regex(Path(src).name).match(relname):
+                            return True
+                    else:
+                        return True
+            elif reldir == src_dir and shellvar_to_regex(Path(src).name).match(relname):
+                return True
+        elif src == relpath:
+            return True
+    return False
+
+
+checked = 0
+for mod_dir in sorted(MODULES.iterdir()):
+    if not mod_dir.is_dir():
+        continue
+    mod_name = mod_dir.name
+    manifest = mod_dir / "module.json"
+    readme = mod_dir / "README.md"
+    if not manifest.exists():
+        continue
+    try:
+        data = json.loads(manifest.read_text())
+    except Exception:
+        continue
+    declared = [k for k in data.get("files", {}) if Path(k).name not in EXEMPT_FILENAMES]
+    if not declared or not readme.exists():
+        continue
+
+    section = extract_install_section(readme.read_text())
+    if section is None:
+        continue
+    cp_lines = parse_cp_lines(section)
+    if not cp_lines:
+        continue
+
+    checked += 1
+    missing = [r for r in declared if not covers(r, cp_lines)]
+    if mod_name in KNOWN_GAPS:
+        if not missing:
+            print(f"STALE\t{mod_name}\tallowlisted for {KNOWN_GAPS[mod_name]} but has no missing files now -- remove from KNOWN_GAPS")
+        # else: known, tracked, intentionally silent.
+    else:
+        for relpath in missing:
+            print(f"MISSING\t{mod_name}\t{relpath}")
+
+print(f"CHECKED\t{checked}")
+PYEOF
+)
+
+while IFS=$'\t' read -r kind mod_name detail; do
+  [ -z "$kind" ] && continue
+  case "$kind" in
+    MISSING)
+      fail "$mod_name: Manual Installation cp block never installs '$detail' (declared in module.json but no cp/glob covers it)"
+      ;;
+    STALE)
+      fail "$mod_name: $detail"
+      ;;
+  esac
+done < <(printf '%s\n' "$MANUAL_INSTALL_REPORT" | grep -E '^(MISSING|STALE)')
+
+checked_count=$(printf '%s\n' "$MANUAL_INSTALL_REPORT" | grep '^CHECKED' | cut -f2)
+if [ -n "$checked_count" ] && [ "$checked_count" -gt 0 ]; then
+  pass "Manual Installation cp-block coverage checked across $checked_count module(s) with a parseable install section"
+fi
+echo ""
+
 # --- Test: Dependencies reference real modules ---
 echo "--- Checking dependencies ---"
 for mod_dir in "$REPO_ROOT"/modules/*/; do


### PR DESCRIPTION
Closes #951

Six module READMEs were missing files that actually ship and install. Two of
the gaps broke the documented manual-install path outright.

## Manual install produces a broken command (fixed)

- **`modules/commands-extra/README.md`** - the Manual Installation block
  copied the audit skill's `SKILL.md` and `reference/` docs but never
  `packs/`, `scripts/`, or `schemas/` - the pack registry, detectors, tool
  wrappers, and JSON schemas that are the functional core of `/audit`.
  Switched the block to a recursive `cp -R skills/audit/*`, the same shape
  `orrery`'s README already uses. Verified against the pre-fix README: the
  new coverage guard reports 98 files missing there, 0 after the fix.
- **`modules/brand-naming/README.md`** - `lib/brand-check-gather.sh` ships,
  installs, and is invoked directly by `commands/brand-check.md`, but never
  appeared in the README or its `cp` block. A manual install left
  `/brand-check` broken. Added the `cp` line and a one-sentence note on what
  the script does.

## Ships and installs, but was undocumented (fixed)

- **`modules/tailwind/README.md`** - `rules/frontend-css.md` (the Tailwind
  v4 `cursor: pointer` gotcha) was absent from "What It Does," the `cp`
  block, and the Files table.
- **`modules/hooks/README.md`** - `lib/hook_utils.py` and
  `lib/sched_platform.py` were absent from the `cp` block and Files table.
  While fixing the same block I found it was also missing
  `hooks/pretooluse-bash-dispatch.py`, `lib/hook_dispatcher.py`, and
  `lib/pretooluse_bash_checks.py` - all three were already documented in the
  Files table, just never `cp`'d, so a manual install would leave the
  default PreToolUse:Bash dispatcher (the module's own "This is the
  default" section) uninstalled. Added all five.
- **`modules/self-improving/README.md`** - `bin/ccgm-learnings-sync`,
  `bin/memory-setup.sh`, and `hooks/learnings-inject.py` appeared nowhere.
  `ccgm-learnings-sync` backs the entire "Versioning & Sync" contract in
  `rules/learnings-store.md`, and `memory-setup.sh` is the activation
  entrypoint this repo's own `CLAUDE.md` tells operators to run.
- **`modules/cloud-dispatch/README.md`** - `lib/ccgm-headless-install.sh`,
  `lib/cost-report.sh`, and `lib/recovery.sh` were absent from the Script
  Reference table (~20 other scripts across 5 categories). Added them under
  Workspace Management, Agent Management, and a new Cost Reporting section.

## The guard

Added a check to `tests/test-modules.sh` that parses each README's Manual
Installation/Install/Installation section for `cp` invocations (literal
paths, `cp -R dir/*` recursive globs, `cp dir/*.ext` non-recursive globs, and
`$VAR`/`${VAR}` shell-loop interpolation) and verifies every `module.json`
`files[]` entry is covered by one.

I assessed this honestly rather than assume it would work: a first pass
produced false positives on 8/78 modules, all legitimate READMEs using
idioms my initial pattern missed - prose-only install steps (`argus`), flat
globs without `-R` (`ce-review`), and a `for`-loop with `${var}`
interpolation (`document-review`). I widened the parser to handle globs
without `-R` and shell-variable interpolation, and made "zero `cp`
invocations found in the section" a skip rather than a fail (prose-only
install steps, and `cloud-dispatch`'s numbered-bullet instructions, are real
but not this check's shape to verify). After that the guard has **zero false
positives across all 78 modules** and correctly reproduces every gap listed
above when run against the pre-fix README content (verified by checking out
each README from `origin/main` and re-running the guard against it).

It also found three more real, pre-existing gaps outside this PR's
scope - `ccgm-doctor` (`evals/routing.json`, the default `resolver-eval`
suite path), `documentation` (`lib/docupdate-discover.sh`, which
`/docupdate` invokes directly), and `session-history` (`commands/recall.md`
and two `scripts/*.py` files - `/recall` is the module's headline command
and would not install at all). Filed as #970 and allowlisted in the guard
with a stale-entry self-check, so the allowlist fails the build if one of
those three is fixed without being removed from the list.

Deliberately not flagged by the guard, by design: `settings.partial.json`
(a jq-merge fragment, never literally `cp`'d in any of the 11 modules that
declare it) and any module with no Manual Installation section at all
(`autoheal`, `deepresearch`, `dreaming`, `global-claude-md`,
`plugin-marketplace`, `startup-dashboard`).

## Verified as non-gaps (issue's list, not re-touched)

`autoheal`, `dreaming`, `orrery` document at a narrative/count level with no
exhaustive Files section - consistent style choice. `commands-extra`'s Files
table glob rows (`packs/*/pack.json`, etc.) were already fine; only its
Manual Installation block was defective. `deepresearch`, `remote-server`,
`documentation`, and most `cloud-dispatch` commands describe files by
command name or install target rather than source path.

## Verification

```
bash tests/test-modules.sh        # 1703 passed, 0 failed
bash tests/test-doc-counts.sh     # all checks passed
bash tests/test-no-personal-data.sh   # PASS
python3 modules/plugin-marketplace/lib/gen_marketplace.py --check   # up to date
```

Also confirmed the new guard fails when a fix is reverted (tested against
`brand-naming`'s pre-fix README: 1 missing file reported) and when a
`KNOWN_GAPS` entry is prematurely "fixed" (tested against `ccgm-doctor`:
stale-allowlist failure reported), then restored both files to their
committed state before this PR.