### PR TITLE
#946: fix echo/tr flag-parsing across brand-naming, cloud-dispatch, commands-extra

### DIFF
--- a/modules/brand-naming/lib/brand-check-gather.sh
+++ b/modules/brand-naming/lib/brand-check-gather.sh
@@ -9,8 +9,11 @@ if [ -z "$NAME" ]; then
   exit 1
 fi
 
-# Normalize to lowercase
-NAME=$(echo "$NAME" | tr '[:upper:]' '[:lower:]')
+# Normalize to lowercase. printf '%s', not echo: bash's builtin echo
+# flag-parses a leading -n/-e, so a name of exactly "-n" would silently
+# become empty output here (bypassing the emptiness guard above, which
+# runs before this normalization).
+NAME=$(printf '%s' "$NAME" | tr '[:upper:]' '[:lower:]')
 
 # TLDs from arg or defaults
 if [ -n "$2" ]; then

--- a/modules/cloud-dispatch/lib/budget-track.sh
+++ b/modules/cloud-dispatch/lib/budget-track.sh
@@ -78,7 +78,10 @@ require_cmd jq
 # hourly_rate <server-type> — print the USD/hr rate for a given server type
 hourly_rate() {
   local stype
-  stype=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+  # printf '%s', not echo: bash's builtin echo flag-parses a leading -n/-e,
+  # so a server-type of exactly "-n" would silently normalize to empty and
+  # fall through to DEFAULT_RATE for the wrong reason.
+  stype=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
   echo "${HOURLY_RATES[$stype]:-${DEFAULT_RATE}}"
 }
 

--- a/modules/cloud-dispatch/lib/workspace-assign.sh
+++ b/modules/cloud-dispatch/lib/workspace-assign.sh
@@ -79,7 +79,9 @@ SSH_KEY="${SSH_KEY_PATH:-${HOME}/.ssh/id_ed25519}"
 
 # Build branch slug: lowercase, replace spaces/non-alphanumeric with hyphens,
 # trim leading/trailing hyphens, collapse repeated hyphens.
-SLUG=$(echo "${ISSUE_TITLE}" \
+# printf '%s', not echo: bash's builtin echo flag-parses a leading -n/-e,
+# so a title of exactly "-n" would silently produce an empty slug.
+SLUG=$(printf '%s' "${ISSUE_TITLE}" \
   | tr '[:upper:]' '[:lower:]' \
   | sed 's/[^a-z0-9]/-/g' \
   | sed 's/-\{2,\}/-/g' \

--- a/modules/cloud-dispatch/lib/workspace-setup-all.sh
+++ b/modules/cloud-dispatch/lib/workspace-setup-all.sh
@@ -129,7 +129,9 @@ else
     exit 1
   fi
   for issue_num in "${ISSUE_LIST[@]}"; do
-    issue_num=$(echo "${issue_num}" | tr -d '[:space:]')
+    # printf '%s', not echo: bash's builtin echo flag-parses a leading -n/-e,
+    # so an issue number of exactly "-n" would silently strip to empty here.
+    issue_num=$(printf '%s' "${issue_num}" | tr -d '[:space:]')
     title=$(gh issue view "${issue_num}" --repo "${REPO}" --json title --jq '.title' 2>/dev/null || echo "issue-${issue_num}")
     ISSUE_TITLES["${issue_num}"]="${title}"
   done
@@ -168,7 +170,7 @@ AGENTS_PER_VM=4
 
 slot=0
 for issue_num in "${ISSUE_LIST[@]}"; do
-  issue_num=$(echo "${issue_num}" | tr -d '[:space:]')
+  issue_num=$(printf '%s' "${issue_num}" | tr -d '[:space:]')
   vm_index=$(( slot / AGENTS_PER_VM ))
   agent_index=$(( slot % AGENTS_PER_VM ))
 
@@ -201,7 +203,9 @@ printf "  %-6s  %-8s  %-20s  %s\n" "------" "--------" "--------------------" "-
 for i in "${!PLAN_ISSUE_NUMBERS[@]}"; do
   num="${PLAN_ISSUE_NUMBERS[$i]}"
   title="${ISSUE_TITLES[$num]:-issue-${num}}"
-  slug=$(echo "${title}" \
+  # printf '%s', not echo: bash's builtin echo flag-parses a leading -n/-e,
+  # so a title of exactly "-n" would silently produce an empty slug.
+  slug=$(printf '%s' "${title}" \
     | tr '[:upper:]' '[:lower:]' \
     | sed 's/[^a-z0-9]/-/g' \
     | sed 's/-\{2,\}/-/g' \

--- a/modules/cloud-dispatch/lib/workspace-setup-all.sh
+++ b/modules/cloud-dispatch/lib/workspace-setup-all.sh
@@ -93,8 +93,10 @@ fi
 if [[ -n "${REPO_OVERRIDE}" ]]; then
   REPO="${REPO_OVERRIDE}"
 else
-  # Strip https://github.com/ prefix and .git suffix
-  REPO=$(echo "${REPO_URL}" | sed 's|https://github.com/||;s|\.git$||')
+  # Strip https://github.com/ prefix and .git suffix. printf '%s', not echo:
+  # bash's builtin echo flag-parses a leading -n/-e, so a repo-url of
+  # exactly "-n" would silently strip to empty here (#946).
+  REPO=$(printf '%s' "${REPO_URL}" | sed 's|https://github.com/||;s|\.git$||')
 fi
 
 # SSH_KEY is passed via SSH_KEY_PATH env to child scripts (workspace-setup.sh, workspace-assign.sh)

--- a/modules/cloud-dispatch/lib/workspace-setup-all.sh
+++ b/modules/cloud-dispatch/lib/workspace-setup-all.sh
@@ -172,6 +172,7 @@ AGENTS_PER_VM=4
 
 slot=0
 for issue_num in "${ISSUE_LIST[@]}"; do
+  # printf '%s', same reasoning as the identical strip above (#946).
   issue_num=$(printf '%s' "${issue_num}" | tr -d '[:space:]')
   vm_index=$(( slot / AGENTS_PER_VM ))
   agent_index=$(( slot % AGENTS_PER_VM ))

--- a/modules/commands-extra/commands/checkpoint.md
+++ b/modules/commands-extra/commands/checkpoint.md
@@ -52,7 +52,9 @@ title was given):
 
 ```bash
 TITLE="${ARG:-$BRANCH}"
-SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' \
+# printf '%s', not echo: bash's builtin echo flag-parses a leading -n/-e,
+# so a title of exactly "-n" would silently produce an empty slug.
+SLUG=$(printf '%s' "$TITLE" | tr '[:upper:]' '[:lower:]' \
   | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' \
   | cut -c1-60)
 [ -z "$SLUG" ] && SLUG="checkpoint"

--- a/modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh
+++ b/modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh
@@ -191,8 +191,11 @@ PYEOF
   if [ -n "${raw_ws:-}" ]; then
     while IFS= read -r pattern; do
       [ -z "$pattern" ] && continue
-      # Strip trailing /* or /** to get a base directory
-      dir_pattern=$(echo "$pattern" | sed 's|/\*\*$||; s|/\*$||')
+      # Strip trailing /* or /** to get a base directory. printf '%s', not
+      # echo: bash's builtin echo flag-parses a leading -n/-e, so a
+      # workspaces[] glob of exactly "-n" would silently strip to empty
+      # here (#946).
+      dir_pattern=$(printf '%s' "$pattern" | sed 's|/\*\*$||; s|/\*$||')
       # Expand to concrete child directories
       while IFS= read -r -d $'\0' d; do
         rel="${d#"$TARGET_DIR"/}"
@@ -230,7 +233,10 @@ PYEOF
   if [ -n "${raw_ws:-}" ]; then
     while IFS= read -r pattern; do
       [ -z "$pattern" ] && continue
-      dir_pattern=$(echo "$pattern" | sed 's|/\*\*$||; s|/\*$||')
+      # printf '%s', not echo: bash's builtin echo flag-parses a leading
+      # -n/-e, so a pnpm-workspace.yaml packages[] glob of exactly "-n"
+      # would silently strip to empty here (#946).
+      dir_pattern=$(printf '%s' "$pattern" | sed 's|/\*\*$||; s|/\*$||')
       while IFS= read -r -d $'\0' d; do
         rel="${d#"$TARGET_DIR"/}"
         monorepo_packages+=("$rel")
@@ -294,7 +300,15 @@ fi
 if [ -f "$TARGET_DIR/requirements.txt" ]; then
   content=$(cat "$TARGET_DIR/requirements.txt")
   for fw in django flask fastapi starlette tornado sanic; do
-    if echo "$content" | grep -qi "^[[:space:]]*${fw}[>=<!\[]"; then
+    # Herestring, not a pipe: under `set -euo pipefail` (line 35), `echo
+    # "$content" | grep -qi ...` can have grep exit on its first match
+    # before echo finishes writing a large requirements.txt, SIGPIPE-killing
+    # echo and making pipefail report a genuine match as a failure (#943,
+    # #945). It is also the echo flag-parsing defect (#946): a
+    # requirements.txt whose entire content is exactly "-n"/"-e" would
+    # silently become empty. A herestring has no second process to race
+    # against and never flag-parses its argument.
+    if grep -qi "^[[:space:]]*${fw}[>=<!\[]" <<< "$content"; then
       frameworks+=("$fw")
     fi
   done
@@ -305,7 +319,9 @@ if has_file "go.mod"; then
   content=$(cat "$TARGET_DIR/go.mod")
   for fw_path in "gin-gonic/gin" "labstack/echo" "gofiber/fiber" "go-chi/chi"; do
     fw_label="${fw_path##*/}"
-    if echo "$content" | grep -q "$fw_path"; then
+    # Herestring, not a pipe: same SIGPIPE-under-pipefail (#943, #945) and
+    # echo flag-parsing (#946) reasoning as the requirements.txt loop above.
+    if grep -q "$fw_path" <<< "$content"; then
       frameworks+=("$fw_label")
     fi
   done

--- a/modules/commands-extra/skills/audit/tests/test-diff-mode.sh
+++ b/modules/commands-extra/skills/audit/tests/test-diff-mode.sh
@@ -87,6 +87,15 @@ for p in paths:
 PYEOF
 }
 
+# Join newline-separated paths with '|'. printf '%s', not echo: bash's
+# builtin echo flag-parses a value of exactly "-n"/"-e" into empty output,
+# which would silently drop a legitimately dash-named path (#946). Shared
+# by GROUP 1's byte-exact round-trip check and GROUP 1b's regression guard
+# below, so a regression in the join is caught wherever it is used.
+join_pipe() {
+  printf '%s' "$1" | tr '\n' '|' | sed 's/|$//'
+}
+
 # Apply the documented diff filter step to spine JSONL.
 # Reads null-delimited changed-files.z; outputs filtered JSONL.
 apply_diff_filter() {
@@ -220,9 +229,7 @@ fi
 # Verify byte-exact round-trip: reading back the -z file should produce the same paths
 Z_PATHS=$(read_z_file "$CHANGES_Z1")
 TXT_PATHS=$(cat "$CHANGES_TXT1" | tr '\n' '|' | sed 's/|$//')
-# printf '%s', not echo: bash's builtin echo flag-parses a leading -n/-e,
-# so a path of exactly "-n" would silently drop out of this comparison.
-Z_PATHS_PIPE=$(printf '%s' "$Z_PATHS" | tr '\n' '|' | sed 's/|$//')
+Z_PATHS_PIPE=$(join_pipe "$Z_PATHS")
 
 if [ "$Z_PATHS_PIPE" = "$TXT_PATHS" ]; then
   pass "python3 -z parse: paths round-trip byte-exact between .z and .txt"
@@ -232,13 +239,11 @@ fi
 
 # ---------------------------------------------------------------------------
 # GROUP 1b: Dash-prefixed path name -- echo flag-parsing regression guard
-# (issue #946). A changed file literally named "-n" is a legal git path. If
-# the Z_PATHS_PIPE join above used `echo "$Z_PATHS"` instead of
-# `printf '%s' "$Z_PATHS"`, bash's builtin echo would flag-parse a
-# single-line "-n" value and print nothing, silently dropping the path from
-# every downstream pipe-joined comparison. Pin the printf-based join here so
-# a future regression back to echo fails loudly instead of returning an
-# empty string that reads as "no changed files."
+# (issue #946). A changed file literally named "-n" is a legal git path.
+# Exercises the SAME join_pipe() helper GROUP 1's round-trip check uses
+# above (not a duplicated copy of its body) -- if join_pipe regresses from
+# `printf '%s'` back to `echo`, bash's builtin echo flag-parses a
+# single-line "-n" value into empty output, and this assertion catches it.
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- [1b] Dash-prefixed path name: echo flag-parsing regression guard ---"
@@ -259,12 +264,12 @@ DASH_Z=$(make_tmp)/dash-changed.z
 git -C "$REPO1B" diff --name-only -z "HEAD~1...HEAD" > "$DASH_Z"
 
 DASH_PATHS=$(read_z_file "$DASH_Z")
-DASH_PATHS_PIPE=$(printf '%s' "$DASH_PATHS" | tr '\n' '|' | sed 's/|$//')
+DASH_PATHS_PIPE=$(join_pipe "$DASH_PATHS")
 
 if [ "$DASH_PATHS_PIPE" = "-n" ]; then
-  pass "dash-prefixed path '-n': printf '%s' preserves it through the pipe-join (echo would flag-parse it to empty)"
+  pass "dash-prefixed path '-n': join_pipe() preserves it (echo would flag-parse it to empty)"
 else
-  fail "dash-prefixed path '-n': should survive the pipe-join as '-n', got '$DASH_PATHS_PIPE'"
+  fail "dash-prefixed path '-n': should survive join_pipe() as '-n', got '$DASH_PATHS_PIPE'"
 fi
 
 # Test --staged: stage a new file and verify git diff --staged detects it

--- a/modules/commands-extra/skills/audit/tests/test-diff-mode.sh
+++ b/modules/commands-extra/skills/audit/tests/test-diff-mode.sh
@@ -220,12 +220,51 @@ fi
 # Verify byte-exact round-trip: reading back the -z file should produce the same paths
 Z_PATHS=$(read_z_file "$CHANGES_Z1")
 TXT_PATHS=$(cat "$CHANGES_TXT1" | tr '\n' '|' | sed 's/|$//')
-Z_PATHS_PIPE=$(echo "$Z_PATHS" | tr '\n' '|' | sed 's/|$//')
+# printf '%s', not echo: bash's builtin echo flag-parses a leading -n/-e,
+# so a path of exactly "-n" would silently drop out of this comparison.
+Z_PATHS_PIPE=$(printf '%s' "$Z_PATHS" | tr '\n' '|' | sed 's/|$//')
 
 if [ "$Z_PATHS_PIPE" = "$TXT_PATHS" ]; then
   pass "python3 -z parse: paths round-trip byte-exact between .z and .txt"
 else
   fail "python3 -z parse: paths differ between .z and .txt (z='$Z_PATHS_PIPE' txt='$TXT_PATHS')"
+fi
+
+# ---------------------------------------------------------------------------
+# GROUP 1b: Dash-prefixed path name -- echo flag-parsing regression guard
+# (issue #946). A changed file literally named "-n" is a legal git path. If
+# the Z_PATHS_PIPE join above used `echo "$Z_PATHS"` instead of
+# `printf '%s' "$Z_PATHS"`, bash's builtin echo would flag-parse a
+# single-line "-n" value and print nothing, silently dropping the path from
+# every downstream pipe-joined comparison. Pin the printf-based join here so
+# a future regression back to echo fails loudly instead of returning an
+# empty string that reads as "no changed files."
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- [1b] Dash-prefixed path name: echo flag-parsing regression guard ---"
+echo ""
+
+REPO1B=$(make_repo)
+printf 'const x = 1;\n' > "$REPO1B/clean.js"
+git -C "$REPO1B" add -A
+git -C "$REPO1B" commit -q -m "base"
+
+# A file literally named "-n" -- a legal git path, and the exact value that
+# bash's builtin echo flag-parses into empty output.
+printf 'const evil = 1;\n' > "$REPO1B/-n"
+git -C "$REPO1B" add -- "-n"
+git -C "$REPO1B" commit -q -m "add dash-prefixed file"
+
+DASH_Z=$(make_tmp)/dash-changed.z
+git -C "$REPO1B" diff --name-only -z "HEAD~1...HEAD" > "$DASH_Z"
+
+DASH_PATHS=$(read_z_file "$DASH_Z")
+DASH_PATHS_PIPE=$(printf '%s' "$DASH_PATHS" | tr '\n' '|' | sed 's/|$//')
+
+if [ "$DASH_PATHS_PIPE" = "-n" ]; then
+  pass "dash-prefixed path '-n': printf '%s' preserves it through the pipe-join (echo would flag-parse it to empty)"
+else
+  fail "dash-prefixed path '-n': should survive the pipe-join as '-n', got '$DASH_PATHS_PIPE'"
 fi
 
 # Test --staged: stage a new file and verify git diff --staged detects it


### PR DESCRIPTION
Closes #946

## What

Bash's builtin `echo` flag-parses a leading `-n`/`-e` in its argument, regardless of what consumes the output. A value of exactly `-n` or `-e` piped through `echo "$var" | <anything>` produces empty output instead of the literal string, and the caller silently proceeds on an empty value. `#931`/`#940` fixed the same shape in `lib/ui.sh` and grepped for the `| tr` variant of this shape (see `ee94dcb`'s commit message). This PR fixes every site of the wider `echo "$var" | <anything>` shape found inside the three modules I own (`brand-naming`, `cloud-dispatch`, `commands-extra`): 8 sites via `| tr`/`| sed` (first push) plus 5 more via `| sed`/`| grep` that the first sweep missed because it only searched for `| tr` (second push, below).

Fix shape, per site:
- **Value reused downstream** (lowercasing, whitespace-stripping, slugifying, newline-to-pipe joining, URL-stripping, glob-trimming): `echo "$var"` -> `printf '%s' "$var"` ahead of the existing `tr`/`sed` pipeline.
- **Value consumed by a quiet-matching `grep -q` under `set -euo pipefail`**: `echo "$var" | grep -q PATTERN` -> `grep -q PATTERN <<< "$var"` (a herestring). This is two sites (`detect-ecosystems.sh:297,308`). Both defects are present in the line, but only one is reachable in effect. The `#943`/`#945` SIGPIPE race is real and directly reproducible here: with a `django>=4.2` match at the head of ~13 MB of content, `echo "$content" | grep -qi` reports NO_MATCH while the herestring reports MATCH. The `#946` flag-parsing half is present as a pattern but cannot flip an outcome at these two lines: it only triggers when `$content` is exactly `-n`/`-e`, and none of the framework names searched for (`django`, `flask`, `fastapi`, `starlette`, `tornado`, `sanic`, `gin-gonic/gin`, `labstack/echo`, `gofiber/fiber`, `go-chi/chi`) can occur inside those strings, so the correct result is NO_MATCH either way. The herestring is still the right fix, and it closes the reachable SIGPIPE defect without changing any match/no-match outcome.

`printf '%s'` was chosen over `case`-bracket rewrites (`#931`'s shape) everywhere a site *transforms a string for reuse*, since `case` only fits a pure yes/no comparison.

## Site inventory

### First push: 8 sites via `| tr`

Ran a multi-line-continuation-aware sweep for `echo .* | tr` across the whole repo. It reproduced exactly the 8 sites `#931`'s commit message listed, all inside my three owned modules.

| # | Site | Fix |
|---|---|---|
| 1 | `modules/brand-naming/lib/brand-check-gather.sh:13` | `printf '%s'` |
| 2 | `modules/cloud-dispatch/lib/workspace-setup-all.sh:132` | `printf '%s'` |
| 3 | `modules/cloud-dispatch/lib/workspace-setup-all.sh:171` | `printf '%s'` |
| 4 | `modules/cloud-dispatch/lib/workspace-setup-all.sh:204` (multi-line continuation) | `printf '%s'` |
| 5 | `modules/cloud-dispatch/lib/workspace-assign.sh:82` (multi-line continuation) | `printf '%s'` |
| 6 | `modules/cloud-dispatch/lib/budget-track.sh:81` | `printf '%s'` |
| 7 | `modules/commands-extra/commands/checkpoint.md:55` (documented snippet) | `printf '%s'` |
| 8 | `modules/commands-extra/skills/audit/tests/test-diff-mode.sh:225` (`tr '\n' '\|'` variant) | `printf '%s'`, extracted into a shared `join_pipe()` helper + regression test |

**Correction (review round 1):** the sweep in this round was scoped only to `| tr`. That was too narrow -- see round 2 below. "No 9th site" in the original version of this PR body was true only for the `| tr` shape, not the general `echo "$var" | <anything>` defect. Retracted; replaced by the wider sweep below.

### Second push: widened sweep, 5 more sites via `| sed`/`| grep`

Re-swept all three owned modules for `echo "$var" | <anything>` (not just `| tr`), collapsing backslash line-continuations first (same script shape as round 1, generalized). Command and full output:

```python
# sweep3.py -- walks modules/{brand-naming,cloud-dispatch,commands-extra}/**/*.{sh,md},
# excludes any path containing /tests/, collapses `\<newline>` continuations,
# and matches echo\b[^\n|]*\|\s*[A-Za-z0-9_./]+
```
```
$ python3 sweep3.py
modules/cloud-dispatch/lib/agent-collect.sh :: echo "${raw_assignment}" | python3        (x4, whitespace variants)
modules/cloud-dispatch/lib/agent-launch.sh :: echo "${ASSIGNMENT}" | python3              (x4, whitespace variants)
modules/cloud-dispatch/lib/agent-status.sh :: echo "${raw_assignment}" | python3          (x3, whitespace variants)
modules/cloud-dispatch/lib/budget-track.sh :: echo "${vm_json}" | jq
modules/cloud-dispatch/lib/budget-track.sh :: echo "Usage: $0 <start|stop...             (literal string, no variable)
modules/cloud-dispatch/lib/cost-report.sh :: echo "${session_json}" | jq                  (x7, whitespace variants)
modules/cloud-dispatch/lib/cost-report.sh :: echo "${stats}" | jq                         (x6, whitespace variants)
modules/cloud-dispatch/lib/cost-report.sh :: echo "Usage: $0 <session|monthly...          (literal string, no variable)
modules/cloud-dispatch/lib/recovery.sh :: echo "${entry}" | jq                            (x3, whitespace variants)
modules/cloud-dispatch/lib/recovery.sh :: echo "${raw}" | python3                         (x7, whitespace variants)
modules/cloud-dispatch/lib/recovery.sh :: echo "${results[*]}")" | jq
modules/cloud-dispatch/lib/recovery.sh :: echo "${result}" | jq                           (x7, whitespace variants)
modules/cloud-dispatch/lib/workspace-collect.sh :: echo "${assignment}" | grep           (x5, whitespace variants)
modules/cloud-dispatch/lib/workspace-collect.sh :: echo "${last_exit}" | grep            (x2, whitespace variants)
modules/cloud-dispatch/lib/workspace-setup-all.sh :: echo "${REPO_URL}" | sed
modules/cloud-dispatch/lib/workspace-setup-all.sh :: echo "${line}" | jq                  (x2, whitespace variants)
modules/cloud-dispatch/packer/scripts/security-hardening.sh :: echo iptables-persistent ... | debconf  (x2, literal strings)
modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh :: echo "$content" | grep  (x2)
modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh :: echo "$pattern" | sed   (x2)
TOTAL (non-test paths only): 58
```

(Filtering out `/tests/` paths per this round's scope; a separate, unfiltered run against the full three modules -- including tests/ -- returns 210 matches, all of them either the same lib/scripts sites above or pre-existing `.sh` test-harness idioms like `echo "$captured_output" | grep` reading a variable that is itself the output of an already-run assertion, not user/repo input.)

Of the 58 non-test matches, 5 are new, verified-reachable sites (fixed in this push); 1 (`workspace-collect.sh:154`, `last_exit`) is a borderline candidate evaluated and left unfixed (see below); the remaining 52 are JSON-blob or literal-string shapes that structurally cannot equal exactly `-n`/`-e` (detail below the table).

| # | Site | Value comes from | Fix |
|---|---|---|---|
| 9 | `modules/cloud-dispatch/lib/workspace-setup-all.sh:97` | `REPO_URL="$1"` -- a positional argument, same shape as site 1's `NAME` | `printf '%s'` |
| 10 | `modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh:195` | `$pattern`, a `workspaces[]` glob from the **scanned repo's** `package.json` | `printf '%s'` |
| 11 | `detect-ecosystems.sh:233` | same, from `pnpm-workspace.yaml` `packages:` | `printf '%s'` |
| 12 | `detect-ecosystems.sh:297` | `content=$(cat requirements.txt)`, multi-line | herestring (`<<<`) -- also fixes a `#943`/`#945`-class SIGPIPE race |
| 13 | `detect-ecosystems.sh:308` | `content=$(cat go.mod)`, multi-line | herestring (`<<<`) -- also fixes the same SIGPIPE race |

**Sixth candidate, evaluated and left unfixed (deferred, not silently skipped):** `modules/cloud-dispatch/lib/workspace-collect.sh:154` -- `if echo "${last_exit}" | grep -qi "exit.*0\|completed\|success"; then` (and its `elif` sibling at 155/156, same shape), where `last_exit=$(ssh_root ... "tail -1 '${run_log}'")` is the last line of a remote agent's arbitrary run log. Unlike sites 1-13, this value is not a bounded CLI arg or a structured repo-manifest field -- it is free-form log text, so "exactly `-n`" requires a real agent's run.log to end with a bare `-n` line, which no tool in this pipeline prints as a terminal line. Even in that case the failure mode is a status misclassification (the surrounding `if`/`elif`/`else` falls to `agent_status="idle"` rather than correctly detecting `"completed"`/`"failed"`) -- not a corrupted domain, branch name, or price lookup like sites 1-13. Left unfixed pending the coordinator's call on whether it belongs in this PR's scope.

**Left untouched, confirmed unreachable (JSON-blob or literal-string shapes, cannot equal exactly `-n`/`-e`):**
- `agent-collect.sh`/`agent-launch.sh`/`agent-status.sh`: `echo "${raw_assignment}"`/`"${ASSIGNMENT}"` `| python3` -- assignment JSON, always `{...}`-shaped (recorded not-vulnerable class from round 1, `ee94dcb`).
- `budget-track.sh`: `echo "${vm_json}" | jq` -- `hcloud server list --output json` output, always JSON array/object.
- `cost-report.sh`: `echo "${session_json}"`/`"${stats}" | jq` -- `session_json` is the budget-file JSON blob; `stats` is `session_stats()`'s own `jq -n '{...}'` output.
- `recovery.sh`: `echo "${raw}" | python3` -- assignment JSON, same shape as `workspace-collect.sh:105`; `echo "${result}" | jq` -- `result=$(classify_agent ...)`, which always returns the literal string `"null"` or a JSON object (verified by reading `classify_agent`'s body); `echo "${results[*]})" | jq` -- a comma-joined array of those same `result` values, wrapped in `printf '[%s]'` for a JSON array.
- `workspace-setup-all.sh:121-122`: `echo "${line}" | jq` -- `line` comes from `jq -r 'to_entries[] | {key, value} | @json'`, always a JSON object string.
- `security-hardening.sh`: `echo iptables-persistent ... | debconf` (x2) -- literal strings, no variable at all.
- Both `budget-track.sh`/`cost-report.sh` "Usage: ..." lines -- literal strings, no variable.

`printf '%s'` vs `printf '%s\n'`: every fixed site assigns the result via `$(...)` (which strips *all* trailing newlines) or feeds a herestring (which does not care about a trailing newline either); used `printf '%s'` uniformly.

## Per-site before/after evidence (sites 1-8, unchanged from round 1)

All commands were run directly (not simulated) with a real `/bin/bash` (macOS 3.2.57), using the exact expressions extracted from each file. "before" re-derives the pre-fix line via `git show HEAD:<path>` from before this PR's first commit; "after" is the fixed file content.

**Site 1 -- `brand-check-gather.sh`, end-to-end `/brand-check -n` path**:
```
--- BEFORE, arg=-n ---
NAME=[]
--- AFTER, arg=-n ---
NAME=[-n]
--- BEFORE, arg=MyBrand (normal input) ---
NAME=[mybrand]
--- AFTER, arg=MyBrand (normal input) ---
NAME=[mybrand]
```

**Sites 2/3 -- `workspace-setup-all.sh` issue_num whitespace-strip**:
```
--- BEFORE, input=-n ---
[]
--- AFTER, input=-n ---
[-n]
--- BEFORE, input=' 42 ' (normal) ---
[42]
--- AFTER, input=' 42 ' (normal) ---
[42]
```

**Sites 4/5 -- slug pipeline** (identical shape in both files; tested once):
```
--- BEFORE, title=-n ---
[]
--- AFTER, title=-n ---
[n]
--- BEFORE, title='Fix Login Bug' (normal) ---
[fix-login-bug]
--- AFTER, title='Fix Login Bug' (normal) ---
[fix-login-bug]
```
(`-n` slugifies to `n`, not `-n`, because the pipeline's own `sed 's/^-//'` trim step strips a leading hyphen identically before and after this fix. The bug is the empty-vs-nonempty difference, not the exact slug shape.)

**Site 6 -- `budget-track.sh` `hourly_rate()` stype normalization** (isolated from the function's `declare -A` lookup table, a separate pre-existing bash-4-only construct in that file, out of scope for this issue):
```
--- BEFORE, input=-n ---
[]
--- AFTER, input=-n ---
[-n]
--- BEFORE, input=CCX63 (normal) ---
[ccx63]
--- AFTER, input=CCX63 (normal) ---
[ccx63]
```

**Site 7 -- `checkpoint.md` documented slug snippet**:
```
--- BEFORE, TITLE=-n ---
[checkpoint]   (silently falls through to the snippet's own default -- wrong, not an error)
--- AFTER, TITLE=-n ---
[n]
--- BEFORE, TITLE='WIP: refactor auth' (normal) ---
[wip-refactor-auth]
--- AFTER, TITLE='WIP: refactor auth' (normal) ---
[wip-refactor-auth]
```

**Site 8 -- `test-diff-mode.sh`** (scratch harness, same shapes as above):
```
--- BEFORE, Z_PATHS=-n ---
[]
--- AFTER, Z_PATHS=-n ---
[-n]
--- BEFORE, Z_PATHS='modified.js' (normal, matches actual test data) ---
[modified.js]
--- AFTER, Z_PATHS='modified.js' (normal, matches actual test data) ---
[modified.js]
--- BEFORE, Z_PATHS=multi-line (a.js, b.js) ---
[a.js|b.js]
--- AFTER, Z_PATHS=multi-line (a.js, b.js) ---
[a.js|b.js]
```

## Site 8's regression test, and a correction made after review round 1

The first push added a `GROUP 1b` test to `test-diff-mode.sh` with its own independent `printf '%s' "$DASH_PATHS" | tr '\n' '|' | sed 's/|$//'` expression. Review caught that this was circular: it duplicated the fixed shape rather than exercising the actual site-8 line (`Z_PATHS_PIPE`), so reverting the real site-8 fix left the suite fully green.

Fixed by extracting the join into a single shared helper, `join_pipe()`, called from both the GROUP 1 byte-exact round-trip check (`Z_PATHS_PIPE=$(join_pipe "$Z_PATHS")`) and GROUP 1b's dash-prefixed-path regression guard (`DASH_PATHS_PIPE=$(join_pipe "$DASH_PATHS")`).

```
# 1. Baseline: === Results: 45 passed, 0 failed ===
# 2. join_pipe() mutated printf '%s' -> echo:
  [FAIL] dash-prefixed path '-n': should survive join_pipe() as '-n', got ''
  === Results: 44 passed, 1 failed ===
# 3. join_pipe() restored: === Results: 45 passed, 0 failed ===
# 4. GROUP 1's original round-trip check, unaffected by the mutation above:
  [PASS] python3 -z parse: paths round-trip byte-exact between .z and .txt
```

## Per-site before/after evidence (sites 9-13, this round)

**Site 9 -- `workspace-setup-all.sh:97` REPO derivation**:
```
--- BEFORE, REPO_URL=-n ---
[]
--- AFTER, REPO_URL=-n ---
[-n]
--- BEFORE, REPO_URL=https://github.com/owner/repo.git (normal) ---
[owner/repo]
--- AFTER, REPO_URL=https://github.com/owner/repo.git (normal) ---
[owner/repo]
```

**Sites 10/11 -- `detect-ecosystems.sh` `dir_pattern` derivation** (identical shape at both sites; tested once):
```
--- BEFORE, pattern=-n ---
[]
--- AFTER, pattern=-n ---
[-n]
--- BEFORE, pattern=packages/* (normal) ---
[packages]
--- AFTER, pattern=packages/* (normal) ---
[packages]
```

**Sites 12/13 -- `detect-ecosystems.sh:297,308` framework detection, herestring fix**:

Part A -- echo flag-parsing, isolated (content is exactly `-n`, pattern `n` should match since `-n` literally contains the letter `n`):
```
--- BEFORE (echo | grep), content=-n, pattern=n ---
NO_MATCH (wrong -- content literally contains 'n')
--- AFTER (herestring), content=-n, pattern=n ---
MATCH
```

Part B -- realistic multi-line `requirements.txt` fixture (`# core deps`, `requests==2.31.0`, `Django>=4.2,<5.0`, `psycopg2-binary==2.9.9`, `gunicorn==21.2.0`), confirming the herestring produces the same match/no-match as echo for both a present and an absent framework:
```
--- BEFORE (echo | grep), fw=django (present) ---     MATCH (django detected)
--- AFTER  (herestring),  fw=django (present) ---      MATCH (django detected)
--- BEFORE (echo | grep), fw=flask  (absent)  ---     NO_MATCH (correct)
--- AFTER  (herestring),  fw=flask  (absent)  ---      NO_MATCH (correct)
```

Part C -- realistic multi-line `go.mod` fixture (`module github.com/example/app`, `go 1.21`, `require (github.com/gin-gonic/gin v1.9.1, github.com/stretchr/testify v1.8.4)`), same confirmation:
```
--- BEFORE (echo | grep), fw_path=gin-gonic/gin (present)   ---   MATCH (gin detected)
--- AFTER  (herestring),  fw_path=gin-gonic/gin (present)   ---   MATCH (gin detected)
--- BEFORE (echo | grep), fw_path=labstack/echo (absent)    ---   NO_MATCH (correct)
--- AFTER  (herestring),  fw_path=labstack/echo (absent)    ---   NO_MATCH (correct)
```

Part D -- SIGPIPE-under-`pipefail` construction proof (same method as `#945`: build content large enough to exceed a pipe buffer, with the match placed near the start so `grep -q` can exit before `echo` finishes writing):
```
--- BEFORE (echo | grep -qi django, pipefail on), big content, match near start ---
NO_MATCH (WRONG -- django is present; SIGPIPE/pipefail flipped a real match to failure)
--- AFTER (herestring), big content, match near start ---
MATCH (correct: django IS present)
```

Note: `test-detect-ecosystems.sh`'s own fixtures for Python/Go repos do not currently assert on `.project_shape.frameworks` contents for those two ecosystems (only JS `react`/`express` are asserted there) -- the scratch harness above is the primary proof for sites 12/13's behavior; the existing suite's 54/54 pass confirms no regression to what it does cover.

## Gates (fresh, current branch state)

```
$ bash -n modules/cloud-dispatch/lib/workspace-setup-all.sh
syntax OK
$ bash -n modules/commands-extra/skills/audit/scripts/detect-ecosystems.sh
syntax OK

$ bash tests/test-modules.sh
  Results: 1705 passed, 0 failed

$ bash tests/test-no-personal-data.sh
PASS: No personal data or secret/PII shapes found

$ bash modules/commands-extra/skills/audit/tests/test-diff-mode.sh
=== Results: 45 passed, 0 failed ===

$ bash modules/commands-extra/skills/audit/tests/test-detect-ecosystems.sh
Results: 54 passed, 0 failed
```

No `module.json` touched (skipped `gen_marketplace.py --check`). No command/skill/agent frontmatter touched (skipped `test-frontmatter-yaml.sh`).

