### PR TITLE
#981: guard grep -c zero-match aborts in test-backup and test-doc-counts

### DIFF
--- a/tests/test-backup.sh
+++ b/tests/test-backup.sh
@@ -156,7 +156,7 @@ for i in 1 2 3 4 5; do
 done
 
 # Verify we have 5
-count_before=$(ls -1d "$BACKUP_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ')
+count_before=$(ls -1d "$BACKUP_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ' || true)
 if [ "$count_before" -eq 5 ]; then
   pass "Created 5 test backups"
 else
@@ -166,7 +166,7 @@ fi
 # Clean keeping only 2
 clean_backups 2
 
-count_after=$(ls -1d "$BACKUP_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ')
+count_after=$(ls -1d "$BACKUP_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ' || true)
 if [ "$count_after" -eq 2 ]; then
   pass "clean_backups(2) kept exactly 2 backups"
 else
@@ -311,7 +311,7 @@ done
 
 clean_backups 2 "$PROJECT_TARGET"
 
-scoped_after=$(ls -1d "$SCOPE_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ')
+scoped_after=$(ls -1d "$SCOPE_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ' || true)
 if [ "$scoped_after" -eq 2 ]; then
   pass "clean_backups(2) scoped to project kept exactly 2 backups"
 else
@@ -482,7 +482,7 @@ for i in 1 2 3 4 5 6; do
   echo "skill snapshot $i" > "$bdir/skills/test.md"
 done
 
-ret_count_before=$(ls -1d "$RET_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ')
+ret_count_before=$(ls -1d "$RET_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ' || true)
 if [ "$ret_count_before" -eq 6 ]; then
   pass "Created 6 dynamic-coverage backups"
 else
@@ -491,7 +491,7 @@ fi
 
 clean_backups 5 "$RET_TARGET"
 
-ret_count_after=$(ls -1d "$RET_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ')
+ret_count_after=$(ls -1d "$RET_BASE"/ccgm-* 2>/dev/null | wc -l | tr -d ' ' || true)
 if [ "$ret_count_after" -eq 5 ]; then
   pass "clean_backups(5) pruned dynamic-coverage backups to 5"
 else
@@ -684,7 +684,7 @@ cat > "$SCOPE_FIXTURE" <<'JSON'
 }
 JSON
 
-scope_targets=$(_backup_files_block "$SCOPE_FIXTURE" | grep -o '"target"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/^"target"[[:space:]]*:[[:space:]]*"//; s/"$//')
+scope_targets=$(_backup_files_block "$SCOPE_FIXTURE" | grep -o '"target"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/^"target"[[:space:]]*:[[:space:]]*"//; s/"$//' || true)
 
 # Herestrings here too -- see the identical rationale on the fixture_paths
 # checks above (#943, #945).
@@ -726,7 +726,7 @@ cat > "$DEDUPE_ROOT/modules/mod-b/module.json" <<'JSON'
 JSON
 
 dedupe_output=$(CCGM_ROOT="$DEDUPE_ROOT" managed_backup_paths 2>/dev/null)
-skills_count=$(echo "$dedupe_output" | grep -cx 'skills')
+skills_count=$(echo "$dedupe_output" | grep -cx 'skills' || true)
 
 if [ "$skills_count" -eq 1 ]; then
   pass "managed_backup_paths lists 'skills' exactly once across two modules"

--- a/tests/test-doc-counts.sh
+++ b/tests/test-doc-counts.sh
@@ -330,7 +330,7 @@ CATALOG_NAMES=$(awk '
   in_tbl { exit }
 ' README.md)
 
-CATALOG_ROW_COUNT=$(printf '%s\n' "$CATALOG_NAMES" | grep -c . | tr -d ' ')
+CATALOG_ROW_COUNT=$(printf '%s\n' "$CATALOG_NAMES" | grep -c . | tr -d ' ' || true)
 
 if [ "$CATALOG_ROW_COUNT" != "$MODULE_COUNT" ]; then
   fail "README module catalog has $CATALOG_ROW_COUNT rows, expected $MODULE_COUNT


### PR DESCRIPTION
Closes #981

Under `set -euo pipefail`, a bare `var=$(... grep -c ...)` assignment aborts the whole suite when the count is zero — `grep -c` exits 1 on zero matches — so the fail branch written to report exactly that case can never fire, and the truncated run reads as a pass. This PR guards those assignments so a zero count reaches its designed fail branch.

## Changes

- `tests/test-backup.sh:729` — the issue's named site (`grep -cx 'skills'`): appended `|| true` inside the substitution, matching the suites' existing convention.
- `tests/test-doc-counts.sh:333` — same class: empty catalog makes `grep -c .` exit 1 and abort before the "has 0 rows, expected N" fail branch.
- Sweep of the same class across the four top-level suites found 6 more sites in `test-backup.sh` (five `ls -1d glob | wc -l` setup/retention counts, one `grep -o | sed` extraction), all with designed fail branches below; guarded identically. `test-installer.sh`: no unguarded sites (its non-zero-exit captures use explicit `set +e` brackets). `test-doc-counts.sh:479,499` were already guarded and are unchanged.

## Left unguarded, deliberately

- `tests/test-modules.sh:530-531` — can only find zero matches if the Python emitter above them died, which `set -e` already catches at that emitter's own assignment; the region is also being rewritten by #980.

## Verification

- Mutation test: with the dedupe fixture neutered so `managed_backup_paths` emits no `skills` line, the pre-fix suite dies mid-run with no FAIL line and no summary; the fixed suite reports `FAIL: managed_backup_paths listed 'skills' 0 times, expected exactly 1` and runs to its summary (55 passed, 1 failed, exit 1).
- Fresh runs after the change: test-backup.sh 56/0, test-doc-counts.sh all checks passed, test-installer.sh 87/0.
- Independent review confirmed all 8 guards sit on genuine "found-nothing is ordinary and handled below" sites, none where a non-zero exit should abort, and that no guarded value can feed an empty string into a numeric comparison.

Review note, not applied: the five `ls -1d ... | wc -l` sites could alternatively adopt the file's existing `find`-instead-of-`ls` idiom (lines 533/655). Both remedies are correct; this PR keeps the minimal guard the issue asked for.