### PR TITLE
#970: fix three Manual Installation README gaps flagged by #951's guard

### DIFF
--- a/modules/ccgm-doctor/README.md
+++ b/modules/ccgm-doctor/README.md
@@ -106,6 +106,9 @@ chmod +x ~/.claude/bin/ccgm-doctor
 
 mkdir -p ~/.claude/lib
 cp lib/doctor.py ~/.claude/lib/doctor.py
+
+mkdir -p ~/.claude/evals
+cp evals/routing.json ~/.claude/evals/routing.json
 ```
 
 `ccgm-doctor` expects `doctor.py` to sit in `../lib/` relative to the executable. If you install it elsewhere, adjust `sys.path` accordingly or run via `python3 -m doctor` with the lib dir on your PYTHONPATH.

--- a/modules/documentation/README.md
+++ b/modules/documentation/README.md
@@ -30,6 +30,9 @@ Spawns 4 parallel audit agents to find every gap between your documentation and 
 
 ```bash
 cp commands/docupdate.md ~/.claude/commands/docupdate.md
+
+mkdir -p ~/.claude/lib
+cp lib/docupdate-discover.sh ~/.claude/lib/docupdate-discover.sh
 ```
 
 ## How It Works

--- a/modules/session-history/README.md
+++ b/modules/session-history/README.md
@@ -40,10 +40,14 @@ Cursor is intentionally out of scope for this module (different transcript forma
 # From the CCGM repo root:
 
 mkdir -p ~/.claude/agents
+mkdir -p ~/.claude/commands
 mkdir -p ~/.claude/scripts
 
 cp modules/session-history/agents/session-historian.md \
    ~/.claude/agents/session-historian.md
+
+cp modules/session-history/commands/recall.md \
+   ~/.claude/commands/recall.md
 
 cp modules/session-history/scripts/discover-sessions.sh \
    ~/.claude/scripts/discover-sessions.sh
@@ -52,6 +56,12 @@ chmod +x ~/.claude/scripts/discover-sessions.sh
 cp modules/session-history/scripts/extract-metadata.py \
    ~/.claude/scripts/extract-metadata.py
 chmod +x ~/.claude/scripts/extract-metadata.py
+
+cp modules/session-history/scripts/recall.py \
+   ~/.claude/scripts/recall.py
+
+cp modules/session-history/scripts/repo_detect.py \
+   ~/.claude/scripts/repo_detect.py
 
 cp modules/session-history/scripts/add-agents-md-symlinks.sh \
    ~/.claude/scripts/add-agents-md-symlinks.sh

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -360,11 +360,15 @@ echo ""
 # never ran) instead of producing a readable failure line.
 #
 # KNOWN_GAPS lists modules this check found to have a real, pre-existing gap
-# that is out of scope for the PR that introduced this check (#951 touched
-# six specific READMEs; these three were discovered by the new check but
-# belong to a different PR). Tracked in #970. A module here whose gap has
-# since been fixed makes this check FAIL (stale allowlist entry) so the
-# list cannot silently outlive the bugs it excuses.
+# that is out of scope for the PR that introduced this check. A module here
+# whose gap has since been fixed makes this check FAIL (stale allowlist
+# entry) so the list cannot silently outlive the bugs it excuses.
+#
+# #951 introduced this check across six specific READMEs; three further
+# gaps it also found (ccgm-doctor, documentation, session-history) were out
+# of scope for that PR and tracked as #970. #970 fixed all three READMEs,
+# so the list is empty again -- add an entry here only for a newly
+# discovered, genuinely out-of-scope gap.
 echo "--- Checking Manual Installation cp-block coverage (module.json vs README) ---"
 MANUAL_INSTALL_REPORT=$(REPO_ROOT="$REPO_ROOT" python3 - <<'PYEOF'
 import json
@@ -381,11 +385,7 @@ CP_LINE_RE = re.compile(r'cp\s+(-[A-Za-z]+\s+)?"?(?:modules/[\w.-]+/)?([\w${}/.*
 EXEMPT_FILENAMES = {"settings.partial.json"}
 
 # module -> tracking issue for a known, out-of-scope pre-existing gap.
-KNOWN_GAPS = {
-    "ccgm-doctor": "#970",
-    "documentation": "#970",
-    "session-history": "#970",
-}
+KNOWN_GAPS = {}
 
 
 def shellvar_to_regex(src):


### PR DESCRIPTION
Closes #970

## What changed

Three module READMEs had Manual Installation `cp` blocks that omitted files the module actually ships, discovered by the `KNOWN_GAPS`-allowlisted entries `#951`'s new guard added:

- `session-history`: the block never copied `commands/recall.md`, `scripts/recall.py`, or `scripts/repo_detect.py` -- meaning `/recall`, that module's headline command, plus its entire implementation and the helper it imports, never installed via the documented manual path.
- `ccgm-doctor`: the block never copied `evals/routing.json`, the default suite `resolver-eval` reads by default (verified the install target `~/.claude/evals/routing.json` matches `bin/ccgm-doctor`'s own default path derivation).
- `documentation`: the block never copied `lib/docupdate-discover.sh`, the script `/docupdate` invokes directly (`bash ~/.claude/lib/docupdate-discover.sh`).

Each README's cp block is extended to cover the missing files, matching that README's own existing structure (mkdir ordering, comment style, target paths) -- not a uniform template imposed across all three.

All three modules are delisted from `KNOWN_GAPS` in `tests/test-modules.sh` in this same PR, since the guard's own stale-allowlist self-check fails the build if a listed module's gap is already fixed. `KNOWN_GAPS` is now `{}`; the explanatory comment above it is updated to stay accurate (it no longer describes "these three" since none remain, but keeps the mechanism explanation and the #951/#970 history).

## Re-derived missing-file list

Ran the guard's own Python with `KNOWN_GAPS` emptied against the pre-fix tree (`27bfe97`):

```
MISSING	ccgm-doctor	evals/routing.json
MISSING	documentation	lib/docupdate-discover.sh
MISSING	session-history	commands/recall.md
MISSING	session-history	scripts/recall.py
MISSING	session-history	scripts/repo_detect.py
CHECKED	67
SKIPPED_COUNT	11
```

Matches the dispatched list exactly.

## Both-directions tree-diff verification

For each module, executed the corrected README block verbatim into a scratch directory (paths redirected off `HOME`, not run against the real `~/.claude`) and diffed the resulting file tree against `jq -r '.files|keys[]' module.json` in both directions.

**session-history** (7 declared files):
```
MISSING (declared but not installed): 0
EXTRA (installed but not declared):   0
```

**ccgm-doctor** (3 declared files):
```
MISSING (declared but not installed): 0
EXTRA (installed but not declared):   0
```

**documentation** (2 declared files):
```
MISSING (declared but not installed): 0
EXTRA (installed but not declared):   0
```

No over-install in any of the three (the #972 `evil; touch PWNED` failure mode this was checked against does not apply here -- none of the three blocks use a broad recursive glob; every added line is an explicit single-file `cp`).

## Mutation tests

**Delist mutation** -- re-added `ccgm-doctor` to `KNOWN_GAPS` with the README fix still in place:

```
FAIL: ccgm-doctor: allowlisted for #970 but has no missing files now -- remove from KNOWN_GAPS
Results: 1705 passed, 1 failed
```

Removed the re-added entry -> back to `1705 passed, 0 failed`. Confirms the stale-allowlist self-check is live and the delist in this PR is required, not cosmetic.

**Coverage mutation** -- with `KNOWN_GAPS` emptied, temporarily reverted the `documentation` README fix:

```
FAIL: documentation: Manual Installation cp block never installs 'lib/docupdate-discover.sh' (declared in module.json but no cp/glob covers it)
Results: 1705 passed, 1 failed
```

Restored the fix -> back to `1705 passed, 0 failed`.

## Gate output (fresh, final state)

```
$ bash tests/test-modules.sh
  Results: 1705 passed, 0 failed

$ bash tests/test-no-personal-data.sh
PASS: No personal data or secret/PII shapes found

$ bash tests/test-doc-counts.sh
test-doc-counts.sh: all checks passed
```
