### PR TITLE
#945: eliminate remaining pipefail/SIGPIPE races in three test suites

### DIFF
--- a/tests/test-backup.sh
+++ b/tests/test-backup.sh
@@ -592,25 +592,30 @@ JSON
 
 fixture_paths=$(CCGM_ROOT="$FIXTURE_ROOT" managed_backup_paths 2>/dev/null)
 
-if ! echo "$fixture_paths" | grep -qx '\.'; then
+# Herestring, not a pipe: `producer | grep -qx` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a successful match (or non-match) into a wrongly
+# reported result (see #943, #945). A herestring has no second process to
+# race against.
+if ! grep -qx '\.' <<< "$fixture_paths"; then
   pass "Derived path list does not contain a literal '.' segment"
 else
   fail "Derived path list contains a dangerous literal '.' segment"
 fi
 
-if ! echo "$fixture_paths" | grep -qx '\.\.'; then
+if ! grep -qx '\.\.' <<< "$fixture_paths"; then
   pass "Derived path list does not contain a literal '..' segment"
 else
   fail "Derived path list contains a dangerous literal '..' segment"
 fi
 
-if ! echo "$fixture_paths" | grep -qx ''; then
+if ! grep -qx '' <<< "$fixture_paths"; then
   pass "Derived path list does not contain an empty segment"
 else
   fail "Derived path list contains an empty segment"
 fi
 
-if echo "$fixture_paths" | grep -qx 'skills'; then
+if grep -qx 'skills' <<< "$fixture_paths"; then
   pass "Legitimate sibling target (skills/) still passes through"
 else
   fail "Legitimate sibling target (skills/) was dropped by the safety filter"
@@ -681,13 +686,13 @@ JSON
 
 scope_targets=$(_backup_files_block "$SCOPE_FIXTURE" | grep -o '"target"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/^"target"[[:space:]]*:[[:space:]]*"//; s/"$//')
 
-if echo "$scope_targets" | grep -qx 'real/path.md'; then
+if grep -qx 'real/path.md' <<< "$scope_targets"; then
   pass "_backup_files_block includes the real files[].target"
 else
   fail "_backup_files_block missed the real files[].target"
 fi
 
-if ! echo "$scope_targets" | grep -qx 'unrelated-decoy'; then
+if ! grep -qx 'unrelated-decoy' <<< "$scope_targets"; then
   pass "_backup_files_block excludes a decoy 'target' key outside files"
 else
   fail "_backup_files_block leaked a decoy 'target' key outside files"

--- a/tests/test-backup.sh
+++ b/tests/test-backup.sh
@@ -686,6 +686,8 @@ JSON
 
 scope_targets=$(_backup_files_block "$SCOPE_FIXTURE" | grep -o '"target"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/^"target"[[:space:]]*:[[:space:]]*"//; s/"$//')
 
+# Herestrings here too -- see the identical rationale on the fixture_paths
+# checks above (#943, #945).
 if grep -qx 'real/path.md' <<< "$scope_targets"; then
   pass "_backup_files_block includes the real files[].target"
 else

--- a/tests/test-doc-counts.sh
+++ b/tests/test-doc-counts.sh
@@ -134,21 +134,14 @@ check_no_wrong_count_phrasing() {
     [ -n "$line" ] || continue
     # Extract the first integer that the phrasing wraps.
     #
-    # No pipe into `head -1`: under `set -o pipefail`, a downstream consumer
-    # that exits after its first line (`head -1`) can SIGPIPE-kill an
-    # upstream `grep` mid-write if more than one match/digit-run exists,
-    # turning a successful extraction into a pipeline failure. This
-    # assignment has no `|| true` guard, so under `set -e` that failure
-    # would abort the entire test run silently partway through (see #943,
-    # #945). Use herestrings for both greps -- neither is early-exiting
-    # (`-oE` alone drains to EOF), so there is no live pipe left to race --
-    # then take the first line with bash parameter expansion instead of a
-    # piped `head -1`. (Named line_match/line_digits, not "matches", so this
-    # per-line extraction never shadows the outer $matches the loop reads
-    # its input from.)
+    # A *live pipe* into an early-exiting consumer (`grep -q`, `head -1`)
+    # can SIGPIPE-kill an upstream writer under `pipefail` (see #943, #945).
+    # Herestrings remove the pipe entirely, so nothing races.
+    # $matches is already bound by the enclosing loop; these must not reuse
+    # that name.
     line_match=$(grep -oE "$regex" <<< "$line" || true)
     line_digits=$(grep -oE '[0-9]+' <<< "$line_match" || true)
-    n="${line_digits%%$'\n'*}"
+    n=$(head -1 <<< "$line_digits")
     if [ -n "$n" ] && [ "$n" != "$MODULE_COUNT" ]; then
       fail "stale '$label' count ($n, expected $MODULE_COUNT): $line"
       found_wrong=1

--- a/tests/test-doc-counts.sh
+++ b/tests/test-doc-counts.sh
@@ -133,7 +133,22 @@ check_no_wrong_count_phrasing() {
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     # Extract the first integer that the phrasing wraps.
-    n=$(printf '%s' "$line" | grep -oE "$regex" | grep -oE '[0-9]+' | head -1)
+    #
+    # No pipe into `head -1`: under `set -o pipefail`, a downstream consumer
+    # that exits after its first line (`head -1`) can SIGPIPE-kill an
+    # upstream `grep` mid-write if more than one match/digit-run exists,
+    # turning a successful extraction into a pipeline failure. This
+    # assignment has no `|| true` guard, so under `set -e` that failure
+    # would abort the entire test run silently partway through (see #943,
+    # #945). Use herestrings for both greps -- neither is early-exiting
+    # (`-oE` alone drains to EOF), so there is no live pipe left to race --
+    # then take the first line with bash parameter expansion instead of a
+    # piped `head -1`. (Named line_match/line_digits, not "matches", so this
+    # per-line extraction never shadows the outer $matches the loop reads
+    # its input from.)
+    line_match=$(grep -oE "$regex" <<< "$line" || true)
+    line_digits=$(grep -oE '[0-9]+' <<< "$line_match" || true)
+    n="${line_digits%%$'\n'*}"
     if [ -n "$n" ] && [ "$n" != "$MODULE_COUNT" ]; then
       fail "stale '$label' count ($n, expected $MODULE_COUNT): $line"
       found_wrong=1
@@ -259,7 +274,11 @@ while IFS= read -r mod; do
     continue
   fi
   # allowlisted?
-  if printf '%s\n' "$ALLOWLIST" | grep -qx "$mod"; then
+  # Herestring, not a pipe: `producer | grep -qx` can SIGPIPE-kill the
+  # producer if grep exits on its first match before the producer finishes
+  # writing, turning a successful match into a reported failure (see #943,
+  # #945). A herestring has no second process to race against.
+  if grep -qx "$mod" <<< "$ALLOWLIST"; then
     ok "$mod in zero presets but allowlisted"
     continue
   fi
@@ -284,7 +303,9 @@ while IFS= read -r mod; do
     STALE="$STALE $mod(missing-module)"
     continue
   fi
-  if printf '%s\n' "$PRESET_MEMBERS" | grep -qx "$mod"; then
+  # Herestring, not a pipe: see the identical rationale on the allowlist
+  # check above (#943, #945).
+  if grep -qx "$mod" <<< "$PRESET_MEMBERS"; then
     STALE="$STALE $mod(now-in-preset)"
   fi
 done <<EOF

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -872,6 +872,8 @@ if [ -x /bin/bash ]; then
   confirm_out=$(printf 'yes\n' | /bin/bash -c \
     "source '$REPO_ROOT/lib/ui.sh'; ui_confirm 'Proceed?' && echo CONFIRMED || echo DECLINED" 2>&1)
   set -e
+  # Herestrings through this whole block -- see the identical rationale at
+  # the top of the file (#943, #945).
   if grep -q "bad substitution" <<< "$confirm_out"; then
     fail "ui_confirm under /bin/bash hit a bash-4 'bad substitution' abort (answer: yes): $confirm_out"
   elif grep -q "CONFIRMED" <<< "$confirm_out"; then

--- a/tests/test-installer.sh
+++ b/tests/test-installer.sh
@@ -507,7 +507,11 @@ else
   fail "--add with unwired placeholders unexpectedly succeeded"
 fi
 
-if echo "$add7_out" | grep -qiE "unexpanded placeholder"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a successful match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if grep -qiE "unexpanded placeholder" <<< "$add7_out"; then
   pass "Failure message names the unexpanded placeholder"
 else
   fail "Failure message did not mention unexpanded placeholder"
@@ -624,7 +628,7 @@ if grep -q "WARNING:" "$mismatch_stderr"; then
 else
   fail "ui_choose --default with an unmatched value did not print a 'WARNING:'-prefixed message: $(cat "$mismatch_stderr")"
 fi
-if echo "$result" | grep -qi "warning"; then
+if grep -qi "warning" <<< "$result"; then
   fail "Warning text leaked into ui_choose's returned value"
 else
   pass "Warning text did not leak into ui_choose's returned value"
@@ -868,9 +872,9 @@ if [ -x /bin/bash ]; then
   confirm_out=$(printf 'yes\n' | /bin/bash -c \
     "source '$REPO_ROOT/lib/ui.sh'; ui_confirm 'Proceed?' && echo CONFIRMED || echo DECLINED" 2>&1)
   set -e
-  if echo "$confirm_out" | grep -q "bad substitution"; then
+  if grep -q "bad substitution" <<< "$confirm_out"; then
     fail "ui_confirm under /bin/bash hit a bash-4 'bad substitution' abort (answer: yes): $confirm_out"
-  elif echo "$confirm_out" | grep -q "CONFIRMED"; then
+  elif grep -q "CONFIRMED" <<< "$confirm_out"; then
     pass "ui_confirm under /bin/bash returns confirmed for 'yes'"
   else
     fail "ui_confirm under /bin/bash did not confirm 'yes': $confirm_out"
@@ -880,9 +884,9 @@ if [ -x /bin/bash ]; then
   decline_out=$(printf 'no\n' | /bin/bash -c \
     "source '$REPO_ROOT/lib/ui.sh'; ui_confirm 'Proceed?' && echo CONFIRMED || echo DECLINED" 2>&1)
   set -e
-  if echo "$decline_out" | grep -q "bad substitution"; then
+  if grep -q "bad substitution" <<< "$decline_out"; then
     fail "ui_confirm under /bin/bash hit a bash-4 'bad substitution' abort (answer: no): $decline_out"
-  elif echo "$decline_out" | grep -q "DECLINED"; then
+  elif grep -q "DECLINED" <<< "$decline_out"; then
     pass "ui_confirm under /bin/bash returns declined for 'no'"
   else
     fail "ui_confirm under /bin/bash did not decline 'no': $decline_out"
@@ -892,7 +896,7 @@ if [ -x /bin/bash ]; then
   mixed_out=$(printf 'YES\n' | /bin/bash -c \
     "source '$REPO_ROOT/lib/ui.sh'; ui_confirm 'Proceed?' && echo CONFIRMED || echo DECLINED" 2>&1)
   set -e
-  if echo "$mixed_out" | grep -q "CONFIRMED"; then
+  if grep -q "CONFIRMED" <<< "$mixed_out"; then
     pass "ui_confirm under /bin/bash lowercases mixed-case 'YES' before matching"
   else
     fail "ui_confirm under /bin/bash did not confirm mixed-case 'YES': $mixed_out"
@@ -909,12 +913,12 @@ if [ -x /bin/bash ]; then
   dashn_out=$(printf -- '-n\nyes\n' | /bin/bash -c \
     "source '$REPO_ROOT/lib/ui.sh'; ui_confirm 'Proceed?' 'no' && echo CONFIRMED || echo DECLINED" 2>&1)
   set -e
-  if echo "$dashn_out" | grep -q "Please answer yes or no"; then
+  if grep -q "Please answer yes or no" <<< "$dashn_out"; then
     pass "ui_confirm under /bin/bash re-prompts on a literal '-n' answer instead of silently taking the default"
   else
     fail "ui_confirm under /bin/bash did not re-prompt on '-n' (silently took the default): $dashn_out"
   fi
-  if echo "$dashn_out" | grep -q "CONFIRMED"; then
+  if grep -q "CONFIRMED" <<< "$dashn_out"; then
     pass "ui_confirm under /bin/bash accepts the real answer ('yes') after rejecting '-n'"
   else
     fail "ui_confirm under /bin/bash did not resolve to the real answer after '-n': $dashn_out"
@@ -924,12 +928,12 @@ if [ -x /bin/bash ]; then
   dashe_out=$(printf -- '-e\nno\n' | /bin/bash -c \
     "source '$REPO_ROOT/lib/ui.sh'; ui_confirm 'Proceed?' 'yes' && echo CONFIRMED || echo DECLINED" 2>&1)
   set -e
-  if echo "$dashe_out" | grep -q "Please answer yes or no"; then
+  if grep -q "Please answer yes or no" <<< "$dashe_out"; then
     pass "ui_confirm under /bin/bash re-prompts on a literal '-e' answer instead of silently taking the default"
   else
     fail "ui_confirm under /bin/bash did not re-prompt on '-e' (silently took the default): $dashe_out"
   fi
-  if echo "$dashe_out" | grep -q "DECLINED"; then
+  if grep -q "DECLINED" <<< "$dashe_out"; then
     pass "ui_confirm under /bin/bash accepts the real answer ('no') after rejecting '-e'"
   else
     fail "ui_confirm under /bin/bash did not resolve to the real answer after '-e': $dashe_out"
@@ -977,7 +981,7 @@ MANIFEST_EOF
   update_exit=$?
   set -e
 
-  if echo "$update_out" | grep -qE "invalid option|bad substitution"; then
+  if grep -qE "invalid option|bad substitution" <<< "$update_out"; then
     fail "update.sh's _install_missing hit a bash-4-only construct under /bin/bash: $update_out"
   elif [ $update_exit -ne 0 ]; then
     fail "update.sh's _check_installed_drift/_install_missing exited $update_exit under /bin/bash: $update_out"


### PR DESCRIPTION
Closes #945

## What this fixes

`set -euo pipefail` lets a pipeline's downstream consumer that exits early (`head -1`, `grep -q`) SIGPIPE-kill an upstream `grep` that is still mid-write. #943 fixed one instance of this in `tests/test-modules.sh`. This PR closes out the remaining instances across the three suites I own: `tests/test-doc-counts.sh`, `tests/test-installer.sh`, `tests/test-backup.sh`.

The issue body estimated "five more sites." That undercounts the real surface, and the severities differ:

| Class | Consequence | Sites found |
|---|---|---|
| **Abort** — bare `var=$(producer \| early-exit-consumer)`, no `\|\| true`, under `set -e` | The whole run dies silently partway through; a partial run looks green | 1 (`test-doc-counts.sh:136`) |
| **Wrong result** — `if producer \| grep -q ...; then` | A successful match is reported as a failure | 20 (`test-doc-counts.sh`: 2, `test-installer.sh`: 12, `test-backup.sh`: 6) |

## The fix

Every site: replace the pipe with a herestring (`<<<`), which has no second process to race against — the same pattern #943 established in `tests/test-modules.sh`. The `:136` abort site chains two `grep`s before a `head -1`, so it also drops the piped `head -1` for bash parameter expansion (`"${var%%$'\n'*}"`) instead of a single herestring swap.

I chose to fix every `if producer | grep -q` site rather than a subset. The fix is mechanical, semantics-preserving (each site's exact flags — `-q`, `-qi`, `-qiE`, `-qx`, `-qE`, negation — are preserved exactly, only the pipe is removed), and the total diff across three files is small.

## What I left untouched, and why

- **`test-doc-counts.sh:64`** — already guarded with `|| true`; the pipe (`grep -n ... | head -3`) feeds diagnostic-only text into a `fail` message, so a truncated read changes nothing about pass/fail.
- **`test-doc-counts.sh:353`** (was `:332` before the `:136` fix added lines) — `diff <(...) <(...) | head -6` embedded inside a `fail` call's string argument. Verified empirically (both `/bin/bash` 3.2.57 and Homebrew bash 5.3) that a failing command substitution embedded in another command's *argument* does not trigger `errexit` — the outer `fail` call still runs with whatever text it got. This can neither abort the run nor flip a pass/fail result; only diagnostic completeness is at (theoretical) risk.
- **`test-backup.sh:727`** — `grep -c` always drains its input to produce an accurate count, so there is no early-exiting consumer and no SIGPIPE race here at all. It does have a different, unrelated risk (`grep -c` exits 1 when the count is zero, which could abort a bare assignment) — that is a distinct grep quirk, not a pipefail/SIGPIPE race, and out of scope for this issue.
- Several `grep -q` / `grep -m1` sites across all three files read directly from a **file** (e.g. `grep -q "WARNING:" "$mismatch_stderr"`), not through a pipe — no producer process exists to race against, so these were never candidates.

## Verification

By construction, not reproduction — matching #943's own experience (0/100 local reproductions, 0/500 by its reviewer) for a producer this small:

- `yes | head -1` under `pipefail` reliably returns 141 (the canonical SIGPIPE-under-pipefail mechanism, always reproducible since `yes` guarantees the writer is still blocked on a full pipe when `head` exits).
- Constructed `if producer | grep -qx TARGET; then` with a producer large enough to exceed the kernel pipe buffer (`TARGET` line first, then ~2M padding lines) reproduces the exact "wrong result" bug live: `TARGET` is genuinely the first line, and the `if` still reports NOT MATCHED. The fixed herestring shape reports MATCHED correctly on the same data, and stays correct on a multi-megabyte herestring too — the fix is not "less likely to race," it structurally has no pipe left to race.

Suite runs, 5x each, all green, both under the default `bash` and `/bin/bash` 3.2.57:

```
test-doc-counts.sh:  5/5 runs — all checks passed (incl. --self-test)
test-installer.sh:   5/5 runs — 87 passed, 0 failed
test-backup.sh:      5/5 runs — 56 passed, 0 failed
```

Required gates, all green:

```
tests/test-modules.sh:          1705 passed, 0 failed
tests/test-no-personal-data.sh: PASS
tests/test-doc-counts.sh:       all checks passed
tests/test-installer.sh:        87 passed, 0 failed
tests/test-backup.sh:           56 passed, 0 failed
```

`bash -n` clean on all three files, individually, under both bash versions.

Untouched: `tests/test-modules.sh` (owned by a concurrent PR from #944).
