### PR TITLE
#954: controlled paths: symlink experiment, version floor, write-path gate

### DIFF
--- a/lib/rule_tiering.py
+++ b/lib/rule_tiering.py
@@ -1,0 +1,152 @@
+"""Rule-tiering support library (plan.md `~/code/plans/ccgm-dynamic-rule-injection/plan.md`,
+Epic 1 -- issue #954).
+
+THIS FILE IS INTENTIONALLY INCOMPLETE. Epic 1's scope is the `paths:`
+version floor only -- Epic 4 owns the real generator (`validate()`,
+`render_frontmatter()` proper, `render_index()`, `strip_frontmatter()`;
+idempotent, atomic, path-confined, byte-reversible). Do not extend this
+module beyond what is documented below without reading Epic 4's spec
+first; a signature added here casually is a signature Epic 4 either has
+to keep or has to break.
+
+What lives here today
+----------------------
+  claude_code_supports_paths(version_string=None) -> bool
+      The version-floor check. `paths:` frontmatter on rule files shipped
+      broken in several point releases before it stabilized (plan.md
+      §1.2 insight 1 cites 2.1.198, 2.1.207, 2.1.211, 2.1.217 as the fix
+      train; research-e-orchestrator-firsthand.md's decisive experiment
+      ran on 2.1.220). MIN_SUPPORTED_VERSION is pinned to 2.1.207, the
+      first release in that train the plan treats as stable.
+
+  render_frontmatter(target_path, paths, *, version_string=None) -> (bool, str)
+      A MINIMAL, gated write path -- NOT the Epic 4 generator. It exists
+      solely so Epic 1's test_version_floor_gates_writes.py has a real
+      write path to prove the version floor actually gates (the security
+      review's finding: a floor that is unit-tested in isolation but
+      never proven to gate the write path is not a floor). It has NONE
+      of the properties the real generator will need: it is not
+      idempotent, not atomic, not byte-reversible, and does not validate
+      that `target_path` is confined to a module directory. Epic 4 owns
+      building that generator from scratch; this function's only
+      contract is "does nothing when the version floor is not met".
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+
+# First Claude Code release this plan treats as a stable `paths:`
+# implementation. Below this, the frontmatter is either ignored (rule
+# loads unconditionally, defeating Tier B silently) or -- per plan.md
+# R6 -- one invalid pattern below 2.1.207 breaks the Read tool for
+# EVERY evaluated file. Either failure mode is worse than not writing
+# the frontmatter at all, hence the fail-safe (False) default below.
+MIN_SUPPORTED_VERSION = (2, 1, 207)
+
+_VERSION_PATTERN = re.compile(r"(\d+)\.(\d+)\.(\d+)")
+
+
+def _parse_version(version_string: str) -> "tuple[int, int, int] | None":
+    """Parse the first X.Y.Z triple out of a version string.
+
+    Accepts both a bare version ("2.1.220") and the real `claude
+    --version` shape ("2.1.220 (Claude Code)") by searching for the
+    pattern anywhere in the string rather than anchoring to its start.
+
+    Returns None if no such triple is found -- the caller (
+    claude_code_supports_paths) treats this as fail-safe False, never
+    as "assume supported".
+    """
+    if not isinstance(version_string, str):
+        return None
+    match = _VERSION_PATTERN.search(version_string)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())  # type: ignore[return-value]
+
+
+def claude_code_supports_paths(version_string: "str | None" = None) -> bool:
+    """True iff the given (or running) Claude Code version supports
+    `paths:` frontmatter on rule files.
+
+    version_string:
+        - If provided, parsed directly (no subprocess call). This is
+          the path every unit test exercises, so the check is fully
+          deterministic in CI with no `claude` CLI required.
+        - If None (the default), shells out to `claude --version` and
+          parses its stdout. Any failure to invoke `claude` at all
+          (not installed, not on PATH, times out) is caught and treated
+          as fail-safe False -- never as "assume supported".
+
+    Fail-safe on every unparseable or unobtainable input: returns False,
+    never True, when the version cannot be determined. A caller that
+    cannot prove the version supports `paths:` must not write it.
+    """
+    if version_string is None:
+        try:
+            result = subprocess.run(
+                ["claude", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        version_string = (result.stdout or "") + (result.stderr or "")
+
+    parsed = _parse_version(version_string)
+    if parsed is None:
+        return False
+    return parsed >= MIN_SUPPORTED_VERSION
+
+
+def render_frontmatter(
+    target_path: str,
+    paths: "list[str]",
+    *,
+    version_string: "str | None" = None,
+) -> "tuple[bool, str]":
+    """Minimal, version-gated write path. NOT the Epic 4 generator -- see
+    the module docstring before extending this.
+
+    Returns (wrote, reason):
+      - (False, reason) and `target_path` is left completely untouched
+        (not created, not modified) when `claude_code_supports_paths()`
+        is False for the given/running version. This is the behavior
+        test_version_floor_gates_writes.py asserts.
+      - (True, reason) and a block-sequence `paths:` frontmatter block
+        is prepended to `target_path`'s existing content (or written
+        alone if `target_path` does not yet exist), when the version
+        check passes.
+
+    `paths` must be a non-empty list of glob strings; each is emitted as
+    its own quoted block-sequence entry (never flow-style `[...]`) per
+    plan.md §8.3's "Emitted YAML" requirement -- flow-style is rejected
+    by the repo's frontmatter-YAML guard.
+    """
+    if not claude_code_supports_paths(version_string):
+        return False, (
+            "claude_code_supports_paths() is False -- refusing to write "
+            f"paths: frontmatter to {target_path!r}"
+        )
+
+    if not paths:
+        return False, "refusing to write paths: frontmatter with an empty paths list"
+
+    frontmatter_lines = ["---", "paths:"]
+    frontmatter_lines.extend(f'  - "{glob}"' for glob in paths)
+    frontmatter_lines.append("---")
+    frontmatter = "\n".join(frontmatter_lines) + "\n"
+
+    existing_body = ""
+    if os.path.isfile(target_path):
+        with open(target_path, "r", encoding="utf-8") as fh:
+            existing_body = fh.read()
+
+    with open(target_path, "w", encoding="utf-8") as fh:
+        fh.write(frontmatter + existing_body)
+
+    return True, f"wrote paths: frontmatter to {target_path!r}"

--- a/modules/relevance-injection/tests/fixtures/arm_check.py
+++ b/modules/relevance-injection/tests/fixtures/arm_check.py
@@ -12,7 +12,10 @@ the caller (test-paths-symlink.sh) reads stdout to distinguish outcomes,
 never the exit code. This matters most for `check-loaded`, where
 LOG_MISSING is itself a meaningful, distinct outcome (see
 lib/loaded_log.py's LogMissingError vs RuleNotLoadedError split) rather
-than a script failure.
+than a script failure. `check-no-self-read` follows the same one-line
+stdout contract; any diagnostic detail it emits (the assistant-message
+count it examined) goes to stderr instead, so the caller's `$(...)`
+capture of stdout is never polluted.
 
 Subcommands
 -----------
@@ -28,12 +31,26 @@ Subcommands
                         lib/loaded_log.py's design)
 
   check-no-self-read <out_json> <real_path> <basename>
-      Scans the `claude -p --output-format json` event array in
-      <out_json> for an assistant `tool_use` block named "Read" whose
-      `input.file_path` contains <real_path> or <basename>. Prints:
-        OK                        -- no such Read call found
+      Scans the `claude -p --output-format json --verbose` event array
+      in <out_json> for an assistant `tool_use` block named "Read" whose
+      `input.file_path` contains <real_path> or <basename>. --verbose is
+      required on the `claude -p` invocation for this check to mean
+      anything: without it, `--output-format json` emits a single
+      `type: "result"` object with no `assistant`-typed entries at all,
+      and a check that finds zero would otherwise report the same "OK"
+      as a check that genuinely examined N assistant turns and found no
+      self-read -- passing vacuously on every run. Prints:
+        OK                         -- examined >=1 assistant-type
+                                       entry, no self-read found
         SELF_READ_DETECTED: <path> -- the first matching Read call
-        CHECK_ERROR: <detail>      -- <out_json> could not be parsed
+        CHECK_ERROR: <detail>      -- <out_json> could not be parsed,
+                                      OR zero assistant-type entries
+                                      were present to examine (the
+                                      shape this check depends on was
+                                      never emitted -- most likely
+                                      `--verbose` was not honored)
+      Also writes a one-line diagnostic to stderr reporting how many
+      assistant-type entries were examined, regardless of outcome.
 """
 from __future__ import annotations
 
@@ -75,9 +92,11 @@ def check_no_self_read(out_json_path: str, real_path: str, basename: str) -> Non
     if not isinstance(data, list):
         data = [data]
 
+    assistant_count = 0
     for item in data:
         if not isinstance(item, dict) or item.get("type") != "assistant":
             continue
+        assistant_count += 1
         message = item.get("message")
         if not isinstance(message, dict):
             continue
@@ -89,8 +108,21 @@ def check_no_self_read(out_json_path: str, real_path: str, basename: str) -> Non
             tool_input = block.get("input") or {}
             file_path = str(tool_input.get("file_path", ""))
             if (real_path and real_path in file_path) or (basename and basename in file_path):
+                print(f"  (examined {assistant_count} assistant-type entries before the match)", file=sys.stderr)
                 print(f"SELF_READ_DETECTED: {file_path}")
                 return
+
+    print(f"  (examined {assistant_count} assistant-type entries)", file=sys.stderr)
+    if assistant_count == 0:
+        # `--output-format json` without `--verbose` emits a single
+        # `type: "result"` object and no `assistant`-typed entries at
+        # all -- this check has nothing to examine and must not report
+        # the same "OK" a genuine pass would. See module docstring.
+        print(
+            f"CHECK_ERROR: no assistant-type entries found in {out_json_path} "
+            "-- was `claude -p` invoked with --output-format json --verbose?"
+        )
+        return
     print("OK")
 
 

--- a/modules/relevance-injection/tests/fixtures/arm_check.py
+++ b/modules/relevance-injection/tests/fixtures/arm_check.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Assertion helper for test-paths-symlink.sh (Epic 1, issue #954).
+
+Kept as a standalone script rather than inline heredocs in the bash
+harness for two reasons: it is independently readable/testable, and it
+sidesteps the bash 3.2 lexer trap plan.md §2 warns about (an apostrophe
+inside a `#` comment inside a quoted heredoc within `$(...)`) entirely,
+by never needing a heredoc-in-command-substitution in the first place.
+
+Every subcommand prints exactly one line to stdout and always exits 0 --
+the caller (test-paths-symlink.sh) reads stdout to distinguish outcomes,
+never the exit code. This matters most for `check-loaded`, where
+LOG_MISSING is itself a meaningful, distinct outcome (see
+lib/loaded_log.py's LogMissingError vs RuleNotLoadedError split) rather
+than a script failure.
+
+Subcommands
+-----------
+  check-loaded <log_dir> <real_path>
+      Scans every loaded-*.jsonl file under <log_dir> (a run may span a
+      UTC day boundary and thus write more than one) for a record naming
+      <real_path>. Prints one of:
+        LOADED       -- at least one log names the rule as loaded
+        NOT_LOADED   -- at least one log exists and parses, but none
+                        name the rule
+        LOG_MISSING  -- no log file exists at all (the hook never fired
+                        -- never conflated with NOT_LOADED, per
+                        lib/loaded_log.py's design)
+
+  check-no-self-read <out_json> <real_path> <basename>
+      Scans the `claude -p --output-format json` event array in
+      <out_json> for an assistant `tool_use` block named "Read" whose
+      `input.file_path` contains <real_path> or <basename>. Prints:
+        OK                        -- no such Read call found
+        SELF_READ_DETECTED: <path> -- the first matching Read call
+        CHECK_ERROR: <detail>      -- <out_json> could not be parsed
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import sys
+
+sys.path.insert(0, os.environ["LOADED_LOG_LIB"])
+import loaded_log  # noqa: E402
+
+
+def check_loaded(log_dir: str, real_path: str) -> None:
+    logs = sorted(glob.glob(os.path.join(log_dir, "loaded-*.jsonl")))
+    saw_any_log = False
+    for log_path in logs:
+        if not os.path.isfile(log_path):
+            continue
+        saw_any_log = True
+        try:
+            loaded_log.assert_loaded(log_path, real_path)
+            print("LOADED")
+            return
+        except loaded_log.RuleNotLoadedError:
+            continue
+        except loaded_log.LogMissingError:
+            continue
+    print("NOT_LOADED" if saw_any_log else "LOG_MISSING")
+
+
+def check_no_self_read(out_json_path: str, real_path: str, basename: str) -> None:
+    try:
+        with open(out_json_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"CHECK_ERROR: could not parse {out_json_path}: {exc}")
+        return
+
+    if not isinstance(data, list):
+        data = [data]
+
+    for item in data:
+        if not isinstance(item, dict) or item.get("type") != "assistant":
+            continue
+        message = item.get("message")
+        if not isinstance(message, dict):
+            continue
+        for block in message.get("content") or []:
+            if not isinstance(block, dict) or block.get("type") != "tool_use":
+                continue
+            if block.get("name") != "Read":
+                continue
+            tool_input = block.get("input") or {}
+            file_path = str(tool_input.get("file_path", ""))
+            if (real_path and real_path in file_path) or (basename and basename in file_path):
+                print(f"SELF_READ_DETECTED: {file_path}")
+                return
+    print("OK")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("USAGE_ERROR: no subcommand given")
+        return
+
+    subcommand = sys.argv[1]
+    if subcommand == "check-loaded" and len(sys.argv) == 4:
+        check_loaded(sys.argv[2], sys.argv[3])
+    elif subcommand == "check-no-self-read" and len(sys.argv) == 5:
+        check_no_self_read(sys.argv[2], sys.argv[3], sys.argv[4])
+    else:
+        print(f"USAGE_ERROR: bad invocation: {sys.argv[1:]!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/relevance-injection/tests/test-paths-symlink.sh
+++ b/modules/relevance-injection/tests/test-paths-symlink.sh
@@ -1,0 +1,517 @@
+#!/usr/bin/env bash
+# test-paths-symlink.sh
+#
+# Epic 1 (issue #954, plan.md
+# ~/code/plans/ccgm-dynamic-rule-injection/plan.md, Epic 1). Settles, on
+# evidence that cannot be explained three ways, whether a SYMLINKED
+# user-level rule carrying `paths:` frontmatter is loaded lazily on a
+# matching file access -- replacing the original decisive experiment
+# (research-e-orchestrator-firsthand.md, Finding E11), which had no
+# control arm and a confounded positive arm, and asserted on the
+# model's verbal self-report instead of a deterministic oracle.
+#
+# Five arms, all asserting on the InstructionsLoaded log (Epic 7's
+# oracle -- lib/loaded_log.py), never on model output:
+#
+#   A - control    : no `paths:` frontmatter, no tools    -> must load
+#   B - negative   : `paths:` scoped to **/*.xyzzy, no tools -> must NOT load
+#   C - positive   : same scoping, session Reads a matching file only
+#                    -> must load, AND the transcript must show no read
+#                       of the canary rule file itself (rules out
+#                       self-discovery)
+#   D - write-trigger : same scoping, session WRITES a new matching
+#                       file, never reads one -> RECORDED, not asserted
+#   E - grep-trigger  : same scoping, session GREPs across matching
+#                       files, never reads one -> RECORDED, not asserted
+#
+# Arms A+B+C together are the sound experiment: A rules out "nothing
+# loads here", B rules out "loaded unconditionally", C rules out "the
+# model found it itself".
+#
+# GATES (plan.md §7.5):
+#   Gate 0 -- if arm A fails, the measurement apparatus itself is
+#     broken. No conclusion may be drawn from ANY other arm, including
+#     the original research finding. This script stops immediately
+#     after arm A on failure and reports BLOCKED.
+#   Gate 1 -- if arm C fails, Tier B is void but Tier C is unaffected.
+#     This script keeps running (D and E still answer their own
+#     independent questions) but reports BLOCKED for the epic.
+#
+# Needs an authenticated `claude` CLI and spends real (small, Haiku)
+# API cost -- this belongs to the plan's model-in-the-loop gate
+# (plan.md §8.4 Gate 2), NOT the per-PR deterministic gate. Do not wire
+# this into .github/workflows/test.yml.
+#
+# MACHINE-GLOBAL STATE DISCIPLINE (plan.md §8.3, R21) -- non-negotiable:
+#   - Every artifact this script writes into the operator's real
+#     ~/.claude/rules/ is named with a PID-unique "zzz-ccgm-test-$$-"
+#     prefix.
+#   - A machine-wide lock (~/.claude/.ccgm-rule-test.lock, mkdir-based
+#     -- `flock` is not available on stock macOS bash 3.2/BSD userland,
+#     so a mkdir lock is this script's `flock`-style equivalent: mkdir
+#     is atomic across POSIX filesystems, fails loudly with EEXIST on
+#     contention, and this script polls it with a bounded timeout and a
+#     named error) is acquired before the first write and released in
+#     a `trap ... EXIT`, so a second concurrent invocation on this
+#     machine waits rather than racing on ~/.claude/rules/.
+#   - Every symlink is removed the moment its arm finishes, and the
+#     trap sweeps any leftovers by the PID-unique prefix as a backstop.
+#   - ~/.claude/rules/'s exact pre-run file list is asserted to be
+#     restored afterwards; a mismatch fails loudly rather than silently.
+#   - Cleanup of temp directories uses `python3 -c "import shutil;
+#     shutil.rmtree(...)"`, never `rm -rf`, per plan.md's own guidance
+#     (mktemp -d lands under /var/folders on macOS, and `rm -rf
+#     /var/...` trips CCGM's own destructive-pattern guard).
+#
+# Run: bash modules/relevance-injection/tests/test-paths-symlink.sh
+#
+# Requires: an authenticated `claude` CLI (2.1.220+) on PATH, network
+# access, and a small amount of real API spend (Haiku, capped per call
+# via --max-budget-usd). Five short claude -p calls; typical run cost
+# observed during development was well under $1 total.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOK_SCRIPT="${MODULE_ROOT}/hooks/instructions-loaded-log.py"
+export LOADED_LOG_LIB="${MODULE_ROOT}/lib"
+ARM_CHECK_PY="${SCRIPT_DIR}/fixtures/arm_check.py"
+
+PASS=0
+FAIL=0
+BLOCKED_REASONS=()
+
+RULES_DIR="${HOME}/.claude/rules"
+LOCK_DIR="${HOME}/.claude/.ccgm-rule-test.lock"
+LOCK_MAIN_TIMEOUT_SECS=120
+LOCK_HELD=0
+PID_PREFIX="zzz-ccgm-test-$$-"
+
+TMP_ROOT=""
+PRE_RUN_LISTING=""
+CLEANUP_RAN=0
+
+# --- reporting helpers -------------------------------------------------
+
+pass_msg() {
+  PASS=$((PASS + 1))
+  echo "PASS: $1"
+}
+
+fail_msg() {
+  FAIL=$((FAIL + 1))
+  echo "FAIL: $1"
+}
+
+record_msg() {
+  echo "RECORDED: $1"
+}
+
+# --- machine-wide lock (mkdir-based; see header comment) ---------------
+
+acquire_lock() {
+  # args: timeout_secs
+  local timeout_secs="$1"
+  local waited=0
+  while true; do
+    if mkdir "${LOCK_DIR}" 2>/dev/null; then
+      echo "$$" > "${LOCK_DIR}/holder.pid" 2>/dev/null
+      return 0
+    fi
+    if [ "${waited}" -ge "${timeout_secs}" ]; then
+      local holder
+      holder="$(cat "${LOCK_DIR}/holder.pid" 2>/dev/null || echo unknown)"
+      echo "ERROR: lock contention -- ${LOCK_DIR} still held (holder pid: ${holder}) after ${timeout_secs}s" >&2
+      return 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+}
+
+release_lock() {
+  rm -f "${LOCK_DIR}/holder.pid" 2>/dev/null
+  rmdir "${LOCK_DIR}" 2>/dev/null
+}
+
+# --- cleanup (registered via trap ... EXIT before any write happens) ---
+
+cleanup() {
+  [ "${CLEANUP_RAN}" -eq 1 ] && return
+  CLEANUP_RAN=1
+
+  # Sweep every symlink this PID could have created, as a backstop --
+  # each arm already removes its own symlink right after it runs.
+  local leftover
+  for leftover in "${RULES_DIR}/${PID_PREFIX}"*; do
+    [ -e "${leftover}" ] || [ -L "${leftover}" ] || continue
+    rm -f "${leftover}"
+  done
+
+  if [ -n "${TMP_ROOT}" ] && [ -d "${TMP_ROOT}" ]; then
+    python3 -c "import shutil,sys; shutil.rmtree(sys.argv[1], ignore_errors=True)" "${TMP_ROOT}"
+  fi
+
+  if [ "${LOCK_HELD}" -eq 1 ]; then
+    release_lock
+    LOCK_HELD=0
+  fi
+
+  # Assert ~/.claude/rules/ is back to its exact pre-run file list.
+  if [ -n "${PRE_RUN_LISTING+set}" ]; then
+    local post_listing
+    post_listing="$(ls -1 "${RULES_DIR}" 2>/dev/null | sort)"
+    if [ "${post_listing}" != "${PRE_RUN_LISTING}" ]; then
+      echo "FAIL: ~/.claude/rules/ is NOT back to its exact pre-run file list" >&2
+      echo "--- pre-run ---" >&2
+      printf '%s\n' "${PRE_RUN_LISTING}" >&2
+      echo "--- post-run ---" >&2
+      printf '%s\n' "${post_listing}" >&2
+      FAIL=$((FAIL + 1))
+    else
+      pass_msg "~/.claude/rules/ restored to its exact pre-run file list"
+    fi
+  fi
+}
+trap cleanup EXIT
+
+# --- preconditions ------------------------------------------------------
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "BLOCKED: no 'claude' CLI on PATH -- this suite requires an authenticated" >&2
+  echo "  Claude Code CLI and belongs to the model-in-the-loop gate (plan.md §8.4" >&2
+  echo "  Gate 2), not the per-PR deterministic gate." >&2
+  exit 1
+fi
+
+if [ ! -d "${RULES_DIR}" ]; then
+  echo "BLOCKED: ${RULES_DIR} does not exist -- nothing to symlink into." >&2
+  exit 1
+fi
+
+echo "=== Epic 1: paths: frontmatter controlled experiment (issue #954) ==="
+echo "claude CLI: $(command -v claude)"
+echo "claude --version: $(claude --version 2>&1 | head -1)"
+echo ""
+
+# --- lock contention self-test (proves "waits, not races") -------------
+#
+# Acquires the real lock first, then -- while still holding it -- spawns
+# a background attempt with a short timeout and confirms it blocks for
+# (approximately) the full timeout rather than racing straight through.
+# The background attempt never succeeds in mkdir'ing (the real lock is
+# held), so it never touches ~/.claude/.ccgm-rule-test.lock itself.
+
+echo "--- Lock contention self-test ---"
+if ! acquire_lock "${LOCK_MAIN_TIMEOUT_SECS}"; then
+  exit 1
+fi
+LOCK_HELD=1
+
+CONTENTION_TIMEOUT=3
+# Pre-allocate the result path BEFORE backgrounding and reference this
+# same variable from both sides. `$$` is not usable for this: inside a
+# `( ... ) &` subshell it still expands to the TOP-LEVEL script's PID
+# (bash caches $$ at shell startup and subshells inherit that cached
+# value, not their own forked PID), while `$!` after backgrounding
+# yields the subshell's real, DIFFERENT PID -- so writer and reader
+# would disagree on the filename. A path fixed by value before the
+# fork sidesteps the mismatch entirely.
+contention_result_file="$(mktemp -t ccgm-lock-selftest)"
+contention_start=$(date +%s)
+(
+  # Re-declare a private copy of acquire_lock's mkdir loop rather than
+  # calling the parent's function, so this subshell can never mutate
+  # LOCK_HELD in a way that would be visible to (or confused with) the
+  # parent's own state.
+  waited=0
+  while true; do
+    if mkdir "${LOCK_DIR}" 2>/dev/null; then
+      echo "acquired" > "${contention_result_file}"
+      rmdir "${LOCK_DIR}" 2>/dev/null
+      exit 0
+    fi
+    if [ "${waited}" -ge "${CONTENTION_TIMEOUT}" ]; then
+      echo "timed-out" > "${contention_result_file}"
+      exit 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+) &
+contention_pid=$!
+wait "${contention_pid}"
+contention_end=$(date +%s)
+contention_elapsed=$((contention_end - contention_start))
+contention_result="$(cat "${contention_result_file}" 2>/dev/null)"
+[ -z "${contention_result}" ] && contention_result="missing"
+rm -f "${contention_result_file}" 2>/dev/null
+
+if [ "${contention_result}" = "timed-out" ] && [ "${contention_elapsed}" -ge "${CONTENTION_TIMEOUT}" ]; then
+  pass_msg "second concurrent lock attempt waited ${contention_elapsed}s then timed out (did not race)"
+else
+  fail_msg "lock contention self-test: expected 'timed-out' after >=${CONTENTION_TIMEOUT}s, got '${contention_result}' after ${contention_elapsed}s"
+fi
+echo ""
+
+# --- pre-run snapshot (checked in cleanup(), above) ---------------------
+
+PRE_RUN_LISTING="$(ls -1 "${RULES_DIR}" 2>/dev/null | sort)"
+
+TMP_ROOT="$(mktemp -d)"
+
+# --- per-arm helpers -----------------------------------------------------
+
+# Sets globals: ARM_DIR, ARM_REAL_PATH, ARM_SYMLINK_PATH
+arm_setup() {
+  local arm_id="$1"
+  local rule_body_file="$2"  # path to a file already containing the canary body
+
+  ARM_DIR="${TMP_ROOT}/arm-${arm_id}"
+  mkdir -p "${ARM_DIR}/src" "${ARM_DIR}/scratch/.claude" "${ARM_DIR}/log"
+
+  local src_file="${ARM_DIR}/src/${PID_PREFIX}arm-${arm_id}.md"
+  cp "${rule_body_file}" "${src_file}"
+
+  ARM_SYMLINK_PATH="${RULES_DIR}/${PID_PREFIX}arm-${arm_id}.md"
+  ln -s "${src_file}" "${ARM_SYMLINK_PATH}"
+
+  # Claude Code reports the RESOLVED symlink target as file_path, not
+  # the ~/.claude/rules/ symlink path itself (confirmed empirically and
+  # recorded in decisions.md) -- so this is what assert_loaded() must
+  # be compared against.
+  ARM_REAL_PATH="$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "${src_file}")"
+
+  cat > "${ARM_DIR}/scratch/.claude/settings.json" <<SETTINGSEOF
+{
+  "hooks": {
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CCGM_RULE_LOADING_DIR=${ARM_DIR}/log python3 ${HOOK_SCRIPT}",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}
+SETTINGSEOF
+}
+
+arm_remove_symlink() {
+  rm -f "${ARM_SYMLINK_PATH}"
+}
+
+# Runs `claude -p` in the arm's scratch dir with a wall-clock watchdog
+# (portable bash 3.2 pattern -- no dependency on GNU `timeout`/`gtimeout`,
+# neither of which is guaranteed present on stock macOS).
+#
+# args: arm_id, prompt, tools_csv
+arm_run_claude() {
+  local arm_id="$1" prompt="$2" tools="$3"
+  local watchdog_timeout=90
+
+  (
+    cd "${ARM_DIR}/scratch" || exit 1
+    claude -p "${prompt}" \
+      --model haiku \
+      --output-format json \
+      --permission-mode bypassPermissions \
+      --tools "${tools}" \
+      --strict-mcp-config \
+      --no-session-persistence \
+      --max-budget-usd 1 \
+      > "${ARM_DIR}/out.json" 2> "${ARM_DIR}/err.txt"
+  ) &
+  local cmd_pid=$!
+
+  (
+    sleep "${watchdog_timeout}"
+    kill -TERM "${cmd_pid}" 2>/dev/null
+  ) &
+  local watchdog_pid=$!
+
+  wait "${cmd_pid}" 2>/dev/null
+  local status=$?
+  kill "${watchdog_pid}" 2>/dev/null
+  wait "${watchdog_pid}" 2>/dev/null
+
+  if [ "${status}" -ne 0 ]; then
+    echo "  (note: arm ${arm_id}'s claude -p exited ${status} -- see ${ARM_DIR}/err.txt)"
+  fi
+  return "${status}"
+}
+
+# Prints LOADED / NOT_LOADED / LOG_MISSING
+arm_check_loaded() {
+  python3 "${ARM_CHECK_PY}" check-loaded "${ARM_DIR}/log" "${ARM_REAL_PATH}"
+}
+
+# Prints OK / SELF_READ_DETECTED: <path> / CHECK_ERROR: <detail>
+arm_check_no_self_read() {
+  local basename
+  basename="$(basename "${ARM_REAL_PATH}")"
+  python3 "${ARM_CHECK_PY}" check-no-self-read "${ARM_DIR}/out.json" "${ARM_REAL_PATH}" "${basename}"
+}
+
+# --- canary bodies -------------------------------------------------------
+
+UNSCOPED_BODY="${TMP_ROOT}/unscoped-body.md"
+cat > "${UNSCOPED_BODY}" <<'BODYEOF'
+This is the Epic 1 control canary. It carries no paths: frontmatter and
+must always load in every session -- proving the InstructionsLoaded
+oracle actually detects a loaded rule at all (Gate 0, plan.md §7.5).
+BODYEOF
+
+SCOPED_BODY="${TMP_ROOT}/scoped-body.md"
+cat > "${SCOPED_BODY}" <<'BODYEOF'
+---
+paths:
+  - "**/*.xyzzy"
+---
+This is an Epic 1 canary scoped to *.xyzzy files. It must NOT load
+unless a matching file is read (or, per arms D/E, possibly written or
+grepped -- that is the open question those arms answer).
+BODYEOF
+
+# =========================================================================
+# Arm A -- control: no frontmatter, no tools -> must load
+# =========================================================================
+echo "--- Arm A (control) ---"
+arm_setup "a" "${UNSCOPED_BODY}"
+arm_run_claude "a" "Reply with the single word done. Do not use any tools." ""
+arm_a_result="$(arm_check_loaded)"
+arm_remove_symlink
+echo "  result: ${arm_a_result}"
+
+if [ "${arm_a_result}" = "LOADED" ]; then
+  pass_msg "arm A (control): unscoped canary IS loaded with no tools"
+else
+  fail_msg "arm A (control): expected LOADED, got ${arm_a_result} -- the measurement apparatus is broken"
+  BLOCKED_REASONS+=("Gate 0: arm A (control) failed (${arm_a_result}) -- no conclusion may be drawn from any other arm, per plan.md §7.5 Gate 0.")
+  echo ""
+  echo "=== BLOCKED: Gate 0 (arm A control) failed. Stopping -- arms B-E would be uninterpretable. ==="
+  for reason in "${BLOCKED_REASONS[@]}"; do
+    echo "  - ${reason}"
+  done
+  exit 1
+fi
+echo ""
+
+# =========================================================================
+# Arm B -- negative: scoped, no tools -> must NOT load
+# =========================================================================
+echo "--- Arm B (negative) ---"
+arm_setup "b" "${SCOPED_BODY}"
+arm_run_claude "b" "Reply with the single word done. Do not use any tools." ""
+arm_b_result="$(arm_check_loaded)"
+arm_remove_symlink
+echo "  result: ${arm_b_result}"
+
+if [ "${arm_b_result}" = "NOT_LOADED" ]; then
+  pass_msg "arm B (negative): scoped canary is NOT loaded with no matching file access"
+else
+  fail_msg "arm B (negative): expected NOT_LOADED, got ${arm_b_result}"
+fi
+echo ""
+
+# =========================================================================
+# Arm C -- positive: scoped, Read a matching file only -> must load,
+# AND the transcript must show no read of the canary rule itself.
+# =========================================================================
+echo "--- Arm C (positive) ---"
+arm_setup "c" "${SCOPED_BODY}"
+echo "trigger content, nothing special" > "${ARM_DIR}/scratch/trigger.xyzzy"
+arm_run_claude "c" "Read the file trigger.xyzzy and then reply with the word done. Do not read any other files." "Read"
+arm_c_result="$(arm_check_loaded)"
+arm_c_self_read="$(arm_check_no_self_read)"
+arm_remove_symlink
+echo "  loaded result: ${arm_c_result}"
+echo "  self-discovery check: ${arm_c_self_read}"
+
+arm_c_ok=1
+if [ "${arm_c_result}" = "LOADED" ]; then
+  pass_msg "arm C (positive): scoped canary IS loaded after reading a matching file"
+else
+  fail_msg "arm C (positive): expected LOADED, got ${arm_c_result}"
+  arm_c_ok=0
+fi
+if [ "${arm_c_self_read}" = "OK" ]; then
+  pass_msg "arm C (positive): transcript shows no read of the canary rule file itself (rules out self-discovery)"
+else
+  fail_msg "arm C (positive): self-discovery check failed: ${arm_c_self_read}"
+  arm_c_ok=0
+fi
+
+if [ "${arm_c_ok}" -eq 0 ]; then
+  BLOCKED_REASONS+=("Gate 1: arm C (positive) failed -- Tier B is void, Tier C is unaffected, per plan.md §7.5 Gate 1. loaded=${arm_c_result} self-discovery=${arm_c_self_read}")
+fi
+echo ""
+
+# =========================================================================
+# Arm D -- write-trigger: scoped, Write a NEW matching file, never Read
+# one -> RECORDED, no pass/fail (plan.md R20 -- nobody has asked this
+# question before; §3.1 says the glob matches files Claude "reads").
+# =========================================================================
+echo "--- Arm D (write-trigger) ---"
+arm_setup "d" "${SCOPED_BODY}"
+arm_run_claude "d" "Create a new file named new.xyzzy containing the text hello. Do not read any files. Then reply with the word done." "Write"
+arm_d_result="$(arm_check_loaded)"
+arm_remove_symlink
+echo "  result: ${arm_d_result}"
+record_msg "arm D (write-trigger): ${arm_d_result}"
+if [ "${arm_d_result}" = "LOG_MISSING" ]; then
+  fail_msg "arm D (write-trigger): harness produced no InstructionsLoaded log at all -- inconclusive, not a valid recorded answer"
+else
+  pass_msg "arm D (write-trigger): produced a valid recorded answer (${arm_d_result})"
+fi
+echo ""
+
+# =========================================================================
+# Arm E -- grep-trigger: scoped, Grep across matching files, never Read
+# one -> RECORDED, no pass/fail.
+# =========================================================================
+echo "--- Arm E (grep-trigger) ---"
+arm_setup "e" "${SCOPED_BODY}"
+echo "needle-value-here" > "${ARM_DIR}/scratch/haystack.xyzzy"
+arm_run_claude "e" "Use Grep to search for the pattern needle-value-here across all .xyzzy files in the current directory. Do not use the Read tool. Then reply with the word done." "Grep"
+arm_e_result="$(arm_check_loaded)"
+arm_remove_symlink
+echo "  result: ${arm_e_result}"
+record_msg "arm E (grep-trigger): ${arm_e_result}"
+if [ "${arm_e_result}" = "LOG_MISSING" ]; then
+  fail_msg "arm E (grep-trigger): harness produced no InstructionsLoaded log at all -- inconclusive, not a valid recorded answer"
+else
+  pass_msg "arm E (grep-trigger): produced a valid recorded answer (${arm_e_result})"
+fi
+echo ""
+
+# --- summary --------------------------------------------------------------
+
+echo "=== Summary ==="
+echo "  arm A (control):        ${arm_a_result}"
+echo "  arm B (negative):       ${arm_b_result}"
+echo "  arm C (positive):       loaded=${arm_c_result} self-discovery=${arm_c_self_read}"
+echo "  arm D (write-trigger):  ${arm_d_result}  (recorded, not asserted)"
+echo "  arm E (grep-trigger):   ${arm_e_result}  (recorded, not asserted)"
+echo ""
+echo "  PASS: ${PASS}  FAIL: ${FAIL}"
+
+if [ "${#BLOCKED_REASONS[@]}" -gt 0 ]; then
+  echo ""
+  echo "=== BLOCKED ==="
+  for reason in "${BLOCKED_REASONS[@]}"; do
+    echo "  - ${reason}"
+  done
+  exit 1
+fi
+
+if [ "${FAIL}" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/modules/relevance-injection/tests/test-paths-symlink.sh
+++ b/modules/relevance-injection/tests/test-paths-symlink.sh
@@ -343,6 +343,18 @@ arm_remove_symlink() {
 # (portable bash 3.2 pattern -- no dependency on GNU `timeout`/`gtimeout`,
 # neither of which is guaranteed present on stock macOS).
 #
+# --verbose is REQUIRED here, not optional. `--output-format json` alone
+# emits exactly one `type: "result"` object; the full per-turn message
+# array (including `assistant` messages with `tool_use` blocks, which
+# arm C's self-discovery check in arm_check.py depends on) is only
+# emitted when verbose mode is on. Confirmed empirically on this CLI
+# (2.1.220): identical `claude -p --output-format json` invocations
+# produced a bare `result` dict when the effective verbose setting was
+# false, and the full message array once `--verbose` forced it true --
+# regardless of the operator's own ~/.claude/settings.json "verbose"
+# value, which must NOT be what makes this deterministic across
+# machines.
+#
 # args: arm_id, prompt, tools_csv
 arm_run_claude() {
   local arm_id="$1" prompt="$2" tools="$3"
@@ -353,6 +365,7 @@ arm_run_claude() {
     claude -p "${prompt}" \
       --model haiku \
       --output-format json \
+      --verbose \
       --permission-mode bypassPermissions \
       --tools "${tools}" \
       --strict-mcp-config \

--- a/modules/relevance-injection/tests/test-paths-symlink.sh
+++ b/modules/relevance-injection/tests/test-paths-symlink.sh
@@ -110,6 +110,35 @@ record_msg() {
 
 # --- machine-wide lock (mkdir-based; see header comment) ---------------
 
+# Break a lock whose recorded holder is no longer running.
+#
+# This is the one property a mkdir-based lock does NOT inherit from real
+# flock: flock lives on the holder's open file descriptor, so the kernel
+# releases it when the process dies for any reason, SIGKILL included. A
+# directory has no such teardown -- without this check, one `kill -9`
+# while the lock is held would deadlock every future run of this suite
+# until a human removed the directory by hand.
+#
+# Only ever breaks a lock we can PROVE is dead: `kill -0` must report the
+# recorded pid as gone. An unreadable, empty, or non-numeric holder.pid
+# is treated as live, so a lock caught mid-write (directory created, pid
+# not yet recorded) is never stolen from a running holder.
+break_stale_lock() {
+  [ -d "${LOCK_DIR}" ] || return 1
+  local holder
+  holder="$(cat "${LOCK_DIR}/holder.pid" 2>/dev/null || true)"
+  case "${holder}" in
+    ''|*[!0-9]*) return 1 ;;   # absent or non-numeric -- assume live
+  esac
+  if kill -0 "${holder}" 2>/dev/null; then
+    return 1                    # holder is alive; genuine contention
+  fi
+  echo "NOTE: breaking stale lock ${LOCK_DIR} (holder pid ${holder} is gone)" >&2
+  rm -f "${LOCK_DIR}/holder.pid" 2>/dev/null
+  rmdir "${LOCK_DIR}" 2>/dev/null
+  return 0
+}
+
 acquire_lock() {
   # args: timeout_secs
   local timeout_secs="$1"
@@ -118,6 +147,10 @@ acquire_lock() {
     if mkdir "${LOCK_DIR}" 2>/dev/null; then
       echo "$$" > "${LOCK_DIR}/holder.pid" 2>/dev/null
       return 0
+    fi
+    # Retry immediately if the blocker turned out to be a dead holder.
+    if break_stale_lock; then
+      continue
     fi
     if [ "${waited}" -ge "${timeout_secs}" ]; then
       local holder

--- a/modules/relevance-injection/tests/test_version_floor.py
+++ b/modules/relevance-injection/tests/test_version_floor.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Unit tests for the `paths:` version floor (Epic 1, issue #954).
+
+Covers `lib/rule_tiering.py`'s `claude_code_supports_paths()`:
+
+  - explicit version strings below / at / above MIN_SUPPORTED_VERSION
+    (2.1.207 -- plan.md §1.2 insight 1 / R6)
+  - unparseable input is fail-safe (False), never "assume supported"
+  - the real `claude --version` output shape ("2.1.220 (Claude Code)")
+    parses correctly
+  - the no-argument (subprocess) path is exercised via mocking only, so
+    this test is fully deterministic and needs no `claude` CLI on PATH
+    -- required for the deterministic CI gate, which has neither
+    (plan.md §8.4)
+"""
+import os
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_HERE, "..", "..", "..", "lib"))
+sys.path.insert(0, _REPO_ROOT)
+
+import rule_tiering  # noqa: E402
+
+
+class ExplicitVersionStringTests(unittest.TestCase):
+    """No subprocess involved -- pure string parsing."""
+
+    def test_below_floor_returns_false(self):
+        self.assertFalse(rule_tiering.claude_code_supports_paths("2.1.206"))
+
+    def test_below_floor_returns_false_with_real_cli_suffix(self):
+        self.assertFalse(rule_tiering.claude_code_supports_paths("2.1.206 (Claude Code)"))
+
+    def test_at_floor_returns_true(self):
+        self.assertTrue(rule_tiering.claude_code_supports_paths("2.1.207"))
+
+    def test_above_floor_returns_true(self):
+        self.assertTrue(rule_tiering.claude_code_supports_paths("2.1.220"))
+
+    def test_above_floor_returns_true_with_real_cli_suffix(self):
+        # This is the exact stdout shape observed from `claude --version`
+        # on 2.1.220 (recorded in decisions.md).
+        self.assertTrue(rule_tiering.claude_code_supports_paths("2.1.220 (Claude Code)"))
+
+    def test_much_older_major_version_returns_false(self):
+        self.assertFalse(rule_tiering.claude_code_supports_paths("1.9.999"))
+
+    def test_much_newer_version_returns_true(self):
+        self.assertTrue(rule_tiering.claude_code_supports_paths("3.0.0"))
+
+
+class UnparseableInputIsFailSafeTests(unittest.TestCase):
+    """An unparseable version must never be treated as 'supported'."""
+
+    def test_empty_string_returns_false(self):
+        self.assertFalse(rule_tiering.claude_code_supports_paths(""))
+
+    def test_garbage_text_returns_false(self):
+        self.assertFalse(rule_tiering.claude_code_supports_paths("not a version at all"))
+
+    def test_whitespace_only_returns_false(self):
+        self.assertFalse(rule_tiering.claude_code_supports_paths("   \n\t  "))
+
+    def test_non_string_input_returns_false(self):
+        # Defensive: a caller passing the wrong type must not raise or
+        # be silently treated as supported.
+        self.assertFalse(rule_tiering.claude_code_supports_paths(12345))  # type: ignore[arg-type]
+
+
+class SubprocessFallbackTests(unittest.TestCase):
+    """version_string=None shells out to `claude --version`. Mocked in
+    every case so these tests are deterministic regardless of whether
+    the `claude` CLI is installed on the machine running them."""
+
+    def test_uses_claude_version_when_not_supplied(self):
+        completed = subprocess.CompletedProcess(
+            args=["claude", "--version"], returncode=0, stdout="2.1.220 (Claude Code)\n", stderr=""
+        )
+        with mock.patch.object(rule_tiering.subprocess, "run", return_value=completed) as run:
+            self.assertTrue(rule_tiering.claude_code_supports_paths())
+        run.assert_called_once()
+        called_args = run.call_args[0][0]
+        self.assertIn("claude", called_args)
+        self.assertIn("--version", called_args)
+
+    def test_subprocess_below_floor_returns_false(self):
+        completed = subprocess.CompletedProcess(
+            args=["claude", "--version"], returncode=0, stdout="2.1.206 (Claude Code)\n", stderr=""
+        )
+        with mock.patch.object(rule_tiering.subprocess, "run", return_value=completed):
+            self.assertFalse(rule_tiering.claude_code_supports_paths())
+
+    def test_subprocess_unparseable_output_is_fail_safe(self):
+        completed = subprocess.CompletedProcess(
+            args=["claude", "--version"], returncode=0, stdout="not a version\n", stderr=""
+        )
+        with mock.patch.object(rule_tiering.subprocess, "run", return_value=completed):
+            self.assertFalse(rule_tiering.claude_code_supports_paths())
+
+    def test_claude_cli_not_found_is_fail_safe(self):
+        # The deterministic CI gate has no `claude` CLI at all (plan.md
+        # §8.4) -- this must not raise, and must not be treated as
+        # "supported".
+        with mock.patch.object(rule_tiering.subprocess, "run", side_effect=FileNotFoundError):
+            self.assertFalse(rule_tiering.claude_code_supports_paths())
+
+    def test_subprocess_timeout_is_fail_safe(self):
+        with mock.patch.object(
+            rule_tiering.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(cmd="claude --version", timeout=10),
+        ):
+            self.assertFalse(rule_tiering.claude_code_supports_paths())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/relevance-injection/tests/test_version_floor_gates_writes.py
+++ b/modules/relevance-injection/tests/test_version_floor_gates_writes.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Proves the version floor actually gates the write path (Epic 1, issue
+#954).
+
+The security review's finding (plan.md Epic 1): a version floor that is
+unit-tested in isolation (test_version_floor.py) but never proven to
+gate the real write path is not a floor at all -- a caller could still
+call `render_frontmatter()` on an unsupported version and silently write
+broken frontmatter. This file asserts that with
+`claude_code_supports_paths()` forced to False, `render_frontmatter()`:
+
+  - writes NOTHING (the target file is left byte-identical, or is never
+    created at all if it did not already exist)
+  - returns (False, <a non-empty skip reason string>)
+
+And, for symmetry, that when the gate passes, `render_frontmatter()`
+actually writes a block-sequence `paths:` block (never flow-style,
+per plan.md §8.3's "Emitted YAML" requirement).
+"""
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_HERE, "..", "..", "..", "lib"))
+sys.path.insert(0, _REPO_ROOT)
+
+import rule_tiering  # noqa: E402
+
+
+class WritesNothingWhenUnsupportedTests(unittest.TestCase):
+    def test_existing_file_is_left_byte_identical(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "some-rule.md")
+            original = "Some rule body.\nSecond line.\n"
+            with open(target, "w", encoding="utf-8") as fh:
+                fh.write(original)
+
+            with mock.patch.object(rule_tiering, "claude_code_supports_paths", return_value=False):
+                wrote, reason = rule_tiering.render_frontmatter(target, ["**/*.xyzzy"])
+
+            self.assertFalse(wrote)
+            self.assertIsInstance(reason, str)
+            self.assertTrue(reason)  # non-empty skip reason
+            with open(target, "r", encoding="utf-8") as fh:
+                self.assertEqual(fh.read(), original)
+
+    def test_nonexistent_target_is_not_created(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "does-not-exist.md")
+
+            with mock.patch.object(rule_tiering, "claude_code_supports_paths", return_value=False):
+                wrote, reason = rule_tiering.render_frontmatter(target, ["**/*.xyzzy"])
+
+            self.assertFalse(wrote)
+            self.assertIsInstance(reason, str)
+            self.assertTrue(reason)
+            self.assertFalse(os.path.exists(target))
+
+    def test_gate_is_consulted_with_the_same_version_string_argument(self):
+        # render_frontmatter must delegate the version check to
+        # claude_code_supports_paths() rather than re-implementing its
+        # own parsing -- a single source of truth for the floor.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "some-rule.md")
+            with mock.patch.object(
+                rule_tiering, "claude_code_supports_paths", return_value=False
+            ) as gate:
+                rule_tiering.render_frontmatter(target, ["**/*.xyzzy"], version_string="2.1.206")
+            gate.assert_called_once_with("2.1.206")
+
+    def test_empty_paths_list_also_refuses_to_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "some-rule.md")
+            with mock.patch.object(rule_tiering, "claude_code_supports_paths", return_value=True):
+                wrote, reason = rule_tiering.render_frontmatter(target, [])
+            self.assertFalse(wrote)
+            self.assertIsInstance(reason, str)
+            self.assertTrue(reason)
+            self.assertFalse(os.path.exists(target))
+
+
+class WritesWhenSupportedTests(unittest.TestCase):
+    """Symmetry coverage: the gate passing actually writes something."""
+
+    def test_writes_block_sequence_frontmatter_never_flow_style(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "some-rule.md")
+            with open(target, "w", encoding="utf-8") as fh:
+                fh.write("Original body.\n")
+
+            with mock.patch.object(rule_tiering, "claude_code_supports_paths", return_value=True):
+                wrote, reason = rule_tiering.render_frontmatter(
+                    target, ["**/*.tsx", "**/*.css"]
+                )
+
+            self.assertTrue(wrote)
+            self.assertIsInstance(reason, str)
+            self.assertTrue(reason)
+            with open(target, "r", encoding="utf-8") as fh:
+                content = fh.read()
+            self.assertTrue(content.startswith("---\npaths:\n"))
+            self.assertIn('  - "**/*.tsx"', content)
+            self.assertIn('  - "**/*.css"', content)
+            self.assertTrue(content.endswith("Original body.\n"))
+            # Never flow-style: no line may open a value with '[' or '{'
+            # (plan.md §8.3's frontmatter-YAML guard rejects that shape).
+            for line in content.splitlines():
+                stripped = line.split(":", 1)[-1].strip()
+                self.assertFalse(stripped.startswith("["))
+                self.assertFalse(stripped.startswith("{"))
+
+    def test_writes_to_a_target_that_does_not_yet_exist(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "new-rule.md")
+            with mock.patch.object(rule_tiering, "claude_code_supports_paths", return_value=True):
+                wrote, _reason = rule_tiering.render_frontmatter(target, ["**/*.xyzzy"])
+            self.assertTrue(wrote)
+            self.assertTrue(os.path.isfile(target))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #954

## Summary

Epic 1 of the dynamic-rule-loading plan (`~/code/plans/ccgm-dynamic-rule-injection/plan.md`). The original "decisive experiment" for `paths:` frontmatter had no control arm and a confounded positive arm, and asserted on the model's verbal self-report. This replaces it with a controlled, five-arm harness that asserts on the deterministic `InstructionsLoaded` log (Epic 7, merged in `a332a60`) instead.

## What changed

- `modules/relevance-injection/tests/test-paths-symlink.sh` -- five arms against a real `~/.claude/rules/` symlink:
  - **A (control)**: no `paths:` frontmatter, no tools -> must load
  - **B (negative)**: scoped to `**/*.xyzzy`, no tools -> must NOT load
  - **C (positive)**: same scoping, session Reads a matching file only -> must load, and the transcript must show no read of the canary rule itself (rules out self-discovery)
  - **D (write-trigger)**: same scoping, session Writes a new matching file, never Reads one -> recorded, not asserted
  - **E (grep-trigger)**: same scoping, session Greps across matching files, never Reads one -> recorded, not asserted
- `lib/rule_tiering.py` -- `claude_code_supports_paths()` (pinned to the 2.1.207 floor) plus a minimal, explicitly-scoped `render_frontmatter()` write path used only to prove the version floor gates writes. The real generator is Epic 4's; this file says so in its own docstring.
- `modules/relevance-injection/tests/test_version_floor.py`, `test_version_floor_gates_writes.py` -- unit tests for the floor and for the write-path gating.
- `modules/relevance-injection/tests/fixtures/arm_check.py` -- assertion helper the bash harness shells out to (avoids inline heredocs inside `$(...)`, which is where the bash 3.2 apostrophe/comment lexer trap lives).

## Results (live run against Claude Code 2.1.220, recorded in `decisions.md`)

Arms A, B, C all pass: a symlinked user-level rule carrying `paths:` frontmatter loads unconditionally when unscoped, does NOT load when scoped with no matching file access, and DOES load (with no self-discovery) after a matching file is Read. Gate 0 and Gate 1 both clear -- Tier B is live.

Arms D and E both recorded `NOT_LOADED`: neither a Write nor a Grep of a matching file triggers the glob -- only a Read does. This is a genuine answer to an open question the plan's §3.1 wording left ambiguous, not a pass/fail result.

New `InstructionsLoaded` payload fields observed for the first time (`load_reason: path_glob_match`, `globs`, `trigger_file_path`) are recorded in `decisions.md` alongside the arm results and the version-floor rationale.

This suite needs an authenticated `claude` CLI and real (small, Haiku, budget-capped) API spend, so it is not wired into `.github/workflows/test.yml` -- it belongs to the plan's model-in-the-loop gate, not the per-PR deterministic gate.

## Test plan

- [x] `python3 -m pytest modules/relevance-injection/tests/test_version_floor.py modules/relevance-injection/tests/test_version_floor_gates_writes.py -v` -- 22 passed
- [x] `bash -n modules/relevance-injection/tests/test-paths-symlink.sh` under `/bin/bash` (3.2) -- parses clean
- [x] `/bin/bash modules/relevance-injection/tests/test-paths-symlink.sh` -- full live run, all 5 arms + lock self-test pass, `~/.claude/rules/` restored to its exact pre-run file list
- [x] `bash tests/test-modules.sh` -- 1705 passed, 0 failed
- [x] `bash tests/test-no-personal-data.sh` -- clean
- [x] `ls ~/.claude/rules/ | grep -c '^zzz-ccgm-test-'` -- 0 after the run