### PR TITLE
#982: sweep pipefail/SIGPIPE sites across the audit skill test suites

### DIFF
--- a/modules/commands-extra/skills/audit/tests/test-audit-manifest-complete.sh
+++ b/modules/commands-extra/skills/audit/tests/test-audit-manifest-complete.sh
@@ -133,7 +133,11 @@ rm -f "$FAKE_FILE"
 
 if [[ $PROBE_EXIT -ne 0 ]]; then
   # Gate correctly detected the unregistered file
-  if echo "$PROBE_OUTPUT" | grep -q "_unregistered_test_fixture.py"; then
+  # Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+  # producer if grep exits on its first match before the producer finishes
+  # writing, turning a genuine match into a reported failure (see #943,
+  # #945). A herestring has no second process to race against.
+  if grep -q "_unregistered_test_fixture.py" <<< "$PROBE_OUTPUT"; then
     pass "non-vacuity: gate FAILS when an unregistered file is present (correctly detected ${FAKE_FILE##*/})"
   else
     pass "non-vacuity: gate FAILS when an unregistered file is present (exit ${PROBE_EXIT})"

--- a/modules/commands-extra/skills/audit/tests/test-baseline.sh
+++ b/modules/commands-extra/skills/audit/tests/test-baseline.sh
@@ -414,7 +414,11 @@ else
 fi
 
 # Stderr should contain an actionable error message
-if echo "$T3_STDERR" | grep -qi "error\|ERROR\|invalid\|not valid"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if grep -qi "error\|ERROR\|invalid\|not valid" <<< "$T3_STDERR"; then
   pass "t3: stderr contains actionable error message"
 else
   fail "t3: stderr does not mention 'error' or 'invalid' (got: $T3_STDERR)"
@@ -560,7 +564,8 @@ else
   fail "t6: missing --baseline exits $T6_EXIT (expected 1)"
 fi
 
-if echo "$T6_STDERR" | grep -qi "error\|ERROR\|cannot\|not found"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -qi "error\|ERROR\|cannot\|not found" <<< "$T6_STDERR"; then
   pass "t6: stderr contains actionable error for missing baseline"
 else
   fail "t6: stderr does not mention error for missing baseline (got: $T6_STDERR)"

--- a/modules/commands-extra/skills/audit/tests/test-detect-defaults.sh
+++ b/modules/commands-extra/skills/audit/tests/test-detect-defaults.sh
@@ -212,7 +212,16 @@ fi
 if [ -f "$CONFIG_FILE" ]; then
   # Check that --ours only appears in a prohibition context, not as an instruction
   # A line that uses --ours without "NEVER" before it on the same line is the old behaviour
-  if grep 'git checkout --ours' "$CONFIG_FILE" | grep -qv 'NEVER'; then
+  # Capture the producer's output, then herestring into the early-exiting
+  # `grep -qv`: a live `producer | grep -q...` pipe can SIGPIPE-kill the
+  # producer if grep exits on its first match before the producer finishes
+  # writing (see #943, #945). A herestring has no second process to race
+  # against. `|| true` preserves the original no-match-is-fine behavior.
+  # The `-n` guard matters here specifically because of `-v`: a herestring
+  # of an empty string is one blank line, not zero bytes, and a blank line
+  # does not contain "NEVER" -- `-v` would wrongly select it as a match.
+  OURS_LINES=$(grep 'git checkout --ours' "$CONFIG_FILE" || true)
+  if [ -n "$OURS_LINES" ] && grep -qv 'NEVER' <<< "$OURS_LINES"; then
     fail "multi-agent-config.md must not instruct 'git checkout --ours' (use NEVER... to prohibit it)" \
       "found in $CONFIG_FILE"
   else

--- a/modules/commands-extra/skills/audit/tests/test-diff-mode.sh
+++ b/modules/commands-extra/skills/audit/tests/test-diff-mode.sh
@@ -194,13 +194,17 @@ git -C "$REPO1" diff --name-only -z "HEAD~1...HEAD" > "$CHANGES_Z1"
 
 PATHS1=$(read_z_file "$CHANGES_Z1")
 
-if echo "$PATHS1" | grep -qxF "modified.js"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if grep -qxF "modified.js" <<< "$PATHS1"; then
   pass "git diff --name-only -z HEAD~1...HEAD includes 'modified.js'"
 else
   fail "git diff --name-only -z HEAD~1...HEAD should include 'modified.js' (got: $PATHS1)"
 fi
 
-if ! echo "$PATHS1" | grep -qxF "clean.js"; then
+if ! grep -qxF "clean.js" <<< "$PATHS1"; then
   pass "git diff --name-only -z HEAD~1...HEAD does NOT include 'clean.js' (unchanged)"
 else
   fail "git diff --name-only -z HEAD~1...HEAD should NOT include 'clean.js'"
@@ -220,7 +224,8 @@ with open(sys.argv[2], "w", encoding="utf-8") as out:
 PYEOF
 
 TXT1_CONTENT=$(cat "$CHANGES_TXT1")
-if echo "$TXT1_CONTENT" | grep -qxF "modified.js"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -qxF "modified.js" <<< "$TXT1_CONTENT"; then
   pass "changed-files.txt (from python3 -z parse) contains 'modified.js'"
 else
   fail "changed-files.txt should contain 'modified.js'"
@@ -281,13 +286,14 @@ git -C "$REPO1" diff --name-only -z --staged > "$STAGED_Z1"
 
 STAGED_PATHS=$(read_z_file "$STAGED_Z1")
 
-if echo "$STAGED_PATHS" | grep -qxF "staged.js"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -qxF "staged.js" <<< "$STAGED_PATHS"; then
   pass "git diff --name-only -z --staged includes 'staged.js'"
 else
   fail "git diff --name-only -z --staged should include 'staged.js' (got: $STAGED_PATHS)"
 fi
 
-if ! echo "$STAGED_PATHS" | grep -qxF "modified.js"; then
+if ! grep -qxF "modified.js" <<< "$STAGED_PATHS"; then
   pass "git diff --name-only -z --staged does NOT include committed 'modified.js'"
 else
   fail "git diff --name-only -z --staged should NOT include already-committed 'modified.js'"
@@ -325,7 +331,8 @@ git -C "$REPO2" diff --name-only -z "HEAD~1...HEAD" > "$EVIL_Z"
 EVIL_PATHS=$(read_z_file "$EVIL_Z")
 
 # The hostile file should appear as inert data
-if echo "$EVIL_PATHS" | grep -qF "$EVIL_NAME"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -qF "$EVIL_NAME" <<< "$EVIL_PATHS"; then
   pass "hostile filename '$EVIL_NAME' appears in changed-set as inert data"
 else
   fail "hostile filename '$EVIL_NAME' missing from changed-set (got: $EVIL_PATHS)"
@@ -517,7 +524,13 @@ else
 fi
 
 # Critical: path round-trips byte-exact through .z and back
-EVIL_Z_ROUNDTRIP=$(read_z_file "$EVIL_Z" | head -1)
+# `|| true` guards the bare assignment: `producer | head -1` can SIGPIPE-kill
+# the producer (read_z_file's python3) once head has read its one line, and
+# under pipefail that turns a genuine, correct result into a script abort
+# instead of a reported failure (see #943, #945; the priority case for this
+# shape was test-doc-counts.sh:136). The captured value is unaffected --
+# head's output is what command substitution captures, not python3's exit.
+EVIL_Z_ROUNDTRIP=$(read_z_file "$EVIL_Z" | head -1 || true)
 if [ "$EVIL_Z_ROUNDTRIP" = "$EVIL_NAME" ]; then
   pass "hostile filename: path round-trips byte-exact through null-delimited .z file"
 else
@@ -762,13 +775,14 @@ if command -v gitleaks >/dev/null 2>&1; then
 
   CHANGED_PATHS3=$(read_z_file "$CHANGES_Z3")
 
-  if echo "$CHANGED_PATHS3" | grep -qxF "changed.js"; then
+  # Herestring, not a pipe: see the identical rationale above (#943, #945).
+  if grep -qxF "changed.js" <<< "$CHANGED_PATHS3"; then
     pass "spine post-filter fixture: 'changed.js' in changed set"
   else
     fail "spine post-filter fixture: 'changed.js' should be in changed set (got: $CHANGED_PATHS3)"
   fi
 
-  if ! echo "$CHANGED_PATHS3" | grep -qxF "unchanged.js"; then
+  if ! grep -qxF "unchanged.js" <<< "$CHANGED_PATHS3"; then
     pass "spine post-filter fixture: 'unchanged.js' NOT in changed set"
   else
     fail "spine post-filter fixture: 'unchanged.js' should NOT be in changed set"
@@ -974,7 +988,8 @@ sys.exit(1)
 PYEOF
 )
 
-if echo "$EMPTY_OUTPUT" | grep -q "no changed files"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "no changed files" <<< "$EMPTY_OUTPUT"; then
   pass "empty diff: documented exit message 'no changed files -- nothing to audit' emitted"
 else
   fail "empty diff: expected 'no changed files' message from empty-set guard"
@@ -1051,26 +1066,27 @@ M_SECTION=$(awk '/^### Phase M2\.1/,/^### Phase M2\.5/' "$SKILL_MD" 2>/dev/null 
 SINGLE_SECTION=$(awk '/^### Phase 1\.5/,/^### Phase 2/' "$SKILL_MD" 2>/dev/null || true)
 set -e
 
-if echo "$M_SECTION" | grep -q "changed-files.z"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "changed-files.z" <<< "$M_SECTION"; then
   pass "SKILL.md M-phase: changed-files.z artifact is documented"
 else
   fail "SKILL.md M-phase: Phase M2.1 must document the changed-files.z artifact"
 fi
 
-if echo "$SINGLE_SECTION" | grep -q "changed-files.z"; then
+if grep -q "changed-files.z" <<< "$SINGLE_SECTION"; then
   pass "SKILL.md --single path: changed-files.z artifact is documented"
 else
   fail "SKILL.md --single path: Phase 1.5 must document the changed-files.z artifact"
 fi
 
 # 5d. The diff-filter step (post-filter model) appears in BOTH paths
-if echo "$M_SECTION" | grep -q "diff.filter\|diff_filter\|filter.*spine\|spine.*filter"; then
+if grep -q "diff.filter\|diff_filter\|filter.*spine\|spine.*filter" <<< "$M_SECTION"; then
   pass "SKILL.md M-phase: spine post-filter step is documented"
 else
   fail "SKILL.md M-phase: Phase M2.1 must document the spine post-filter step"
 fi
 
-if echo "$SINGLE_SECTION" | grep -q "diff.filter\|diff_filter\|filter.*spine\|spine.*filter\|post.filter\|postfilter"; then
+if grep -q "diff.filter\|diff_filter\|filter.*spine\|spine.*filter\|post.filter\|postfilter" <<< "$SINGLE_SECTION"; then
   pass "SKILL.md --single path: spine post-filter step is documented"
 else
   fail "SKILL.md --single path: Phase 1.5 must document the spine post-filter step"

--- a/modules/commands-extra/skills/audit/tests/test-emit-findings.sh
+++ b/modules/commands-extra/skills/audit/tests/test-emit-findings.sh
@@ -156,7 +156,11 @@ JSON
 T1_OUT=$(AUDIT_FINDINGS_PATH="$T1_DIR/findings.jsonl" \
   python3 "$EMIT_SCRIPT" "$T1_INPUT" 2>&1 && echo "exit:0" || echo "exit:1")
 
-if echo "$T1_OUT" | grep -q "exit:1"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if grep -q "exit:1" <<< "$T1_OUT"; then
   fail "t1: emitter exit code" "$T1_OUT"
 else
   pass "t1: emitter exited 0"

--- a/modules/commands-extra/skills/audit/tests/test-exclusion.sh
+++ b/modules/commands-extra/skills/audit/tests/test-exclusion.sh
@@ -211,7 +211,11 @@ else
   fail "t2: $TYPE_RECS type records survived (expected 2)"
 fi
 
-if echo "$FILTER_STDERR" | grep -q "dropped 2 junk-path"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if grep -q "dropped 2 junk-path" <<< "$FILTER_STDERR"; then
   pass "t2: stderr reports dropped count (2)"
 else
   fail "t2: stderr drop count wrong (got: $FILTER_STDERR)"

--- a/modules/commands-extra/skills/audit/tests/test-merge.sh
+++ b/modules/commands-extra/skills/audit/tests/test-merge.sh
@@ -1005,7 +1005,11 @@ else
   fail "t8a: tool-detection finding was incorrectly dropped by dismissed verdict"
 fi
 
-if echo "$T8A_STDERR" | grep -q "WARNING.*non-hybrid\|WARNING.*not dismissible"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if grep -q "WARNING.*non-hybrid\|WARNING.*not dismissible" <<< "$T8A_STDERR"; then
   pass "t8a: stderr warning emitted for attempted non-hybrid dismissal"
 else
   fail "t8a: no warning on stderr for attempted non-hybrid dismissal (got: $T8A_STDERR)"
@@ -1069,7 +1073,8 @@ else
 fi
 
 # No bare traceback should ever leak.
-if echo "$T8B_STDERR" | grep -q "Traceback\|TypeError"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "Traceback\|TypeError" <<< "$T8B_STDERR"; then
   fail "t8b: bare Python traceback leaked to stderr (got: $T8B_STDERR)"
 else
   pass "t8b: no bare traceback in stderr"
@@ -1234,13 +1239,14 @@ else
   fail "t8d: finding unexpectedly dropped -- AB=$T8D_PRESENT_AB, BA=$T8D_PRESENT_BA"
 fi
 
-if echo "$T8D_STDERR_AB" | grep -q "WARNING.*conflict\|WARNING.*unanimity\|WARNING.*dismissal"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "WARNING.*conflict\|WARNING.*unanimity\|WARNING.*dismissal" <<< "$T8D_STDERR_AB"; then
   pass "t8d: warning emitted for conflicting verdicts (A+B order)"
 else
   fail "t8d: no conflict warning in A+B order (stderr: $T8D_STDERR_AB)"
 fi
 
-if echo "$T8D_STDERR_BA" | grep -q "WARNING.*conflict\|WARNING.*unanimity\|WARNING.*dismissal"; then
+if grep -q "WARNING.*conflict\|WARNING.*unanimity\|WARNING.*dismissal" <<< "$T8D_STDERR_BA"; then
   pass "t8d: warning emitted for conflicting verdicts (B+A order)"
 else
   fail "t8d: no conflict warning in B+A order (stderr: $T8D_STDERR_BA)"
@@ -1321,37 +1327,38 @@ print("none")
 PYEOF
 )"
 
-if echo "$T9_FIELDS" | grep -q "path=src/util.js"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "path=src/util.js" <<< "$T9_FIELDS"; then
   pass "t9: absolute worktree path normalized to repo-relative (src/util.js)"
 else
   fail "t9: path not normalized ($T9_FIELDS)"
 fi
-if echo "$T9_FIELDS" | grep -q "line=60"; then
+if grep -q "line=60" <<< "$T9_FIELDS"; then
   pass "t9: comma-list line coerced to first integer (60)"
 else
   fail "t9: line not coerced ($T9_FIELDS)"
 fi
-if echo "$T9_FIELDS" | grep -q "det=llm"; then
+if grep -q "det=llm" <<< "$T9_FIELDS"; then
   pass "t9: missing detection defaulted to llm"
 else
   fail "t9: detection not defaulted ($T9_FIELDS)"
 fi
-if echo "$T9_FIELDS" | grep -q "msg=yes"; then
+if grep -q "msg=yes" <<< "$T9_FIELDS"; then
   pass "t9: message synthesized from title/description"
 else
   fail "t9: message not synthesized ($T9_FIELDS)"
 fi
-if echo "$T9_FIELDS" | grep -q "extra=none"; then
+if grep -q "extra=none" <<< "$T9_FIELDS"; then
   pass "t9: redundant flat keys stripped (schema-clean output)"
 else
   fail "t9: flat keys leaked into output ($T9_FIELDS)"
 fi
-if echo "$T9_STDERR" | grep -q "dropped 0 invalid"; then
+if grep -q "dropped 0 invalid" <<< "$T9_STDERR"; then
   pass "t9: summary reports 'dropped 0' (no silent loss)"
 else
   # 'dropped 0' only prints in the write summary; without --output the loud
   # line is suppressed when total_dropped==0. Accept either: no drop warning.
-  if echo "$T9_STDERR" | grep -q "dropped [1-9]"; then
+  if grep -q "dropped [1-9]" <<< "$T9_STDERR"; then
     fail "t9: merge reported a nonzero drop for a recoverable finding ($T9_STDERR)"
   else
     pass "t9: no nonzero-drop warning emitted (variant fully recovered)"
@@ -1400,7 +1407,8 @@ if [[ $T10_EXIT -eq 0 ]]; then
 else
   fail "t10: merge exits $T10_EXIT (expected 0)"
 fi
-if echo "$T10_STDERR" | grep -q "dropped 1 invalid finding"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "dropped 1 invalid finding" <<< "$T10_STDERR"; then
   pass "t10: loud 'dropped 1 invalid finding(s)' headline emitted"
 else
   fail "t10: no loud dropped-count headline (got: $T10_STDERR)"

--- a/modules/commands-extra/skills/audit/tests/test-orchestration.sh
+++ b/modules/commands-extra/skills/audit/tests/test-orchestration.sh
@@ -319,7 +319,11 @@ PYEOF
 )
 set -e
 
-if echo "$BALANCE_CHECK" | grep -q "^OK"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if grep -q "^OK" <<< "$BALANCE_CHECK"; then
   pass "assign-packs.py: worker pack distribution is balanced (no overload, no starvation) ($BALANCE_CHECK)"
 else
   fail "assign-packs.py: pack distribution imbalanced ($BALANCE_CHECK)"
@@ -367,7 +371,8 @@ PYEOF
 )
 set -e
 
-if echo "$SMALL_CHECK" | grep -q "^OK"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "^OK" <<< "$SMALL_CHECK"; then
   pass "assign-packs.py: surplus workers get empty lists ($SMALL_CHECK)"
 else
   fail "assign-packs.py: surplus workers check failed: $SMALL_CHECK"
@@ -716,13 +721,14 @@ done
 set +e
 SINGLE_SECTION=$(awk 'found && /^## /{exit} /^## Single-Session Mode/{found=1} found' "$SKILL_MD" 2>/dev/null || true)
 set -e
-if echo "$SINGLE_SECTION" | grep -q "spine/run.sh\|spine.*run.sh"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "spine/run.sh\|spine.*run.sh" <<< "$SINGLE_SECTION"; then
   pass "SKILL.md: --single section references spine/run.sh"
 else
   fail "SKILL.md: --single section must reference spine/run.sh"
 fi
 
-if echo "$SINGLE_SECTION" | grep -q "merge-findings.py"; then
+if grep -q "merge-findings.py" <<< "$SINGLE_SECTION"; then
   pass "SKILL.md: --single section references merge-findings.py"
 else
   fail "SKILL.md: --single section must reference merge-findings.py"

--- a/modules/commands-extra/skills/audit/tests/test-pack-accessibility.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-accessibility.sh
@@ -82,7 +82,11 @@ run_registry_with_a11y_pack() {
 # ---------------------------------------------------------------------------
 echo "--- Test 1: pack.json validates (stdlib)"
 result=""
-if result=$(validate_pack_file "${PACK_DIR}/pack.json" 2>&1) && echo "${result}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if result=$(validate_pack_file "${PACK_DIR}/pack.json" 2>&1) && grep -q "^VALID$" <<< "${result}"; then
     pass "accessibility/pack.json validates against pack.schema.json"
 else
     fail "accessibility/pack.json failed validation: ${result}"
@@ -99,9 +103,10 @@ output=$(python3 "${LINTER}" \
     --rubric "${RUBRIC}" 2>&1) || exit_code=$?
 
 # We want accessibility to appear as PASS (not FAIL) in linter output
-if echo "${output}" | grep -q "^PASS: accessibility"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "^PASS: accessibility" <<< "${output}"; then
     pass "checks.md contains all required sections (lint-pack.py passes)"
-elif echo "${output}" | grep -q "^FAIL: accessibility"; then
+elif grep -q "^FAIL: accessibility" <<< "${output}"; then
     fail "checks.md missing required section: ${output}"
 else
     fail "lint-pack.py output did not mention accessibility pack: ${output}"
@@ -147,9 +152,10 @@ output=$(python3 "${LINTER}" \
     --packs-dir "${AUDIT_DIR}/packs" \
     --rubric "${RUBRIC}" 2>&1) || exit_code=$?
 
-if [ "${exit_code}" -eq 0 ] && echo "${output}" | grep -q "^PASS: accessibility"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${exit_code}" -eq 0 ] && grep -q "^PASS: accessibility" <<< "${output}"; then
     pass "lint-pack.py exits 0 and reports PASS: accessibility"
-elif echo "${output}" | grep -q "^FAIL: accessibility"; then
+elif grep -q "^FAIL: accessibility" <<< "${output}"; then
     fail "lint-pack.py reports FAIL for accessibility: ${output}"
 else
     # Other packs may fail; we only care that accessibility is PASS and no error
@@ -169,7 +175,8 @@ else
     solo_out=$(python3 "${LINTER}" \
         --packs-dir "${solo_tmp}" \
         --rubric "${RUBRIC}" 2>&1) || solo_exit=$?
-    if [ "${solo_exit}" -eq 0 ] && echo "${solo_out}" | grep -q "^PASS: accessibility"; then
+    # Herestring, not a pipe: see the identical rationale above (#943, #945).
+    if [ "${solo_exit}" -eq 0 ] && grep -q "^PASS: accessibility" <<< "${solo_out}"; then
         pass "lint-pack.py exits 0 and reports PASS: accessibility (solo run)"
     else
         fail "lint-pack.py solo run failed for accessibility (exit=${solo_exit}): ${solo_out}"

--- a/modules/commands-extra/skills/audit/tests/test-pack-api.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-api.sh
@@ -67,7 +67,11 @@ _T1_RESULT=""
 _T1_EXIT=0
 _T1_RESULT=$(python3 "${_T1_PY}" "${REGISTRY}" "${PACK_DIR}/pack.json" 2>&1) || _T1_EXIT=$?
 
-if [ "${_T1_EXIT}" -eq 0 ] && echo "${_T1_RESULT}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if [ "${_T1_EXIT}" -eq 0 ] && grep -q "^VALID$" <<< "${_T1_RESULT}"; then
     pass "api-contract/pack.json validates against pack.schema.json"
 else
     fail "api-contract/pack.json failed validation: ${_T1_RESULT}"
@@ -87,7 +91,11 @@ EXPECTED_IDS=(
 
 _T2_MISSING=""
 for check_id in "${EXPECTED_IDS[@]}"; do
-    if ! python3 -c "
+    # Producer is a real command (python3), not an echo/printf of a
+    # variable: capture its output to a variable first, then herestring
+    # into the early-exiting `grep -q` (see #943, #945). `|| true` keeps
+    # python3's exit-1-on-missing from aborting this now-bare assignment.
+    _T2_CHECK=$(python3 -c "
 import json, sys
 rubric = json.load(open('${RUBRIC}', encoding='utf-8'))
 checks = rubric.get('checks', {})
@@ -96,7 +104,8 @@ if '${check_id}' not in checks:
     sys.exit(1)
 print('FOUND')
 sys.exit(0)
-" 2>/dev/null | grep -q "^FOUND$"; then
+" 2>/dev/null || true)
+    if ! grep -q "^FOUND$" <<< "${_T2_CHECK}"; then
         _T2_MISSING="${_T2_MISSING} ${check_id}"
     fi
 done
@@ -118,7 +127,8 @@ _T3_OUTPUT=$(python3 "${LINTER}" \
     --packs-dir "${AUDIT_DIR}/packs" \
     --rubric "${RUBRIC}" 2>&1) || _T3_EXIT=$?
 
-if [ "${_T3_EXIT}" -eq 0 ] && echo "${_T3_OUTPUT}" | grep -q "^PASS: api-contract"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${_T3_EXIT}" -eq 0 ] && grep -q "^PASS: api-contract" <<< "${_T3_OUTPUT}"; then
     pass "lint-pack.py reports PASS for api-contract pack"
 else
     fail "lint-pack.py did not report PASS for api-contract: exit=${_T3_EXIT}, output=${_T3_OUTPUT}"
@@ -185,12 +195,13 @@ PYEOF
 )
 
     # True positive marker
-    if ! echo "${_SECTION}" | grep -q "True positive\|FINDS:"; then
+    # Herestring, not a pipe: see the identical rationale above (#943, #945).
+    if ! grep -q "True positive\|FINDS:" <<< "${_SECTION}"; then
         _T5_ERRORS="${_T5_ERRORS}\n  no True positive fixture found for '${check_id}'"
     fi
 
     # True negative marker
-    if ! echo "${_SECTION}" | grep -q "True negative\|should produce NO"; then
+    if ! grep -q "True negative\|should produce NO" <<< "${_SECTION}"; then
         _T5_ERRORS="${_T5_ERRORS}\n  no True negative fixture found for '${check_id}'"
     fi
 done
@@ -340,7 +351,8 @@ _T7_LINT_OUTPUT=$(python3 "${LINTER}" \
     --packs-dir "${AUDIT_DIR}/packs" \
     --rubric "${RUBRIC}" 2>&1) || _T7_LINT_EXIT=$?
 
-if [ "${_T7_LINT_EXIT}" -eq 0 ] && echo "${_T7_LINT_OUTPUT}" | grep -q "^PASS: api-contract"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${_T7_LINT_EXIT}" -eq 0 ] && grep -q "^PASS: api-contract" <<< "${_T7_LINT_OUTPUT}"; then
     pass "lint-pack.py still reports PASS for api-contract after adding rubric entries"
 else
     fail "lint-pack.py failed after rubric entries added: exit=${_T7_LINT_EXIT}, output=${_T7_LINT_OUTPUT}"

--- a/modules/commands-extra/skills/audit/tests/test-pack-ccgm.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-ccgm.sh
@@ -76,7 +76,11 @@ _T1_RESULT=""
 _T1_EXIT=0
 _T1_RESULT=$(python3 "${_VALIDATE_PY}" "${REGISTRY}" "${HYGIENE_PACK}/pack.json" 2>&1) || _T1_EXIT=$?
 
-if [ "${_T1_EXIT}" -eq 0 ] && echo "${_T1_RESULT}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if [ "${_T1_EXIT}" -eq 0 ] && grep -q "^VALID$" <<< "${_T1_RESULT}"; then
     pass "ccgm-hygiene/pack.json validates against pack.schema.json"
 else
     fail "ccgm-hygiene/pack.json failed validation: ${_T1_RESULT}"
@@ -91,7 +95,8 @@ _T2_RESULT=""
 _T2_EXIT=0
 _T2_RESULT=$(python3 "${_VALIDATE_PY}" "${REGISTRY}" "${STANDARDS_PACK}/pack.json" 2>&1) || _T2_EXIT=$?
 
-if [ "${_T2_EXIT}" -eq 0 ] && echo "${_T2_RESULT}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${_T2_EXIT}" -eq 0 ] && grep -q "^VALID$" <<< "${_T2_RESULT}"; then
     pass "ccgm-standards/pack.json validates against pack.schema.json"
 else
     fail "ccgm-standards/pack.json failed validation: ${_T2_RESULT}"
@@ -112,7 +117,11 @@ EXPECTED_IDS=(
 
 _T3_MISSING=""
 for check_id in "${EXPECTED_IDS[@]}"; do
-    if ! python3 -c "
+    # Producer is a real command (python3), not an echo/printf of a
+    # variable: capture its output to a variable first, then herestring
+    # into the early-exiting `grep -q` (see #943, #945). `|| true` keeps
+    # python3's exit-1-on-missing from aborting this now-bare assignment.
+    _T3_CHECK=$(python3 -c "
 import json, sys
 rubric = json.load(open('${RUBRIC}', encoding='utf-8'))
 checks = rubric.get('checks', {})
@@ -121,7 +130,8 @@ if '${check_id}' not in checks:
     sys.exit(1)
 print('FOUND')
 sys.exit(0)
-" 2>/dev/null | grep -q "^FOUND$"; then
+" 2>/dev/null || true)
+    if ! grep -q "^FOUND$" <<< "${_T3_CHECK}"; then
         _T3_MISSING="${_T3_MISSING} ${check_id}"
     fi
 done
@@ -144,7 +154,8 @@ _T4_OUTPUT=$(python3 "${LINTER}" \
     --packs-dir "${AUDIT_DIR}/packs" \
     --rubric "${RUBRIC}" 2>&1) || _T4_EXIT=$?
 
-if [ "${_T4_EXIT}" -eq 0 ] && echo "${_T4_OUTPUT}" | grep -q "^PASS: ccgm-hygiene"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${_T4_EXIT}" -eq 0 ] && grep -q "^PASS: ccgm-hygiene" <<< "${_T4_OUTPUT}"; then
     pass "lint-pack.py reports PASS for ccgm-hygiene"
 else
     fail "lint-pack.py did not PASS for ccgm-hygiene: exit=${_T4_EXIT}, output=${_T4_OUTPUT}"
@@ -155,7 +166,8 @@ fi
 # ---------------------------------------------------------------------------
 echo "--- Test 5: lint-pack.py passes on ccgm-standards pack"
 
-if [ "${_T4_EXIT}" -eq 0 ] && echo "${_T4_OUTPUT}" | grep -q "^PASS: ccgm-standards"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${_T4_EXIT}" -eq 0 ] && grep -q "^PASS: ccgm-standards" <<< "${_T4_OUTPUT}"; then
     pass "lint-pack.py reports PASS for ccgm-standards"
 else
     fail "lint-pack.py did not PASS for ccgm-standards: exit=${_T4_EXIT}, output=${_T4_OUTPUT}"
@@ -252,11 +264,12 @@ if m:
 PYEOF
 )
 
-    if ! echo "${_SECTION}" | grep -q "True positive\|FINDS:"; then
+    # Herestring, not a pipe: see the identical rationale above (#943, #945).
+    if ! grep -q "True positive\|FINDS:" <<< "${_SECTION}"; then
         _T8_ERRORS="${_T8_ERRORS}\n  no True positive fixture found for '${check_id}'"
     fi
 
-    if ! echo "${_SECTION}" | grep -q "True negative\|should produce NO"; then
+    if ! grep -q "True negative\|should produce NO" <<< "${_SECTION}"; then
         _T8_ERRORS="${_T8_ERRORS}\n  no True negative fixture found for '${check_id}'"
     fi
 done

--- a/modules/commands-extra/skills/audit/tests/test-pack-ci-cd.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-ci-cd.sh
@@ -114,9 +114,13 @@ LINT_OUTPUT="$(python3 "${SCRIPTS_DIR}/lint-pack.py" \
   --packs-dir "${AUDIT_DIR}/packs" \
   --rubric "${RUBRIC}" 2>&1)" || LINT_EXIT=$?
 
-if echo "$LINT_OUTPUT" | grep -q "^PASS: ci-cd"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if grep -q "^PASS: ci-cd" <<< "$LINT_OUTPUT"; then
   pass "lint-pack.py PASS for ci-cd pack"
-elif echo "$LINT_OUTPUT" | grep -q "^FAIL: ci-cd"; then
+elif grep -q "^FAIL: ci-cd" <<< "$LINT_OUTPUT"; then
   fail "lint-pack.py FAIL for ci-cd pack: ${LINT_OUTPUT}"
 else
   # lint-pack may print a NOTE and still pass overall
@@ -282,7 +286,8 @@ print(' '.join(sorted(set(ids))))
 " "$ZI_OUT" 2>/dev/null || true)"
 
 for EXPECTED_CID in cicd/dangerous-trigger cicd/excessive-permissions cicd/script-injection; do
-  if echo "$CHECKS" | grep -q "$EXPECTED_CID"; then
+  # Herestring, not a pipe: see the identical rationale above (#943, #945).
+  if grep -q "$EXPECTED_CID" <<< "$CHECKS"; then
     pass "parse-zizmor.py emits $EXPECTED_CID"
   else
     fail "parse-zizmor.py did not emit $EXPECTED_CID (got: $CHECKS)"
@@ -564,7 +569,8 @@ print(" ".join(ids))
 PYEOF
 )" || SELECTED_TRUE=""
 
-if echo "$SELECTED_TRUE" | grep -q "ccgm/ci-cd"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "ccgm/ci-cd" <<< "$SELECTED_TRUE"; then
   pass "ci-cd pack selected when has_workflows=true"
 else
   fail "ci-cd pack NOT selected when has_workflows=true (got: $SELECTED_TRUE)"
@@ -604,7 +610,8 @@ print(" ".join(ids))
 PYEOF
 )" || SELECTED_FALSE=""
 
-if ! echo "$SELECTED_FALSE" | grep -q "ccgm/ci-cd"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if ! grep -q "ccgm/ci-cd" <<< "$SELECTED_FALSE"; then
   pass "ci-cd pack NOT selected when has_workflows=false"
 else
   fail "ci-cd pack selected when has_workflows=false (should be excluded)"

--- a/modules/commands-extra/skills/audit/tests/test-pack-correctness.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-correctness.sh
@@ -83,14 +83,18 @@ else
 fi
 
 # Check for lint/eqeqeq finding
-if printf '%s\n' "$PARSE_OUTPUT" | grep -q '"lint/eqeqeq"'; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if grep -q '"lint/eqeqeq"' <<< "$PARSE_OUTPUT"; then
   pass "parse-eslint.py emits lint/eqeqeq check_id"
 else
   fail "parse-eslint.py did not emit lint/eqeqeq check_id"
 fi
 
 # Check for lint/no-unreachable finding
-if printf '%s\n' "$PARSE_OUTPUT" | grep -q '"lint/no-unreachable"'; then
+if grep -q '"lint/no-unreachable"' <<< "$PARSE_OUTPUT"; then
   pass "parse-eslint.py emits lint/no-unreachable check_id"
 else
   fail "parse-eslint.py did not emit lint/no-unreachable check_id"
@@ -252,7 +256,8 @@ else
 fi
 
 # Explicitly check that correctness pack is PASS (not just that there are no errors)
-if printf '%s\n' "$LINT_OUTPUT" | grep -q '^PASS: correctness$'; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q '^PASS: correctness$' <<< "$LINT_OUTPUT"; then
   pass "lint-pack.py reports PASS: correctness"
 else
   fail "lint-pack.py did not report PASS: correctness (output: ${LINT_OUTPUT})"
@@ -269,7 +274,12 @@ CHECKS_MD="${PACK_DIR}/checks.md"
 LLM_CHECKS=("off-by-one" "float-equality" "wrong-branch-logic")
 for check in "${LLM_CHECKS[@]}"; do
   # Look for the check section and verify LOW confidence is mentioned
-  if grep -A 5 "correctness/${check}" "$CHECKS_MD" | grep -qi "low"; then
+  # Producer is a real command (grep -A5 on a file), not an echo/printf of
+  # a variable: capture its output to a variable first, then herestring
+  # into the early-exiting `grep -qi` (see #943, #945). `|| true` keeps a
+  # not-found section from aborting this now-bare assignment.
+  _SECTION=$(grep -A 5 "correctness/${check}" "$CHECKS_MD" || true)
+  if grep -qi "low" <<< "$_SECTION"; then
     pass "checks.md marks correctness/${check} as low confidence"
   else
     fail "checks.md does not mark correctness/${check} as low confidence"
@@ -311,7 +321,10 @@ if command -v shellcheck > /dev/null 2>&1; then
     pass "shellcheck clean: wrap-eslint.sh"
   else
     fail "shellcheck issues in wrap-eslint.sh:"
-    printf '%s\n' "$SC_OUTPUT" | head -10
+    # Herestring, not a pipe: `producer | head` can SIGPIPE-kill the
+    # producer once head has read its N lines and closes early (see #943,
+    # #945). A herestring has no second process to race against.
+    head -10 <<< "$SC_OUTPUT"
   fi
 else
   pass "shellcheck not installed -- shell safety check skipped (install shellcheck for full coverage)"

--- a/modules/commands-extra/skills/audit/tests/test-pack-data-migrations.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-data-migrations.sh
@@ -64,7 +64,11 @@ if [[ ! -f "$PACK_DIR/pack.json" ]]; then
 else
   # Use lint-pack.py with a nonexistent rubric to test schema validation only
   OUT="$(python3 "$LINTER" --packs-dir "$(dirname "$PACK_DIR")" --rubric "$TESTRUN_TMPDIR/no-rubric.json" 2>&1 || true)"
-  if echo "$OUT" | grep -q "^PASS: data-migrations"; then
+  # Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+  # producer if grep exits on its first match before the producer finishes
+  # writing, turning a genuine match into a reported failure (see #943,
+  # #945). A herestring has no second process to race against.
+  if grep -q "^PASS: data-migrations" <<< "$OUT"; then
     pass "pack.json passes schema validation (no rubric)"
   else
     fail "pack.json schema validation failed: $OUT"
@@ -133,7 +137,8 @@ fi
 printf '\nTest 4: lint-pack.py PASS on data-migrations pack (real rubric)\n'
 
 OUT="$(python3 "$LINTER" --packs-dir "$(dirname "$PACK_DIR")" --rubric "$RUBRIC" 2>&1 || true)"
-if echo "$OUT" | grep -q "^PASS: data-migrations"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "^PASS: data-migrations" <<< "$OUT"; then
   pass "lint-pack.py reports PASS for data-migrations with real rubric"
 else
   fail "lint-pack.py did NOT report PASS for data-migrations: $OUT"

--- a/modules/commands-extra/skills/audit/tests/test-pack-dependencies-deep.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-dependencies-deep.sh
@@ -94,7 +94,11 @@ if [[ ! -f "$PACK_DIR/pack.json" ]]; then
   fail "pack.json does not exist at $PACK_DIR/pack.json"
 else
   OUT="$(python3 "$LINTER" --packs-dir "$(dirname "$PACK_DIR")" --rubric "$TESTRUN_TMPDIR/no-rubric.json" 2>&1 || true)"
-  if echo "$OUT" | grep -q "^PASS: dependencies"; then
+  # Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+  # producer if grep exits on its first match before the producer finishes
+  # writing, turning a genuine match into a reported failure (see #943,
+  # #945). A herestring has no second process to race against.
+  if grep -q "^PASS: dependencies" <<< "$OUT"; then
     pass "pack.json passes schema validation (no rubric)"
   else
     fail "pack.json schema validation failed: $OUT"
@@ -162,7 +166,8 @@ fi
 printf '\nTest 4: lint-pack.py PASS on dependencies pack (real rubric)\n'
 
 OUT="$(python3 "$LINTER" --packs-dir "$(dirname "$PACK_DIR")" --rubric "$RUBRIC" 2>&1 || true)"
-if echo "$OUT" | grep -q "^PASS: dependencies"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "^PASS: dependencies" <<< "$OUT"; then
   pass "lint-pack.py reports PASS for dependencies with real rubric"
 else
   fail "lint-pack.py did NOT report PASS for dependencies: $OUT"

--- a/modules/commands-extra/skills/audit/tests/test-pack-infra.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-infra.sh
@@ -541,7 +541,10 @@ if command -v shellcheck > /dev/null 2>&1; then
     pass "shellcheck clean: wrap-checkov.sh"
   else
     fail "shellcheck issues in wrap-checkov.sh:"
-    printf '%s\n' "$SC_OUTPUT" | head -10
+    # Herestring, not a pipe: `producer | head` can SIGPIPE-kill the
+    # producer once head has read its N lines and closes early (see #943,
+    # #945). A herestring has no second process to race against.
+    head -10 <<< "$SC_OUTPUT"
   fi
 else
   skip "shellcheck not installed -- wrap-checkov.sh shell-safety check skipped"

--- a/modules/commands-extra/skills/audit/tests/test-pack-lint.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-lint.sh
@@ -207,7 +207,11 @@ output=""
 exit_code=0
 output=$(python3 "${LINTER}" --packs-dir "${_T1_DIR}" --rubric "${_T1_DIR}/nonexistent-rubric.json" 2>&1) || exit_code=$?
 
-if [ "${exit_code}" -eq 0 ] && echo "${output}" | grep -q "^PASS: test-valid"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if [ "${exit_code}" -eq 0 ] && grep -q "^PASS: test-valid" <<< "${output}"; then
     pass "well-formed pack passes linter (no rubric)"
 else
     fail "well-formed pack should pass but exit_code=${exit_code}: ${output}"
@@ -227,8 +231,9 @@ output=""
 exit_code=0
 output=$(python3 "${LINTER}" --packs-dir "${_T2_DIR}" --rubric "${_T2_DIR}/nonexistent-rubric.json" 2>&1) || exit_code=$?
 
-if [ "${exit_code}" -ne 0 ] && echo "${output}" | grep -q "^FAIL: test-missing"; then
-    if echo "${output}" | grep -qi "missing required section"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${exit_code}" -ne 0 ] && grep -q "^FAIL: test-missing" <<< "${output}"; then
+    if grep -qi "missing required section" <<< "${output}"; then
         pass "pack missing section correctly rejected with clear error"
     else
         fail "pack missing section rejected but error message unclear: ${output}"
@@ -251,8 +256,9 @@ output=""
 exit_code=0
 output=$(python3 "${LINTER}" --packs-dir "${_T3_DIR}" --rubric "${_T3_DIR}/nonexistent-rubric.json" 2>&1) || exit_code=$?
 
-if [ "${exit_code}" -ne 0 ] && echo "${output}" | grep -q "^FAIL: test-invalid"; then
-    if echo "${output}" | grep -qi "schema validation failed\|missing required"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${exit_code}" -ne 0 ] && grep -q "^FAIL: test-invalid" <<< "${output}"; then
+    if grep -qi "schema validation failed\|missing required" <<< "${output}"; then
         pass "invalid pack.json correctly rejected with clear error"
     else
         fail "invalid pack.json rejected but error message unclear: ${output}"
@@ -282,8 +288,9 @@ output=""
 exit_code=0
 output=$(python3 "${LINTER}" --packs-dir "${_T4_DIR}" --rubric "${_T4_DIR}/rubric.json" 2>&1) || exit_code=$?
 
-if [ "${exit_code}" -ne 0 ] && echo "${output}" | grep -q "^FAIL: test-orphan"; then
-    if echo "${output}" | grep -qi "no entry in severity-rubric"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${exit_code}" -ne 0 ] && grep -q "^FAIL: test-orphan" <<< "${output}"; then
+    if grep -qi "no entry in severity-rubric" <<< "${output}"; then
         pass "orphan check-id correctly rejected when rubric is present"
     else
         fail "orphan check-id rejected but error message unclear: ${output}"
@@ -312,7 +319,8 @@ output=""
 exit_code=0
 output=$(python3 "${LINTER}" --packs-dir "${_T5_DIR}" --rubric "${_T5_DIR}/rubric.json" 2>&1) || exit_code=$?
 
-if [ "${exit_code}" -eq 0 ] && echo "${output}" | grep -q "^PASS: test-covered"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${exit_code}" -eq 0 ] && grep -q "^PASS: test-covered" <<< "${output}"; then
     pass "well-formed pack with matching rubric passes linter"
 else
     fail "well-formed pack + matching rubric should pass but exit_code=${exit_code}: ${output}"
@@ -337,7 +345,8 @@ output=""
 exit_code=0
 output=$(python3 "${LINTER}" --packs-dir "${_T6_DIR}" --rubric "${_T6_DIR}/nonexistent-rubric.json" 2>&1) || exit_code=$?
 
-if [ "${exit_code}" -eq 0 ] && ! echo "${output}" | grep -q "^FAIL: _TEMPLATE"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${exit_code}" -eq 0 ] && ! grep -q "^FAIL: _TEMPLATE" <<< "${output}"; then
     pass "_TEMPLATE directory is skipped by linter"
 else
     fail "_TEMPLATE should be skipped but exit_code=${exit_code}: ${output}"
@@ -355,7 +364,8 @@ output=""
 exit_code=0
 output=$(python3 "${LINTER}" --packs-dir "${_T7_DIR}/nonexistent" --rubric "${_T7_DIR}/nonexistent-rubric.json" 2>&1) || exit_code=$?
 
-if [ "${exit_code}" -eq 0 ] && echo "${output}" | grep -qi "packs directory not found\|nothing to lint"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${exit_code}" -eq 0 ] && grep -qi "packs directory not found\|nothing to lint" <<< "${output}"; then
     pass "absent packs/ directory handled gracefully (exit 0)"
 else
     fail "absent packs/ directory should exit 0 with NOTE but exit_code=${exit_code}: ${output}"

--- a/modules/commands-extra/skills/audit/tests/test-pack-privacy-obs.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-privacy-obs.sh
@@ -78,7 +78,11 @@ _T1_RESULT=""
 _T1_EXIT=0
 _T1_RESULT=$(python3 "${_T_PY}" "${REGISTRY}" "${PRIVACY_PACK_DIR}/pack.json" 2>&1) || _T1_EXIT=$?
 
-if [ "${_T1_EXIT}" -eq 0 ] && echo "${_T1_RESULT}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if [ "${_T1_EXIT}" -eq 0 ] && grep -q "^VALID$" <<< "${_T1_RESULT}"; then
     pass "privacy/pack.json validates against pack.schema.json"
 else
     fail "privacy/pack.json failed validation: ${_T1_RESULT}"
@@ -93,7 +97,8 @@ _T2_RESULT=""
 _T2_EXIT=0
 _T2_RESULT=$(python3 "${_T_PY}" "${REGISTRY}" "${OBS_PACK_DIR}/pack.json" 2>&1) || _T2_EXIT=$?
 
-if [ "${_T2_EXIT}" -eq 0 ] && echo "${_T2_RESULT}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${_T2_EXIT}" -eq 0 ] && grep -q "^VALID$" <<< "${_T2_RESULT}"; then
     pass "observability/pack.json validates against pack.schema.json"
 else
     fail "observability/pack.json failed validation: ${_T2_RESULT}"
@@ -112,7 +117,11 @@ PRIVACY_IDS=(
 
 _T3_MISSING=""
 for check_id in "${PRIVACY_IDS[@]}"; do
-    if ! python3 -c "
+    # Producer is a real command (python3), not an echo/printf of a
+    # variable: capture its output to a variable first, then herestring
+    # into the early-exiting `grep -q` (see #943, #945). `|| true` keeps
+    # python3's exit-1-on-missing from aborting this now-bare assignment.
+    _T3_CHECK=$(python3 -c "
 import json, sys
 rubric = json.load(open('${RUBRIC}', encoding='utf-8'))
 checks = rubric.get('checks', {})
@@ -121,7 +130,8 @@ if '${check_id}' not in checks:
     sys.exit(1)
 print('FOUND')
 sys.exit(0)
-" 2>/dev/null | grep -q "^FOUND$"; then
+" 2>/dev/null || true)
+    if ! grep -q "^FOUND$" <<< "${_T3_CHECK}"; then
         _T3_MISSING="${_T3_MISSING} ${check_id}"
     fi
 done
@@ -145,7 +155,9 @@ OBS_IDS=(
 
 _T4_MISSING=""
 for check_id in "${OBS_IDS[@]}"; do
-    if ! python3 -c "
+    # Producer is a real command (python3): see the identical rationale
+    # above (#943, #945).
+    _T4_CHECK=$(python3 -c "
 import json, sys
 rubric = json.load(open('${RUBRIC}', encoding='utf-8'))
 checks = rubric.get('checks', {})
@@ -154,7 +166,8 @@ if '${check_id}' not in checks:
     sys.exit(1)
 print('FOUND')
 sys.exit(0)
-" 2>/dev/null | grep -q "^FOUND$"; then
+" 2>/dev/null || true)
+    if ! grep -q "^FOUND$" <<< "${_T4_CHECK}"; then
         _T4_MISSING="${_T4_MISSING} ${check_id}"
     fi
 done
@@ -176,7 +189,8 @@ _T5_OUTPUT=$(python3 "${LINTER}" \
     --packs-dir "${AUDIT_DIR}/packs" \
     --rubric "${RUBRIC}" 2>&1) || _T5_EXIT=$?
 
-if [ "${_T5_EXIT}" -eq 0 ] && echo "${_T5_OUTPUT}" | grep -q "^PASS: privacy"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${_T5_EXIT}" -eq 0 ] && grep -q "^PASS: privacy" <<< "${_T5_OUTPUT}"; then
     pass "lint-pack.py reports PASS for privacy pack"
 else
     fail "lint-pack.py did not report PASS for privacy: exit=${_T5_EXIT}, output=${_T5_OUTPUT}"
@@ -193,7 +207,8 @@ _T6_OUTPUT=$(python3 "${LINTER}" \
     --packs-dir "${AUDIT_DIR}/packs" \
     --rubric "${RUBRIC}" 2>&1) || _T6_EXIT=$?
 
-if [ "${_T6_EXIT}" -eq 0 ] && echo "${_T6_OUTPUT}" | grep -q "^PASS: observability"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${_T6_EXIT}" -eq 0 ] && grep -q "^PASS: observability" <<< "${_T6_OUTPUT}"; then
     pass "lint-pack.py reports PASS for observability pack"
 else
     fail "lint-pack.py did not report PASS for observability: exit=${_T6_EXIT}, output=${_T6_OUTPUT}"
@@ -268,11 +283,12 @@ if m:
 PYEOF
 )
 
-    if ! echo "${_SECTION}" | grep -q "True positive\|FINDS:"; then
+    # Herestring, not a pipe: see the identical rationale above (#943, #945).
+    if ! grep -q "True positive\|FINDS:" <<< "${_SECTION}"; then
         _T9_ERRORS="${_T9_ERRORS}\n  no True positive fixture found for '${check_id}'"
     fi
 
-    if ! echo "${_SECTION}" | grep -q "True negative\|should produce NO"; then
+    if ! grep -q "True negative\|should produce NO" <<< "${_SECTION}"; then
         _T9_ERRORS="${_T9_ERRORS}\n  no True negative fixture found for '${check_id}'"
     fi
 done
@@ -307,11 +323,12 @@ if m:
 PYEOF
 )
 
-    if ! echo "${_SECTION}" | grep -q "True positive\|FINDS:"; then
+    # Herestring, not a pipe: see the identical rationale above (#943, #945).
+    if ! grep -q "True positive\|FINDS:" <<< "${_SECTION}"; then
         _T10_ERRORS="${_T10_ERRORS}\n  no True positive fixture found for '${check_id}'"
     fi
 
-    if ! echo "${_SECTION}" | grep -q "True negative\|should produce NO"; then
+    if ! grep -q "True negative\|should produce NO" <<< "${_SECTION}"; then
         _T10_ERRORS="${_T10_ERRORS}\n  no True negative fixture found for '${check_id}'"
     fi
 done
@@ -339,7 +356,8 @@ if aw == ['always']:
 else:
     print('WRONG: ' + str(aw))
 " 2>/dev/null)
-    if ! echo "${_AW}" | grep -q "^OK$"; then
+    # Herestring, not a pipe: see the identical rationale above (#943, #945).
+    if ! grep -q "^OK$" <<< "${_AW}"; then
         _PACK_NAME=$(basename "$(dirname "${pack_path}")")
         _T11_ERRORS="${_T11_ERRORS}\n  ${_PACK_NAME}/pack.json applies_when is not [\"always\"]: ${_AW}"
     fi
@@ -467,7 +485,8 @@ else:
 PYEOF
 )
 
-if echo "${_T15_OVERLAP}" | grep -q "^DISTINCT$"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "^DISTINCT$" <<< "${_T15_OVERLAP}"; then
     pass "privacy check ids are fully distinct from tos-compliance check ids"
 else
     fail "privacy and tos-compliance share check ids: ${_T15_OVERLAP}"

--- a/modules/commands-extra/skills/audit/tests/test-pack-reliability.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-reliability.sh
@@ -71,7 +71,11 @@ _T1_RESULT=""
 _T1_EXIT=0
 _T1_RESULT=$(python3 "${_T1_PY}" "${REGISTRY}" "${PACK_DIR}/pack.json" 2>&1) || _T1_EXIT=$?
 
-if [ "${_T1_EXIT}" -eq 0 ] && echo "${_T1_RESULT}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if [ "${_T1_EXIT}" -eq 0 ] && grep -q "^VALID$" <<< "${_T1_RESULT}"; then
     pass "reliability/pack.json validates against pack.schema.json"
 else
     fail "reliability/pack.json failed validation: ${_T1_RESULT}"
@@ -94,7 +98,11 @@ EXPECTED_IDS=(
 
 _T2_MISSING=""
 for check_id in "${EXPECTED_IDS[@]}"; do
-    if ! python3 -c "
+    # Producer is a real command (python3), not an echo/printf of a
+    # variable: capture its output to a variable first, then herestring
+    # into the early-exiting `grep -q` (see #943, #945). `|| true` keeps
+    # python3's exit-1-on-missing from aborting this now-bare assignment.
+    _T2_CHECK=$(python3 -c "
 import json, sys
 rubric = json.load(open('${RUBRIC}', encoding='utf-8'))
 checks = rubric.get('checks', {})
@@ -103,7 +111,8 @@ if '${check_id}' not in checks:
     sys.exit(1)
 print('FOUND')
 sys.exit(0)
-" 2>/dev/null | grep -q "^FOUND$"; then
+" 2>/dev/null || true)
+    if ! grep -q "^FOUND$" <<< "${_T2_CHECK}"; then
         _T2_MISSING="${_T2_MISSING} ${check_id}"
     fi
 done
@@ -125,7 +134,8 @@ _T3_OUTPUT=$(python3 "${LINTER}" \
     --packs-dir "${AUDIT_DIR}/packs" \
     --rubric "${RUBRIC}" 2>&1) || _T3_EXIT=$?
 
-if [ "${_T3_EXIT}" -eq 0 ] && echo "${_T3_OUTPUT}" | grep -q "^PASS: reliability"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${_T3_EXIT}" -eq 0 ] && grep -q "^PASS: reliability" <<< "${_T3_OUTPUT}"; then
     pass "lint-pack.py reports PASS for reliability pack"
 else
     fail "lint-pack.py did not report PASS for reliability: exit=${_T3_EXIT}, output=${_T3_OUTPUT}"
@@ -205,12 +215,13 @@ PYEOF
 )
 
     # True positive fixture marker present in section
-    if ! echo "${_SECTION}" | grep -q "True positive\|FINDS:"; then
+    # Herestring, not a pipe: see the identical rationale above (#943, #945).
+    if ! grep -q "True positive\|FINDS:" <<< "${_SECTION}"; then
         _T5_ERRORS="${_T5_ERRORS}\n  no True positive fixture found for '${check_id}'"
     fi
 
     # True negative fixture marker present in section
-    if ! echo "${_SECTION}" | grep -q "True negative\|should produce NO"; then
+    if ! grep -q "True negative\|should produce NO" <<< "${_SECTION}"; then
         _T5_ERRORS="${_T5_ERRORS}\n  no True negative fixture found for '${check_id}'"
     fi
 done

--- a/modules/commands-extra/skills/audit/tests/test-pack-secrets.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-secrets.sh
@@ -64,9 +64,13 @@ LINT_EXIT=$?
 set -e
 
 # Grep for the secrets pack specifically
-if echo "$LINT_OUT" | grep -q "PASS: secrets"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if grep -q "PASS: secrets" <<< "$LINT_OUT"; then
   pass "t1: lint-pack PASS for secrets pack"
-elif echo "$LINT_OUT" | grep -q "FAIL: secrets"; then
+elif grep -q "FAIL: secrets" <<< "$LINT_OUT"; then
   fail "t1: lint-pack FAIL for secrets pack"
   printf '    Output: %s\n' "$LINT_OUT" >&2
 else

--- a/modules/commands-extra/skills/audit/tests/test-pack-testing-deep.sh
+++ b/modules/commands-extra/skills/audit/tests/test-pack-testing-deep.sh
@@ -68,7 +68,11 @@ _T1_RESULT=""
 _T1_EXIT=0
 _T1_RESULT=$(python3 "${_T1_PY}" "${REGISTRY}" "${PACK_DIR}/pack.json" 2>&1) || _T1_EXIT=$?
 
-if [ "${_T1_EXIT}" -eq 0 ] && echo "${_T1_RESULT}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if [ "${_T1_EXIT}" -eq 0 ] && grep -q "^VALID$" <<< "${_T1_RESULT}"; then
     pass "testing/pack.json validates against pack.schema.json"
 else
     fail "testing/pack.json failed validation: ${_T1_RESULT}"
@@ -91,7 +95,11 @@ EXPECTED_IDS=(
 
 _T2_MISSING=""
 for check_id in "${EXPECTED_IDS[@]}"; do
-    if ! python3 -c "
+    # Producer is a real command (python3), not an echo/printf of a
+    # variable: capture its output to a variable first, then herestring
+    # into the early-exiting `grep -q` (see #943, #945). `|| true` keeps
+    # python3's exit-1-on-missing from aborting this now-bare assignment.
+    _T2_CHECK=$(python3 -c "
 import json, sys
 rubric = json.load(open('${RUBRIC}', encoding='utf-8'))
 checks = rubric.get('checks', {})
@@ -100,7 +108,8 @@ if '${check_id}' not in checks:
     sys.exit(1)
 print('FOUND')
 sys.exit(0)
-" 2>/dev/null | grep -q "^FOUND$"; then
+" 2>/dev/null || true)
+    if ! grep -q "^FOUND$" <<< "${_T2_CHECK}"; then
         _T2_MISSING="${_T2_MISSING} ${check_id}"
     fi
 done
@@ -122,7 +131,8 @@ _T3_OUTPUT=$(python3 "${LINTER}" \
     --packs-dir "${AUDIT_DIR}/packs" \
     --rubric "${RUBRIC}" 2>&1) || _T3_EXIT=$?
 
-if [ "${_T3_EXIT}" -eq 0 ] && echo "${_T3_OUTPUT}" | grep -q "^PASS: testing"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if [ "${_T3_EXIT}" -eq 0 ] && grep -q "^PASS: testing" <<< "${_T3_OUTPUT}"; then
     pass "lint-pack.py reports PASS for testing pack"
 else
     fail "lint-pack.py did not report PASS for testing: exit=${_T3_EXIT}, output=${_T3_OUTPUT}"
@@ -198,12 +208,13 @@ PYEOF
 )
 
     # True positive fixture present
-    if ! echo "${_SECTION}" | grep -q "True positive\|FINDS:"; then
+    # Herestring, not a pipe: see the identical rationale above (#943, #945).
+    if ! grep -q "True positive\|FINDS:" <<< "${_SECTION}"; then
         _T5_ERRORS="${_T5_ERRORS}\n  no True positive fixture found for '${check_id}'"
     fi
 
     # True negative fixture present
-    if ! echo "${_SECTION}" | grep -q "True negative\|should produce NO"; then
+    if ! grep -q "True negative\|should produce NO" <<< "${_SECTION}"; then
         _T5_ERRORS="${_T5_ERRORS}\n  no True negative fixture found for '${check_id}'"
     fi
 done
@@ -367,14 +378,15 @@ _T7E_GREP_OUTPUT=""
 _T7E_GREP_OUTPUT=$(grep -rn --include="*.test.*" --include="*.spec.*" \
     -E '\.(only|skip)\s*\(' "${TMPDIR_FIXTURE}/tests/" 2>/dev/null || true)
 
-if echo "${_T7E_GREP_OUTPUT}" | grep -q "auth.test.ts"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "auth.test.ts" <<< "${_T7E_GREP_OUTPUT}"; then
     pass "grep detects .only in auth.test.ts (only-or-skip-committed TP)"
 else
     fail "grep should detect .only in auth.test.ts: output='${_T7E_GREP_OUTPUT}'"
 fi
 
 # 7f: grep does NOT flag the clean file (TN)
-if echo "${_T7E_GREP_OUTPUT}" | grep -q "format.test.ts"; then
+if grep -q "format.test.ts" <<< "${_T7E_GREP_OUTPUT}"; then
     fail "grep should NOT flag format.test.ts (only-or-skip-committed TN)"
 else
     pass "grep correctly excludes format.test.ts (only-or-skip-committed TN)"

--- a/modules/commands-extra/skills/audit/tests/test-packs-migration.sh
+++ b/modules/commands-extra/skills/audit/tests/test-packs-migration.sh
@@ -135,10 +135,16 @@ for pack_name in "${CANONICAL_PACKS[@]}"; do
 
     # ---- 3. lint-pack.py result for this pack (from pre-run output above) ----
     # Filter the single lint run's output to this pack's result line
-    if echo "${LINT_OUTPUT}" | grep -q "^PASS: ${pack_name}$"; then
+    # Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+    # producer if grep exits on its first match before the producer finishes
+    # writing, turning a genuine match into a reported failure (see #943,
+    # #945). A herestring has no second process to race against.
+    if grep -q "^PASS: ${pack_name}$" <<< "${LINT_OUTPUT}"; then
         pass "${pack_name}: lint-pack.py passed"
-    elif echo "${LINT_OUTPUT}" | grep -q "^FAIL: ${pack_name}$"; then
+    elif grep -q "^FAIL: ${pack_name}$" <<< "${LINT_OUTPUT}"; then
         # Extract error lines specific to this pack (stop at the next PASS:/FAIL:/blank boundary)
+        # pack_errors below is left as-is: already `|| true`-guarded and
+        # feeds diagnostic-only text -- same exclusion as test-doc-counts.sh:64.
         pack_errors=$(echo "${LINT_OUTPUT}" | awk "/^FAIL: ${pack_name}$/{found=1; next} found && /^(PASS:|FAIL:|$)/{exit} found && /ERROR:/{print}" | head -10 || true)
         fail "${pack_name}: lint-pack.py failed — ${pack_errors}"
     else

--- a/modules/commands-extra/skills/audit/tests/test-provenance.sh
+++ b/modules/commands-extra/skills/audit/tests/test-provenance.sh
@@ -233,7 +233,11 @@ run_scenario_a() {
   # optional_checks_ran contains the passed check id
   local got_opts
   got_opts="$(jsonl_header_field "$out_file" optional_checks_ran)"
-  if echo "$got_opts" | grep -q "security/extra-check"; then
+  # Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+  # producer if grep exits on its first match before the producer finishes
+  # writing, turning a genuine match into a reported failure (see #943,
+  # #945). A herestring has no second process to race against.
+  if grep -q "security/extra-check" <<< "$got_opts"; then
     pass "scenario-a: optional_checks_ran contains passed id"
   else
     fail "scenario-a: optional_checks_ran='$got_opts' missing 'security/extra-check'"

--- a/modules/commands-extra/skills/audit/tests/test-reference-wiring.sh
+++ b/modules/commands-extra/skills/audit/tests/test-reference-wiring.sh
@@ -313,7 +313,13 @@ else
   # shellcheck disable=SC2016  # literal backtick in pattern is intentional, not a variable
   FIX_TABLE_DOC=$(grep -A1 '| `documentation`' "$FIX_PATTERNS_DOC" 2>/dev/null | head -2 || true)
   set -e
-  if echo "$FIX_TABLE_DOC" | grep -q 'No\|no'; then
+  # Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+  # producer if grep exits on its first match before the producer finishes
+  # writing, turning a genuine match into a reported failure (see #943,
+  # #945). A herestring has no second process to race against. (The
+  # FIX_TABLE_DOC capture above is left as-is: already `|| true`-guarded
+  # and feeds diagnostic-only text -- same exclusion as test-doc-counts.sh:64.)
+  if grep -q 'No\|no' <<< "$FIX_TABLE_DOC"; then
     pass "fix-patterns.md Fix Type Reference confirms documentation is not auto-fixable (No)"
   else
     fail "fix-patterns.md Fix Type Reference should list documentation as 'No' for auto-fixable" \

--- a/modules/commands-extra/skills/audit/tests/test-registry.sh
+++ b/modules/commands-extra/skills/audit/tests/test-registry.sh
@@ -106,7 +106,11 @@ assert '$pack_id' not in ids, '$pack_id should NOT be in result, got: ' + str(id
 # ---------------------------------------------------------------------------
 echo "--- Test 1: pack-go.json validates (stdlib)"
 result=""
-if result=$(validate_pack_file "${FIXTURES}/pack-go.json" 2>&1) && echo "${result}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if result=$(validate_pack_file "${FIXTURES}/pack-go.json" 2>&1) && grep -q "^VALID$" <<< "${result}"; then
     pass "pack-go.json is valid"
 else
     fail "pack-go.json failed validation: ${result}"
@@ -117,7 +121,8 @@ fi
 # ---------------------------------------------------------------------------
 echo "--- Test 2: pack-secrets.json validates (stdlib)"
 result=""
-if result=$(validate_pack_file "${FIXTURES}/pack-secrets.json" 2>&1) && echo "${result}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if result=$(validate_pack_file "${FIXTURES}/pack-secrets.json" 2>&1) && grep -q "^VALID$" <<< "${result}"; then
     pass "pack-secrets.json is valid"
 else
     fail "pack-secrets.json failed validation: ${result}"
@@ -166,7 +171,8 @@ result=""
 if result=$(validate_pack_file "${FIXTURES}/pack-malformed.json" 2>&1); then
     fail "pack-malformed.json should have failed validation but passed: ${result}"
 else
-    if echo "${result}" | grep -q "INVALID:"; then
+    # Herestring, not a pipe: see the identical rationale above (#943, #945).
+    if grep -q "INVALID:" <<< "${result}"; then
         pass "pack-malformed.json correctly rejected with clear error: ${result}"
     else
         fail "pack-malformed.json rejected but error message unclear: ${result}"
@@ -288,10 +294,11 @@ cat > "${_T6_PACK}" <<'JSON'
 }
 JSON
 result=""
-if result=$(validate_pack_from_file "${_T6_PACK}" 2>&1) && echo "${result}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if result=$(validate_pack_from_file "${_T6_PACK}" 2>&1) && grep -q "^VALID$" <<< "${result}"; then
     fail "check-id 'bad/check,id' should have been rejected but was VALID"
 else
-    if echo "${result}" | grep -q "INVALID:"; then
+    if grep -q "INVALID:" <<< "${result}"; then
         pass "check-id 'bad/check,id' correctly rejected: ${result}"
     else
         fail "check-id 'bad/check,id' rejected but error unclear: ${result}"
@@ -320,7 +327,8 @@ cat > "${_T7A_FINDING}" <<JSON
 }
 JSON
 result=""
-if result=$(validate_finding_file "${_T7A_FINDING}" 2>&1) && echo "${result}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if result=$(validate_finding_file "${_T7A_FINDING}" 2>&1) && grep -q "^VALID$" <<< "${result}"; then
     pass "tool-native fingerprint '${TOOL_NATIVE_FINGERPRINT}' accepted by finding.schema.json"
 else
     fail "tool-native fingerprint '${TOOL_NATIVE_FINGERPRINT}' was incorrectly rejected: ${result}"
@@ -346,10 +354,11 @@ cat > "${_T7B_FINDING}" <<'JSON'
 }
 JSON
 result=""
-if result=$(validate_finding_file "${_T7B_FINDING}" 2>&1) && echo "${result}" | grep -q "^VALID$"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if result=$(validate_finding_file "${_T7B_FINDING}" 2>&1) && grep -q "^VALID$" <<< "${result}"; then
     fail "empty fingerprint should have been rejected but was VALID"
 else
-    if echo "${result}" | grep -q "INVALID:"; then
+    if grep -q "INVALID:" <<< "${result}"; then
         pass "empty fingerprint correctly rejected: ${result}"
     else
         fail "empty fingerprint rejected but error unclear: ${result}"

--- a/modules/commands-extra/skills/audit/tests/test-smoke-audits.sh
+++ b/modules/commands-extra/skills/audit/tests/test-smoke-audits.sh
@@ -377,14 +377,18 @@ print(",".join(ids))
 PYEOF
 )"
 
-if echo "$SELECTED_A_IDS" | grep -q "ccgm/secrets"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if grep -q "ccgm/secrets" <<< "$SELECTED_A_IDS"; then
   pass "smoke-A: registry selected ccgm/secrets (always pack)"
 else
   fail "smoke-A: registry did not select ccgm/secrets (expected for JS fixture)"
 fi
 
 # JS-gated packs must be present: at least ccgm/typescript-react or ccgm/accessibility
-if echo "$SELECTED_A_IDS" | grep -qE "ccgm/typescript-react|ccgm/accessibility"; then
+if grep -qE "ccgm/typescript-react|ccgm/accessibility" <<< "$SELECTED_A_IDS"; then
   pass "smoke-A: registry selected at least one language:javascript-gated pack"
 else
   fail "smoke-A: no language:javascript-gated packs selected (expected for JS+TS fixture)"
@@ -438,14 +442,15 @@ print(",".join(ids))
 PYEOF
 )"
 
-if echo "$SELECTED_B_IDS" | grep -q "ccgm/secrets"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "ccgm/secrets" <<< "$SELECTED_B_IDS"; then
   pass "smoke-B: registry selected ccgm/secrets (always pack)"
 else
   fail "smoke-B: registry did not select ccgm/secrets"
 fi
 
 # Go fixture must NOT select JS-only packs (typescript-react is JS-gated)
-if echo "$SELECTED_B_IDS" | grep -q "ccgm/typescript-react"; then
+if grep -q "ccgm/typescript-react" <<< "$SELECTED_B_IDS"; then
   fail "smoke-B: registry selected ccgm/typescript-react for a Go-only fixture (unexpected)"
 else
   pass "smoke-B: registry did not select JS-gated pack ccgm/typescript-react (correct for Go fixture)"
@@ -503,13 +508,14 @@ print(",".join(ids))
 PYEOF
 )"
 
-if echo "$SELECTED_C_IDS" | grep -q "ccgm/data-migrations"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -q "ccgm/data-migrations" <<< "$SELECTED_C_IDS"; then
   pass "smoke-C: registry selected ccgm/data-migrations (has_migrations pack)"
 else
   fail "smoke-C: registry did not select ccgm/data-migrations (expected for supabase/migrations/ fixture)"
 fi
 
-if echo "$SELECTED_C_IDS" | grep -q "ccgm/secrets"; then
+if grep -q "ccgm/secrets" <<< "$SELECTED_C_IDS"; then
   pass "smoke-C: registry selected ccgm/secrets (always pack)"
 else
   fail "smoke-C: registry did not select ccgm/secrets"

--- a/modules/commands-extra/skills/audit/tests/test-spine-excludes.sh
+++ b/modules/commands-extra/skills/audit/tests/test-spine-excludes.sh
@@ -195,7 +195,18 @@ for f in leaked:
 PYEOF
 )"
 
-get() { printf '%s\n' "$ANALYSIS" | grep "^$1=" | head -1 | cut -d= -f2; }
+# `producer | head` can SIGPIPE-kill the producer once head has read its
+# one line and closes early, and under pipefail that turns a genuine,
+# correct result into a script abort for every bare `$(get ...)` call site
+# below (see #943, #945 -- the priority case for this shape was
+# test-doc-counts.sh:136). Herestring the grep stage (echo/printf of a
+# variable converts directly); the trailing head|cut stays a plain pipe
+# since cut never exits early, so there is nothing left to race.
+get() {
+  local matched
+  matched=$(grep "^$1=" <<< "$ANALYSIS" || true)
+  head -1 <<< "$matched" | cut -d= -f2
+}
 
 TOTAL="$(get TOTAL)"
 EXCLUDED="$(get EXCLUDED)"

--- a/modules/commands-extra/skills/audit/tests/test-spine.sh
+++ b/modules/commands-extra/skills/audit/tests/test-spine.sh
@@ -484,7 +484,10 @@ if command -v shellcheck > /dev/null 2>&1; then
       pass "shellcheck clean: $(basename "$script")"
     else
       fail "shellcheck issues in $(basename "$script"):"
-      printf '%s\n' "$SC_OUTPUT" | head -10
+      # Herestring, not a pipe: `producer | head` can SIGPIPE-kill the
+      # producer once head has read its N lines and closes early (see
+      # #943, #945). A herestring has no second process to race against.
+      head -10 <<< "$SC_OUTPUT"
     fi
   done
 else

--- a/modules/commands-extra/skills/audit/tests/test-suppression.sh
+++ b/modules/commands-extra/skills/audit/tests/test-suppression.sh
@@ -332,7 +332,11 @@ else
 fi
 
 # A warning must be emitted to stderr
-if echo "$TC_STDERR" | grep -qi "warning\|WARNING\|reason\|missing"; then
+# Herestring, not a pipe: `producer | grep -q` can SIGPIPE-kill the
+# producer if grep exits on its first match before the producer finishes
+# writing, turning a genuine match into a reported failure (see #943,
+# #945). A herestring has no second process to race against.
+if grep -qi "warning\|WARNING\|reason\|missing" <<< "$TC_STDERR"; then
   pass "(c): warning emitted to stderr for missing reason"
 else
   fail "(c): no warning on stderr for missing reason (got: $TC_STDERR)"
@@ -397,7 +401,8 @@ else
 fi
 
 # A warning must be emitted
-if echo "$TD_STDERR" | grep -qi "warning\|WARNING\|expir"; then
+# Herestring, not a pipe: see the identical rationale above (#943, #945).
+if grep -qi "warning\|WARNING\|expir" <<< "$TD_STDERR"; then
   pass "(d): warning emitted for expired suppression"
 else
   fail "(d): no warning for expired suppression (got: $TD_STDERR)"


### PR DESCRIPTION
Closes #982

The audit skill's 33 test suites all run under `set -euo pipefail` and carried ~130 `echo "$VAR" | grep -q ...` pipelines — the same class #943/#944/#945 eliminated from the four top-level suites. `grep -q` exits on first match while the producer may still be writing; SIGPIPE kills the producer and pipefail turns a genuine match into a reported failure. PR #977's review reproduced this live 5/5 with output large enough to exceed the pipe buffer, and several of these sites capture multi-KB tool output.

## Changes

- 128 pipeline sites converted to herestrings across 29 files, preserving each site's exact grep flags (`-q`, `-qi`, `-qE`, `-qx`, `-qxF`, `-qF`, `-qv` are all present and not interchangeable) and patterns byte-for-byte.
- 7 real-command producers (`python3 -c ...`, `grep -A5 ...`) captured to a guarded variable first, then herestring — matching the #945 precedent.
- 2 bare-assignment abort-class sites guarded: `test-diff-mode.sh`'s `EVIL_Z_ROUNDTRIP=$(... | head -1)` and `test-spine-excludes.sh`'s `get()` helper (fixed once at the helper, covering its 4 call sites).
- One semantic edge handled explicitly: `grep -qv` reading a herestring of an empty capture sees one blank line (a match), unlike a truly empty pipe — `test-detect-defaults.sh` gets a load-bearing `[ -n ... ] &&` guard, empirically verified equivalent in all four input cases.
- 10 already-guarded `grep -c` sites in `test-diff-mode.sh` confirmed individually (not assumed) and left alone — `grep -c` drains its input, so it has no SIGPIPE risk.
- 4 files had zero candidate sites (`test-command-skill-parity`, `test-detect-ecosystems`, `test-pack-validate`, `test-rubric`). Deliberately untouched per the issue: `modules/cloud-dispatch/lib/workspace-collect.sh:152,154`.

## Residue

Every remaining pipeline feeds a drain-to-EOF consumer (`grep -c`, `grep -oE`, `jq -e`, `sort`, `tr`, `sed` without early quit, `wc`) — zero live early-exiting-consumer pipelines remain across the 33 suites (independently re-enumerated at review).

## Verification

- Exhaustive fidelity check at review: 285 grep invocations before and after, multiset of (flags, verbatim pattern) identical, 0 mutations; canonicalizing herestrings back to pipes reproduces 18/29 files byte-for-byte, with the other 11 differing only by the intended capture/guard rewrites.
- Full suite from a clean checkout path: 33 passed / 0 failed at both merge-base and HEAD. From a `.claude/worktrees/...` checkout, `test-spine.sh` fails its two gitleaks checks at BOTH merge-base and HEAD identically — a pre-existing path sensitivity in that test, now tracked as #992.
- Every touched suite also run individually (all pass), `bash -n` on all 33, `shellcheck -S error` clean on the 29 touched files.