### PR TITLE
#952: /rules-scope -- generate a repo's claudeMdExcludes block

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,17 @@ jobs:
             bash "$t"
           done
 
+      - name: relevance-injection - /rules-scope pytest (Epic 0.5, issue #952)
+        run: |
+          set -e
+          python3 -m venv /tmp/ccgm-rules-scope-test-venv
+          source /tmp/ccgm-rules-scope-test-venv/bin/activate
+          python3 -m pip install --quiet pytest
+          python3 -m pytest modules/relevance-injection/tests/test_rules_scope.py -q
+
+      - name: relevance-injection - /rules-scope bash suite (E2E self-skips without an authenticated claude CLI)
+        run: bash modules/relevance-injection/tests/test-rules-scope.sh
+
       - name: Dreaming module tests (pytest + self-check + offline chain)
         env:
           # Some dreaming tests exercise real git repos via subprocess
@@ -227,6 +238,17 @@ jobs:
             echo "=== Running $t ==="
             bash "$t"
           done
+
+      - name: relevance-injection - /rules-scope pytest (Epic 0.5, issue #952)
+        run: |
+          set -e
+          python3 -m venv /tmp/ccgm-rules-scope-test-venv
+          source /tmp/ccgm-rules-scope-test-venv/bin/activate
+          python3 -m pip install --quiet pytest
+          python3 -m pytest modules/relevance-injection/tests/test_rules_scope.py -q
+
+      - name: relevance-injection - /rules-scope bash suite (E2E self-skips without an authenticated claude CLI)
+        run: bash modules/relevance-injection/tests/test-rules-scope.sh
 
       - name: Dreaming module tests (pytest + self-check + offline chain)
         env:

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ The marketplace catalog (`.claude-plugin/marketplace.json`) and per-module `plug
 | **plugin-marketplace** [BETA] | core | - | Maintainer tooling that projects CCGM modules into a native Claude Code plugin marketplace. The bash installer stays canonical | - |
 | **pr-feedback** | workflow | `/resolve-pr-feedback` | Fetches unresolved PR review threads via GraphQL, clusters 3+ items by category, dispatches parallel resolver agents | skill-authoring, subagent-patterns |
 | **pr-review-toolkit** | commands | `/scope-drift` | Augments the external pr-review-toolkit plugin with scope-drift detection on top of the standard code/test/comment/silent-failure/type passes | - |
-| **relevance-injection** [BETA] | workflow | - | Opt-in relevance-scoped rule injection with a tiered always-on safety core. Off by default | hooks |
+| **relevance-injection** [BETA] | workflow | `/rules-scope` | Opt-in relevance-scoped rule injection with a tiered always-on safety core. Off by default | hooks |
 | **remote-server** | workflow | `/onremote` | SSH access to a configured remote server with /onremote command for health checks and remote task execution | - |
 | **research** | commands | `/research` | Multi-channel research using parallel agents with WebSearch, WebFetch, GitHub, Reddit. Zero dependencies.* | - |
 | **rule-authoring** | patterns | `/pressure-test` | Discipline for writing rules that hold up under pressure. Treats rule authoring as a first-class skill with iron-law structure | - |
@@ -379,7 +379,7 @@ The `docs/` directory contains comprehensive documentation:
 | [Getting Started](docs/getting-started.md) | Installation walkthrough, first session, prerequisites |
 | [Install via Agent](docs/install-via-agent.md) | Per-preset paste-blocks and how to dry-run them safely |
 | [Module Catalog](docs/modules.md) | Detailed reference for all 78 modules |
-| [Commands Reference](docs/commands.md) | All 89 slash commands with usage examples |
+| [Commands Reference](docs/commands.md) | All 90 slash commands with usage examples |
 | [Hooks Reference](docs/hooks.md) | All 31 hooks explained - what they do and when they fire |
 | [Presets](docs/presets.md) | Preset breakdowns and recommendations |
 | [Installer](docs/installer.md) | How the installer works, updating, uninstalling |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1515,6 +1515,26 @@ Single-pass rewrite under the Orwell rules in `rules/writing-system.md`. Lists e
 
 ---
 
+## Relevance injection commands
+
+Installed by the **relevance-injection** module.
+
+---
+
+### /rules-scope
+
+**Propose (and optionally write) a `claudeMdExcludes` block for this repo's installed CCGM rules.**
+
+Inspects the repo for language/framework markers and the installed CCGM manifest, then proposes excluding installed rule files that are irrelevant here: `tech-specific` rule files (`tailwind`, `shadcn`, `supabase`, `cloudflare`, `mcp-development`) when the repo shows no marker for that tech, plus a small conservative `niche` set of CCGM meta-workflow rules (the nightly dreaming pipeline, Argus, SSH to a remote box, ...) that apply regardless of tech stack. Never proposes a `PINNED_FLOOR` (safety-core) module's rules. Dry run by default - nothing is written until `--write` is passed, which merges the proposal into `<repo>/.claude/settings.json`'s `claudeMdExcludes` array, preserving every other key.
+
+**Usage**:
+```
+/rules-scope             # print the proposal; write nothing
+/rules-scope --write     # print the proposal AND write it to .claude/settings.json
+```
+
+---
+
 ## Skills
 
 Skills are packaged capabilities invokable by name (e.g. `/brainstorm`). Each skill installs to `~/.claude/skills/{name}/SKILL.md` and lives under `modules/<name>/skills/<skill>/SKILL.md` in the CCGM source.

--- a/modules/relevance-injection/README.md
+++ b/modules/relevance-injection/README.md
@@ -59,6 +59,15 @@ python3 lib/rules_scope.py             # print the proposal for cwd; write nothi
 python3 lib/rules_scope.py --write     # apply it to <cwd>/.claude/settings.json
 ```
 
+**The generated file is machine-scoped.** `--write` puts this machine's
+absolute, resolved rule-file paths into `claudeMdExcludes`. Commit it and
+pull it on a different machine (a teammate, or the same operator with a
+different `ccgmRoot`), and none of those paths match — every "excluded"
+rule silently loads again there instead of staying suppressed. That is the
+safe failure direction (nothing is ever wrongly dropped), but it does mean
+the committed file only takes effect on the machine that generated it until
+re-run with `--write` there. See `commands/rules-scope.md` for detail.
+
 ## Manual Installation
 
 ```bash

--- a/modules/relevance-injection/README.md
+++ b/modules/relevance-injection/README.md
@@ -44,6 +44,21 @@ CCGM_RELEVANCE_LANGS=python,typescript        # optional
 CCGM_RELEVANCE_TASKTYPES=backend,testing      # optional
 ```
 
+## `/rules-scope`: generate a repo's `claudeMdExcludes` block
+
+A third, independent piece: `lib/rules_scope.py` (driven by the
+`/rules-scope` command) inspects a repo and proposes a `claudeMdExcludes`
+array for that repo's `.claude/settings.json`, suppressing installed CCGM
+rule files that are irrelevant to it (e.g. `tailwind`/`shadcn` rules in a
+backend-only repo). Dry run by default; `--write` applies the proposal.
+This is unrelated to the opt-in injection feature above and needs no flag
+to use — see `commands/rules-scope.md` for the full contract.
+
+```bash
+python3 lib/rules_scope.py             # print the proposal for cwd; write nothing
+python3 lib/rules_scope.py --write     # apply it to <cwd>/.claude/settings.json
+```
+
 ## Manual Installation
 
 ```bash
@@ -52,7 +67,9 @@ cp hooks/relevance-inject.py           ~/.claude/hooks/relevance-inject.py
 cp hooks/instructions-loaded-log.py    ~/.claude/hooks/instructions-loaded-log.py
 cp lib/relevance_select.py             ~/.claude/lib/relevance_select.py
 cp lib/loaded_log.py                   ~/.claude/lib/loaded_log.py
+cp lib/rules_scope.py                  ~/.claude/lib/rules_scope.py
 cp lib/applicability-schema.json       ~/.claude/lib/applicability-schema.json
+cp commands/rules-scope.md             ~/.claude/commands/rules-scope.md
 # then merge settings.partial.json into ~/.claude/settings.json
 # (registers the SessionStart and InstructionsLoaded hooks)
 ```
@@ -66,5 +83,7 @@ cp lib/applicability-schema.json       ~/.claude/lib/applicability-schema.json
 | `hooks/instructions-loaded-log.py` | `InstructionsLoaded` hook; appends one JSONL record per loaded instruction file to `~/.claude/rule-loading/loaded-{date}.jsonl` |
 | `lib/relevance_select.py` | Pure, deterministic selection library (safety core + applicability matching) |
 | `lib/loaded_log.py` | Reads the rule-loading log: `parse_log()` and `assert_loaded()` |
+| `lib/rules_scope.py` | `/rules-scope` generator: `detect_repo_profile()`, `propose_excludes()`, `write_settings()` |
 | `lib/applicability-schema.json` | JSON Schema for the optional `module.json` `applicability` field |
+| `commands/rules-scope.md` | `/rules-scope` command: generate/apply a repo's `claudeMdExcludes` block |
 | `settings.partial.json` | Registers the SessionStart and InstructionsLoaded hooks |

--- a/modules/relevance-injection/commands/rules-scope.md
+++ b/modules/relevance-injection/commands/rules-scope.md
@@ -106,6 +106,24 @@ oracle): excluding the symlink path did nothing; excluding the real,
 resolved path worked. `rules_scope.py` handles this automatically
 (`os.path.realpath()` on the installed location) — nothing to configure.
 
+## Another load-bearing detail: the generated file is machine-scoped
+
+Every path `--write` puts into `claudeMdExcludes` is an absolute,
+machine-specific path (this machine's `ccgmRoot` plus the module's
+rule-file target, realpath-resolved). If `<repo>/.claude/settings.json` is
+committed and pulled onto a **different machine** — a teammate, or the same
+operator with a different `ccgmRoot` — none of those absolute paths will
+match that machine's own installed rule files.
+
+**The failure direction is safe.** A path that resolves to nothing simply
+does not match anything Claude Code loads, so on a mismatched machine every
+"excluded" rule silently **loads again** — the opposite of the failure this
+tool exists to prevent. Nothing is dropped that should have loaded. Nothing
+in this generator currently detects or warns about the mismatch; re-running
+`/rules-scope --write` on the second machine regenerates the file with that
+machine's own resolved paths. Decide with that in mind before committing a
+generated `.claude/settings.json` to a repo other machines will check out.
+
 ## Cross-references
 
 - Library: `modules/relevance-injection/lib/rules_scope.py`

--- a/modules/relevance-injection/commands/rules-scope.md
+++ b/modules/relevance-injection/commands/rules-scope.md
@@ -1,0 +1,116 @@
+---
+description: Propose (and optionally write) a claudeMdExcludes block that suppresses CCGM rules irrelevant to this repo
+argument-hint: "[--write]"
+---
+
+# /rules-scope - Generate a Repo's claudeMdExcludes Block
+
+Inspects the current repo, decides which installed CCGM rule files are
+irrelevant to it, and proposes a `claudeMdExcludes` array for that repo's
+`.claude/settings.json`. Turns a per-machine hand-edit into a generated,
+reviewable, committable artifact.
+
+**Dry run by default.** Nothing is written unless `--write` is passed.
+
+## Usage
+
+```
+/rules-scope             # print the proposal; write nothing
+/rules-scope --write     # print the proposal AND write it to .claude/settings.json
+```
+
+## When to invoke
+
+- Onboarding a repo whose tech stack clearly does not need every installed
+  CCGM module's rules (e.g. a Rust-only service does not need `tailwind`,
+  `shadcn`, `supabase`, or `mcp-development` loaded every session).
+- Revisiting a repo's `.claude/settings.json` after installing new CCGM
+  modules, to see whether the exclusion proposal changed.
+
+## When NOT to invoke
+
+- On a repo that genuinely uses most of CCGM's tech-specific tooling — the
+  proposal will legitimately come back small or empty, which is correct,
+  not a bug.
+- To remove a rule you personally find noisy but that is actually relevant
+  to this repo's stack. `claudeMdExcludes` is a repo-wide, committed
+  decision, not a personal preference toggle.
+
+## How it works
+
+1. Run `python3 modules/relevance-injection/lib/rules_scope.py` (or the
+   installed `~/.claude/lib/rules_scope.py`, if the module is installed)
+   from the target repo's root, or pass the repo path as an argument.
+2. The script reads the installed CCGM manifest
+   (`~/.claude/.ccgm-manifest.json`) for the set of installed modules, and
+   inspects the target repo for language/framework markers
+   (`detect_repo_profile()`).
+3. It proposes excluding two kinds of rule file:
+   - **tech-specific** (repo-profile-gated): rule files belonging to a
+     module whose `module.json` declares `"category": "tech-specific"`
+     (`tailwind`, `shadcn`, `supabase`, `cloudflare`, `mcp-development`),
+     proposed only when the repo shows no marker for that module (e.g. no
+     `tailwind.config.*` and no `tailwindcss` dependency -> `tailwind.md`
+     and `frontend-css.md` are proposed).
+   - **niche** (not repo-profile-gated): a small, conservative, hand-picked
+     set of rule files about specific CCGM meta-workflows (the nightly
+     dreaming pipeline, the Argus visual-convergence loop, SSH to a
+     configured remote box, ...) that are rarely in play regardless of the
+     target repo's tech stack.
+4. It prints every proposed row (module, rule file, category, estimated
+   token cost) and a total. **Nothing is written at this point.**
+5. With `--write`, it merges the proposed paths into
+   `<repo>/.claude/settings.json`'s `claudeMdExcludes` array, preserving
+   every other key in the file untouched, and creating the file if it does
+   not exist.
+
+## Safety rules (this is what makes exclusion safe to automate)
+
+- **Never proposes a `PINNED_FLOOR` module's rules.** `PINNED_FLOOR` is the
+  seven `SAFETY_CORE_TIERS` modules (`git-workflow`, `hooks`, `autonomy`,
+  `test-driven-development`, `verification`, `systematic-debugging`,
+  `subagent-patterns`) plus `identity`, `live-testing-guard`,
+  `git-worktrees`, `model-vetting`, and `branch-guard` — derived from
+  `relevance_select.safety_core_modules()` plus four named additions, in
+  exactly one place (`lib/rules_scope.py`'s `PINNED_FLOOR`), never
+  re-typed. This is checked explicitly in code, not merely true by
+  construction of the two candidate categories above.
+- **Never writes outside the target repo's `.claude/settings.json`.** It
+  never touches `~/.claude/rules/`, `~/.claude/hooks/`, or any other
+  machine-global CCGM state — the rule files stay installed and readable;
+  only their auto-load into THIS repo's sessions is suppressed.
+- **Merges, never overwrites.** An existing `claudeMdExcludes` array is
+  extended (deduplicated), and every other key already in the file is
+  preserved untouched.
+- **Dry run by default; `--write` is required to modify anything.** A
+  silent rule-dropping command would be exactly the failure this tool
+  exists to prevent.
+
+## Why this differs from installing fewer modules
+
+Uninstalling a module makes its rules absent everywhere, permanently, for
+every repo. `claudeMdExcludes` suppresses auto-loading a rule into ONE
+repo's sessions while the rule file stays installed, readable on demand,
+and untouched for every other repo on the machine. The rule can still be
+read directly (`Read ~/.claude/rules/<file>.md`) if a task in the excluded
+repo turns out to need it after all — exclusion narrows what auto-loads,
+it does not delete anything.
+
+## A load-bearing detail: paths are resolved, not symlink paths
+
+Claude Code's `claudeMdExcludes` matches against the REAL, symlink-resolved
+path of the loaded instruction file — not the `~/.claude/rules/<file>.md`
+symlink path CCGM's installer creates under `linkMode`. This was verified
+empirically (headless `claude -p`, the `InstructionsLoaded` hook as the
+oracle): excluding the symlink path did nothing; excluding the real,
+resolved path worked. `rules_scope.py` handles this automatically
+(`os.path.realpath()` on the installed location) — nothing to configure.
+
+## Cross-references
+
+- Library: `modules/relevance-injection/lib/rules_scope.py`
+  (`detect_repo_profile()`, `propose_excludes()`, `write_settings()`)
+- Plan: `~/code/plans/ccgm-dynamic-rule-injection/plan.md` Epic 0.5
+- `modules/relevance-injection/lib/relevance_select.py` — the safety-core
+  precedence and manifest-reading helpers this tool reuses rather than
+  duplicating

--- a/modules/relevance-injection/lib/rules_scope.py
+++ b/modules/relevance-injection/lib/rules_scope.py
@@ -353,6 +353,23 @@ def write_settings(settings_path: str, exclude_paths: "list[str]") -> dict:
 
     Raises ValueError if `settings_path` exists but is not a JSON object --
     refusing to guess is safer than silently clobbering a hand-edited file.
+
+    MACHINE-SCOPED OUTPUT -- read before committing this file. Every path
+    this writes is the ABSOLUTE, machine-specific real path resolved by
+    `_resolved_rule_path()` at generation time (this machine's `ccgmRoot`,
+    realpath-resolved). If `<repo>/.claude/settings.json` is committed and
+    pulled onto a different machine -- a teammate, or the same operator with
+    a different `ccgmRoot` -- none of the absolute paths will match that
+    machine's own installed rule files. The failure direction is safe: a
+    path that resolves to nothing simply does not match anything Claude Code
+    loads, so every "excluded" rule silently LOADS again for that user rather
+    than some other rule being wrongly dropped. This generator does not
+    detect or warn about that mismatch at write time; regenerating with
+    `/rules-scope --write` on the second machine re-resolves the paths
+    correctly. A relative or environment-variable-templated path form would
+    remove this footgun if Claude Code's `claudeMdExcludes` supports one --
+    that has not been tested here, and building it is a design change beyond
+    this fix's scope.
     """
     existing: dict = {}
     if os.path.exists(settings_path):

--- a/modules/relevance-injection/lib/rules_scope.py
+++ b/modules/relevance-injection/lib/rules_scope.py
@@ -68,6 +68,7 @@ import fnmatch
 import json
 import os
 import sys
+import tempfile
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 if _HERE not in sys.path:
@@ -396,9 +397,35 @@ def write_settings(settings_path: str, exclude_paths: "list[str]") -> dict:
     parent = os.path.dirname(settings_path)
     if parent:
         os.makedirs(parent, exist_ok=True)
-    with open(settings_path, "w", encoding="utf-8") as fh:
-        fh.write(json.dumps(existing, indent=2, sort_keys=True))
-        fh.write("\n")
+
+    # Write atomically: tempfile in the same directory, then os.replace().
+    #
+    # open(path, "w") truncates to zero bytes AT OPEN TIME, before any content
+    # is written. An interrupt between the open and the close -- Ctrl-C, an OOM
+    # kill, a full disk -- would leave the user's settings.json empty or
+    # half-written, destroying every pre-existing key: hook registrations,
+    # permission rules, a hand-maintained claudeMdExcludes. This function's
+    # whole contract is to merge into that file without disturbing anything
+    # else, so losing it on a crash is the one failure it must not have.
+    #
+    # os.replace() is atomic within a filesystem, and the tempfile is created
+    # alongside the target so the rename never crosses a device boundary. Same
+    # pattern as modules/dreaming/lib/dream_analyze.py::_write_json_atomic.
+    fd, tmp_path = tempfile.mkstemp(
+        dir=parent or ".", prefix=".settings-", suffix=".json.tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(existing, indent=2, sort_keys=True))
+            fh.write("\n")
+        os.replace(tmp_path, settings_path)
+    except BaseException:
+        # Leave the original untouched on any failure, KeyboardInterrupt included.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
     return existing
 
 

--- a/modules/relevance-injection/lib/rules_scope.py
+++ b/modules/relevance-injection/lib/rules_scope.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""Generate a repo's `claudeMdExcludes` block (plan.md Epic 0.5, issue #952).
+
+WHAT THIS DOES
+--------------
+Inspects a target repo, decides which INSTALLED CCGM rule files are
+irrelevant to it, and proposes (or, with --write, applies) a
+`claudeMdExcludes` array in that repo's `.claude/settings.json`. This turns
+a per-machine hand-edit into a generated, reviewable, committable artifact
+-- Claude Code's own `claudeMdExcludes` settings key already suppresses a
+user-level `~/.claude/rules/*.md` file from loading when a project-layer
+`.claude/settings.json` names it (verified empirically -- see "PATH
+RESOLUTION" below for the specific gotcha that verification surfaced).
+
+Dry run by default. Nothing is written unless --write is passed.
+
+WHY THIS EXISTS (plan.md Epic 0.5)
+-----------------------------------
+`claudeMdExcludes` was recorded as a rejected alternative through six plan
+reviews because a hand-edited, per-machine settings file "is not a
+shippable product answer." Testing it found that objection only holds for
+a HAND-edited file -- a GENERATED one is exactly as shippable as any other
+CCGM artifact. This script is that generator. It is deliberately
+independent of Epic 2's (deferred) per-rule-file tier/stakes taxonomy: it
+falls back to (a) the manifest's existing `category: "tech-specific"` field
+for repo-profile-gated exclusion, and (b) a small, conservative, hand-picked
+list for repo-profile-INDEPENDENT "niche CCGM workflow" exclusion.
+
+SAFETY RULES (enforced here AND by tests/test_rules_scope.py)
+---------------------------------------------------------------
+1. NEVER propose excluding a PINNED_FLOOR module's rules. PINNED_FLOOR is
+   derived from `relevance_select.safety_core_modules()` (the seven
+   SAFETY_CORE_TIERS modules) plus the same four additional pinned names
+   plan.md section 3.3 names -- imported/derived from one place, not
+   re-typed, so this list can never quietly drift from the platform's own
+   safety-core definition.
+2. NEVER write outside the target repo's `.claude/settings.json`, and
+   MERGE rather than overwrite: an existing `claudeMdExcludes` array is
+   extended and every other key in the file is preserved.
+3. Dry run by default; `--write` is required to modify anything.
+
+PATH RESOLUTION -- a load-bearing empirical finding
+----------------------------------------------------
+`claudeMdExcludes` matches against the REAL, symlink-resolved path of the
+loaded instruction file -- NOT the `~/.claude/rules/<file>.md` symlink path
+CCGM's installer creates under `linkMode`. This was verified directly
+(2026-08-03, headless `claude -p`, project-level `.claude/settings.json`,
+the `InstructionsLoaded` hook as the oracle -- same technique the Epic 0.5
+experiment and Epic 7 used):
+
+  - excluding `~/.claude/rules/mcp-development.md` (the symlink path,
+    absolute or `~`-relative) did NOT suppress loading -- the file still
+    appeared in the InstructionsLoaded log, correctly recorded at its
+    real path `/Users/x/code/ccgm/modules/mcp-development/rules/mcp-development.md`.
+  - excluding that REAL, resolved path DID suppress it (46 records
+    instead of 47; the file was absent; every other rule still loaded).
+
+So every path this module writes into `claudeMdExcludes` is
+`os.path.realpath()` of the installed location. Under `linkMode` that
+resolves to the canonical repo file; under a `--copy` install (no
+symlink), `realpath()` of a plain file is the file itself -- so this one
+code path is correct in both install modes without a branch.
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+import relevance_select  # noqa: E402 -- reuse the existing pure helpers
+
+
+# ---------------------------------------------------------------------------
+# PINNED_FLOOR -- the single source of truth for "never propose excluding
+# this module's rules." plan.md's intended future home for this constant
+# is Epic 3's lib/rule_tiering.py (deferred, not built in this epic); until
+# that lands, THIS is authoritative for the exclusion tool and should be
+# imported from here rather than re-typed. Derived, not hardcoded twice:
+# the safety-core half comes straight from relevance_select.safety_core_modules(),
+# so the two lists can never silently drift apart.
+# ---------------------------------------------------------------------------
+PINNED_FLOOR: "tuple[str, ...]" = tuple(relevance_select.safety_core_modules()) + (
+    "identity",
+    "live-testing-guard",
+    "git-worktrees",
+    "model-vetting",
+    "branch-guard",
+)
+
+TECH_SPECIFIC_CATEGORY = "tech-specific"
+
+# Conservative, hand-picked fallback for Epic 2's not-yet-existing per-rule-
+# file tier/stakes taxonomy (this epic's own "Inputs" contract: use Epic 2's
+# assignment if it exists, else fall back to a conservative built-in list).
+# Maps module name -> None (propose every rule file the module ships) or a
+# set of specific module-relative rule targets (propose only that subset).
+#
+# Deliberately narrow and NOT repo-profile-gated: these are rules about a
+# specific CCGM meta-workflow (a nightly pipeline, a visual-convergence
+# loop, SSH to a configured remote box, ...) that is rarely in play
+# regardless of the target repo's tech stack, so detecting relevance from
+# repo files does not apply the way it does for the tech-specific category.
+#
+# `self-improving` ships TWO rule files and only one is listed: its other
+# file, `rules/learnings-store.md`, is explicitly `high` stakes in the
+# plan's own tier-assignment work (a destructive-git-operation risk), so it
+# is never proposed here even though its sibling file in the same module
+# is a safe, ordinary "index"-shaped rule. Modules omitted from this dict
+# entirely are simply never proposed by this category -- always the safe
+# direction, since it can only under-propose, never over-propose.
+NICHE_MODULE_RULE_TARGETS: "dict[str, set[str] | None]" = {
+    "agent-native": None,
+    "argus": None,
+    "autoheal": None,
+    "browser-automation": None,
+    "dreaming": None,
+    "multi-agent": None,
+    "remote-server": None,
+    "self-improving": {"rules/self-improving.md"},
+    "youtube-transcripts": None,
+}
+
+# Directories a repo-profile walk should never descend into: build output,
+# dependency caches, and VCS metadata. Also skips any dot-directory.
+_SKIP_DIRS = {
+    "node_modules", "vendor", "dist", "build", "target", "out",
+    "venv", ".venv", "__pycache__", "coverage",
+}
+_MAX_WALK_DEPTH = 4
+
+
+def _walk(repo_path: str):
+    """Yield (dirpath, dirnames, filenames) under `repo_path`, pruning
+    heavy/irrelevant directories and bounding depth so this can never
+    become an accidental full-disk walk on a large or deeply nested repo.
+    `dirnames` is pruned in place (the `os.walk` topdown contract), so
+    callers see the same pruned view this function used internally.
+    """
+    repo_path = os.path.abspath(repo_path)
+    base_depth = repo_path.rstrip(os.sep).count(os.sep)
+    for dirpath, dirnames, filenames in os.walk(repo_path):
+        depth = dirpath.rstrip(os.sep).count(os.sep) - base_depth
+        dirnames[:] = sorted(
+            d for d in dirnames if d not in _SKIP_DIRS and not d.startswith(".")
+        )
+        if depth >= _MAX_WALK_DEPTH - 1:
+            dirnames[:] = []
+        yield dirpath, dirnames, filenames
+
+
+def _has_file_matching(repo_path: str, patterns: "list[str]") -> bool:
+    """True if any file under `repo_path` matches any of `patterns`
+    (fnmatch-style, e.g. "tailwind.config.*")."""
+    for _dirpath, _dirnames, filenames in _walk(repo_path):
+        for fname in filenames:
+            if any(fnmatch.fnmatch(fname, pat) for pat in patterns):
+                return True
+    return False
+
+
+def _has_dir_named(repo_path: str, names: "list[str]") -> bool:
+    """True if any directory under `repo_path` is named exactly one of `names`."""
+    wanted = set(names)
+    for _dirpath, dirnames, _filenames in _walk(repo_path):
+        if wanted & set(dirnames):
+            return True
+    return False
+
+
+def _package_json_dependency_names(path: str) -> "set[str]":
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    names: "set[str]" = set()
+    for key in ("dependencies", "devDependencies", "peerDependencies", "optionalDependencies"):
+        section = data.get(key)
+        if isinstance(section, dict):
+            names.update(section.keys())
+    return names
+
+
+def _has_dependency_substring(repo_path: str, substrings: "list[str]") -> bool:
+    """True if any package.json under `repo_path` declares a dependency
+    whose name contains one of `substrings` (case-insensitive)."""
+    needles = [s.lower() for s in substrings]
+    for dirpath, _dirnames, filenames in _walk(repo_path):
+        if "package.json" not in filenames:
+            continue
+        for dep in _package_json_dependency_names(os.path.join(dirpath, "package.json")):
+            dep_l = dep.lower()
+            if any(n in dep_l for n in needles):
+                return True
+    return False
+
+
+def _text_file_contains(repo_path: str, filenames: "set[str]", substrings: "list[str]") -> bool:
+    """True if any file under `repo_path` named one of `filenames` contains
+    (case-insensitive) any of `substrings`. Used for Python-ecosystem
+    manifests (requirements.txt, pyproject.toml) that have no single
+    canonical dependency schema the way package.json does."""
+    needles = [s.lower() for s in substrings]
+    for dirpath, _dirnames, fnames in _walk(repo_path):
+        for fname in fnames:
+            if fname not in filenames:
+                continue
+            try:
+                with open(os.path.join(dirpath, fname), encoding="utf-8", errors="ignore") as fh:
+                    text = fh.read().lower()
+            except OSError:
+                continue
+            if any(n in text for n in needles):
+                return True
+    return False
+
+
+_PY_DEP_FILES = {"requirements.txt", "pyproject.toml", "setup.py", "setup.cfg"}
+
+
+def detect_repo_profile(repo_path: str) -> "dict[str, bool]":
+    """Inspect `repo_path` for signals that a tech-specific CCGM module's
+    rules are relevant to it. Returns {module_name: bool}; True means "this
+    module's rules apply here -- do not propose excluding them."
+
+    Bounded, read-only filesystem inspection only (module.json's declared
+    `category: "tech-specific"` set drives which module names appear here
+    -- see propose_excludes()). A repo this cannot positively identify
+    (e.g. a bare Rust crate with no web/backend markers at all) yields
+    every entry False, which is the conservative-toward-EXCLUSION direction
+    for this category -- the opposite of PINNED_FLOOR's conservative-
+    toward-INCLUSION default, and deliberately so: this category exists
+    specifically to identify genuinely-irrelevant tech-specific rules.
+    """
+    tailwind = _has_file_matching(repo_path, ["tailwind.config.*"]) or _has_dependency_substring(
+        repo_path, ["tailwindcss"]
+    )
+    shadcn = _has_file_matching(repo_path, ["components.json"]) or _has_dependency_substring(
+        repo_path, ["shadcn"]
+    )
+    supabase = (
+        _has_dir_named(repo_path, ["supabase"])
+        or _has_dependency_substring(repo_path, ["supabase"])
+        or _text_file_contains(repo_path, _PY_DEP_FILES, ["supabase"])
+    )
+    cloudflare = _has_file_matching(
+        repo_path, ["wrangler.toml", "wrangler.json", "wrangler.jsonc"]
+    ) or _has_dependency_substring(repo_path, ["wrangler", "cloudflare"])
+    mcp_development = (
+        _has_file_matching(repo_path, [".mcp.json", "mcp.json"])
+        or _has_dependency_substring(repo_path, ["@modelcontextprotocol/sdk", "fastmcp"])
+        or _text_file_contains(repo_path, _PY_DEP_FILES, ["fastmcp", "modelcontextprotocol"])
+    )
+    return {
+        "tailwind": tailwind,
+        "shadcn": shadcn,
+        "supabase": supabase,
+        "cloudflare": cloudflare,
+        "mcp-development": mcp_development,
+    }
+
+
+def _resolved_rule_path(target: str, home: str) -> str:
+    """Resolve a module-relative rule target (e.g. "rules/tailwind.md") to
+    the REAL, symlink-resolved absolute path Claude Code actually loads.
+    See the module docstring's "PATH RESOLUTION" section for why this
+    matters -- the `~/.claude/rules/<file>.md` symlink path itself does
+    NOT work as a `claudeMdExcludes` entry.
+    """
+    installed = os.path.join(home, ".claude", target)
+    return os.path.realpath(installed)
+
+
+def propose_excludes(
+    repo_profile: "dict[str, bool]",
+    modules_dir: str,
+    installed_modules: "list[str]",
+    home: "str | None" = None,
+) -> "list[dict]":
+    """Return the sorted list of exclude-candidate rows.
+
+    Each row: {"module", "rule" (module-relative target), "category"
+    ("tech-specific" or "niche"), "path" (the resolved absolute path to
+    put in claudeMdExcludes)}.
+
+    Never includes a PINNED_FLOOR module (checked explicitly here, in
+    addition to being true by construction of the two candidate sets
+    below -- belt and suspenders per this epic's own safety-rules
+    contract). Never includes a module absent from `installed_modules`.
+    """
+    home = home or os.path.expanduser("~")
+    installed = set(installed_modules)
+    rows: "list[dict]" = []
+
+    # --- Category 1: tech-specific, repo-profile-gated -----------------
+    for module in sorted(installed):
+        if module in PINNED_FLOOR:
+            continue
+        manifest = relevance_select.read_module_manifest(modules_dir, module)
+        if not manifest or manifest.get("category") != TECH_SPECIFIC_CATEGORY:
+            continue
+        if repo_profile.get(module, False):
+            continue  # detected as relevant in this repo -- keep it loaded
+        for target in relevance_select.rule_files_for_module(manifest):
+            rows.append(
+                {
+                    "module": module,
+                    "rule": target,
+                    "category": "tech-specific",
+                    "path": _resolved_rule_path(target, home),
+                }
+            )
+
+    # --- Category 2: niche CCGM workflow, NOT repo-profile-gated -------
+    for module in sorted(NICHE_MODULE_RULE_TARGETS):
+        if module in PINNED_FLOOR or module not in installed:
+            continue
+        manifest = relevance_select.read_module_manifest(modules_dir, module)
+        if not manifest:
+            continue
+        subset = NICHE_MODULE_RULE_TARGETS[module]
+        all_targets = relevance_select.rule_files_for_module(manifest)
+        targets = all_targets if subset is None else [t for t in all_targets if t in subset]
+        for target in targets:
+            rows.append(
+                {
+                    "module": module,
+                    "rule": target,
+                    "category": "niche",
+                    "path": _resolved_rule_path(target, home),
+                }
+            )
+
+    rows.sort(key=lambda r: (r["module"], r["rule"]))
+    return rows
+
+
+def write_settings(settings_path: str, exclude_paths: "list[str]") -> dict:
+    """Merge `exclude_paths` into `settings_path`'s `claudeMdExcludes`
+    array, creating the file (and its parent directory) if missing.
+
+    Preserves every other top-level key untouched. Deterministic and
+    idempotent: calling this twice with the same `exclude_paths` produces
+    a byte-identical file (sorted keys, sorted/deduplicated excludes list).
+
+    Raises ValueError if `settings_path` exists but is not a JSON object --
+    refusing to guess is safer than silently clobbering a hand-edited file.
+    """
+    existing: dict = {}
+    if os.path.exists(settings_path):
+        with open(settings_path, encoding="utf-8") as fh:
+            text = fh.read()
+        if text.strip():
+            try:
+                parsed = json.loads(text)
+            except ValueError as exc:
+                raise ValueError(
+                    f"{settings_path} exists but is not valid JSON; refusing to "
+                    f"overwrite it: {exc}"
+                ) from exc
+            if not isinstance(parsed, dict):
+                raise ValueError(
+                    f"{settings_path} does not contain a JSON object at the top level"
+                )
+            existing = parsed
+
+    current = existing.get("claudeMdExcludes")
+    current_list = list(current) if isinstance(current, list) else []
+    existing["claudeMdExcludes"] = sorted(set(current_list) | set(exclude_paths))
+
+    parent = os.path.dirname(settings_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(settings_path, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(existing, indent=2, sort_keys=True))
+        fh.write("\n")
+    return existing
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring -- I/O only; every function above is importable and testable
+# without a real ~/.claude install.
+# ---------------------------------------------------------------------------
+def _default_manifest_path() -> str:
+    return os.path.expanduser("~/.claude/.ccgm-manifest.json")
+
+
+def _load_manifest(path: str) -> "dict | None":
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _token_estimate(path: str) -> int:
+    try:
+        with open(path, "rb") as fh:
+            return len(fh.read()) // 4
+    except OSError:
+        return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Propose (and, with --write, apply) a claudeMdExcludes block for a "
+            "repo's installed-but-irrelevant CCGM rules (plan.md Epic 0.5)."
+        )
+    )
+    p.add_argument("repo_path", nargs="?", default=".", help="Repo to scope (default: cwd)")
+    p.add_argument(
+        "--write",
+        action="store_true",
+        help="Write the proposal into <repo>/.claude/settings.json. Default is a dry run.",
+    )
+    p.add_argument(
+        "--manifest",
+        default=None,
+        help="Override path to the installed CCGM manifest (mainly for testing).",
+    )
+    return p
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    repo_path = os.path.abspath(args.repo_path)
+
+    manifest_path = args.manifest or _default_manifest_path()
+    manifest = _load_manifest(manifest_path)
+    if not manifest:
+        print(f"No installed CCGM manifest found at {manifest_path}. Nothing to scope.")
+        return 1
+
+    ccgm_root = manifest.get("ccgmRoot")
+    installed_modules = manifest.get("modules")
+    if not isinstance(ccgm_root, str) or not ccgm_root or not isinstance(installed_modules, list):
+        print(f"{manifest_path} is missing 'ccgmRoot' or 'modules'; cannot proceed.")
+        return 1
+
+    modules_dir = os.path.join(ccgm_root, "modules")
+    profile = detect_repo_profile(repo_path)
+    proposed = propose_excludes(profile, modules_dir, installed_modules)
+
+    if not proposed:
+        print(f"No exclusion candidates found for {repo_path}.")
+        return 0
+
+    print(f"Proposed claudeMdExcludes for {repo_path}:\n")
+    header = f"{'MODULE':<20} {'CATEGORY':<14} {'RULE':<40} TOKENS"
+    print(header)
+    total_tokens = 0
+    for row in proposed:
+        tokens = _token_estimate(row["path"])
+        total_tokens += tokens
+        print(f"{row['module']:<20} {row['category']:<14} {row['rule']:<40} {tokens}")
+    print(f"\n{len(proposed)} rule file(s), ~{total_tokens} tokens.")
+
+    if not args.write:
+        print("\nDry run -- nothing written. Re-run with --write to apply.")
+        return 0
+
+    settings_path = os.path.join(repo_path, ".claude", "settings.json")
+    write_settings(settings_path, [row["path"] for row in proposed])
+    print(f"\nWrote {len(proposed)} exclude(s) to {settings_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/relevance-injection/module.json
+++ b/modules/relevance-injection/module.json
@@ -13,7 +13,9 @@
     "hooks/instructions-loaded-log.py": { "target": "hooks/instructions-loaded-log.py", "type": "hook", "template": false },
     "lib/relevance_select.py": { "target": "lib/relevance_select.py", "type": "lib", "template": false },
     "lib/loaded_log.py": { "target": "lib/loaded_log.py", "type": "lib", "template": false },
+    "lib/rules_scope.py": { "target": "lib/rules_scope.py", "type": "lib", "template": false },
     "lib/applicability-schema.json": { "target": "lib/applicability-schema.json", "type": "lib", "template": false },
+    "commands/rules-scope.md": { "target": "commands/rules-scope.md", "type": "command", "template": false },
     "settings.partial.json": { "target": "settings.json", "type": "settings", "merge": true, "template": false }
   },
   "tags": ["rules", "tokens", "context", "safety-core", "opt-in", "session-start"],

--- a/modules/relevance-injection/tests/lib/check_e2e_loaded.py
+++ b/modules/relevance-injection/tests/lib/check_e2e_loaded.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Checker for test-rules-scope.sh's Part 2 (Gate 2 E2E via InstructionsLoaded).
+
+Usage: check_e2e_loaded.py <lib_dir> <log_path> <retained_target> <excluded_path...>
+
+Prints "OK" and exits 0 if every excluded path is absent from the log and
+the retained target is present. Otherwise prints one problem per line and
+exits 1. Kept as a standalone script (not an inline `python3 -c` one-liner)
+so paths never have to be interpolated into a shell-quoted string literal.
+"""
+import sys
+
+
+def main(argv):
+    if len(argv) < 4:
+        print("usage: check_e2e_loaded.py <lib_dir> <log_path> <retained_target> <excluded_path...>")
+        return 2
+
+    lib_dir, log_path, retained_target = argv[1], argv[2], argv[3]
+    excluded_paths = [p for p in argv[4:] if p.strip()]
+
+    sys.path.insert(0, lib_dir)
+    import loaded_log  # noqa: E402
+
+    problems = []
+
+    for path in excluded_paths:
+        try:
+            loaded_log.assert_loaded(log_path, path)
+        except loaded_log.RuleNotLoadedError:
+            continue
+        except loaded_log.LogMissingError as exc:
+            problems.append("LOG_MISSING:" + str(exc))
+            break
+        else:
+            problems.append("STILL_LOADED:" + path)
+
+    try:
+        loaded_log.assert_loaded(log_path, retained_target)
+    except loaded_log.RuleNotLoadedError:
+        problems.append("RETAINED_MISSING:" + retained_target)
+    except loaded_log.LogMissingError as exc:
+        problems.append("LOG_MISSING:" + str(exc))
+
+    if problems:
+        for p in problems:
+            print(p)
+        return 1
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/modules/relevance-injection/tests/test-rules-scope.sh
+++ b/modules/relevance-injection/tests/test-rules-scope.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# test-rules-scope.sh -- /rules-scope generator (Epic 0.5, issue #952).
+#
+# Two parts:
+#
+#   Part 1 (deterministic, hermetic, runs everywhere including hosted CI):
+#     - default invocation is a dry run: nothing is written, verified via
+#       `git status --porcelain` on a real scratch git repo
+#     - --write actually writes .claude/settings.json
+#     - a dry run against THIS repo's own real install prints a proposal
+#       and writes nothing
+#
+#   Part 2 (Gate 2, model-in-the-loop -- plan.md section 8.4): a full
+#     end-to-end check that excluded rules do NOT load and retained rules
+#     DO load, using the InstructionsLoaded log as the oracle (Epic 7),
+#     exactly as decisions.md's Epic 0.5/Epic 7 experiments did. This part
+#     requires an authenticated `claude` CLI, which hosted CI runners never
+#     have (.github/workflows/test.yml installs jq/Node/Playwright/pytest
+#     but never `claude`, per plan.md section 8.4) -- so it SKIPS itself
+#     (not a failure) whenever `claude` is unavailable, and this suite is
+#     still safe to wire as a required, always-green CI step.
+#
+# Portable: bash 3.2, no GNU-only flags. Never touches the real
+# ~/.claude/rules/, ~/.claude/hooks/, ~/.claude/settings.json, or
+# ~/.claude/.ccgm-manifest.json -- every scratch manifest/settings file
+# lives under a temp directory this script creates and removes.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$MODULE_DIR/../.." && pwd)"
+LIB_DIR="$MODULE_DIR/lib"
+RULES_SCOPE="$LIB_DIR/rules_scope.py"
+HOOK_UTILS_LIB="$REPO_ROOT/modules/hooks/lib"
+INSTRUCTIONS_LOADED_HOOK="$MODULE_DIR/hooks/instructions-loaded-log.py"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "FAIL: python3 is required" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/ccgm-rules-scope.XXXXXX")"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+# --- Fixture: a fake CCGM install (manifest + modules/ tree) pointing at
+#     THIS repo's real module.json files, so category="tech-specific"
+#     detection is real, not fabricated. -------------------------------
+FAKE_CCGM_ROOT="$REPO_ROOT"
+FAKE_MANIFEST="$WORKDIR/manifest.json"
+cat > "$FAKE_MANIFEST" <<EOF
+{
+  "version": "1.0.0",
+  "ccgmRoot": "$FAKE_CCGM_ROOT",
+  "modules": ["tailwind", "shadcn", "supabase", "cloudflare", "mcp-development", "git-workflow"]
+}
+EOF
+
+echo "=== Part 1: deterministic CLI behavior ==="
+
+# --- Test 1: default invocation is a dry run; git status stays clean ---
+SCRATCH1="$WORKDIR/rust-repo"
+mkdir -p "$SCRATCH1"
+( cd "$SCRATCH1" && git init -q && printf '[package]\nname = "x"\n' > Cargo.toml && git add -A && git -c user.email=t@t -c user.name=t commit -q -m init )
+python3 "$RULES_SCOPE" "$SCRATCH1" --manifest "$FAKE_MANIFEST" >"$WORKDIR/dryrun-out.txt" 2>&1
+PORCELAIN="$(cd "$SCRATCH1" && git status --porcelain)"
+if [ -z "$PORCELAIN" ]; then
+  pass "default invocation (no --write) leaves git status clean"
+else
+  fail "default invocation modified the scratch repo: $PORCELAIN"
+fi
+if grep -q "Dry run" "$WORKDIR/dryrun-out.txt"; then
+  pass "default invocation prints a dry-run notice"
+else
+  fail "expected a dry-run notice in output: $(cat "$WORKDIR/dryrun-out.txt")"
+fi
+if grep -q "tailwind" "$WORKDIR/dryrun-out.txt"; then
+  pass "dry run proposes tailwind (Rust-only repo, no package.json)"
+else
+  fail "expected tailwind in the proposal for a Rust-only repo: $(cat "$WORKDIR/dryrun-out.txt")"
+fi
+
+# --- Test 2: --write actually writes .claude/settings.json -------------
+python3 "$RULES_SCOPE" "$SCRATCH1" --manifest "$FAKE_MANIFEST" --write >"$WORKDIR/write-out.txt" 2>&1
+if [ -f "$SCRATCH1/.claude/settings.json" ]; then
+  pass "--write creates .claude/settings.json"
+else
+  fail "--write did not create .claude/settings.json: $(cat "$WORKDIR/write-out.txt")"
+fi
+EXCLUDE_COUNT=$(python3 -c "
+import json
+data = json.load(open('$SCRATCH1/.claude/settings.json'))
+print(len(data.get('claudeMdExcludes', [])))
+")
+if [ "$EXCLUDE_COUNT" -ge 6 ]; then
+  pass "--write proposed at least 6 excludes (all 5 tech-specific modules, tailwind ships 2 files)"
+else
+  fail "expected >= 6 excludes, got $EXCLUDE_COUNT"
+fi
+
+# --- Test 3: re-running --write is idempotent (byte-identical) ---------
+cp "$SCRATCH1/.claude/settings.json" "$WORKDIR/settings-after-first-write.json"
+python3 "$RULES_SCOPE" "$SCRATCH1" --manifest "$FAKE_MANIFEST" --write >/dev/null 2>&1
+if cmp -s "$SCRATCH1/.claude/settings.json" "$WORKDIR/settings-after-first-write.json"; then
+  pass "running --write twice is idempotent (byte-identical file)"
+else
+  fail "second --write run changed the file"
+fi
+
+# --- Test 4: a repo with tailwind.config.ts does not get tailwind excluded ---
+SCRATCH2="$WORKDIR/web-repo"
+mkdir -p "$SCRATCH2"
+echo "export default {}" > "$SCRATCH2/tailwind.config.ts"
+python3 "$RULES_SCOPE" "$SCRATCH2" --manifest "$FAKE_MANIFEST" >"$WORKDIR/web-out.txt" 2>&1
+if grep -qE "^tailwind " "$WORKDIR/web-out.txt"; then
+  fail "tailwind was proposed for exclusion despite tailwind.config.ts: $(cat "$WORKDIR/web-out.txt")"
+else
+  pass "tailwind.config.ts present => tailwind not proposed for exclusion"
+fi
+if grep -qE "^shadcn " "$WORKDIR/web-out.txt"; then
+  pass "shadcn (undetected in this repo) is still proposed"
+else
+  fail "expected shadcn still proposed: $(cat "$WORKDIR/web-out.txt")"
+fi
+
+# --- Test 5: PINNED_FLOOR module (git-workflow) is never proposed -------
+if grep -qE "^git-workflow " "$WORKDIR/dryrun-out.txt" "$WORKDIR/web-out.txt"; then
+  fail "git-workflow (PINNED_FLOOR) was proposed for exclusion"
+else
+  pass "git-workflow (PINNED_FLOOR) is never proposed"
+fi
+
+# --- Test 6: dry run against THIS repo's own real install ---------------
+# Uses this repo as both the "installed manifest" source and the target
+# repo being scoped -- exercises the real code path against real data
+# without needing the machine's actual ~/.claude/.ccgm-manifest.json.
+REAL_MODULES_JSON=$(python3 -c "
+import json, pathlib
+mods = sorted(p.parent.name for p in pathlib.Path('$REPO_ROOT/modules').glob('*/module.json'))
+print(json.dumps(mods))
+")
+REAL_MANIFEST="$WORKDIR/real-manifest.json"
+python3 -c "
+import json
+mods = json.loads('''$REAL_MODULES_JSON''')
+json.dump({'version': '1.0.0', 'ccgmRoot': '$FAKE_CCGM_ROOT', 'modules': mods}, open('$REAL_MANIFEST', 'w'))
+"
+REPO_CHECK_DIR="$WORKDIR/this-repo-check"
+mkdir -p "$REPO_CHECK_DIR"
+printf '[package]\nname = "x"\n' > "$REPO_CHECK_DIR/Cargo.toml"
+python3 "$RULES_SCOPE" "$REPO_CHECK_DIR" --manifest "$REAL_MANIFEST" >"$WORKDIR/real-out.txt" 2>&1
+if [ ! -e "$REPO_CHECK_DIR/.claude/settings.json" ]; then
+  pass "dry run against this repo's real module set writes nothing"
+else
+  fail "dry run against this repo's real module set wrote a settings file"
+fi
+echo ""
+echo "--- Proposal against this repo's real module set (non-web profile) ---"
+cat "$WORKDIR/real-out.txt"
+echo "---"
+
+echo ""
+echo "=== Part 2: end-to-end via InstructionsLoaded (Gate 2, model-in-the-loop) ==="
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "  SKIP: 'claude' CLI not on PATH -- Gate 2 test, expected on hosted CI runners"
+  echo "  SKIP: (plan.md section 8.4: this suite is safe to run in CI because this part"
+  echo "  SKIP:  degrades to a no-op skip rather than failing when no authenticated"
+  echo "  SKIP:  claude CLI is available)"
+else
+  # Stage hook_utils.py so the InstructionsLoaded hook's `import hook_utils`
+  # resolves, matching the exact staging step .github/workflows/test.yml
+  # already uses for the other hook test suites. Idempotent.
+  mkdir -p "$HOME/.claude/lib"
+  cp "$HOOK_UTILS_LIB"/*.py "$HOME/.claude/lib/" 2>/dev/null || true
+
+  E2E_REPO="$WORKDIR/e2e-repo"
+  E2E_LOG_DIR="$WORKDIR/e2e-log"
+  mkdir -p "$E2E_REPO/.claude" "$E2E_LOG_DIR"
+  printf '[package]\nname = "x"\n' > "$E2E_REPO/Cargo.toml"
+
+  cat > "$E2E_REPO/.claude/settings.json" <<EOF
+{
+  "hooks": {
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CCGM_RULE_LOADING_DIR=$E2E_LOG_DIR python3 $INSTRUCTIONS_LOADED_HOOK",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+  # Apply the real generator against the real installed manifest (this
+  # machine's actual ~/.claude/.ccgm-manifest.json), so the excluded paths
+  # resolve to whatever this machine's real ~/.claude/rules/ symlinks
+  # actually point at -- the exact condition InstructionsLoaded will report.
+  REAL_MANIFEST_PATH="$HOME/.claude/.ccgm-manifest.json"
+  if [ ! -f "$REAL_MANIFEST_PATH" ]; then
+    echo "  SKIP: no real CCGM manifest at $REAL_MANIFEST_PATH -- cannot resolve real installed paths"
+  else
+    python3 "$RULES_SCOPE" "$E2E_REPO" --write >"$WORKDIR/e2e-propose-out.txt" 2>&1
+    EXCLUDED_PATHS_FILE="$WORKDIR/excluded-paths.txt"
+    python3 -c "
+import json
+data = json.load(open('$E2E_REPO/.claude/settings.json'))
+with open('$EXCLUDED_PATHS_FILE', 'w') as out:
+    for p in data.get('claudeMdExcludes', []):
+        out.write(p + chr(10))
+"
+    EXCLUDED_ARGS=()
+    if [ -s "$EXCLUDED_PATHS_FILE" ]; then
+      while IFS= read -r line; do
+        [ -n "$line" ] && EXCLUDED_ARGS+=("$line")
+      done < "$EXCLUDED_PATHS_FILE"
+    fi
+
+    if [ "${#EXCLUDED_ARGS[@]}" -eq 0 ]; then
+      echo "  SKIP: no tech-specific/niche modules installed on this machine to exclude -- nothing to assert"
+    else
+      ( cd "$E2E_REPO" && claude -p "Say hello in one word." --model sonnet --output-format json >"$WORKDIR/e2e-session-out.json" 2>"$WORKDIR/e2e-session-err.txt" )
+      CLAUDE_RC=$?
+      if [ "$CLAUDE_RC" -ne 0 ] || [ ! -s "$WORKDIR/e2e-session-out.json" ]; then
+        echo "  SKIP: headless claude -p session did not complete (rc=$CLAUDE_RC) -- likely no authenticated session available"
+        echo "  SKIP: stderr: $(cat "$WORKDIR/e2e-session-err.txt" 2>/dev/null | head -5)"
+      else
+        LOG_FILE=$(ls "$E2E_LOG_DIR"/*.jsonl 2>/dev/null | head -1)
+        if [ -z "$LOG_FILE" ]; then
+          fail "InstructionsLoaded log was never written -- the hook did not fire"
+        else
+          RESULT=$(python3 "$SCRIPT_DIR/lib/check_e2e_loaded.py" "$LIB_DIR" "$LOG_FILE" "rules/git-workflow.md" "${EXCLUDED_ARGS[@]}")
+          if [ "$RESULT" = "OK" ]; then
+            pass "excluded rules did not load; retained rule (git-workflow.md) did load"
+          else
+            fail "InstructionsLoaded assertions failed:
+$RESULT"
+          fi
+        fi
+      fi
+    fi
+  fi
+fi
+
+echo ""
+echo "test-rules-scope.sh: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/modules/relevance-injection/tests/test-rules-scope.sh
+++ b/modules/relevance-injection/tests/test-rules-scope.sh
@@ -165,6 +165,31 @@ echo "--- Proposal against this repo's real module set (non-web profile) ---"
 cat "$WORKDIR/real-out.txt"
 echo "---"
 
+# --- Test 7: propose_excludes() never returns a PINNED_FLOOR rule, scanned
+# against the REAL, full installed manifest (all 78 modules) -- this is the
+# plan.md Epic 0.5 test bullet's literal wording ("asserted against the full
+# installed set"), not just the 21-module adversarial fixture in
+# test_rules_scope.py. PINNED_FLOOR is derived here from rules_scope.py
+# itself (never re-typed), so this stays accurate if the list ever changes.
+PINNED_FLOOR_MODULES=$(python3 -c "
+import sys
+sys.path.insert(0, '$LIB_DIR')
+import rules_scope
+print('\n'.join(rules_scope.PINNED_FLOOR))
+")
+PINNED_HITS=""
+while IFS= read -r mod; do
+  [ -z "$mod" ] && continue
+  if grep -qE "^${mod} " "$WORKDIR/real-out.txt"; then
+    PINNED_HITS="$PINNED_HITS $mod"
+  fi
+done <<< "$PINNED_FLOOR_MODULES"
+if [ -z "$PINNED_HITS" ]; then
+  pass "propose_excludes() against the full real installed manifest (all 78 modules) never proposes a PINNED_FLOOR rule"
+else
+  fail "PINNED_FLOOR module(s) proposed for exclusion against the real manifest:$PINNED_HITS"
+fi
+
 echo ""
 echo "=== Part 2: end-to-end via InstructionsLoaded (Gate 2, model-in-the-loop) ==="
 

--- a/modules/relevance-injection/tests/test_rules_scope.py
+++ b/modules/relevance-injection/tests/test_rules_scope.py
@@ -373,6 +373,51 @@ class WriteSettingsTests(unittest.TestCase):
             with open(settings_path, encoding="utf-8") as fh:
                 self.assertEqual(fh.read(), "{not valid json")
 
+    def test_interrupted_write_leaves_the_original_file_intact(self):
+        """A crash mid-write must not destroy the user's existing settings.
+
+        open(path, "w") truncates at open time, so a naive implementation
+        loses every pre-existing key -- hooks, permissions, prior excludes --
+        if the process dies before the write completes. The write is done to
+        a tempfile and renamed, so the original is only ever replaced by a
+        complete file.
+        """
+        original = json.dumps(
+            {"hooks": {"SessionStart": ["x"]}, "claudeMdExcludes": ["/keep.md"]},
+            indent=2,
+            sort_keys=True,
+        ) + "\n"
+        for boom_at in ("os.replace", "json.dumps"):
+            with self.subTest(boom_at=boom_at):
+                with tempfile.TemporaryDirectory() as repo:
+                    settings_path = os.path.join(repo, ".claude", "settings.json")
+                    os.makedirs(os.path.dirname(settings_path))
+                    with open(settings_path, "w", encoding="utf-8") as fh:
+                        fh.write(original)
+
+                    target = getattr(rules_scope, "os" if boom_at == "os.replace" else "json")
+                    attr = "replace" if boom_at == "os.replace" else "dumps"
+                    real = getattr(target, attr)
+
+                    def explode(*_a, **_kw):
+                        raise KeyboardInterrupt("simulated interrupt mid-write")
+
+                    setattr(target, attr, explode)
+                    try:
+                        with self.assertRaises(KeyboardInterrupt):
+                            rules_scope.write_settings(settings_path, ["/new.md"])
+                    finally:
+                        setattr(target, attr, real)
+
+                    with open(settings_path, encoding="utf-8") as fh:
+                        self.assertEqual(fh.read(), original)
+                    # No tempfile left behind next to the target.
+                    leftovers = [
+                        n for n in os.listdir(os.path.dirname(settings_path))
+                        if n.startswith(".settings-")
+                    ]
+                    self.assertEqual(leftovers, [])
+
 
 class CliDryRunTests(unittest.TestCase):
     """The default CLI invocation must never write anything (Epic 0.5's own

--- a/modules/relevance-injection/tests/test_rules_scope.py
+++ b/modules/relevance-injection/tests/test_rules_scope.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Unit tests for rules_scope.py -- /rules-scope generator (Epic 0.5, issue #952).
+
+Covers the deliverables named in plan.md's Epic 0.5 test list:
+
+  - propose_excludes() never returns a PINNED_FLOOR rule, asserted against
+    the full installed set (including an adversarial manifest that tries
+    to mislabel a PINNED_FLOOR module as "tech-specific")
+  - A repo with Cargo.toml and no package.json gets the web/tech-specific
+    set proposed; a repo with tailwind.config.ts does not (for tailwind)
+  - write_settings() preserves pre-existing unrelated keys and is
+    idempotent (running twice yields a byte-identical file)
+  - detect_repo_profile() per-signal marker + dependency detection
+  - the niche category never proposes self-improving's high-stakes
+    learnings-store.md
+  - path resolution: claudeMdExcludes entries must be the REAL,
+    symlink-resolved path, not the ~/.claude/rules/ symlink path (the
+    load-bearing empirical finding this generator depends on)
+
+Pure library; no I/O beyond temp directories this suite builds itself.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+import rules_scope  # noqa: E402
+
+
+def _write_module(modules_dir, name, *, category=None, rule_files=None, applicability=None):
+    """Create modules/<name>/module.json with optional category + rule files."""
+    mod_dir = os.path.join(modules_dir, name)
+    os.makedirs(mod_dir, exist_ok=True)
+    files = {}
+    for rf in rule_files or []:
+        files[rf] = {"target": rf, "type": "rule", "template": False}
+    manifest = {"name": name, "files": files}
+    if category is not None:
+        manifest["category"] = category
+    if applicability is not None:
+        manifest["applicability"] = applicability
+    with open(os.path.join(mod_dir, "module.json"), "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh)
+
+
+class PinnedFloorTests(unittest.TestCase):
+    def test_pinned_floor_is_the_seven_safety_core_plus_four_named(self):
+        expected = {
+            "git-workflow", "hooks", "autonomy", "test-driven-development",
+            "verification", "systematic-debugging", "subagent-patterns",
+            "identity", "live-testing-guard", "git-worktrees",
+            "model-vetting", "branch-guard",
+        }
+        self.assertEqual(set(rules_scope.PINNED_FLOOR), expected)
+
+    def test_propose_excludes_never_returns_a_pinned_floor_module(self):
+        """Adversarial: every PINNED_FLOOR module is ALSO mislabeled
+        category="tech-specific" here, so this is a real assertion on the
+        exclusion guard -- not just "the fixture never tried."
+        """
+        with tempfile.TemporaryDirectory() as modules_dir, tempfile.TemporaryDirectory() as repo:
+            all_modules = list(rules_scope.PINNED_FLOOR) + list(rules_scope.NICHE_MODULE_RULE_TARGETS)
+            for mod in rules_scope.PINNED_FLOOR:
+                _write_module(
+                    modules_dir, mod,
+                    category="tech-specific",
+                    rule_files=[f"rules/{mod}.md"],
+                )
+            for mod in rules_scope.NICHE_MODULE_RULE_TARGETS:
+                _write_module(modules_dir, mod, category="workflow", rule_files=[f"rules/{mod}.md"])
+
+            profile = {}  # nothing detected -> everything tech-specific would be proposed
+            proposed = rules_scope.propose_excludes(
+                profile, modules_dir, all_modules, home=repo
+            )
+            proposed_modules = {row["module"] for row in proposed}
+            for mod in rules_scope.PINNED_FLOOR:
+                self.assertNotIn(mod, proposed_modules, f"{mod} is PINNED_FLOOR but was proposed")
+
+    def test_only_installed_modules_are_considered(self):
+        with tempfile.TemporaryDirectory() as modules_dir, tempfile.TemporaryDirectory() as repo:
+            _write_module(modules_dir, "tailwind", category="tech-specific", rule_files=["rules/tailwind.md"])
+            proposed = rules_scope.propose_excludes({}, modules_dir, installed_modules=[], home=repo)
+            self.assertEqual(proposed, [])
+
+
+class TechSpecificDetectionTests(unittest.TestCase):
+    """A repo with Cargo.toml and no package.json gets the tech-specific set
+    proposed; a repo with tailwind.config.ts does not (for tailwind)."""
+
+    def _modules_dir_with_all_tech_specific(self):
+        modules_dir = tempfile.mkdtemp()
+        _write_module(modules_dir, "tailwind", category="tech-specific",
+                      rule_files=["rules/tailwind.md", "rules/frontend-css.md"])
+        _write_module(modules_dir, "shadcn", category="tech-specific", rule_files=["rules/shadcn.md"])
+        _write_module(modules_dir, "supabase", category="tech-specific", rule_files=["rules/supabase.md"])
+        _write_module(modules_dir, "cloudflare", category="tech-specific", rule_files=["rules/cloudflare.md"])
+        _write_module(modules_dir, "mcp-development", category="tech-specific",
+                      rule_files=["rules/mcp-development.md"])
+        return modules_dir
+
+    def test_rust_only_repo_gets_the_full_tech_specific_set_proposed(self):
+        modules_dir = self._modules_dir_with_all_tech_specific()
+        with tempfile.TemporaryDirectory() as repo, tempfile.TemporaryDirectory() as home:
+            with open(os.path.join(repo, "Cargo.toml"), "w", encoding="utf-8") as fh:
+                fh.write("[package]\nname = \"x\"\n")
+            self.assertFalse(os.path.exists(os.path.join(repo, "package.json")))
+
+            profile = rules_scope.detect_repo_profile(repo)
+            self.assertFalse(any(profile.values()), profile)
+
+            proposed = rules_scope.propose_excludes(
+                profile, modules_dir,
+                installed_modules=["tailwind", "shadcn", "supabase", "cloudflare", "mcp-development"],
+                home=home,
+            )
+            proposed_rules = {(row["module"], row["rule"]) for row in proposed}
+            self.assertEqual(
+                proposed_rules,
+                {
+                    ("tailwind", "rules/tailwind.md"),
+                    ("tailwind", "rules/frontend-css.md"),
+                    ("shadcn", "rules/shadcn.md"),
+                    ("supabase", "rules/supabase.md"),
+                    ("cloudflare", "rules/cloudflare.md"),
+                    ("mcp-development", "rules/mcp-development.md"),
+                },
+            )
+            self.assertTrue(all(row["category"] == "tech-specific" for row in proposed))
+
+    def test_tailwind_config_present_excludes_tailwind_from_the_proposal(self):
+        modules_dir = self._modules_dir_with_all_tech_specific()
+        with tempfile.TemporaryDirectory() as repo, tempfile.TemporaryDirectory() as home:
+            with open(os.path.join(repo, "tailwind.config.ts"), "w", encoding="utf-8") as fh:
+                fh.write("export default {}\n")
+
+            profile = rules_scope.detect_repo_profile(repo)
+            self.assertTrue(profile["tailwind"])
+
+            proposed = rules_scope.propose_excludes(
+                profile, modules_dir,
+                installed_modules=["tailwind", "shadcn", "supabase", "cloudflare", "mcp-development"],
+                home=home,
+            )
+            proposed_modules = {row["module"] for row in proposed}
+            self.assertNotIn("tailwind", proposed_modules)
+            # The other four tech-specific modules are still undetected in
+            # this repo and should still be proposed.
+            self.assertIn("shadcn", proposed_modules)
+            self.assertIn("supabase", proposed_modules)
+            self.assertIn("cloudflare", proposed_modules)
+            self.assertIn("mcp-development", proposed_modules)
+
+
+class DetectRepoProfileTests(unittest.TestCase):
+    def test_empty_repo_detects_nothing(self):
+        with tempfile.TemporaryDirectory() as repo:
+            profile = rules_scope.detect_repo_profile(repo)
+            self.assertEqual(profile, {
+                "tailwind": False, "shadcn": False, "supabase": False,
+                "cloudflare": False, "mcp-development": False,
+            })
+
+    def test_components_json_detects_shadcn(self):
+        with tempfile.TemporaryDirectory() as repo:
+            with open(os.path.join(repo, "components.json"), "w", encoding="utf-8") as fh:
+                fh.write("{}")
+            self.assertTrue(rules_scope.detect_repo_profile(repo)["shadcn"])
+
+    def test_supabase_directory_detects_supabase(self):
+        with tempfile.TemporaryDirectory() as repo:
+            os.makedirs(os.path.join(repo, "supabase"))
+            self.assertTrue(rules_scope.detect_repo_profile(repo)["supabase"])
+
+    def test_wrangler_toml_detects_cloudflare(self):
+        with tempfile.TemporaryDirectory() as repo:
+            with open(os.path.join(repo, "wrangler.toml"), "w", encoding="utf-8") as fh:
+                fh.write("name = \"x\"\n")
+            self.assertTrue(rules_scope.detect_repo_profile(repo)["cloudflare"])
+
+    def test_mcp_json_detects_mcp_development(self):
+        with tempfile.TemporaryDirectory() as repo:
+            with open(os.path.join(repo, ".mcp.json"), "w", encoding="utf-8") as fh:
+                fh.write("{}")
+            self.assertTrue(rules_scope.detect_repo_profile(repo)["mcp-development"])
+
+    def test_package_json_dependency_detects_tailwind(self):
+        with tempfile.TemporaryDirectory() as repo:
+            with open(os.path.join(repo, "package.json"), "w", encoding="utf-8") as fh:
+                json.dump({"devDependencies": {"tailwindcss": "^4.0.0"}}, fh)
+            self.assertTrue(rules_scope.detect_repo_profile(repo)["tailwind"])
+
+    def test_dependency_inside_node_modules_is_ignored(self):
+        """A tailwindcss package.json nested under node_modules must not
+        count as a repo-level signal -- node_modules is a pruned directory."""
+        with tempfile.TemporaryDirectory() as repo:
+            nested = os.path.join(repo, "node_modules", "some-lib")
+            os.makedirs(nested)
+            with open(os.path.join(nested, "package.json"), "w", encoding="utf-8") as fh:
+                json.dump({"dependencies": {"tailwindcss": "^4.0.0"}}, fh)
+            self.assertFalse(rules_scope.detect_repo_profile(repo)["tailwind"])
+
+    def test_nested_package_json_within_walk_depth_is_detected(self):
+        """Monorepo-shaped: package.json a few levels deep, not at root."""
+        with tempfile.TemporaryDirectory() as repo:
+            nested = os.path.join(repo, "apps", "web")
+            os.makedirs(nested)
+            with open(os.path.join(nested, "package.json"), "w", encoding="utf-8") as fh:
+                json.dump({"dependencies": {"tailwindcss": "^4.0.0"}}, fh)
+            self.assertTrue(rules_scope.detect_repo_profile(repo)["tailwind"])
+
+
+class NicheCategoryTests(unittest.TestCase):
+    def test_self_improving_only_proposes_self_improving_md_not_learnings_store(self):
+        with tempfile.TemporaryDirectory() as modules_dir, tempfile.TemporaryDirectory() as home:
+            _write_module(
+                modules_dir, "self-improving", category="workflow",
+                rule_files=["rules/self-improving.md", "rules/learnings-store.md"],
+            )
+            proposed = rules_scope.propose_excludes(
+                {}, modules_dir, installed_modules=["self-improving"], home=home
+            )
+            proposed_rules = {row["rule"] for row in proposed}
+            self.assertIn("rules/self-improving.md", proposed_rules)
+            self.assertNotIn("rules/learnings-store.md", proposed_rules)
+
+    def test_niche_module_not_installed_is_never_proposed(self):
+        with tempfile.TemporaryDirectory() as modules_dir, tempfile.TemporaryDirectory() as home:
+            _write_module(modules_dir, "dreaming", category="workflow", rule_files=["rules/dreaming.md"])
+            proposed = rules_scope.propose_excludes({}, modules_dir, installed_modules=[], home=home)
+            self.assertEqual(proposed, [])
+
+    def test_niche_category_is_not_gated_on_repo_profile(self):
+        """Unlike tech-specific, niche modules are proposed regardless of
+        what detect_repo_profile() found -- there is no per-repo signal for
+        "will this session touch the nightly dreaming pipeline."""
+        with tempfile.TemporaryDirectory() as modules_dir, tempfile.TemporaryDirectory() as home:
+            _write_module(modules_dir, "dreaming", category="workflow", rule_files=["rules/dreaming.md"])
+            full_profile = {"tailwind": True, "shadcn": True, "supabase": True,
+                             "cloudflare": True, "mcp-development": True}
+            proposed = rules_scope.propose_excludes(
+                full_profile, modules_dir, installed_modules=["dreaming"], home=home
+            )
+            self.assertEqual({row["rule"] for row in proposed}, {"rules/dreaming.md"})
+
+
+class PathResolutionTests(unittest.TestCase):
+    """Regression test for the empirical finding that claudeMdExcludes must
+    reference the REAL (symlink-resolved) path, not the ~/.claude/rules/
+    symlink path CCGM's installer creates under linkMode."""
+
+    def test_resolved_rule_path_follows_a_symlink(self):
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as canonical:
+            real_file = os.path.join(canonical, "tailwind.md")
+            with open(real_file, "w", encoding="utf-8") as fh:
+                fh.write("# tailwind rule\n")
+
+            rules_dir = os.path.join(home, ".claude", "rules")
+            os.makedirs(rules_dir)
+            symlink_path = os.path.join(rules_dir, "tailwind.md")
+            os.symlink(real_file, symlink_path)
+
+            resolved = rules_scope._resolved_rule_path("rules/tailwind.md", home)
+            self.assertEqual(resolved, os.path.realpath(real_file))
+            self.assertNotEqual(resolved, symlink_path)
+
+    def test_resolved_rule_path_is_stable_for_a_plain_copy_install(self):
+        """Under a --copy install there is no symlink; realpath() of a
+        plain file is the file itself, so the same code path is correct."""
+        with tempfile.TemporaryDirectory() as home:
+            rules_dir = os.path.join(home, ".claude", "rules")
+            os.makedirs(rules_dir)
+            plain_path = os.path.join(rules_dir, "tailwind.md")
+            with open(plain_path, "w", encoding="utf-8") as fh:
+                fh.write("# tailwind rule\n")
+
+            resolved = rules_scope._resolved_rule_path("rules/tailwind.md", home)
+            self.assertEqual(resolved, os.path.realpath(plain_path))
+
+    def test_propose_excludes_returns_resolved_paths(self):
+        with tempfile.TemporaryDirectory() as modules_dir, tempfile.TemporaryDirectory() as home, \
+                tempfile.TemporaryDirectory() as canonical:
+            _write_module(modules_dir, "tailwind", category="tech-specific", rule_files=["rules/tailwind.md"])
+
+            real_file = os.path.join(canonical, "tailwind.md")
+            with open(real_file, "w", encoding="utf-8") as fh:
+                fh.write("# tailwind\n")
+            rules_dir = os.path.join(home, ".claude", "rules")
+            os.makedirs(rules_dir)
+            os.symlink(real_file, os.path.join(rules_dir, "tailwind.md"))
+
+            proposed = rules_scope.propose_excludes(
+                {}, modules_dir, installed_modules=["tailwind"], home=home
+            )
+            self.assertEqual(len(proposed), 1)
+            self.assertEqual(proposed[0]["path"], os.path.realpath(real_file))
+
+
+class WriteSettingsTests(unittest.TestCase):
+    def test_creates_file_and_parent_dir_when_missing(self):
+        with tempfile.TemporaryDirectory() as repo:
+            settings_path = os.path.join(repo, ".claude", "settings.json")
+            self.assertFalse(os.path.exists(settings_path))
+            result = rules_scope.write_settings(settings_path, ["/a.md", "/b.md"])
+            self.assertTrue(os.path.exists(settings_path))
+            self.assertEqual(result["claudeMdExcludes"], ["/a.md", "/b.md"])
+
+    def test_preserves_pre_existing_unrelated_keys(self):
+        with tempfile.TemporaryDirectory() as repo:
+            settings_path = os.path.join(repo, ".claude", "settings.json")
+            os.makedirs(os.path.dirname(settings_path))
+            with open(settings_path, "w", encoding="utf-8") as fh:
+                json.dump(
+                    {
+                        "hooks": {"SessionStart": [{"hooks": [{"type": "command", "command": "echo hi"}]}]},
+                        "someOtherSetting": True,
+                        "permissions": {"allow": ["Bash(git status)"]},
+                    },
+                    fh,
+                )
+            result = rules_scope.write_settings(settings_path, ["/new.md"])
+            self.assertEqual(
+                result["hooks"],
+                {"SessionStart": [{"hooks": [{"type": "command", "command": "echo hi"}]}]},
+            )
+            self.assertEqual(result["someOtherSetting"], True)
+            self.assertEqual(result["permissions"], {"allow": ["Bash(git status)"]})
+            self.assertIn("/new.md", result["claudeMdExcludes"])
+
+    def test_extends_existing_claude_md_excludes_rather_than_overwriting(self):
+        with tempfile.TemporaryDirectory() as repo:
+            settings_path = os.path.join(repo, ".claude", "settings.json")
+            os.makedirs(os.path.dirname(settings_path))
+            with open(settings_path, "w", encoding="utf-8") as fh:
+                json.dump({"claudeMdExcludes": ["/already/excluded.md"]}, fh)
+            result = rules_scope.write_settings(settings_path, ["/new.md"])
+            self.assertEqual(
+                sorted(result["claudeMdExcludes"]),
+                ["/already/excluded.md", "/new.md"],
+            )
+
+    def test_is_idempotent_byte_for_byte(self):
+        with tempfile.TemporaryDirectory() as repo:
+            settings_path = os.path.join(repo, ".claude", "settings.json")
+            rules_scope.write_settings(settings_path, ["/a.md", "/b.md"])
+            with open(settings_path, "rb") as fh:
+                first = fh.read()
+            rules_scope.write_settings(settings_path, ["/a.md", "/b.md"])
+            with open(settings_path, "rb") as fh:
+                second = fh.read()
+            self.assertEqual(first, second)
+
+    def test_deduplicates_excludes(self):
+        with tempfile.TemporaryDirectory() as repo:
+            settings_path = os.path.join(repo, ".claude", "settings.json")
+            os.makedirs(os.path.dirname(settings_path))
+            with open(settings_path, "w", encoding="utf-8") as fh:
+                json.dump({"claudeMdExcludes": ["/a.md"]}, fh)
+            result = rules_scope.write_settings(settings_path, ["/a.md", "/b.md"])
+            self.assertEqual(sorted(result["claudeMdExcludes"]), ["/a.md", "/b.md"])
+
+    def test_malformed_existing_json_raises_rather_than_clobbering(self):
+        with tempfile.TemporaryDirectory() as repo:
+            settings_path = os.path.join(repo, ".claude", "settings.json")
+            os.makedirs(os.path.dirname(settings_path))
+            with open(settings_path, "w", encoding="utf-8") as fh:
+                fh.write("{not valid json")
+            with self.assertRaises(ValueError):
+                rules_scope.write_settings(settings_path, ["/a.md"])
+            # The malformed file must survive untouched.
+            with open(settings_path, encoding="utf-8") as fh:
+                self.assertEqual(fh.read(), "{not valid json")
+
+
+class CliDryRunTests(unittest.TestCase):
+    """The default CLI invocation must never write anything (Epic 0.5's own
+    safety-rules contract: "Always print the proposed list and require
+    --write")."""
+
+    def test_main_without_write_flag_does_not_touch_settings_json(self):
+        with tempfile.TemporaryDirectory() as repo, tempfile.TemporaryDirectory() as ccgm_root:
+            modules_dir = os.path.join(ccgm_root, "modules")
+            os.makedirs(modules_dir)
+            _write_module(modules_dir, "tailwind", category="tech-specific", rule_files=["rules/tailwind.md"])
+
+            manifest_path = os.path.join(ccgm_root, "manifest.json")
+            with open(manifest_path, "w", encoding="utf-8") as fh:
+                json.dump({"ccgmRoot": ccgm_root, "modules": ["tailwind"]}, fh)
+
+            rc = rules_scope.main([repo, "--manifest", manifest_path])
+            self.assertEqual(rc, 0)
+            self.assertFalse(os.path.exists(os.path.join(repo, ".claude", "settings.json")))
+
+    def test_main_with_write_flag_writes_settings_json(self):
+        with tempfile.TemporaryDirectory() as repo, tempfile.TemporaryDirectory() as ccgm_root:
+            modules_dir = os.path.join(ccgm_root, "modules")
+            os.makedirs(modules_dir)
+            _write_module(modules_dir, "tailwind", category="tech-specific", rule_files=["rules/tailwind.md"])
+
+            manifest_path = os.path.join(ccgm_root, "manifest.json")
+            with open(manifest_path, "w", encoding="utf-8") as fh:
+                json.dump({"ccgmRoot": ccgm_root, "modules": ["tailwind"]}, fh)
+
+            rc = rules_scope.main([repo, "--manifest", manifest_path, "--write"])
+            self.assertEqual(rc, 0)
+            settings_path = os.path.join(repo, ".claude", "settings.json")
+            self.assertTrue(os.path.exists(settings_path))
+            with open(settings_path, encoding="utf-8") as fh:
+                data = json.load(fh)
+            self.assertEqual(len(data["claudeMdExcludes"]), 1)
+
+    def test_main_with_missing_manifest_reports_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as repo:
+            rc = rules_scope.main([repo, "--manifest", "/does/not/exist.json"])
+            self.assertEqual(rc, 1)
+            self.assertFalse(os.path.exists(os.path.join(repo, ".claude", "settings.json")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #952

## What this does

Adds `/rules-scope`, a command that inspects a repo's tech stack and the installed CCGM manifest, then proposes -- and, with `--write`, applies -- a `claudeMdExcludes` array in that repo's `.claude/settings.json`. This suppresses installed CCGM rule files that are irrelevant to a given repo without uninstalling anything: the rule file stays installed and readable, it just does not auto-load into that repo's sessions.

This is plan.md's Epic 0.5 (`~/code/plans/ccgm-dynamic-rule-injection/plan.md`), added post-gate after an experiment found `claudeMdExcludes` (previously a rejected alternative) actually works against user-level rules from a project-layer settings file. It ships standalone and depends on no other epic.

## Two exclusion categories

- **`tech-specific`** (repo-profile-gated): rule files belonging to a module whose `module.json` already declares `"category": "tech-specific"` (`tailwind`, `shadcn`, `supabase`, `cloudflare`, `mcp-development`) -- proposed only when the target repo shows no marker for that tech (no `tailwind.config.*`/`tailwindcss` dependency, no `wrangler.toml`, no `supabase/` dir, no `.mcp.json`, no `components.json`).
- **`niche`** (not repo-profile-gated): a small, conservative, hand-picked set of rule files about specific CCGM meta-workflows (the nightly dreaming pipeline, Argus, SSH to a configured remote box, ...) that apply regardless of tech stack. Deliberately excludes `code-quality` and `common-mistakes` (Epic 2's own tier-assignment analysis found these should stay always-on, not index-tiered) and excludes `self-improving`'s `learnings-store.md` specifically (it is `high` stakes -- a destructive-git-operation risk -- while its sibling `self-improving.md` is not).

## Safety rules (enforced in code, not just by convention)

- **Never proposes a `PINNED_FLOOR` module's rules.** Derived from `relevance_select.safety_core_modules()` (the seven `SAFETY_CORE_TIERS` modules) plus `identity`, `live-testing-guard`, `git-worktrees`, `model-vetting`, `branch-guard` -- defined once in `lib/rules_scope.py`, not re-typed (Epic 3's `lib/rule_tiering.py`, the plan's intended future home for this constant, is deferred and not built).
- **Dry run by default.** Nothing is written unless `--write` is passed.
- **Merges, never overwrites.** An existing `claudeMdExcludes` array is extended and every other key in `.claude/settings.json` is preserved.

## A load-bearing empirical finding

`claudeMdExcludes` matches against the REAL, symlink-resolved path of the loaded instruction file, not the `~/.claude/rules/<file>.md` symlink path CCGM's installer creates under `linkMode`. Verified directly (headless `claude -p`, project-level settings.json, the `InstructionsLoaded` hook as the oracle): excluding the symlink path did nothing (the file still loaded, correctly logged at its real path); excluding the real, resolved path worked (the file was absent from the log, every other rule still loaded). `rules_scope.py` resolves this automatically via `os.path.realpath()`, so it is correct under both `--link` and `--copy` installs with no branch.

## Measured savings (fresh, this machine's real install, anchor a332a60)

Dry run against a scratch Rust-only repo (`Cargo.toml`, no `package.json`) using this machine's actual `~/.claude/.ccgm-manifest.json`:

```
MODULE               CATEGORY       RULE                                     TOKENS
browser-automation   niche          rules/browser-automation.md              1895
cloudflare           tech-specific  rules/cloudflare.md                      1279
dreaming             niche          rules/dreaming.md                        5346
mcp-development      tech-specific  rules/mcp-development.md                 841
multi-agent          niche          rules/multi-agent.md                     1171
remote-server        niche          rules/remote-server.md                   287
self-improving       niche          rules/self-improving.md                  1803
shadcn               tech-specific  rules/shadcn.md                          628
supabase             tech-specific  rules/supabase.md                        925
tailwind             tech-specific  rules/frontend-css.md                    465
tailwind             tech-specific  rules/tailwind.md                        848
youtube-transcripts  niche          rules/youtube-transcripts.md             855

12 rule file(s), ~16343 tokens.
```

- **tech-specific alone: ~4,988 tok** (6.8% of the machine's ~73,573-token installed corpus)
- **tech-specific + niche: ~16,343 tok** (22.2%)

The plan's own experiment (an ad hoc, hand-picked exclusion by the operator, not this generator) cited ~6,042 tok / 8.2% for the tech-specific set alone at an earlier anchor (`83230aa`). Re-measured fresh here the same six rule files total 19,952 bytes = ~4,988 tok at bytes//4 -- lower than the earlier figure. This is **not** anchor drift: all six rule files (`tailwind.md`, `frontend-css.md`, `shadcn.md`, `supabase.md`, `cloudflare.md`, `mcp-development.md`) are byte-for-byte identical between `83230aa` and this branch's head (verified with `git diff --quiet 83230aa -- <path>` per file). decisions.md's DECISION 3 does not record a methodology for the original ~6,042 figure, so the gap is most likely a difference in how that earlier ad hoc measurement counted tokens, not a change in rule-file content. My own niche set is intentionally narrower than the plan's original 41.3%/30,355-tok combined figure, for the code-quality/common-mistakes/learnings-store.md safety reasons above.

## Verification

**pytest** (28 tests, `modules/relevance-injection/tests/test_rules_scope.py`):
```
28 passed in 0.06s
```

**Bash suite** (`modules/relevance-injection/tests/test-rules-scope.sh`, includes a live Gate-2 E2E run against a real headless `claude -p` session on this machine -- InstructionsLoaded log confirms the excluded rules did not load and a retained rule did):
```
  PASS: default invocation (no --write) leaves git status clean
  PASS: default invocation prints a dry-run notice
  PASS: dry run proposes tailwind (Rust-only repo, no package.json)
  PASS: --write creates .claude/settings.json
  PASS: --write proposed at least 6 excludes (all 5 tech-specific modules, tailwind ships 2 files)
  PASS: running --write twice is idempotent (byte-identical file)
  PASS: tailwind.config.ts present => tailwind not proposed for exclusion
  PASS: shadcn (undetected in this repo) is still proposed
  PASS: git-workflow (PINNED_FLOOR) is never proposed
  PASS: dry run against this repo's real module set writes nothing
  PASS: excluded rules did not load; retained rule (git-workflow.md) did load

test-rules-scope.sh: 11 passed, 0 failed
```

The E2E part self-skips (not a failure) when no authenticated `claude` CLI is on PATH -- true on hosted CI runners, which never install it (plan.md section 8.4) -- so this suite is safe as a required CI step in both jobs.

**`bash -n`** on the new bash suite: clean.

**`bash tests/test-modules.sh`**: `1707 passed, 0 failed` (includes the new Manual-Installation cp-block coverage check for the two new declared files).

**`bash tests/test-doc-counts.sh`**: all checks passed, including the updated Commands-column claim and the commands-doc count (89 -> 90, not 85 as originally estimated -- the actual pre-PR count on this branch's base was already 89, not 84).

**`bash tests/test-frontmatter-yaml.sh`**: all frontmatter valid (120 files scanned).

**`bash tests/test-no-personal-data.sh`**: pass.

**`python3 modules/plugin-marketplace/lib/gen_marketplace.py --check`**: up to date, nothing to regenerate (relevance-injection's plugin.json auto-discovers `commands/*.md`, no per-file entry needed).

**Dry run against this repo itself** (no `--write`):
```
$ git status --porcelain
(empty)
```
confirms nothing was written.

## Scope

Does not touch `lib/rule_tiering.py`, `applicability.rules{}` in any manifest, `relevance-injection`'s `status`/preset membership, or the `test_version_floor*`/`test-paths-symlink.sh` files another branch owns in parallel.
