### PR TITLE
#980: add mkdir -p bootstrap to README install blocks and guard it

### DIFF
--- a/modules/agent-manager/README.md
+++ b/modules/agent-manager/README.md
@@ -67,6 +67,7 @@ source ~/.zshrc
 4. Copy the slash command to your Claude commands directory:
 
 ```bash
+mkdir -p ~/.claude/commands
 cp modules/agent-manager/commands/agents.md ~/.claude/commands/agents.md
 ```
 

--- a/modules/ask-context/README.md
+++ b/modules/ask-context/README.md
@@ -38,6 +38,7 @@ Transcript parsing details: every content block in a Claude Code transcript flus
 ## Manual Installation
 
 ```bash
+mkdir -p ~/.claude/hooks ~/.claude/rules
 cp modules/ask-context/hooks/ask-context-gate.py ~/.claude/hooks/
 cp modules/ask-context/rules/ask-context.md ~/.claude/rules/
 # Merge modules/ask-context/settings.partial.json into ~/.claude/settings.json

--- a/modules/autonomy/README.md
+++ b/modules/autonomy/README.md
@@ -18,10 +18,12 @@ Copy the rule files into your Claude configuration:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/autonomy.md ~/.claude/rules/autonomy.md
 cp rules/confusion-protocol.md ~/.claude/rules/confusion-protocol.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/autonomy.md .claude/rules/autonomy.md
 cp rules/confusion-protocol.md .claude/rules/confusion-protocol.md
 ```

--- a/modules/brand-naming/README.md
+++ b/modules/brand-naming/README.md
@@ -73,6 +73,7 @@ All APIs used by these commands are free with no authentication required:
 Copy the command files and the `/brand-check` gather script to your Claude Code config directory:
 
 ```bash
+mkdir -p ~/.claude/commands
 cp commands/brand.md ~/.claude/commands/brand.md
 cp commands/brand-check.md ~/.claude/commands/brand-check.md
 mkdir -p ~/.claude/lib

--- a/modules/browser-automation/README.md
+++ b/modules/browser-automation/README.md
@@ -18,9 +18,11 @@ Copy `rules/browser-automation.md` into your Claude configuration:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/browser-automation.md ~/.claude/rules/browser-automation.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/browser-automation.md .claude/rules/browser-automation.md
 ```
 

--- a/modules/capability-router/README.md
+++ b/modules/capability-router/README.md
@@ -35,6 +35,7 @@ The map notes which entries depend on external tooling and skips anything not in
 ## Manual Installation
 
 ```bash
+mkdir -p ~/.claude/commands ~/.claude/rules
 cp commands/capabilities.md ~/.claude/commands/capabilities.md
 cp rules/capability-map.md ~/.claude/rules/capability-map.md
 ```

--- a/modules/ccgm-doctor/README.md
+++ b/modules/ccgm-doctor/README.md
@@ -101,6 +101,7 @@ The checks are pure functions of the filesystem. They run in milliseconds and re
 ## Manual Installation
 
 ```bash
+mkdir -p ~/.claude/bin
 cp bin/ccgm-doctor ~/.claude/bin/ccgm-doctor
 chmod +x ~/.claude/bin/ccgm-doctor
 

--- a/modules/cloudflare/README.md
+++ b/modules/cloudflare/README.md
@@ -18,9 +18,11 @@ Copy `rules/cloudflare.md` into your Claude configuration:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/cloudflare.md ~/.claude/rules/cloudflare.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/cloudflare.md .claude/rules/cloudflare.md
 ```
 

--- a/modules/code-quality/README.md
+++ b/modules/code-quality/README.md
@@ -22,6 +22,7 @@ Copy `rules/code-quality.md` into your Claude configuration:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/code-quality.md ~/.claude/rules/code-quality.md
 cp rules/change-philosophy.md ~/.claude/rules/change-philosophy.md
 cp rules/latent-vs-deterministic.md ~/.claude/rules/latent-vs-deterministic.md
@@ -32,6 +33,7 @@ cp rules/spec-is-the-artifact.md ~/.claude/rules/spec-is-the-artifact.md
 cp rules/menu-gen-test.md ~/.claude/rules/menu-gen-test.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/code-quality.md .claude/rules/code-quality.md
 cp rules/change-philosophy.md .claude/rules/change-philosophy.md
 cp rules/latent-vs-deterministic.md .claude/rules/latent-vs-deterministic.md

--- a/modules/commands-extra/README.md
+++ b/modules/commands-extra/README.md
@@ -78,6 +78,7 @@ Copy the command files into your Claude configuration:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/commands
 cp commands/audit.md ~/.claude/commands/audit.md
 cp commands/pwv.md ~/.claude/commands/pwv.md
 cp commands/walkthrough.md ~/.claude/commands/walkthrough.md
@@ -101,6 +102,7 @@ cp -R skills/audit/scripts ~/.claude/skills/audit/scripts
 find ~/.claude/skills/audit/scripts -type d -name '__pycache__' -exec rm -rf {} +
 
 # Project-level
+mkdir -p .claude/commands
 cp commands/audit.md .claude/commands/audit.md
 cp commands/pwv.md .claude/commands/pwv.md
 cp commands/walkthrough.md .claude/commands/walkthrough.md

--- a/modules/commands-preamble/README.md
+++ b/modules/commands-preamble/README.md
@@ -62,6 +62,7 @@ Edit `~/.claude/preamble/preamble.md` to change what gets injected. Keep it comp
 
 ```bash
 # Copy the hook
+mkdir -p ~/.claude/hooks
 cp hooks/inject-preamble.py ~/.claude/hooks/
 chmod +x ~/.claude/hooks/inject-preamble.py
 

--- a/modules/commands-utility/README.md
+++ b/modules/commands-utility/README.md
@@ -42,6 +42,7 @@ Produces `docs/user-test-problems.md` and `docs/user-test-solutions.md` in the p
 ## Manual Installation
 
 ```bash
+mkdir -p ~/.claude/commands
 cp commands/cws-submit.md ~/.claude/commands/cws-submit.md
 cp commands/ccgm-sync.md ~/.claude/commands/ccgm-sync.md
 cp commands/user-test.md ~/.claude/commands/user-test.md

--- a/modules/common-mistakes/README.md
+++ b/modules/common-mistakes/README.md
@@ -21,9 +21,11 @@ Copy `rules/common-mistakes.md` into your Claude configuration:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/common-mistakes.md ~/.claude/rules/common-mistakes.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/common-mistakes.md .claude/rules/common-mistakes.md
 ```
 

--- a/modules/copycat/README.md
+++ b/modules/copycat/README.md
@@ -34,5 +34,6 @@ Clones (or reads) an external Claude Code config repo, analyzes its contents wit
 ## Manual Installation
 
 ```bash
+mkdir -p ~/.claude/commands
 cp commands/copycat.md ~/.claude/commands/copycat.md
 ```

--- a/modules/debugging/README.md
+++ b/modules/debugging/README.md
@@ -22,6 +22,7 @@ Delegates to an Opus 4.6 agent for deep root-cause analysis. Follows a strict 7-
 ## Manual Installation
 
 ```bash
+mkdir -p ~/.claude/commands
 cp commands/debug.md ~/.claude/commands/debug.md
 ```
 

--- a/modules/documentation/README.md
+++ b/modules/documentation/README.md
@@ -29,6 +29,7 @@ Spawns 4 parallel audit agents to find every gap between your documentation and 
 ## Manual Installation
 
 ```bash
+mkdir -p ~/.claude/commands
 cp commands/docupdate.md ~/.claude/commands/docupdate.md
 
 mkdir -p ~/.claude/lib

--- a/modules/git-workflow/README.md
+++ b/modules/git-workflow/README.md
@@ -19,9 +19,11 @@ Copy `rules/git-workflow.md` into your Claude configuration:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/git-workflow.md ~/.claude/rules/git-workflow.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/git-workflow.md .claude/rules/git-workflow.md
 ```
 

--- a/modules/identity/README.md
+++ b/modules/identity/README.md
@@ -60,6 +60,7 @@ If not using the CCGM installer:
 
 ```bash
 # Copy template files to your Claude Code rules directory
+mkdir -p ~/.claude/rules
 cp rules/soul.md ~/.claude/rules/soul.md
 cp rules/human-context.md ~/.claude/rules/human-context.md
 

--- a/modules/live-testing-guard/README.md
+++ b/modules/live-testing-guard/README.md
@@ -21,9 +21,11 @@ Copy `rules/live-testing-guard.md` into your Claude configuration:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/live-testing-guard.md ~/.claude/rules/live-testing-guard.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/live-testing-guard.md .claude/rules/live-testing-guard.md
 ```
 

--- a/modules/mcp-development/README.md
+++ b/modules/mcp-development/README.md
@@ -17,9 +17,11 @@ Installs a rules file covering MCP server development:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/mcp-development.md ~/.claude/rules/mcp-development.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/mcp-development.md .claude/rules/mcp-development.md
 ```
 

--- a/modules/model-vetting/README.md
+++ b/modules/model-vetting/README.md
@@ -19,9 +19,11 @@ Copy `rules/model-vetting.md` into your Claude configuration:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/model-vetting.md ~/.claude/rules/model-vetting.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/model-vetting.md .claude/rules/model-vetting.md
 ```
 

--- a/modules/output-formatting/README.md
+++ b/modules/output-formatting/README.md
@@ -20,9 +20,11 @@ Copy `rules/copy-paste-output.md` into your Claude configuration:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/copy-paste-output.md ~/.claude/rules/copy-paste-output.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/copy-paste-output.md .claude/rules/copy-paste-output.md
 ```
 

--- a/modules/pr-review-toolkit/README.md
+++ b/modules/pr-review-toolkit/README.md
@@ -38,6 +38,7 @@ mkdir -p ~/.claude/skills/scope-drift
 cp skills/scope-drift/SKILL.md ~/.claude/skills/scope-drift/SKILL.md
 
 # Rule
+mkdir -p ~/.claude/rules
 cp rules/fix-first-review.md ~/.claude/rules/fix-first-review.md
 ```
 

--- a/modules/relevance-injection/README.md
+++ b/modules/relevance-injection/README.md
@@ -71,6 +71,7 @@ re-run with `--write` there. See `commands/rules-scope.md` for detail.
 ## Manual Installation
 
 ```bash
+mkdir -p ~/.claude/rules ~/.claude/hooks ~/.claude/lib ~/.claude/commands
 cp rules/relevance-injection.md        ~/.claude/rules/relevance-injection.md
 cp hooks/relevance-inject.py           ~/.claude/hooks/relevance-inject.py
 cp hooks/instructions-loaded-log.py    ~/.claude/hooks/instructions-loaded-log.py

--- a/modules/research/README.md
+++ b/modules/research/README.md
@@ -32,5 +32,6 @@ For higher-quality, faster, and cheaper research, install **[lem-deepresearch](h
 ## Manual Installation
 
 ```bash
+mkdir -p ~/.claude/commands
 cp commands/research.md ~/.claude/commands/research.md
 ```

--- a/modules/rule-authoring/README.md
+++ b/modules/rule-authoring/README.md
@@ -30,11 +30,13 @@ The methodology is adapted from obra/superpowers' `writing-skills` discipline, w
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules ~/.claude/commands
 cp rules/rule-authoring.md ~/.claude/rules/rule-authoring.md
 cp rules/pressure-testing.md ~/.claude/rules/pressure-testing.md
 cp commands/pressure-test.md ~/.claude/commands/pressure-test.md
 
 # Project-level
+mkdir -p .claude/rules .claude/commands
 cp rules/rule-authoring.md .claude/rules/rule-authoring.md
 cp rules/pressure-testing.md .claude/rules/pressure-testing.md
 cp commands/pressure-test.md .claude/commands/pressure-test.md

--- a/modules/self-improving/README.md
+++ b/modules/self-improving/README.md
@@ -74,10 +74,12 @@ These are soft references, not hard dependencies. The self-improving module work
 
 ```bash
 # Rules
+mkdir -p ~/.claude/rules
 cp rules/self-improving.md ~/.claude/rules/self-improving.md
 cp rules/learnings-store.md ~/.claude/rules/learnings-store.md
 
 # Commands
+mkdir -p ~/.claude/commands
 cp commands/reflect.md ~/.claude/commands/reflect.md
 cp commands/consolidate.md ~/.claude/commands/consolidate.md
 cp commands/retro.md ~/.claude/commands/retro.md
@@ -95,6 +97,7 @@ mkdir -p ~/.claude/lib
 cp lib/learnings_store.py ~/.claude/lib/learnings_store.py
 
 # Hooks
+mkdir -p ~/.claude/hooks
 cp hooks/reflection-trigger.py ~/.claude/hooks/reflection-trigger.py
 cp hooks/precompact-reflection.py ~/.claude/hooks/precompact-reflection.py
 cp hooks/learnings-inject.py ~/.claude/hooks/learnings-inject.py

--- a/modules/settings/README.md
+++ b/modules/settings/README.md
@@ -55,6 +55,7 @@ The allow list intentionally does **not** grant these prefixes:
 
 ```bash
 # 1. Copy the base settings
+mkdir -p ~/.claude
 cp settings.base.json ~/.claude/settings.json
 
 # 2. Replace template variables

--- a/modules/shadcn/README.md
+++ b/modules/shadcn/README.md
@@ -16,9 +16,11 @@ Installs a rules file covering shadcn/ui workflows:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/shadcn.md ~/.claude/rules/shadcn.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/shadcn.md .claude/rules/shadcn.md
 ```
 

--- a/modules/skill-authoring/README.md
+++ b/modules/skill-authoring/README.md
@@ -21,9 +21,11 @@ Ported from the cross-platform skill-authoring checklist in EveryInc/compound-en
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/skill-authoring.md ~/.claude/rules/skill-authoring.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/skill-authoring.md .claude/rules/skill-authoring.md
 ```
 

--- a/modules/skillify/README.md
+++ b/modules/skillify/README.md
@@ -23,11 +23,13 @@ Inspired by the skillify pattern: every repeated failure becomes structurally un
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/commands ~/.claude/bin
 cp commands/skillify.md ~/.claude/commands/skillify.md
 cp bin/ccgm-skillify-check ~/.claude/bin/ccgm-skillify-check
 chmod +x ~/.claude/bin/ccgm-skillify-check
 
 # Project-level
+mkdir -p .claude/commands
 cp commands/skillify.md .claude/commands/skillify.md
 ```
 

--- a/modules/statusline/README.md
+++ b/modules/statusline/README.md
@@ -27,6 +27,7 @@ This module packages the statusline as a **first-class, installable unit**: it s
 ## Manual Installation
 
 ```bash
+mkdir -p ~/.claude
 cp statusline.sh ~/.claude/statusline.sh
 chmod +x ~/.claude/statusline.sh
 ```

--- a/modules/subagent-patterns/README.md
+++ b/modules/subagent-patterns/README.md
@@ -22,6 +22,7 @@ Installs rules covering subagent coordination:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/subagent-patterns.md ~/.claude/rules/subagent-patterns.md
 cp rules/concurrency-and-rate-limits.md ~/.claude/rules/concurrency-and-rate-limits.md
 mkdir -p ~/.claude/agents

--- a/modules/supabase/README.md
+++ b/modules/supabase/README.md
@@ -17,9 +17,11 @@ Copy `rules/supabase.md` into your Claude configuration:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/supabase.md ~/.claude/rules/supabase.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/supabase.md .claude/rules/supabase.md
 ```
 

--- a/modules/systematic-debugging/README.md
+++ b/modules/systematic-debugging/README.md
@@ -24,6 +24,7 @@ The parent rule is backed by four focused sub-rules that give agents named moves
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/systematic-debugging.md ~/.claude/rules/systematic-debugging.md
 cp rules/debugging.md ~/.claude/rules/debugging.md
 cp rules/root-cause-tracing.md ~/.claude/rules/root-cause-tracing.md
@@ -32,6 +33,7 @@ cp rules/condition-based-waiting.md ~/.claude/rules/condition-based-waiting.md
 cp rules/animals-vs-ghosts.md ~/.claude/rules/animals-vs-ghosts.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/systematic-debugging.md .claude/rules/systematic-debugging.md
 cp rules/debugging.md .claude/rules/debugging.md
 cp rules/root-cause-tracing.md .claude/rules/root-cause-tracing.md

--- a/modules/tailwind/README.md
+++ b/modules/tailwind/README.md
@@ -20,10 +20,12 @@ Installs two rules files covering Tailwind v4 architecture and a known gotcha:
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/tailwind.md ~/.claude/rules/tailwind.md
 cp rules/frontend-css.md ~/.claude/rules/frontend-css.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/tailwind.md .claude/rules/tailwind.md
 cp rules/frontend-css.md .claude/rules/frontend-css.md
 ```

--- a/modules/test-driven-development/README.md
+++ b/modules/test-driven-development/README.md
@@ -16,10 +16,12 @@ Covers new features (test each behavior incrementally), bug fixes (reproduce fir
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/test-driven-development.md ~/.claude/rules/test-driven-development.md
 cp rules/testing-anti-patterns.md ~/.claude/rules/testing-anti-patterns.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/test-driven-development.md .claude/rules/test-driven-development.md
 cp rules/testing-anti-patterns.md .claude/rules/testing-anti-patterns.md
 ```

--- a/modules/verification/README.md
+++ b/modules/verification/README.md
@@ -18,11 +18,13 @@ Covers tests, linting, builds, bug fixes, deployments, and type checking. Preven
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules
 cp rules/verification.md ~/.claude/rules/verification.md
 cp rules/evidence-tier-gate.md ~/.claude/rules/evidence-tier-gate.md
 cp rules/config-change-detection.md ~/.claude/rules/config-change-detection.md
 
 # Project-level
+mkdir -p .claude/rules
 cp rules/verification.md .claude/rules/verification.md
 cp rules/evidence-tier-gate.md .claude/rules/evidence-tier-gate.md
 cp rules/config-change-detection.md .claude/rules/config-change-detection.md

--- a/modules/writing-system/README.md
+++ b/modules/writing-system/README.md
@@ -26,6 +26,7 @@ The rules never touch code, identifiers, API names, or technical terms whose pla
 
 ```bash
 # Global (all projects)
+mkdir -p ~/.claude/rules ~/.claude/commands
 cp rules/writing-system.md ~/.claude/rules/writing-system.md
 cp commands/rewrite.md ~/.claude/commands/rewrite.md
 ```

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -313,7 +313,7 @@ for mod_dir in "$REPO_ROOT"/modules/*/; do
 done
 echo ""
 
-# --- Test: Manual Installation cp-block coverage (#951) ---
+# --- Test: Manual Installation cp block -- coverage (#951) + bootstrap (#980) ---
 # Both checks above compare module.json against the DISK (declared file
 # exists / shipped file is declared). Neither one looks at the README's
 # human-facing "Manual Installation" cp block, which is a hand-maintained
@@ -328,7 +328,49 @@ echo ""
 # interpolation as used in a `for` loop) and verifies every declared file
 # (module.json files[] key) is covered by at least one of them.
 #
-# This check is COVERAGE-ONLY, deliberately one-directional: it verifies
+# It checks TWO dimensions of the same block:
+#
+#   1. COVERAGE (#951) -- every declared file is copied by some `cp`.
+#   2. DIRECTORY BOOTSTRAP (#980) -- every `cp` destination directory is
+#      created by a preceding `mkdir -p` in the same section. #980 measured
+#      ~40 READMEs copying into `~/.claude/commands`, `~/.claude/rules`,
+#      `~/.claude/bin` and friends with no `mkdir -p`, so the documented
+#      from-scratch path died on its first line with "No such file or
+#      directory" for anyone who had not already run start.sh once.
+#
+# Bootstrap resolves a `cp`'s required destination directory statically:
+# a dest ending in '/' IS the directory; a dest whose basename matches the
+# source's is the copied file/dir itself, so its PARENT is the directory;
+# any other single-source non-recursive copy is a renaming file copy
+# (`cp settings.base.json ~/.claude/settings.json`) -- on a fresh tree the
+# dest directory never pre-exists, so real cp treats dest as a file path
+# and again only its PARENT must exist; anything else (multi-source or
+# recursive with a differing basename) is treated as a directory target.
+# A directory counts as bootstrapped by an earlier `mkdir -p X` where X is
+# that directory or any descendant of it (mkdir -p creates ancestors), by
+# any arg of a multi-arg `mkdir -p a b c`, or by an earlier `cp -R` that
+# already created it.
+#
+# Bootstrap is checked by STATIC PARSING, not by executing the block into a
+# scratch HOME (the approach #980 floats, and the method #970 used by hand).
+# README install blocks are not hermetic and not side-effect-free: across
+# the module set they `curl | tar -xz` from GitHub Releases, `git clone`,
+# call `gh`, run `claude mcp add`, `bash postInstall.sh`, `npm install`,
+# `source ~/.zshrc`, and `touch` opt-in flag files. Executing them in CI
+# would make this suite network-dependent, slow, and capable of mutating
+# the developer's real environment when a `~` slipped past the HOME
+# redirect. Static parsing gives the same signal for the property actually
+# under test -- "is the destination directory created first?" -- with none
+# of that exposure.
+#
+# When a `cp` destination cannot be resolved with confidence, bootstrap
+# SKIPS the line rather than guessing: `$VAR`/`${VAR}` or glob destinations
+# (document-review's `for agent in ...; do cp ... "~/.claude/agents/${agent}-reviewer.md"`)
+# and absolute paths outside `~` (docs-for-agents' `/path/to/your/project`
+# placeholder). A false failure here would train readers to ignore this
+# guard; a miss only leaves an already-existing gap unreported.
+#
+# The COVERAGE check is one-directional, deliberately: it verifies
 # every declared file is copied by *something* in the cp block, but does
 # NOT verify the block copies *nothing else*. A block that recursively
 # globs a whole directory (e.g. `cp -R skills/foo/*`) passes this check even
@@ -369,11 +411,12 @@ echo ""
 # of scope for that PR and tracked as #970. #970 fixed all three READMEs,
 # so the list is empty again -- add an entry here only for a newly
 # discovered, genuinely out-of-scope gap.
-echo "--- Checking Manual Installation cp-block coverage (module.json vs README) ---"
+echo "--- Checking Manual Installation cp blocks (file coverage + directory bootstrap) ---"
 MANUAL_INSTALL_REPORT=$(REPO_ROOT="$REPO_ROOT" python3 - <<'PYEOF'
 import json
 import os
 import re
+import shlex
 from pathlib import Path
 
 REPO_ROOT = Path(os.environ["REPO_ROOT"])
@@ -383,6 +426,10 @@ HEADING_RE = re.compile(r'^##\s+(Manual Installation|Install|Installation)\s*$',
 ANY_HEADING_RE = re.compile(r'^##\s+', re.MULTILINE)
 CP_LINE_RE = re.compile(r'cp\s+(-[A-Za-z]+\s+)?"?(?:modules/[\w.-]+/)?([\w${}/.*-]+)"?')
 EXEMPT_FILENAMES = {"settings.partial.json"}
+
+FENCE_RE = re.compile(r'^\s*```')
+SHELL_SPLIT_RE = re.compile(r'&&|\|\||;|\|')
+SHELL_LEAD_TOKENS = {"do", "then", "else", "sudo"}
 
 # module -> tracking issue for a known, out-of-scope pre-existing gap.
 KNOWN_GAPS = {}
@@ -411,6 +458,146 @@ def parse_cp_lines(section):
         flags = m.group(1) or ""
         out.append((bool(re.search(r'[Rr]', flags)), m.group(2)))
     return out
+
+
+def shell_lines(section):
+    """Yield logical shell lines from the section's fenced code blocks.
+
+    Physical lines ending in `\\` are joined with the following line first, so
+    a `cp <src> \\` / `<dest>` pair (agent-native, ce-review,
+    compound-knowledge, document-review, onboarding, pr-feedback,
+    session-history, ship-readiness, todos all wrap this way) parses as one
+    command that has a destination, instead of two half-commands that do not.
+    Restricting to fenced blocks keeps prose that merely mentions `cp` out of
+    the parse.
+    """
+    in_fence = False
+    pending = ""
+    for raw in section.split("\n"):
+        if FENCE_RE.match(raw):
+            in_fence = not in_fence
+            pending = ""
+            continue
+        if not in_fence:
+            continue
+        line = raw.rstrip()
+        if line.endswith("\\"):
+            pending += line[:-1].rstrip() + " "
+            continue
+        yield pending + line
+        pending = ""
+    if pending:
+        yield pending
+
+
+def shell_commands(section):
+    """Yield an argv token list for each shell command in the install block."""
+    for line in shell_lines(section):
+        text = line.strip()
+        if text.startswith("#"):
+            continue
+        for part in SHELL_SPLIT_RE.split(text):
+            part = part.strip()
+            if not part:
+                continue
+            try:
+                tokens = shlex.split(part, posix=True)
+            except ValueError:
+                continue  # unbalanced quotes -- not confidently parseable
+            while tokens and tokens[0] in SHELL_LEAD_TOKENS:
+                tokens = tokens[1:]
+            if tokens:
+                yield tokens
+
+
+def norm_dir(path):
+    stripped = path.rstrip('/')
+    return stripped if stripped else '/'
+
+
+def is_unresolvable(path):
+    return '$' in path or '*' in path or '?' in path
+
+
+def required_dest_dir(recursive, sources, dest):
+    """The directory a `cp` needs to already exist. See the header comment."""
+    if dest.endswith('/'):
+        return norm_dir(dest)
+    if len(sources) == 1 and not is_unresolvable(sources[0]):
+        src = sources[0]
+        # Same basename: dest names the copied file/dir itself, so only its
+        # parent has to pre-exist (with -R, cp creates the last component).
+        if Path(src).name == Path(dest).name:
+            return norm_dir(str(Path(dest).parent))
+        # Renaming file copy (`cp settings.base.json ~/.claude/settings.json`):
+        # with a single non-recursive source, real cp only treats dest as a
+        # directory when that directory already exists -- which on a fresh
+        # tree it never does -- so dest is a file path and its parent is what
+        # must pre-exist. Restricting this to matching extensions would
+        # misfire on extensionless renames (`cp bin/tool ~/.claude/bin/t2`),
+        # demanding a mkdir of the destination FILE. The residual trade-off
+        # (a doc line intending dest as a bare directory, `cp a.md ~/x/dir`,
+        # is under-required to its parent) is a mis-install cp would not
+        # error on, so bootstrap cannot see it either way; 0 instances exist.
+        if not recursive:
+            return norm_dir(str(Path(dest).parent))
+    return norm_dir(dest)
+
+
+def dirs_created_by(recursive, sources, dest):
+    """Directories a `cp -R` itself creates, satisfying later copies into them."""
+    if not recursive:
+        return []
+    made = []
+    for src in sources:
+        if is_unresolvable(src):
+            continue
+        if dest.endswith('/') or Path(src).name != Path(dest).name:
+            made.append(norm_dir(dest.rstrip('/') + '/' + Path(src).name))
+        else:
+            made.append(norm_dir(dest))
+    return made
+
+
+def is_bootstrapped(needed, made):
+    # `mkdir -p a/b/c` creates a/b too, so a descendant entry satisfies it.
+    return any(d == needed or d.startswith(needed + '/') for d in made)
+
+
+def missing_bootstrap(section):
+    """Return [(directory, offending destination)] for un-mkdir'd cp targets."""
+    made = []
+    missing = []
+    reported = set()
+    for tokens in shell_commands(section):
+        if tokens[0] == 'mkdir':
+            for arg in tokens[1:]:
+                if not arg.startswith('-'):
+                    made.append(norm_dir(arg))
+            continue
+        if tokens[0] != 'cp':
+            continue
+        flags = ''
+        operands = []
+        for tok in tokens[1:]:
+            if tok.startswith('-') and len(tok) > 1:
+                flags += tok
+            else:
+                operands.append(tok)
+        if len(operands) < 2:
+            continue
+        recursive = bool(re.search(r'[Rr]', flags))
+        sources, dest = operands[:-1], operands[-1]
+        # Unresolvable or user-supplied absolute destinations are skipped,
+        # never guessed at -- a false failure is worse than a miss here.
+        if is_unresolvable(dest) or dest.startswith('/'):
+            continue
+        needed = required_dest_dir(recursive, sources, dest)
+        if not is_bootstrapped(needed, made) and needed not in reported:
+            reported.add(needed)
+            missing.append((needed, dest))
+        made.extend(dirs_created_by(recursive, sources, dest))
+    return missing
 
 
 def covers(relpath, cp_lines):
@@ -505,6 +692,11 @@ for mod_dir in sorted(MODULES.iterdir()):
         for relpath in missing:
             print(f"MISSING\t{mod_name}\t{relpath}")
 
+    # Dimension 2 (#980): destination directories must be created first.
+    # KNOWN_GAPS allowlists file-coverage gaps only, so it does not apply.
+    for needed, dest in missing_bootstrap(section):
+        print(f"NOMKDIR\t{mod_name}\t'{needed}' (copy destination: {dest})")
+
 print(f"CHECKED\t{checked}")
 print(f"SKIPPED_COUNT\t{skipped}")
 for mod_name, reason in skip_reasons:
@@ -518,6 +710,9 @@ while IFS=$'\t' read -r kind mod_name detail; do
     MISSING)
       fail "$mod_name: Manual Installation cp block never installs '$detail' (declared in module.json but no cp/glob covers it)"
       ;;
+    NOMKDIR)
+      fail "$mod_name: Manual Installation block copies into $detail with no preceding 'mkdir -p' -- the documented steps fail against a fresh ~/.claude"
+      ;;
     STALE)
       fail "$mod_name: $detail"
       ;;
@@ -525,7 +720,7 @@ while IFS=$'\t' read -r kind mod_name detail; do
       fail "$mod_name: $detail -- cannot check Manual Installation coverage"
       ;;
   esac
-done < <(printf '%s\n' "$MANUAL_INSTALL_REPORT" | grep -E '^(MISSING|STALE|DECODE_FAIL)')
+done < <(printf '%s\n' "$MANUAL_INSTALL_REPORT" | grep -E '^(MISSING|NOMKDIR|STALE|DECODE_FAIL)')
 
 checked_count=$(printf '%s\n' "$MANUAL_INSTALL_REPORT" | grep '^CHECKED' | cut -f2)
 skipped_count=$(printf '%s\n' "$MANUAL_INSTALL_REPORT" | grep '^SKIPPED_COUNT' | cut -f2)
@@ -534,7 +729,7 @@ skipped_count=$(printf '%s\n' "$MANUAL_INSTALL_REPORT" | grep '^SKIPPED_COUNT' |
 # output, or its silence gets mistaken for completeness.
 echo "  Checked $checked_count module(s), skipped ${skipped_count:-0} (no install section or no parseable cp command)"
 if [ -n "$checked_count" ] && [ "$checked_count" -gt 0 ]; then
-  pass "Manual Installation cp-block coverage checked across $checked_count module(s)"
+  pass "Manual Installation cp-block coverage + directory bootstrap checked across $checked_count module(s)"
 fi
 if [ "$VERBOSE" = "1" ] && [ -n "$skipped_count" ] && [ "$skipped_count" -gt 0 ]; then
   echo "  Skipped modules:"


### PR DESCRIPTION
Closes #980

Module READMEs document a Manual Installation cp block, and most of those blocks copy into `~/.claude/commands`, `~/.claude/rules`, `~/.claude/bin` and friends without a preceding `mkdir -p` — so the documented from-scratch path fails on its first line against a fresh `~/.claude`. This PR fixes every affected README and adds an automated check so the gap cannot recur.

## Part 1 — READMEs

61 `mkdir -p` lines added across 39 READMEs. Placement matches each README's own convention: one mkdir at the head of each contiguous copy run (multi-arg where a run needs several directories, the style adversarial-review already used; paired where the README already paired, like ccgm-doctor). Project-level `.claude/rules` / `.claude/commands` targets are covered too. No block was restructured — the diffs are pure insertions.

## Part 2 — the guard

The #951 cp-block check in `tests/test-modules.sh` now checks a second dimension of the same section: every parsed cp destination directory must be created by a preceding `mkdir -p` (or an earlier `cp -R` that creates it). New `NOMKDIR` report kind fails with the module, the missing directory, and the offending destination.

The check is static parsing, not block execution — install blocks are not hermetic (`curl | tar -xz`, `git clone`, `gh`, `claude mcp add`, `bash postInstall.sh`, `source ~/.zshrc`), so executing them in CI would be network-dependent and able to mutate a real environment. The rationale is recorded in the guard's header. Unresolvable destinations (`$VAR` loops, absolute placeholder paths) are skipped, never guessed at. Skip semantics and the checked/skipped counts (67/11) are unchanged, byte-identical reasons included. The over-copy limitation stays documented and unimplemented — that is #983.

## Verification

- Full `tests/test-modules.sh`: 1707 passed, 0 failed, 67/11 counts unchanged.
- The new guard run against the pre-fix (origin/main) READMEs reports 71 missing-bootstrap failures across exactly the 39 modules this PR fixes — detection set equals fix set, both directions.
- All 39 fixed blocks (mkdir/cp/chmod lines) executed against an empty scratch HOME by an independent review harness: 0 real failures; the same harness on origin/main content fails every sampled module with "No such file or directory".
- Mutation proofs: deleting an added mkdir (batch and paired styles, plus multi-arg lines) makes the guard fail naming the module and directory; a mkdir moved after its cp is still flagged (order-aware).
- 16-case parser unit fixture table (continuations, multi-arg mkdir, cp -R creation, `&&` chains, for-loops, renames, `$VAR` skips) all correct; 7-case re-verification after review fixes below.
- `tests/test-no-personal-data.sh`, `tests/test-doc-counts.sh`, `tests/test-installer.sh` all pass.

## Review fixes applied

- Rename classification broadened from "same extension" to any single-source non-recursive copy with a differing basename — closes a latent wrong-mkdir demand on extensionless renames; residual trade-off documented in the code.
- Speculative `expand_braces` helper removed (zero brace-expansion mkdirs exist in the corpus; multi-arg mkdir covers the real cases).