### PR TITLE
#997: add docs/preset-descriptions.json + key-set assertion

### DIFF
--- a/docs/preset-descriptions.json
+++ b/docs/preset-descriptions.json
@@ -1,0 +1,7 @@
+{
+  "minimal": "Trying CCGM for the first time, or environments where you want light-touch guidance with no hooks or settings changes.",
+  "standard": "Most individual developers. The recommended starting point.",
+  "team": "Teams with shared repositories who want consistent practices across contributors.",
+  "full": "Power users who want the complete CCGM experience, including multi-agent coordination, brand research, and tech-specific guides.",
+  "cloud-agent": "Running CCGM on headless cloud VMs that dispatch parallel agents to work on GitHub issues."
+}

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -1023,6 +1023,47 @@ for preset_file in "$REPO_ROOT"/presets/*.json; do
 done
 echo ""
 
+# --- Test: docs/preset-descriptions.json key set matches presets/*.json ---
+# The ccgm.dev site ingests per-preset descriptions from this file, since
+# presets/*.json are bare arrays with nowhere to carry prose and presets/
+# itself is glob-enumerated (any new file there becomes a bogus preset -- see
+# list_preset_names() in lib/modules.sh). The file is optional: it is only
+# checked if present, so this is a no-op until the file exists. Once it
+# exists, its keys must exactly equal the live preset name set in both
+# directions -- no preset without a description, no description for a
+# preset that no longer exists.
+echo "--- Checking docs/preset-descriptions.json key set ---"
+DESCRIPTIONS_FILE="$REPO_ROOT/docs/preset-descriptions.json"
+if [ -f "$DESCRIPTIONS_FILE" ]; then
+  if jq empty "$DESCRIPTIONS_FILE" 2>/dev/null; then
+    pass "docs/preset-descriptions.json: valid JSON"
+
+    live_names=()
+    for preset_file in "$REPO_ROOT"/presets/*.json; do
+      [ -f "$preset_file" ] || continue
+      live_names+=("$(basename "$preset_file" .json)")
+    done
+    live_presets_json=$(printf '%s\n' "${live_names[@]}" | jq -R . | jq -s .)
+
+    missing_from_doc=$(jq -r --argjson live "$live_presets_json" '($live - keys) | .[]' "$DESCRIPTIONS_FILE" 2>/dev/null)
+    extra_in_doc=$(jq -r --argjson live "$live_presets_json" '(keys - $live) | .[]' "$DESCRIPTIONS_FILE" 2>/dev/null)
+
+    if [ -z "$missing_from_doc" ] && [ -z "$extra_in_doc" ]; then
+      pass "docs/preset-descriptions.json: key set matches presets/*.json exactly"
+    else
+      if [ -n "$missing_from_doc" ]; then
+        fail "docs/preset-descriptions.json: missing description(s) for preset(s):$(printf ' %s' $missing_from_doc)"
+      fi
+      if [ -n "$extra_in_doc" ]; then
+        fail "docs/preset-descriptions.json: description(s) for non-existent preset(s):$(printf ' %s' $extra_in_doc)"
+      fi
+    fi
+  else
+    fail "docs/preset-descriptions.json: invalid JSON"
+  fi
+fi
+echo ""
+
 # --- Test: every tests/test-*.sh suite is wired into CI, in every job ---
 # tests/run-all.sh discovers suites by globbing "$SCRIPT_DIR"/test-*.sh, but
 # .github/workflows/test.yml enumerates each suite by hand as its own step,

--- a/tests/test-modules.sh
+++ b/tests/test-modules.sh
@@ -1038,25 +1038,39 @@ if [ -f "$DESCRIPTIONS_FILE" ]; then
   if jq empty "$DESCRIPTIONS_FILE" 2>/dev/null; then
     pass "docs/preset-descriptions.json: valid JSON"
 
-    live_names=()
-    for preset_file in "$REPO_ROOT"/presets/*.json; do
-      [ -f "$preset_file" ] || continue
-      live_names+=("$(basename "$preset_file" .json)")
-    done
-    live_presets_json=$(printf '%s\n' "${live_names[@]}" | jq -R . | jq -s .)
+    # jq empty only checks JSON syntax; a top-level scalar/array/null is
+    # still syntactically valid but breaks the `keys` call below. Gate on
+    # shape before touching keys so a malformed file fails cleanly instead
+    # of aborting the whole suite under set -e.
+    if jq -e 'type == "object"' "$DESCRIPTIONS_FILE" >/dev/null 2>&1; then
+      live_names=()
+      for preset_file in "$REPO_ROOT"/presets/*.json; do
+        [ -f "$preset_file" ] || continue
+        live_names+=("$(basename "$preset_file" .json)")
+      done
+      # bash 3.2 (this repo's documented minimum) treats "${arr[@]}" on an
+      # empty array as an unbound variable under set -u -- guard it.
+      if [ "${#live_names[@]}" -gt 0 ]; then
+        live_presets_json=$(printf '%s\n' "${live_names[@]}" | jq -R . | jq -s .)
+      else
+        live_presets_json='[]'
+      fi
 
-    missing_from_doc=$(jq -r --argjson live "$live_presets_json" '($live - keys) | .[]' "$DESCRIPTIONS_FILE" 2>/dev/null)
-    extra_in_doc=$(jq -r --argjson live "$live_presets_json" '(keys - $live) | .[]' "$DESCRIPTIONS_FILE" 2>/dev/null)
+      missing_from_doc=$(jq -r --argjson live "$live_presets_json" '($live - keys) | .[]' "$DESCRIPTIONS_FILE" 2>/dev/null)
+      extra_in_doc=$(jq -r --argjson live "$live_presets_json" '(keys - $live) | .[]' "$DESCRIPTIONS_FILE" 2>/dev/null)
 
-    if [ -z "$missing_from_doc" ] && [ -z "$extra_in_doc" ]; then
-      pass "docs/preset-descriptions.json: key set matches presets/*.json exactly"
+      if [ -z "$missing_from_doc" ] && [ -z "$extra_in_doc" ]; then
+        pass "docs/preset-descriptions.json: key set matches presets/*.json exactly"
+      else
+        if [ -n "$missing_from_doc" ]; then
+          fail "docs/preset-descriptions.json: missing description(s) for preset(s):$(printf ' %s' $missing_from_doc)"
+        fi
+        if [ -n "$extra_in_doc" ]; then
+          fail "docs/preset-descriptions.json: description(s) for non-existent preset(s):$(printf ' %s' $extra_in_doc)"
+        fi
+      fi
     else
-      if [ -n "$missing_from_doc" ]; then
-        fail "docs/preset-descriptions.json: missing description(s) for preset(s):$(printf ' %s' $missing_from_doc)"
-      fi
-      if [ -n "$extra_in_doc" ]; then
-        fail "docs/preset-descriptions.json: description(s) for non-existent preset(s):$(printf ' %s' $extra_in_doc)"
-      fi
+      fail "docs/preset-descriptions.json: top-level value must be a JSON object"
     fi
   else
     fail "docs/preset-descriptions.json: invalid JSON"


### PR DESCRIPTION
Closes #997

The ccgm.dev site plans to ingest per-preset descriptions to render on the site. Today those descriptions only exist as prose in `docs/presets.md`, so there's nothing machine-readable to pull from.

`presets/*.json` are bare arrays of module names — there's no field to hang a description on. Adding a description file *into* `presets/` isn't an option either: that directory is glob-enumerated by both the installer (`lib/modules.sh`'s `list_preset_names()`) and the test suite, so any non-array JSON file dropped in there becomes a bogus sixth preset and reds CI.

This adds `docs/preset-descriptions.json`, an object keyed by preset name with a one-sentence description for each, seeded from the "Best for" lines in `docs/presets.md`. It lives under `docs/` because that path is safe: the doc-count scanner in `tests/test-doc-counts.sh` only looks at tracked `.md` files, so a `.json` file there is invisible to it.

`tests/test-modules.sh` gets a new check: if `docs/preset-descriptions.json` exists, its key set must exactly equal the live preset set derived the same way the installer derives it (`presets/*.json` basenames) — no preset missing a description, no description for a preset that no longer exists. The check is a no-op if the file is absent, but from this PR forward it always exists.

## Verification

- `bash tests/test-modules.sh` — 1709 passed, 0 failed (includes the new check)
- `bash tests/test-doc-counts.sh` — all checks passed
- `bash tests/test-no-personal-data.sh` — no personal data or secret/PII shapes found
- Manually verified the new assertion fails correctly in both directions (temporarily removed a key, temporarily added a bogus key) before restoring the correct file
