### PR TITLE
#985: run the relevance-injection test suites in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,13 +82,26 @@ jobs:
             bash "$t"
           done
 
-      - name: relevance-injection - /rules-scope pytest (Epic 0.5, issue #952)
+      - name: relevance-injection - pytest suites (issue #985)
+        # The whole tests/ directory, not one file: test_loaded_log.py,
+        # test_relevance_select.py and both test_version_floor*.py were
+        # otherwise gated by nothing. pytest does not collect .sh files, so
+        # test-paths-symlink.sh (which needs an authenticated claude CLI and
+        # writes into the operator's real ~/.claude/rules/) is never picked
+        # up here -- it belongs to the plan's model-in-the-loop gate.
+        #
+        # System python3 on hosted runners is PEP 668 "externally managed",
+        # so a venv rather than --break-system-packages, matching every other
+        # pytest step in this workflow.
         run: |
           set -e
-          python3 -m venv /tmp/ccgm-rules-scope-test-venv
-          source /tmp/ccgm-rules-scope-test-venv/bin/activate
+          python3 -m venv /tmp/ccgm-relevance-injection-test-venv
+          source /tmp/ccgm-relevance-injection-test-venv/bin/activate
           python3 -m pip install --quiet pytest
-          python3 -m pytest modules/relevance-injection/tests/test_rules_scope.py -q
+          python3 -m pytest modules/relevance-injection/tests/ -q
+
+      - name: relevance-injection - SessionStart hook no-op suite (issue #985)
+        run: bash modules/relevance-injection/tests/test-relevance-hook.sh
 
       - name: relevance-injection - /rules-scope bash suite (E2E self-skips without an authenticated claude CLI)
         run: bash modules/relevance-injection/tests/test-rules-scope.sh
@@ -239,13 +252,26 @@ jobs:
             bash "$t"
           done
 
-      - name: relevance-injection - /rules-scope pytest (Epic 0.5, issue #952)
+      - name: relevance-injection - pytest suites (issue #985)
+        # The whole tests/ directory, not one file: test_loaded_log.py,
+        # test_relevance_select.py and both test_version_floor*.py were
+        # otherwise gated by nothing. pytest does not collect .sh files, so
+        # test-paths-symlink.sh (which needs an authenticated claude CLI and
+        # writes into the operator's real ~/.claude/rules/) is never picked
+        # up here -- it belongs to the plan's model-in-the-loop gate.
+        #
+        # System python3 on hosted runners is PEP 668 "externally managed",
+        # so a venv rather than --break-system-packages, matching every other
+        # pytest step in this workflow.
         run: |
           set -e
-          python3 -m venv /tmp/ccgm-rules-scope-test-venv
-          source /tmp/ccgm-rules-scope-test-venv/bin/activate
+          python3 -m venv /tmp/ccgm-relevance-injection-test-venv
+          source /tmp/ccgm-relevance-injection-test-venv/bin/activate
           python3 -m pip install --quiet pytest
-          python3 -m pytest modules/relevance-injection/tests/test_rules_scope.py -q
+          python3 -m pytest modules/relevance-injection/tests/ -q
+
+      - name: relevance-injection - SessionStart hook no-op suite (issue #985)
+        run: bash modules/relevance-injection/tests/test-relevance-hook.sh
 
       - name: relevance-injection - /rules-scope bash suite (E2E self-skips without an authenticated claude CLI)
         run: bash modules/relevance-injection/tests/test-rules-scope.sh

--- a/modules/relevance-injection/tests/test-paths-symlink.sh
+++ b/modules/relevance-injection/tests/test-paths-symlink.sh
@@ -88,6 +88,29 @@ LOCK_MAIN_TIMEOUT_SECS=120
 LOCK_HELD=0
 PID_PREFIX="zzz-ccgm-test-$$-"
 
+# Explicit opt-in, checked before ANY state is captured or trap registered,
+# because running this is neither free nor local-only: it spends real API
+# budget and symlinks canary rules into the operator's REAL ~/.claude/rules/
+# while other Claude Code sessions may be live.
+#
+# tests/run-unit-tests.sh discovers every modules/*/tests/test-*.sh by glob,
+# so without this gate a developer running the ordinary unit-test sweep on a
+# machine that happens to have an authenticated claude CLI would silently
+# trigger a paid experiment against their live config. Skip loudly and exit 0
+# so the sweep stays green; anyone actually running plan.md section 8.4's
+# Gate 2 sets the variable named below.
+#
+# This sits above `trap cleanup EXIT` deliberately -- registering the trap
+# first would fire cleanup() on the skip path and report a spurious
+# "not back to its pre-run file list" failure against an empty snapshot.
+if [ "${CCGM_RUN_MODEL_GATE:-}" != "1" ]; then
+  echo "SKIP: ${0##*/} is a model-in-the-loop gate (plan.md section 8.4 Gate 2)."
+  echo "  It spends API budget and writes into ${RULES_DIR}, so it does not run"
+  echo "  as part of an ordinary unit-test sweep."
+  echo "  To run it deliberately:  CCGM_RUN_MODEL_GATE=1 bash ${0##*/}"
+  exit 0
+fi
+
 TMP_ROOT=""
 PRE_RUN_LISTING=""
 CLEANUP_RAN=0

--- a/modules/relevance-injection/tests/test-relevance-hook.sh
+++ b/modules/relevance-injection/tests/test-relevance-hook.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# test_relevance_hook.sh — verify the SessionStart hook is a strict no-op
+# test-relevance-hook.sh — verify the SessionStart hook is a strict no-op
 # unless the opt-in flag is set, and emits the safety core when enabled.
 #
 # Property (a) at the hook level: default (no flag) => zero output, behavior
@@ -103,5 +103,5 @@ else
 fi
 
 echo ""
-echo "test_relevance_hook.sh: $PASS passed, $FAIL failed"
+echo "test-relevance-hook.sh: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #985

## What this does

`modules/relevance-injection/tests/` ran in **no CI job**. `.github/workflows/test.yml` reaches module bash suites only via explicitly named steps, and `module-tests.yml` covers only the dreaming and self-improving suites. So:

- `test_relevance_select.py` and `test_relevance_hook.sh` had **never** executed in CI
- `test_loaded_log.py` (#971) and both `test_version_floor*.py` (#978) merged straight into the same gap

An uninvoked suite is an uncertified surface, not a covered one.

## Changes

| Change | Why |
|---|---|
| Broaden the pytest step from one file to the whole `tests/` directory, both jobs | Covers all five pytest files at once. pytest does not collect `.sh`, so the model-gated shell suite is not swept in |
| Named step for `test-relevance-hook.sh`, both jobs | Module bash suites reach CI only via explicit steps — the #935 enumeration-drift guard only sees top-level `tests/test-*.sh` |
| `test_relevance_hook.sh` → `test-relevance-hook.sh` | `tests/run-unit-tests.sh` globs `modules/*/tests/test-*.sh` with a **hyphen**; the underscore name was invisible to the repo's own runner too |
| Gate `test-paths-symlink.sh` behind `CCGM_RUN_MODEL_GATE=1` | See below |

## The opt-in gate is a safety fix, not bookkeeping

`test-paths-symlink.sh` spends real API budget and symlinks canary rules into the operator's **live** `~/.claude/rules/`. `run-unit-tests.sh`'s glob would discover it, so an ordinary unit-test sweep on a machine that happens to have an authenticated `claude` CLI would silently trigger a paid experiment against live config — while other Claude Code sessions may be running.

It now skips loudly and exits 0, naming the variable to set for a deliberate Gate 2 run. The check sits **above** the `EXIT` trap: registering the trap first fired `cleanup()` on the skip path and reported a spurious "not back to its pre-run file list" failure against an empty snapshot.

## Verification

```
tests/test-modules.sh          1707 passed, 0 failed
tests/test-doc-counts.sh       all checks passed
tests/test-frontmatter-yaml.sh all frontmatter valid
tests/test-no-personal-data.sh PASS
pytest modules/relevance-injection/tests/   89 passed, 2 subtests
test-relevance-hook.sh         7 passed, 0 failed
gen_marketplace.py --check     up to date
```

Both gate paths checked: no opt-in → loud SKIP, exit 0, no residue in `~/.claude/rules/`; with `CCGM_RUN_MODEL_GATE=1` and no `claude` on PATH → reaches the real precondition and reports BLOCKED as before.