### PR TITLE
#938: make the reverse manifest-completeness gate follow symlinks

### DIFF
--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -254,19 +254,38 @@ for mod_dir in "$REPO_ROOT"/modules/*/; do
 
   shipped_count=0
   missing_count=0
+  contributed_labels=""
   for subdir in lib commands rules; do
     [ -d "$mod_dir/$subdir" ] || continue
-    # Match shell scripts in lib/, markdown in commands/ and rules/.
+    # Match shell scripts in lib/, markdown in commands/ and rules/. label is
+    # the singular noun for the VERBOSE pass message below.
     if [ "$subdir" = "lib" ]; then
       pattern="*.sh"
+      label="lib"
+    elif [ "$subdir" = "commands" ]; then
+      pattern="*.md"
+      label="command"
     else
       pattern="*.md"
+      label="rule"
     fi
+    subdir_shipped=0
+    # -L follows symlinks, so a shipped rule/command/lib file installed as a
+    # symlink (not a plain file) is still found and checked against the
+    # manifest - this is the fix for #938. A BROKEN symlink stays invisible
+    # here: under -L, find only reports -type l for a link whose target does
+    # not exist, so it never matches -type f. That is deliberate, not an
+    # oversight - if the broken symlink IS declared, the manifest-existence
+    # gate above already fails it by name (it uses [ -e ], which a broken
+    # symlink fails); if it is NOT declared, it cannot install as a working
+    # file either way, so there is nothing this gate would prevent by also
+    # flagging it.
     while IFS= read -r abs_path; do
       [ -z "$abs_path" ] && continue
       rel_path="${abs_path#"$mod_dir"}"
       rel_path="${rel_path#/}"
       shipped_count=$((shipped_count + 1))
+      subdir_shipped=$((subdir_shipped + 1))
       # Herestring, not a pipe: under `set -o pipefail`, `producer | grep -q`
       # can die with SIGPIPE if grep exits on its first match before the
       # producer finishes writing, turning a successful match into a
@@ -278,11 +297,18 @@ for mod_dir in "$REPO_ROOT"/modules/*/; do
         fail "$mod_name: shipped '$rel_path' is not in module.json files[] (will never install)"
         missing_count=$((missing_count + 1))
       fi
-    done < <(find "$mod_dir/$subdir" -maxdepth 1 -type f -name "$pattern" 2>/dev/null)
+    done < <(find -L "$mod_dir/$subdir" -maxdepth 1 -type f -name "$pattern" 2>/dev/null)
+    if [ "$subdir_shipped" -gt 0 ]; then
+      if [ -z "$contributed_labels" ]; then
+        contributed_labels="$label"
+      else
+        contributed_labels="$contributed_labels/$label"
+      fi
+    fi
   done
 
   if [ "$shipped_count" -gt 0 ] && [ "$missing_count" -eq 0 ]; then
-    pass "$mod_name: all $shipped_count shipped lib/command/rule file(s) declared in manifest"
+    pass "$mod_name: all $shipped_count shipped $contributed_labels file(s) declared in manifest"
   fi
 done
 echo ""


### PR DESCRIPTION
Closes #938

## What

The reverse manifest-completeness gate in `tests/test-modules.sh` enumerated shipped `lib/*.sh`, `commands/*.md`, and `rules/*.md` files with `find ... -type f`, which tests the directory entry's own type and never matches a symlink - even one pointing at a regular file. A rule, lib, or command file shipped as a symlink with no `module.json` `files[]` entry was invisible to this gate: the exact silent-non-install class it exists to catch (#930), reached via a symlink instead of a plain file.

Fix: added `-L` so `find` follows symlinks and tests the target's type.

**No module ships lib/commands/rules content as a symlink today** (confirmed: `find modules -maxdepth 3 \( -path '*/lib/*' -o -path '*/commands/*' -o -path '*/rules/*' \) -type l` returns nothing). This lands as a regression guard, not a fix for a currently-broken module.

### Broken-symlink behavior (deliberate, documented in-line)

Under `-L`, a *broken* symlink stops matching `-type f` - both GNU find and BSD find only report `-type l` for a link under `-L` when its target does not exist, so a broken symlink never satisfies `-type f`. Verified empirically on this machine (BSD find):

```
$ find -L . -maxdepth 1 -type f -name "*.md"   # good_link.md resolves to a real file
./good_link.md
./real.md
$ find -L . -maxdepth 1 -type l -name "*.md"   # broken_link.md points nowhere
./broken_link.md
```

That means an *undeclared* broken symlink stays invisible to this gate. I chose to leave that as-is rather than widen the fix to also flag `-type l`, because:

- If the broken symlink **is declared** in `module.json`, the separate manifest-existence gate (the `[ -e ]` check a few lines above this one) already fails it by name. Verified: `[ -e ]` on a broken symlink returns false (`bash -c 'if [ -e broken_link.md ]; then echo EXISTS; else echo MISSING; fi'` → `MISSING`), so a declared-but-broken symlink is never silently unchecked.
- If it is **not declared**, it cannot install as a working file either way, so there is nothing this gate would prevent by also flagging it.

This reasoning is recorded as an inline comment next to the `find -L` call.

### Ride-along: VERBOSE pass message named a fixed string

`pass "$mod_name: all $shipped_count shipped lib/command/rule file(s) declared in manifest"` said "lib/command/rule" regardless of which subdir(s) actually contributed - a rules-only module reported "lib/command/rule" even though only `rules/` was scanned. Now the message names only the subdir(s) that actually shipped a matching file (e.g. "rule", "lib/command", "lib/command/rule"), built without associative arrays to stay bash-3.2-safe.

## Mutation-test evidence

With the fix in place, I symlinked an undeclared `.md` file into `modules/branch-guard/rules/` (target lived outside the repo; symlink removed before committing) and re-ran `bash tests/test-modules.sh`:

```
FAIL: branch-guard: shipped 'rules/undeclared-symlink.md' is not in module.json files[] (will never install)
...
Results: 1704 passed, 1 failed
```

Removed the symlink, re-ran, back to green:

```
Results: 1705 passed, 0 failed
```

Then confirmed the *pre-fix* code genuinely misses this: restored the original `find` (no `-L`) via `git checkout -- tests/test-modules.sh`, re-added the same symlink, re-ran:

```
Results: 1705 passed, 0 failed   # no FAIL line for undeclared-symlink.md at all
```

Confirming the old code stayed green with the same undeclared symlink present. Restored my fix afterward and re-ran clean (`1705 passed, 0 failed`).

## Gates

- `bash tests/test-modules.sh` → 1705 passed, 0 failed
- `bash tests/test-no-personal-data.sh` → PASS: No personal data or secret/PII shapes found

No docs, module counts, frontmatter, or `module.json` files were touched, so `/docupdate` and the marketplace-manifest regen do not apply here.