### PR TITLE
#997: document preset-descriptions.json contract in presets.md

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -2,6 +2,8 @@
 
 Presets are named collections of modules for quick installation. Each preset is a JSON array in the `presets/` directory listing module names.
 
+Machine-readable one-line descriptions of these presets live in `docs/preset-descriptions.json` (consumed by the ccgm.dev site). CI asserts its keys match `presets/*.json` exactly, so adding or renaming a preset requires updating that file in the same PR.
+
 ## Available presets
 
 ### minimal


### PR DESCRIPTION
Closes #997 (follow-up to #998).

One line in docs/presets.md pointing at docs/preset-descriptions.json: what it is (machine-readable preset descriptions consumed by ccgm.dev) and the CI contract (keys must match presets/*.json, so a new or renamed preset updates it in the same PR). Without this, the key-set assertion added in #998 fails a future preset PR with no discoverable explanation.